### PR TITLE
Simplify MD rules in the book

### DIFF
--- a/book/.markdownlint.yml
+++ b/book/.markdownlint.yml
@@ -1,15 +1,6 @@
-# MD010: https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md#md010---hard-tabs
-MD010:
-  # Set code blocks to false so that code blocks will be ignored, default is true
-  code_blocks: false
-
 #MD013 line length: https://github.com/DavidAnson/markdownlint/blob/main/doc/md013.md
 # Set to false as this will also interfere with help_x.md files, and it is not necessary to comply with the line length of 80
 MD013: false
-
-# MD028: set to false to allow blank line between blockquote: https://github.com/DavidAnson/markdownlint/blob/main/doc/md028.md
-# This is because the blockquotes are shown separatedly (a deisred outcome) when having a blank line in between
-MD028: false
 
 # MD024: set siblings_only to true so that same headings with different parent headings are allowed
 # https://github.com/DavidAnson/markdownlint/blob/main/doc/md024.md
@@ -22,7 +13,3 @@ MD033: false
 
 # MD036 set to false to preserve the emphasis on deprecation notice on key-management.md (a heading is not necessary)
 MD036: false
-
-# MD040 code blocks should have a language specified: https://github.com/DavidAnson/markdownlint/blob/main/doc/md040.md
-# Set to false as the help_x.md files are code blocks without a language specified, which is fine and does not need to change
-MD040: false

--- a/book/src/contributing.md
+++ b/book/src/contributing.md
@@ -59,7 +59,7 @@ All `TODO` statements should be accompanied by a GitHub issue.
 ```rust
 pub fn my_function(&mut self, _something &[u8]) -> Result<String, Error> {
   // TODO: something_here
-  // https://github.com/sigp/lighthouse/issues/XX
+  // https://github.com/sigp/anchor/issues/XX
 }
 ```
 
@@ -82,7 +82,7 @@ fn validate_attestation() {} // A comment on the same line after a space
 - The comments should come before attributes.
 
 ```rust
-/// Stores the core configuration for this Lighthouse instance.
+/// Stores the core configuration for this instance.
 /// This struct is general, other components may implement more
 /// specialized config structs.
 #[derive(Clone)]

--- a/book/src/faq.md
+++ b/book/src/faq.md
@@ -1,6 +1,6 @@
 # Frequently Asked Questions
 
-- [What is sigp/anchor](#sigp-anchor)
+- [What is sigp/anchor?](#sigp-anchor)
 
 ## <a name="sigp-anchor"></a> What is sigp/anchor
 

--- a/book/src/intro.md
+++ b/book/src/intro.md
@@ -7,7 +7,7 @@ highly performant and secure.
 
 This book aims to provide help and support to users and developers of this client.
 
-> Note: The Anchor client is currently under heavily development and should not be used in a
+> Note: The Anchor client is currently under active development and should not be used in a
 production setting.
 
 ## About this Book


### PR DESCRIPTION
Remove some MD rules so that the Anchor book is closer the mdbook linter without bypassing/disabling any rules. 

Also some other minor fix