### PR TITLE
Windows shutdown

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ perf.data*
 
 # VSCode
 /.vscode
+
+# cross
+/zcross

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,7 +25,9 @@ dependencies = [
 [[package]]
 name = "addr2line"
 version = "0.24.2"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
 checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
 dependencies = [
  "gimli",
@@ -115,7 +117,9 @@ dependencies = [
 [[package]]
 name = "allocator-api2"
 version = "0.2.21"
+version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
@@ -170,7 +174,9 @@ dependencies = [
 [[package]]
 name = "alloy-primitives"
 version = "0.8.14"
+version = "0.8.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9db948902dfbae96a73c2fbf1f7abec62af034ab883e4c777c3fd29702bd6e2c"
 checksum = "9db948902dfbae96a73c2fbf1f7abec62af034ab883e4c777c3fd29702bd6e2c"
 dependencies = [
  "alloy-rlp",
@@ -181,7 +187,9 @@ dependencies = [
  "derive_arbitrary",
  "derive_more 1.0.0",
  "foldhash",
+ "foldhash",
  "getrandom",
+ "hashbrown 0.15.2",
  "hashbrown 0.15.2",
  "hex-literal",
  "indexmap",
@@ -194,6 +202,7 @@ dependencies = [
  "rand",
  "ruint",
  "rustc-hash 2.1.0",
+ "rustc-hash 2.1.0",
  "serde",
  "sha3 0.10.8",
  "tiny-keccak",
@@ -202,8 +211,10 @@ dependencies = [
 [[package]]
 name = "alloy-rlp"
 version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da0822426598f95e45dd1ea32a738dac057529a709ee645fcc516ffa4cbde08f"
+checksum = "f542548a609dca89fcd72b3b9f355928cf844d4363c5eed9c5273a3dd225e097"
 dependencies = [
  "alloy-rlp-derive",
  "arrayvec",
@@ -213,11 +224,14 @@ dependencies = [
 [[package]]
 name = "alloy-rlp-derive"
 version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b09cae092c27b6f1bde952653a22708691802e57bfef4a2973b80bea21efd3f"
+checksum = "5a833d97bf8a5f0f878daf2c8451fff7de7f9de38baa5a45d936ec718d81255a"
 dependencies = [
  "proc-macro2",
  "quote",
+ "syn 2.0.90",
  "syn 2.0.90",
 ]
 
@@ -257,7 +271,9 @@ dependencies = [
 [[package]]
 name = "anstream"
 version = "0.6.18"
+version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8acc5369981196006228e28809f761875c0327210a891e941f4c683b3a99529b"
 checksum = "8acc5369981196006228e28809f761875c0327210a891e941f4c683b3a99529b"
 dependencies = [
  "anstyle",
@@ -272,13 +288,17 @@ dependencies = [
 [[package]]
 name = "anstyle"
 version = "1.0.10"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
 checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
 
 [[package]]
 name = "anstyle-parse"
 version = "0.2.6"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
 checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
 dependencies = [
  "utf8parse",
@@ -287,32 +307,42 @@ dependencies = [
 [[package]]
 name = "anstyle-query"
 version = "1.1.2"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
+checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
 dependencies = [
+ "windows-sys 0.59.0",
  "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "anstyle-wincon"
 version = "3.0.6"
+version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2109dbce0e72be3ec00bed26e6a7479ca384ad226efdd66db8fa2e3a38c83125"
 checksum = "2109dbce0e72be3ec00bed26e6a7479ca384ad226efdd66db8fa2e3a38c83125"
 dependencies = [
  "anstyle",
+ "windows-sys 0.59.0",
  "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "anyhow"
 version = "1.0.93"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c95c10ba0b00a02636238b814946408b1322d5ac4760326e6fb8ec956d85775"
+checksum = "c1fd03a028ef38ba2276dce7e33fcd6369c158a1bca17946c4b1b701891c1ff7"
 
 [[package]]
 name = "arbitrary"
 version = "1.4.1"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dde20b3d026af13f561bdd0f15edf01fc734f0dafcedbaf42bba506a9517f223"
 checksum = "dde20b3d026af13f561bdd0f15edf01fc734f0dafcedbaf42bba506a9517f223"
 dependencies = [
  "derive_arbitrary",
@@ -482,6 +512,7 @@ dependencies = [
  "num-traits",
  "rusticata-macros",
  "thiserror 1.0.69",
+ "thiserror 1.0.69",
  "time",
 ]
 
@@ -494,6 +525,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.90",
+ "syn 2.0.90",
  "synstructure",
 ]
 
@@ -505,6 +537,7 @@ checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
 dependencies = [
  "proc-macro2",
  "quote",
+ "syn 2.0.90",
  "syn 2.0.90",
 ]
 
@@ -528,7 +561,9 @@ dependencies = [
 [[package]]
 name = "async-io"
 version = "2.4.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a2b323ccce0a1d90b449fd71f2a06ca7faa7c54c2751f06c9bd851fc061059"
 checksum = "43a2b323ccce0a1d90b449fd71f2a06ca7faa7c54c2751f06c9bd851fc061059"
 dependencies = [
  "async-lock",
@@ -538,6 +573,7 @@ dependencies = [
  "futures-lite",
  "parking",
  "polling",
+ "rustix 0.38.41",
  "rustix 0.38.41",
  "slab",
  "tracing",
@@ -563,6 +599,7 @@ checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
 dependencies = [
  "proc-macro2",
  "quote",
+ "syn 2.0.90",
  "syn 2.0.90",
 ]
 
@@ -599,6 +636,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.90",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -610,16 +648,19 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 [[package]]
 name = "axum"
 version = "0.7.9"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
 checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
 dependencies = [
  "async-trait",
  "axum-core",
  "bytes",
  "futures-util",
- "http 1.1.0",
+ "http 1.2.0",
  "http-body 1.0.1",
  "http-body-util",
+ "hyper 1.5.1",
  "hyper 1.5.1",
  "hyper-util",
  "itoa",
@@ -633,6 +674,7 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
+ "sync_wrapper 1.0.2",
  "sync_wrapper 1.0.2",
  "tokio",
  "tower",
@@ -650,12 +692,13 @@ dependencies = [
  "async-trait",
  "bytes",
  "futures-util",
- "http 1.1.0",
+ "http 1.2.0",
  "http-body 1.0.1",
  "http-body-util",
  "mime",
  "pin-project-lite",
  "rustversion",
+ "sync_wrapper 1.0.2",
  "sync_wrapper 1.0.2",
  "tower-layer",
  "tower-service",
@@ -722,6 +765,7 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 [[package]]
 name = "beacon_chain"
 version = "0.2.0"
+source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
 source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
 dependencies = [
  "alloy-primitives",
@@ -877,6 +921,7 @@ checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
 name = "bls"
 version = "0.2.0"
 source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
+source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -896,6 +941,7 @@ dependencies = [
 [[package]]
 name = "bls"
 version = "0.2.0"
+source = "git+https://github.com/sigp/lighthouse?branch=unstable#fec502db9f93923f5fa965aad970ac244930c321"
 source = "git+https://github.com/sigp/lighthouse?branch=unstable#fec502db9f93923f5fa965aad970ac244930c321"
 dependencies = [
  "alloy-primitives",
@@ -954,6 +1000,7 @@ dependencies = [
 name = "builder_client"
 version = "0.1.0"
 source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
+source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
 dependencies = [
  "eth2",
  "lighthouse_version 0.1.0 (git+https://github.com/agemanning/lighthouse?branch=modularize-vc)",
@@ -983,7 +1030,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 [[package]]
 name = "bytes"
 version = "1.9.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
 checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
 dependencies = [
  "serde",
@@ -1028,8 +1077,10 @@ dependencies = [
 [[package]]
 name = "cc"
 version = "1.2.2"
+version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f34d93e62b03caf570cccc334cbc6c2fceca82f39211051345108adcba3eebdc"
+checksum = "27f657647bcff5394bf56c7317665bbf790a137a50eaaa5c6bfbb9e27a518f2d"
 dependencies = [
  "jobserver",
  "libc",
@@ -1107,8 +1158,10 @@ dependencies = [
 [[package]]
 name = "clap"
 version = "4.5.21"
+version = "4.5.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb3b4b9e5a7c7514dfa52869339ee98b3156b0bfb4e8a77c4ff4babb64b1604f"
+checksum = "3135e7ec2ef7b10c6ed8950f0f792ed96ee093fa088608f1c76e569722700c84"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1117,8 +1170,10 @@ dependencies = [
 [[package]]
 name = "clap_builder"
 version = "4.5.21"
+version = "4.5.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b17a95aa67cc7b5ebd32aa5370189aa0d79069ef1c64ce893bd30fb24bff20ec"
+checksum = "30582fc632330df2bd26877bde0c1f4470d57c582bbc070376afcd04d8cb4838"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1137,17 +1192,21 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.90",
+ "syn 2.0.90",
 ]
 
 [[package]]
 name = "clap_lex"
 version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "afb84c814227b90d6895e01398aee0d8033c00e7466aca416fb6a8e0eb19d8a7"
+checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
 name = "clap_utils"
 version = "0.1.0"
+source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
 source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
 dependencies = [
  "alloy-primitives",
@@ -1165,6 +1224,7 @@ dependencies = [
 [[package]]
 name = "clap_utils"
 version = "0.1.0"
+source = "git+https://github.com/sigp/lighthouse?branch=unstable#fec502db9f93923f5fa965aad970ac244930c321"
 source = "git+https://github.com/sigp/lighthouse?branch=unstable#fec502db9f93923f5fa965aad970ac244930c321"
 dependencies = [
  "alloy-primitives",
@@ -1190,6 +1250,7 @@ dependencies = [
  "http_api",
  "http_metrics",
  "hyper 1.5.1",
+ "hyper 1.5.1",
  "network",
  "parking_lot 0.12.3",
  "sensitive_url 0.1.0 (git+https://github.com/agemanning/lighthouse?branch=modularize-vc)",
@@ -1205,7 +1266,9 @@ dependencies = [
 [[package]]
 name = "cmake"
 version = "0.1.52"
+version = "0.1.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c682c223677e0e5b6b7f63a64b9351844c3f1b1678a68b7ee617e30fb082620e"
 checksum = "c682c223677e0e5b6b7f63a64b9351844c3f1b1678a68b7ee617e30fb082620e"
 dependencies = [
  "cc",
@@ -1214,12 +1277,15 @@ dependencies = [
 [[package]]
 name = "colorchoice"
 version = "1.0.3"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
 name = "compare_fields"
 version = "0.2.0"
+source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
 source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
 dependencies = [
  "itertools 0.10.5",
@@ -1229,6 +1295,7 @@ dependencies = [
 name = "compare_fields"
 version = "0.2.0"
 source = "git+https://github.com/sigp/lighthouse?branch=unstable#fec502db9f93923f5fa965aad970ac244930c321"
+source = "git+https://github.com/sigp/lighthouse?branch=unstable#fec502db9f93923f5fa965aad970ac244930c321"
 dependencies = [
  "itertools 0.10.5",
 ]
@@ -1236,6 +1303,7 @@ dependencies = [
 [[package]]
 name = "compare_fields_derive"
 version = "0.2.0"
+source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
 source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
 dependencies = [
  "quote",
@@ -1245,6 +1313,7 @@ dependencies = [
 [[package]]
 name = "compare_fields_derive"
 version = "0.2.0"
+source = "git+https://github.com/sigp/lighthouse?branch=unstable#fec502db9f93923f5fa965aad970ac244930c321"
 source = "git+https://github.com/sigp/lighthouse?branch=unstable#fec502db9f93923f5fa965aad970ac244930c321"
 dependencies = [
  "quote",
@@ -1263,7 +1332,9 @@ dependencies = [
 [[package]]
 name = "const-hex"
 version = "1.14.0"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b0485bab839b018a8f1723fc5391819fea5f8f0f32288ef8a735fd096b6160c"
 checksum = "4b0485bab839b018a8f1723fc5391819fea5f8f0f32288ef8a735fd096b6160c"
 dependencies = [
  "cfg-if",
@@ -1322,7 +1393,9 @@ dependencies = [
 [[package]]
 name = "cpufeatures"
 version = "0.2.16"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16b80225097f2e5ae4e7179dd2266824648f3e2f49d9134d584b76389d31c4c3"
 checksum = "16b80225097f2e5ae4e7179dd2266824648f3e2f49d9134d584b76389d31c4c3"
 dependencies = [
  "libc",
@@ -1537,6 +1610,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.90",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -1585,6 +1659,7 @@ dependencies = [
  "quote",
  "strsim 0.11.1",
  "syn 2.0.90",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -1606,6 +1681,7 @@ checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core 0.20.10",
  "quote",
+ "syn 2.0.90",
  "syn 2.0.90",
 ]
 
@@ -1692,6 +1768,7 @@ dependencies = [
 name = "deposit_contract"
 version = "0.2.0"
 source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
+source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
 dependencies = [
  "ethabi 16.0.0",
  "ethereum_ssz",
@@ -1761,11 +1838,14 @@ dependencies = [
 [[package]]
 name = "derive_arbitrary"
 version = "1.4.1"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30542c1ad912e0e3d22a1935c290e12e8a29d704a420177a31faad4a601a0800"
 checksum = "30542c1ad912e0e3d22a1935c290e12e8a29d704a420177a31faad4a601a0800"
 dependencies = [
  "proc-macro2",
  "quote",
+ "syn 2.0.90",
  "syn 2.0.90",
 ]
 
@@ -1777,6 +1857,7 @@ checksum = "5f33878137e4dafd7fa914ad4e259e18a4e8e532b9617a2d0150262bf53abfce"
 dependencies = [
  "proc-macro2",
  "quote",
+ "syn 2.0.90",
  "syn 2.0.90",
 ]
 
@@ -1798,6 +1879,7 @@ dependencies = [
  "convert_case",
  "proc-macro2",
  "quote",
+ "syn 2.0.90",
  "syn 2.0.90",
  "unicode-xid",
 ]
@@ -1827,6 +1909,7 @@ dependencies = [
 name = "directory"
 version = "0.1.0"
 source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
+source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
 dependencies = [
  "clap",
  "clap_utils 0.1.0 (git+https://github.com/agemanning/lighthouse?branch=modularize-vc)",
@@ -1836,6 +1919,7 @@ dependencies = [
 [[package]]
 name = "directory"
 version = "0.1.0"
+source = "git+https://github.com/sigp/lighthouse?branch=unstable#fec502db9f93923f5fa965aad970ac244930c321"
 source = "git+https://github.com/sigp/lighthouse?branch=unstable#fec502db9f93923f5fa965aad970ac244930c321"
 dependencies = [
  "clap",
@@ -1918,6 +2002,7 @@ dependencies = [
  "ctr 0.9.2",
  "delay_map 0.3.0",
  "enr 0.12.1",
+ "enr 0.12.1",
  "fnv",
  "futures",
  "hashlink 0.8.4",
@@ -1951,6 +2036,7 @@ dependencies = [
  "ctr 0.9.2",
  "delay_map 0.4.0",
  "enr 0.12.1",
+ "enr 0.12.1",
  "fnv",
  "futures",
  "hashlink 0.9.1",
@@ -1962,6 +2048,40 @@ dependencies = [
  "parking_lot 0.12.3",
  "rand",
  "smallvec",
+ "socket2 0.5.8",
+ "tokio",
+ "tracing",
+ "uint 0.10.0",
+ "zeroize",
+]
+
+[[package]]
+name = "discv5"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "898d136ecb64116ec68aecf14d889bd30f8b1fe0c19e262953f7388dbe77052e"
+dependencies = [
+ "aes 0.8.4",
+ "aes-gcm",
+ "alloy-rlp",
+ "arrayvec",
+ "ctr 0.9.2",
+ "delay_map 0.4.0",
+ "enr 0.13.0",
+ "fnv",
+ "futures",
+ "hashlink 0.9.1",
+ "hex",
+ "hkdf",
+ "lazy_static",
+ "libp2p-identity",
+ "lru",
+ "more-asserts",
+ "multiaddr",
+ "parking_lot 0.12.3",
+ "rand",
+ "smallvec",
+ "socket2 0.5.8",
  "socket2 0.5.8",
  "tokio",
  "tracing",
@@ -2010,6 +2130,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
+ "syn 2.0.90",
  "syn 2.0.90",
 ]
 
@@ -2163,6 +2284,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "enr"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "851bd664a3d3a3c175cff92b2f0df02df3c541b4895d0ae307611827aae46152"
+dependencies = [
+ "alloy-rlp",
+ "base64 0.22.1",
+ "bytes",
+ "ed25519-dalek",
+ "hex",
+ "k256 0.13.4",
+ "log",
+ "rand",
+ "serde",
+ "sha3 0.10.8",
+ "zeroize",
+]
+
+[[package]]
 name = "enum-as-inner"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2172,11 +2312,13 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.90",
+ "syn 2.0.90",
 ]
 
 [[package]]
 name = "environment"
 version = "0.1.2"
+source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
 source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
 dependencies = [
  "async-channel",
@@ -2214,10 +2356,13 @@ dependencies = [
 [[package]]
 name = "errno"
 version = "0.3.10"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
+ "windows-sys 0.59.0",
  "windows-sys 0.59.0",
 ]
 
@@ -2234,6 +2379,7 @@ dependencies = [
 [[package]]
 name = "eth1"
 version = "0.2.0"
+source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
 source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
 dependencies = [
  "eth2",
@@ -2259,6 +2405,7 @@ dependencies = [
 [[package]]
 name = "eth2"
 version = "0.1.0"
+source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
 source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
 dependencies = [
  "account_utils",
@@ -2292,6 +2439,7 @@ dependencies = [
 name = "eth2_config"
 version = "0.2.0"
 source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
+source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
 dependencies = [
  "paste",
  "types 0.2.1 (git+https://github.com/agemanning/lighthouse?branch=modularize-vc)",
@@ -2301,6 +2449,7 @@ dependencies = [
 name = "eth2_config"
 version = "0.2.0"
 source = "git+https://github.com/sigp/lighthouse?branch=unstable#fec502db9f93923f5fa965aad970ac244930c321"
+source = "git+https://github.com/sigp/lighthouse?branch=unstable#fec502db9f93923f5fa965aad970ac244930c321"
 dependencies = [
  "paste",
  "types 0.2.1 (git+https://github.com/sigp/lighthouse?branch=unstable)",
@@ -2309,6 +2458,7 @@ dependencies = [
 [[package]]
 name = "eth2_interop_keypairs"
 version = "0.2.0"
+source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
 source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
 dependencies = [
  "bls 0.2.0 (git+https://github.com/agemanning/lighthouse?branch=modularize-vc)",
@@ -2322,6 +2472,7 @@ dependencies = [
 [[package]]
 name = "eth2_interop_keypairs"
 version = "0.2.0"
+source = "git+https://github.com/sigp/lighthouse?branch=unstable#fec502db9f93923f5fa965aad970ac244930c321"
 source = "git+https://github.com/sigp/lighthouse?branch=unstable#fec502db9f93923f5fa965aad970ac244930c321"
 dependencies = [
  "bls 0.2.0 (git+https://github.com/sigp/lighthouse?branch=unstable)",
@@ -2336,6 +2487,7 @@ dependencies = [
 name = "eth2_key_derivation"
 version = "0.1.0"
 source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
+source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
 dependencies = [
  "bls 0.2.0 (git+https://github.com/agemanning/lighthouse?branch=modularize-vc)",
  "num-bigint-dig",
@@ -2347,6 +2499,7 @@ dependencies = [
 [[package]]
 name = "eth2_keystore"
 version = "0.1.0"
+source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
 source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
 dependencies = [
  "aes 0.7.5",
@@ -2370,6 +2523,7 @@ dependencies = [
 name = "eth2_network_config"
 version = "0.2.0"
 source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
+source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
 dependencies = [
  "bytes",
  "discv5 0.7.0",
@@ -2391,8 +2545,10 @@ dependencies = [
 name = "eth2_network_config"
 version = "0.2.0"
 source = "git+https://github.com/sigp/lighthouse?branch=unstable#fec502db9f93923f5fa965aad970ac244930c321"
+source = "git+https://github.com/sigp/lighthouse?branch=unstable#fec502db9f93923f5fa965aad970ac244930c321"
 dependencies = [
  "bytes",
+ "discv5 0.9.0",
  "discv5 0.9.0",
  "eth2_config 0.2.0 (git+https://github.com/sigp/lighthouse?branch=unstable)",
  "kzg 0.1.0 (git+https://github.com/sigp/lighthouse?branch=unstable)",
@@ -2411,6 +2567,7 @@ dependencies = [
 [[package]]
 name = "eth2_wallet"
 version = "0.1.0"
+source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
 source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
 dependencies = [
  "eth2_key_derivation",
@@ -2435,6 +2592,7 @@ dependencies = [
  "serde_json",
  "sha3 0.9.1",
  "thiserror 1.0.69",
+ "thiserror 1.0.69",
  "uint 0.9.5",
 ]
 
@@ -2451,6 +2609,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha3 0.10.8",
+ "thiserror 1.0.69",
  "thiserror 1.0.69",
  "uint 0.9.5",
 ]
@@ -2558,6 +2717,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.90",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -2581,6 +2741,7 @@ dependencies = [
  "serde",
  "serde_json",
  "strum",
+ "thiserror 1.0.69",
  "thiserror 1.0.69",
  "tiny-keccak",
  "unicode-xid",
@@ -2606,7 +2767,9 @@ dependencies = [
 [[package]]
 name = "event-listener-strategy"
 version = "0.5.3"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c3e4e0dd3673c1139bf041f3008816d9cf2946bbfac2945c09e523b8d7b05b2"
 checksum = "3c3e4e0dd3673c1139bf041f3008816d9cf2946bbfac2945c09e523b8d7b05b2"
 dependencies = [
  "event-listener 5.3.1",
@@ -2616,6 +2779,7 @@ dependencies = [
 [[package]]
 name = "execution_layer"
 version = "0.1.0"
+source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
 source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
 dependencies = [
  "alloy-consensus",
@@ -2682,8 +2846,10 @@ checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 [[package]]
 name = "fastrand"
 version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "486f806e73c5707928240ddc295403b1b93c96a02038563881c4a2fd84b81ac4"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "fastrlp"
@@ -2703,6 +2869,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e182f7dbc2ef73d9ef67351c5fbbea084729c48362d3ce9dd44c28e32e277fe5"
 dependencies = [
  "libc",
+ "thiserror 1.0.69",
  "thiserror 1.0.69",
 ]
 
@@ -2753,6 +2920,7 @@ dependencies = [
 name = "filesystem"
 version = "0.1.0"
 source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
+source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
 dependencies = [
  "winapi",
  "windows-acl",
@@ -2786,6 +2954,7 @@ dependencies = [
 name = "fixed_bytes"
 version = "0.1.0"
 source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
+source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
 dependencies = [
  "alloy-primitives",
  "safe_arith 0.1.0 (git+https://github.com/agemanning/lighthouse?branch=modularize-vc)",
@@ -2795,6 +2964,7 @@ dependencies = [
 name = "fixed_bytes"
 version = "0.1.0"
 source = "git+https://github.com/sigp/lighthouse?branch=unstable#fec502db9f93923f5fa965aad970ac244930c321"
+source = "git+https://github.com/sigp/lighthouse?branch=unstable#fec502db9f93923f5fa965aad970ac244930c321"
 dependencies = [
  "alloy-primitives",
  "safe_arith 0.1.0 (git+https://github.com/sigp/lighthouse?branch=unstable)",
@@ -2803,7 +2973,9 @@ dependencies = [
 [[package]]
 name = "flate2"
 version = "1.0.35"
+version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c936bfdafb507ebbf50b8074c54fa31c5be9a1e7e5f467dd659697041407d07c"
 checksum = "c936bfdafb507ebbf50b8074c54fa31c5be9a1e7e5f467dd659697041407d07c"
 dependencies = [
  "crc32fast",
@@ -2841,6 +3013,7 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 [[package]]
 name = "fork_choice"
 version = "0.1.0"
+source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
 source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
 dependencies = [
  "ethereum_ssz",
@@ -2945,7 +3118,9 @@ checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 [[package]]
 name = "futures-lite"
 version = "2.5.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cef40d21ae2c515b51041df9ed313ed21e572df340ea58a922a0aefe7e8891a1"
 checksum = "cef40d21ae2c515b51041df9ed313ed21e572df340ea58a922a0aefe7e8891a1"
 dependencies = [
  "futures-core",
@@ -2961,6 +3136,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.90",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -2970,6 +3146,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f2f12607f92c69b12ed746fabf9ca4f5c482cba46679c1a75b874ed7c26adb"
 dependencies = [
  "futures-io",
+ "rustls 0.23.19",
  "rustls 0.23.19",
  "rustls-pki-types",
 ]
@@ -3036,6 +3213,7 @@ dependencies = [
 name = "genesis"
 version = "0.2.0"
 source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
+source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
 dependencies = [
  "environment",
  "eth1",
@@ -3078,7 +3256,9 @@ dependencies = [
 [[package]]
 name = "gimli"
 version = "0.31.1"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
@@ -3099,6 +3279,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.90",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -3110,6 +3291,7 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 [[package]]
 name = "gossipsub"
 version = "0.5.0"
+source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
 source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
 dependencies = [
  "async-channel",
@@ -3140,6 +3322,7 @@ dependencies = [
 [[package]]
 name = "gossipsub"
 version = "0.5.0"
+source = "git+https://github.com/sigp/lighthouse?branch=unstable#fec502db9f93923f5fa965aad970ac244930c321"
 source = "git+https://github.com/sigp/lighthouse?branch=unstable#fec502db9f93923f5fa965aad970ac244930c321"
 dependencies = [
  "async-channel",
@@ -3237,12 +3420,15 @@ dependencies = [
 [[package]]
 name = "hashbrown"
 version = "0.15.2"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
 checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
 dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash",
+ "serde",
  "serde",
 ]
 
@@ -3352,6 +3538,8 @@ dependencies = [
  "rand",
  "socket2 0.5.8",
  "thiserror 1.0.69",
+ "socket2 0.5.8",
+ "thiserror 1.0.69",
  "tinyvec",
  "tokio",
  "tracing",
@@ -3374,6 +3562,7 @@ dependencies = [
  "rand",
  "resolv-conf",
  "smallvec",
+ "thiserror 1.0.69",
  "thiserror 1.0.69",
  "tokio",
  "tracing",
@@ -3452,9 +3641,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258"
+checksum = "f16ca2af56261c99fba8bac40a10251ce8188205a4c448fbb745a2e4daa76fea"
 dependencies = [
  "bytes",
  "fnv",
@@ -3479,7 +3668,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http 1.1.0",
+ "http 1.2.0",
 ]
 
 [[package]]
@@ -3490,7 +3679,7 @@ checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
 dependencies = [
  "bytes",
  "futures-util",
- "http 1.1.0",
+ "http 1.2.0",
  "http-body 1.0.1",
  "pin-project-lite",
 ]
@@ -3552,6 +3741,7 @@ dependencies = [
  "itoa",
  "pin-project-lite",
  "socket2 0.5.8",
+ "socket2 0.5.8",
  "tokio",
  "tower-service",
  "tracing",
@@ -3561,13 +3751,15 @@ dependencies = [
 [[package]]
 name = "hyper"
 version = "1.5.1"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97818827ef4f364230e16705d4706e2897df2bb60617d6ca15d598025a3c481f"
 checksum = "97818827ef4f364230e16705d4706e2897df2bb60617d6ca15d598025a3c481f"
 dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http 1.1.0",
+ "http 1.2.0",
  "http-body 1.0.1",
  "httparse",
  "httpdate",
@@ -3607,13 +3799,16 @@ dependencies = [
 [[package]]
 name = "hyper-util"
 version = "0.1.10"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df2dcfbe0677734ab2f3ffa7fa7bfd4706bfdc1ef393f2ee30184aed67e631b4"
 checksum = "df2dcfbe0677734ab2f3ffa7fa7bfd4706bfdc1ef393f2ee30184aed67e631b4"
 dependencies = [
  "bytes",
  "futures-util",
- "http 1.1.0",
+ "http 1.2.0",
  "http-body 1.0.1",
+ "hyper 1.5.1",
  "hyper 1.5.1",
  "pin-project-lite",
  "tokio",
@@ -3632,6 +3827,7 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
  "windows-core 0.52.0",
+ "windows-core 0.52.0",
 ]
 
 [[package]]
@@ -3641,6 +3837,124 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "icu_collections"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db2fa452206ebee18c4b5c2274dbf1de17008e874b4dc4f0aea9d01ca79e4526"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locid"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13acbb8371917fc971be86fc8057c41a64b521c184808a698c02acc242dbf637"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locid_transform"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01d11ac35de8e40fdeda00d9e1e9d92525f3f9d887cdd7aa81d727596788b54e"
+dependencies = [
+ "displaydoc",
+ "icu_locid",
+ "icu_locid_transform_data",
+ "icu_provider",
+ "tinystr",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locid_transform_data"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdc8ff3388f852bede6b579ad4e978ab004f139284d7b28715f773507b946f6e"
+
+[[package]]
+name = "icu_normalizer"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19ce3e0da2ec68599d193c93d088142efd7f9c5d6fc9b803774855747dc6a84f"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "utf16_iter",
+ "utf8_iter",
+ "write16",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8cafbf7aa791e9b22bec55a167906f9e1215fd475cd22adfcf660e03e989516"
+
+[[package]]
+name = "icu_properties"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93d6020766cfc6302c15dbbc9c8778c37e62c14427cb7f6e601d849e092aeef5"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_locid_transform",
+ "icu_properties_data",
+ "icu_provider",
+ "tinystr",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67a8effbc3dd3e4ba1afa8ad918d5684b8868b3b26500753effea8d2eed19569"
+
+[[package]]
+name = "icu_provider"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ed421c8a8ef78d3e2dbc98a973be2f3770cb42b606e3ab18d6237c4dfde68d9"
+dependencies = [
+ "displaydoc",
+ "icu_locid",
+ "icu_provider_macros",
+ "stable_deref_trait",
+ "tinystr",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_provider_macros"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -3780,9 +4094,24 @@ dependencies = [
 [[package]]
 name = "idna"
 version = "1.0.3"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e"
+checksum = "686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e"
 dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daca1df1c957320b2cf139ac61e7bd64fed304c5040df000a745aa1de3b4ef71"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
  "idna_adapter",
  "smallvec",
  "utf8_iter",
@@ -3811,7 +4140,9 @@ dependencies = [
 [[package]]
 name = "if-watch"
 version = "3.2.1"
+version = "3.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdf9d64cfcf380606e64f9a0bcf493616b65331199f984151a6fa11a7b3cde38"
 checksum = "cdf9d64cfcf380606e64f9a0bcf493616b65331199f984151a6fa11a7b3cde38"
 dependencies = [
  "async-io",
@@ -3825,7 +4156,12 @@ dependencies = [
  "netlink-packet-route",
  "netlink-proto",
  "netlink-sys",
+ "netlink-packet-core",
+ "netlink-packet-route",
+ "netlink-proto",
+ "netlink-sys",
  "rtnetlink",
+ "system-configuration 0.6.1",
  "system-configuration 0.6.1",
  "tokio",
  "windows",
@@ -3898,22 +4234,28 @@ dependencies = [
 [[package]]
 name = "impl-trait-for-tuples"
 version = "0.2.3"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0eb5a3343abf848c0984fe4604b2b105da9539376e24fc0a3b0007411ae4fd9"
 checksum = "a0eb5a3343abf848c0984fe4604b2b105da9539376e24fc0a3b0007411ae4fd9"
 dependencies = [
  "proc-macro2",
  "quote",
+ "syn 2.0.90",
  "syn 2.0.90",
 ]
 
 [[package]]
 name = "indexmap"
 version = "2.7.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62f822373a4fe84d4bb149bf54e584a7f4abec90e072ed49cda0edea5b95471f"
 checksum = "62f822373a4fe84d4bb149bf54e584a7f4abec90e072ed49cda0edea5b95471f"
 dependencies = [
  "arbitrary",
  "equivalent",
+ "hashbrown 0.15.2",
  "hashbrown 0.15.2",
  "serde",
 ]
@@ -3940,6 +4282,7 @@ dependencies = [
 name = "int_to_bytes"
 version = "0.2.0"
 source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
+source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
 dependencies = [
  "bytes",
 ]
@@ -3947,6 +4290,7 @@ dependencies = [
 [[package]]
 name = "int_to_bytes"
 version = "0.2.0"
+source = "git+https://github.com/sigp/lighthouse?branch=unstable#fec502db9f93923f5fa965aad970ac244930c321"
 source = "git+https://github.com/sigp/lighthouse?branch=unstable#fec502db9f93923f5fa965aad970ac244930c321"
 dependencies = [
  "bytes",
@@ -3978,6 +4322,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b58db92f96b720de98181bbbe63c831e87005ab460c1bf306eb2622b4707997f"
 dependencies = [
+ "socket2 0.5.8",
  "socket2 0.5.8",
  "widestring 1.1.0",
  "windows-sys 0.48.0",
@@ -4028,7 +4373,9 @@ dependencies = [
 [[package]]
 name = "itoa"
 version = "1.0.14"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
 checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
 
 [[package]]
@@ -4043,9 +4390,12 @@ dependencies = [
 [[package]]
 name = "js-sys"
 version = "0.3.74"
+version = "0.3.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a865e038f7f6ed956f788f0d7d60c541fff74c7bd74272c5d4cf15c63743e705"
+checksum = "6717b6b5b077764fb5966237269cb3c64edddde4b14ce42647430a78ced9e7b7"
 dependencies = [
+ "once_cell",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -4125,6 +4475,7 @@ dependencies = [
 name = "kzg"
 version = "0.1.0"
 source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
+source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
 dependencies = [
  "arbitrary",
  "c-kzg",
@@ -4143,6 +4494,7 @@ dependencies = [
 [[package]]
 name = "kzg"
 version = "0.1.0"
+source = "git+https://github.com/sigp/lighthouse?branch=unstable#fec502db9f93923f5fa965aad970ac244930c321"
 source = "git+https://github.com/sigp/lighthouse?branch=unstable#fec502db9f93923f5fa965aad970ac244930c321"
 dependencies = [
  "arbitrary",
@@ -4194,7 +4546,9 @@ dependencies = [
 [[package]]
 name = "libc"
 version = "0.2.167"
+version = "0.2.167"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09d6582e104315a817dff97f75133544b2e094ee22447d2acf4a74e189ba06fc"
 checksum = "09d6582e104315a817dff97f75133544b2e094ee22447d2acf4a74e189ba06fc"
 
 [[package]]
@@ -4224,7 +4578,9 @@ dependencies = [
 [[package]]
 name = "libm"
 version = "0.2.11"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8355be11b20d696c8f18f6cc018c4e372165b1fa8126cef092399c9951984ffa"
 checksum = "8355be11b20d696c8f18f6cc018c4e372165b1fa8126cef092399c9951984ffa"
 
 [[package]]
@@ -4258,6 +4614,7 @@ dependencies = [
  "multiaddr",
  "pin-project",
  "rw-stream-sink",
+ "thiserror 1.0.69",
  "thiserror 1.0.69",
 ]
 
@@ -4306,6 +4663,7 @@ dependencies = [
  "rand",
  "rw-stream-sink",
  "smallvec",
+ "thiserror 1.0.69",
  "thiserror 1.0.69",
  "tracing",
  "unsigned-varint 0.8.0",
@@ -4379,6 +4737,7 @@ dependencies = [
  "quick-protobuf-codec",
  "smallvec",
  "thiserror 1.0.69",
+ "thiserror 1.0.69",
  "tracing",
  "void",
 ]
@@ -4386,7 +4745,9 @@ dependencies = [
 [[package]]
 name = "libp2p-identity"
 version = "0.2.10"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "257b5621d159b32282eac446bed6670c39c7dc68a200a992d8f056afa0066f6d"
 checksum = "257b5621d159b32282eac446bed6670c39c7dc68a200a992d8f056afa0066f6d"
 dependencies = [
  "asn1_der",
@@ -4400,6 +4761,7 @@ dependencies = [
  "rand",
  "sec1 0.7.3",
  "sha2 0.10.8",
+ "thiserror 1.0.69",
  "thiserror 1.0.69",
  "tracing",
  "zeroize",
@@ -4420,6 +4782,7 @@ dependencies = [
  "libp2p-swarm",
  "rand",
  "smallvec",
+ "socket2 0.5.8",
  "socket2 0.5.8",
  "tokio",
  "tracing",
@@ -4484,6 +4847,7 @@ dependencies = [
  "snow",
  "static_assertions",
  "thiserror 1.0.69",
+ "thiserror 1.0.69",
  "tracing",
  "x25519-dalek",
  "zeroize",
@@ -4543,6 +4907,9 @@ dependencies = [
  "rustls 0.23.19",
  "socket2 0.5.8",
  "thiserror 1.0.69",
+ "rustls 0.23.19",
+ "socket2 0.5.8",
+ "thiserror 1.0.69",
  "tokio",
  "tracing",
 ]
@@ -4581,6 +4948,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.90",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -4595,6 +4963,7 @@ dependencies = [
  "libc",
  "libp2p-core",
  "libp2p-identity",
+ "socket2 0.5.8",
  "socket2 0.5.8",
  "tokio",
  "tracing",
@@ -4613,7 +4982,9 @@ dependencies = [
  "rcgen",
  "ring 0.17.8",
  "rustls 0.23.19",
+ "rustls 0.23.19",
  "rustls-webpki 0.101.7",
+ "thiserror 1.0.69",
  "thiserror 1.0.69",
  "x509-parser",
  "yasna",
@@ -4645,8 +5016,10 @@ dependencies = [
  "futures",
  "libp2p-core",
  "thiserror 1.0.69",
+ "thiserror 1.0.69",
  "tracing",
  "yamux 0.12.1",
+ "yamux 0.13.4",
  "yamux 0.13.4",
 ]
 
@@ -4734,6 +5107,7 @@ dependencies = [
 name = "lighthouse_network"
 version = "0.2.0"
 source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
+source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -4784,13 +5158,16 @@ dependencies = [
 name = "lighthouse_network"
 version = "0.2.0"
 source = "git+https://github.com/sigp/lighthouse?branch=unstable#fec502db9f93923f5fa965aad970ac244930c321"
+source = "git+https://github.com/sigp/lighthouse?branch=unstable#fec502db9f93923f5fa965aad970ac244930c321"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "bytes",
  "delay_map 0.4.0",
+ "delay_map 0.4.0",
  "directory 0.1.0 (git+https://github.com/sigp/lighthouse?branch=unstable)",
  "dirs 3.0.2",
+ "discv5 0.9.0",
  "discv5 0.9.0",
  "either",
  "ethereum_ssz",
@@ -4833,6 +5210,7 @@ dependencies = [
 name = "lighthouse_version"
 version = "0.1.0"
 source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
+source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
 dependencies = [
  "git-version",
  "target_info",
@@ -4841,6 +5219,7 @@ dependencies = [
 [[package]]
 name = "lighthouse_version"
 version = "0.1.0"
+source = "git+https://github.com/sigp/lighthouse?branch=unstable#fec502db9f93923f5fa965aad970ac244930c321"
 source = "git+https://github.com/sigp/lighthouse?branch=unstable#fec502db9f93923f5fa965aad970ac244930c321"
 dependencies = [
  "git-version",
@@ -4872,6 +5251,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ee93343901ab17bd981295f2cf0026d4ad018c7c31ba84549a4ddbb47a45104"
 
 [[package]]
+name = "litemap"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ee93343901ab17bd981295f2cf0026d4ad018c7c31ba84549a4ddbb47a45104"
+
+[[package]]
 name = "lock_api"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4884,6 +5269,7 @@ dependencies = [
 [[package]]
 name = "lockfile"
 version = "0.1.0"
+source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
 source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
 dependencies = [
  "fs2",
@@ -4898,6 +5284,7 @@ checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 [[package]]
 name = "logging"
 version = "0.2.0"
+source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
 source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
 dependencies = [
  "chrono",
@@ -4920,6 +5307,7 @@ dependencies = [
 [[package]]
 name = "logging"
 version = "0.2.0"
+source = "git+https://github.com/sigp/lighthouse?branch=unstable#fec502db9f93923f5fa965aad970ac244930c321"
 source = "git+https://github.com/sigp/lighthouse?branch=unstable#fec502db9f93923f5fa965aad970ac244930c321"
 dependencies = [
  "chrono",
@@ -4946,6 +5334,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
 dependencies = [
  "hashbrown 0.15.2",
+ "hashbrown 0.15.2",
 ]
 
 [[package]]
@@ -4961,6 +5350,7 @@ dependencies = [
 name = "lru_cache"
 version = "0.1.0"
 source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
+source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
 dependencies = [
  "fnv",
 ]
@@ -4968,6 +5358,7 @@ dependencies = [
 [[package]]
 name = "lru_cache"
 version = "0.1.0"
+source = "git+https://github.com/sigp/lighthouse?branch=unstable#fec502db9f93923f5fa965aad970ac244930c321"
 source = "git+https://github.com/sigp/lighthouse?branch=unstable#fec502db9f93923f5fa965aad970ac244930c321"
 dependencies = [
  "fnv",
@@ -5034,6 +5425,7 @@ dependencies = [
 name = "merkle_proof"
 version = "0.2.0"
 source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
+source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
 dependencies = [
  "alloy-primitives",
  "ethereum_hashing",
@@ -5045,6 +5437,7 @@ dependencies = [
 name = "merkle_proof"
 version = "0.2.0"
 source = "git+https://github.com/sigp/lighthouse?branch=unstable#fec502db9f93923f5fa965aad970ac244930c321"
+source = "git+https://github.com/sigp/lighthouse?branch=unstable#fec502db9f93923f5fa965aad970ac244930c321"
 dependencies = [
  "alloy-primitives",
  "ethereum_hashing",
@@ -5055,7 +5448,9 @@ dependencies = [
 [[package]]
 name = "metastruct"
 version = "0.1.3"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d74f54f231f9a18d77393ecc5cc7ab96709b2a61ee326c2b2b291009b0cc5a07"
 checksum = "d74f54f231f9a18d77393ecc5cc7ab96709b2a61ee326c2b2b291009b0cc5a07"
 dependencies = [
  "metastruct_macro",
@@ -5064,7 +5459,9 @@ dependencies = [
 [[package]]
 name = "metastruct_macro"
 version = "0.1.3"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "985e7225f3a4dfbec47a0c6a730a874185fda840d365d7bbd6ba199dd81796d5"
 checksum = "985e7225f3a4dfbec47a0c6a730a874185fda840d365d7bbd6ba199dd81796d5"
 dependencies = [
  "darling 0.13.4",
@@ -5079,6 +5476,7 @@ dependencies = [
 name = "metrics"
 version = "0.2.0"
 source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
+source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
 dependencies = [
  "prometheus",
 ]
@@ -5086,6 +5484,7 @@ dependencies = [
 [[package]]
 name = "metrics"
 version = "0.2.0"
+source = "git+https://github.com/sigp/lighthouse?branch=unstable#fec502db9f93923f5fa965aad970ac244930c321"
 source = "git+https://github.com/sigp/lighthouse?branch=unstable#fec502db9f93923f5fa965aad970ac244930c321"
 dependencies = [
  "prometheus",
@@ -5148,7 +5547,9 @@ dependencies = [
 [[package]]
 name = "mio"
 version = "1.0.3"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
 checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
 dependencies = [
  "libc",
@@ -5195,10 +5596,13 @@ dependencies = [
 [[package]]
 name = "multihash"
 version = "0.19.2"
+version = "0.19.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc41f430805af9d1cf4adae4ed2149c759b877b01d909a1f40256188d09345d2"
+checksum = "6b430e7953c29dd6a09afc29ff0bb69c6e306329ee6794700aee27b76a1aea8d"
 dependencies = [
  "core2",
+ "unsigned-varint 0.8.0",
  "unsigned-varint 0.8.0",
 ]
 
@@ -5236,7 +5640,9 @@ dependencies = [
 [[package]]
 name = "netlink-packet-core"
 version = "0.7.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72724faf704479d67b388da142b186f916188505e7e0b26719019c525882eda4"
 checksum = "72724faf704479d67b388da142b186f916188505e7e0b26719019c525882eda4"
 dependencies = [
  "anyhow",
@@ -5247,7 +5653,9 @@ dependencies = [
 [[package]]
 name = "netlink-packet-route"
 version = "0.17.1"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053998cea5a306971f88580d0829e90f270f940befd7cf928da179d4187a5a66"
 checksum = "053998cea5a306971f88580d0829e90f270f940befd7cf928da179d4187a5a66"
 dependencies = [
  "anyhow",
@@ -5268,12 +5676,15 @@ dependencies = [
  "byteorder",
  "paste",
  "thiserror 1.0.69",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "netlink-proto"
 version = "0.11.3"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86b33524dc0968bfad349684447bfce6db937a9ac3332a1fe60c0c5a5ce63f21"
 checksum = "86b33524dc0968bfad349684447bfce6db937a9ac3332a1fe60c0c5a5ce63f21"
 dependencies = [
  "bytes",
@@ -5281,6 +5692,7 @@ dependencies = [
  "log",
  "netlink-packet-core",
  "netlink-sys",
+ "thiserror 1.0.69",
  "thiserror 1.0.69",
  "tokio",
 ]
@@ -5320,6 +5732,17 @@ name = "nix"
 version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa52e972a9a719cecb6864fb88568781eb706bac2cd1d4f04a648542dbf78069"
+dependencies = [
+ "bitflags 1.3.2",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
+name = "nix"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
 dependencies = [
  "bitflags 1.3.2",
  "cfg-if",
@@ -5452,7 +5875,9 @@ dependencies = [
 [[package]]
 name = "object"
 version = "0.36.5"
+version = "0.36.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aedf0a2d09c573ed1d8d85b30c119153926a2b36dce0ab28322c09a117a4683e"
 checksum = "aedf0a2d09c573ed1d8d85b30c119153926a2b36dce0ab28322c09a117a4683e"
 dependencies = [
  "memchr",
@@ -5470,12 +5895,15 @@ dependencies = [
 [[package]]
 name = "once_cell"
 version = "1.20.2"
+version = "1.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 
 [[package]]
 name = "oneshot_broadcast"
 version = "0.1.0"
+source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
 source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
 dependencies = [
  "parking_lot 0.12.3",
@@ -5536,6 +5964,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.90",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -5547,7 +5976,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 [[package]]
 name = "openssl-src"
 version = "300.4.1+3.4.0"
+version = "300.4.1+3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faa4eac4138c62414b5622d1b31c5c304f34b406b013c079c2bbc652fdd6678c"
 checksum = "faa4eac4138c62414b5622d1b31c5c304f34b406b013c079c2bbc652fdd6678c"
 dependencies = [
  "cc",
@@ -5569,6 +6000,7 @@ dependencies = [
 [[package]]
 name = "operation_pool"
 version = "0.2.0"
+source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
 source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
 dependencies = [
  "bitvec 1.0.1",
@@ -5791,18 +6223,23 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 [[package]]
 name = "pest"
 version = "2.7.14"
+version = "2.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879952a81a83930934cbf1786752d6dedc3b1f29e8f8fb2ad1d0a36f377cf442"
+checksum = "8b7cafe60d6cf8e62e1b9b2ea516a089c008945bb5a275416789e7db0bc199dc"
 dependencies = [
  "memchr",
  "thiserror 1.0.69",
+ "thiserror 2.0.6",
  "ucd-trie",
 ]
 
 [[package]]
 name = "pin-project"
 version = "1.1.7"
+version = "1.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be57f64e946e500c8ee36ef6331845d40a93055567ec57e8fae13efd33759b95"
 checksum = "be57f64e946e500c8ee36ef6331845d40a93055567ec57e8fae13efd33759b95"
 dependencies = [
  "pin-project-internal",
@@ -5811,18 +6248,23 @@ dependencies = [
 [[package]]
 name = "pin-project-internal"
 version = "1.1.7"
+version = "1.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c0f5fad0874fc7abcd4d750e76917eaebbecaa2c20bde22e1dbeeba8beb758c"
 checksum = "3c0f5fad0874fc7abcd4d750e76917eaebbecaa2c20bde22e1dbeeba8beb758c"
 dependencies = [
  "proc-macro2",
  "quote",
+ "syn 2.0.90",
  "syn 2.0.90",
 ]
 
 [[package]]
 name = "pin-project-lite"
 version = "0.2.15"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "915a1e146535de9163f3987b8944ed8cf49a18bb0056bcebcdcece385cece4ff"
 checksum = "915a1e146535de9163f3987b8944ed8cf49a18bb0056bcebcdcece385cece4ff"
 
 [[package]]
@@ -5866,13 +6308,16 @@ checksum = "e8d0eef3571242013a0d5dc84861c3ae4a652e56e12adf8bdc26ff5f8cb34c94"
 [[package]]
 name = "polling"
 version = "3.7.4"
+version = "3.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a604568c3202727d1507653cb121dbd627a58684eb09a820fd746bee38b4442f"
 checksum = "a604568c3202727d1507653cb121dbd627a58684eb09a820fd746bee38b4442f"
 dependencies = [
  "cfg-if",
  "concurrent-queue",
  "hermit-abi 0.4.0",
  "pin-project-lite",
+ "rustix 0.38.41",
  "rustix 0.38.41",
  "tracing",
  "windows-sys 0.59.0",
@@ -5920,6 +6365,7 @@ dependencies = [
 name = "pretty_reqwest_error"
 version = "0.1.0"
 source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
+source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
 dependencies = [
  "reqwest",
  "sensitive_url 0.1.0 (git+https://github.com/agemanning/lighthouse?branch=modularize-vc)",
@@ -5928,6 +6374,7 @@ dependencies = [
 [[package]]
 name = "pretty_reqwest_error"
 version = "0.1.0"
+source = "git+https://github.com/sigp/lighthouse?branch=unstable#fec502db9f93923f5fa965aad970ac244930c321"
 source = "git+https://github.com/sigp/lighthouse?branch=unstable#fec502db9f93923f5fa965aad970ac244930c321"
 dependencies = [
  "reqwest",
@@ -5992,7 +6439,9 @@ dependencies = [
 [[package]]
 name = "proc-macro2"
 version = "1.0.92"
+version = "1.0.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0"
 checksum = "37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0"
 dependencies = [
  "unicode-ident",
@@ -6026,6 +6475,7 @@ dependencies = [
  "parking_lot 0.12.3",
  "protobuf",
  "thiserror 1.0.69",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -6048,6 +6498,7 @@ checksum = "440f724eba9f6996b75d63681b0a92b06947f1457076d503a4d2e2c8f56442b8"
 dependencies = [
  "proc-macro2",
  "quote",
+ "syn 2.0.90",
  "syn 2.0.90",
 ]
 
@@ -6080,11 +6531,13 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.90",
+ "syn 2.0.90",
 ]
 
 [[package]]
 name = "proto_array"
 version = "0.2.0"
+source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
 source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
 dependencies = [
  "ethereum_ssz",
@@ -6117,6 +6570,7 @@ dependencies = [
  "num_cpus",
  "once_cell",
  "platforms",
+ "thiserror 1.0.69",
  "thiserror 1.0.69",
  "unescape",
 ]
@@ -6157,13 +6611,16 @@ dependencies = [
  "bytes",
  "quick-protobuf",
  "thiserror 1.0.69",
+ "thiserror 1.0.69",
  "unsigned-varint 0.8.0",
 ]
 
 [[package]]
 name = "quinn"
 version = "0.11.6"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62e96808277ec6f97351a2380e6c25114bc9e67037775464979f3037c92d05ef"
 checksum = "62e96808277ec6f97351a2380e6c25114bc9e67037775464979f3037c92d05ef"
 dependencies = [
  "bytes",
@@ -6175,6 +6632,10 @@ dependencies = [
  "rustls 0.23.19",
  "socket2 0.5.8",
  "thiserror 2.0.3",
+ "rustc-hash 2.1.0",
+ "rustls 0.23.19",
+ "socket2 0.5.8",
+ "thiserror 2.0.6",
  "tokio",
  "tracing",
 ]
@@ -6182,32 +6643,44 @@ dependencies = [
 [[package]]
 name = "quinn-proto"
 version = "0.11.9"
+version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2fe5ef3495d7d2e377ff17b1a8ce2ee2ec2a18cde8b6ad6619d65d0701c135d"
 checksum = "a2fe5ef3495d7d2e377ff17b1a8ce2ee2ec2a18cde8b6ad6619d65d0701c135d"
 dependencies = [
  "bytes",
+ "getrandom",
  "getrandom",
  "rand",
  "ring 0.17.8",
  "rustc-hash 2.1.0",
  "rustls 0.23.19",
  "rustls-pki-types",
+ "rustc-hash 2.1.0",
+ "rustls 0.23.19",
+ "rustls-pki-types",
  "slab",
  "thiserror 2.0.3",
+ "thiserror 2.0.6",
  "tinyvec",
  "tracing",
+ "web-time",
  "web-time",
 ]
 
 [[package]]
 name = "quinn-udp"
 version = "0.5.7"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5a626c6807713b15cac82a6acaccd6043c9a5408c24baae07611fec3f243da"
 checksum = "7d5a626c6807713b15cac82a6acaccd6043c9a5408c24baae07611fec3f243da"
 dependencies = [
  "cfg_aliases",
+ "cfg_aliases",
  "libc",
  "once_cell",
+ "socket2 0.5.8",
  "socket2 0.5.8",
  "tracing",
  "windows-sys 0.59.0",
@@ -6354,6 +6827,7 @@ dependencies = [
  "getrandom",
  "libredox",
  "thiserror 1.0.69",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -6364,6 +6838,7 @@ checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
+ "regex-automata 0.4.9",
  "regex-automata 0.4.9",
  "regex-syntax 0.8.5",
 ]
@@ -6380,7 +6855,9 @@ dependencies = [
 [[package]]
 name = "regex-automata"
 version = "0.4.9"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
 checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
 dependencies = [
  "aho-corasick",
@@ -6431,6 +6908,7 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper 0.1.2",
+ "system-configuration 0.5.1",
  "system-configuration 0.5.1",
  "tokio",
  "tokio-native-tls",
@@ -6556,15 +7034,22 @@ dependencies = [
 [[package]]
 name = "rtnetlink"
 version = "0.13.1"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a552eb82d19f38c3beed3f786bd23aa434ceb9ac43ab44419ca6d67a7e186c0"
 checksum = "7a552eb82d19f38c3beed3f786bd23aa434ceb9ac43ab44419ca6d67a7e186c0"
 dependencies = [
  "futures",
  "log",
  "netlink-packet-core",
+ "netlink-packet-core",
  "netlink-packet-route",
  "netlink-packet-utils",
+ "netlink-packet-utils",
  "netlink-proto",
+ "netlink-sys",
+ "nix 0.26.4",
+ "thiserror 1.0.69",
  "netlink-sys",
  "nix 0.26.4",
  "thiserror 1.0.69",
@@ -6619,7 +7104,9 @@ dependencies = [
 [[package]]
 name = "rust_eth_kzg"
 version = "0.5.1"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3291fd0d9c629a56537d74bbc1e7bcaf5be610f2f7b55af85c4fea843c6aeca3"
 checksum = "3291fd0d9c629a56537d74bbc1e7bcaf5be610f2f7b55af85c4fea843c6aeca3"
 dependencies = [
  "crate_crypto_internal_eth_kzg_bls12_381",
@@ -6645,7 +7132,9 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 [[package]]
 name = "rustc-hash"
 version = "2.1.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7fb8039b3032c191086b10f11f319a6e99e1e82889c5cc6046f515c9db1d497"
 checksum = "c7fb8039b3032c191086b10f11f319a6e99e1e82889c5cc6046f515c9db1d497"
 
 [[package]]
@@ -6698,7 +7187,9 @@ dependencies = [
 [[package]]
 name = "rustix"
 version = "0.38.41"
+version = "0.38.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7f649912bc1495e167a6edee79151c84b1bad49748cb4f1f1167f459f6224f6"
 checksum = "d7f649912bc1495e167a6edee79151c84b1bad49748cb4f1f1167f459f6224f6"
 dependencies = [
  "bitflags 2.6.0",
@@ -6737,7 +7228,9 @@ dependencies = [
 [[package]]
 name = "rustls"
 version = "0.23.19"
+version = "0.23.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "934b404430bb06b3fae2cba809eb45a1ab1aecd64491213d7c3301b88393f8d1"
 checksum = "934b404430bb06b3fae2cba809eb45a1ab1aecd64491213d7c3301b88393f8d1"
 dependencies = [
  "once_cell",
@@ -6774,6 +7267,9 @@ checksum = "16f1201b3c9a7ee8039bcadc17b7e605e2945b27eee7631788c1bd2b0643674b"
 dependencies = [
  "web-time",
 ]
+dependencies = [
+ "web-time",
+]
 
 [[package]]
 name = "rustls-webpki"
@@ -6799,7 +7295,9 @@ dependencies = [
 [[package]]
 name = "rustversion"
 version = "1.0.18"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e819f2bc632f285be6d7cd36e25940d45b2391dd6d9b939e79de557f7014248"
 checksum = "0e819f2bc632f285be6d7cd36e25940d45b2391dd6d9b939e79de557f7014248"
 
 [[package]]
@@ -6835,10 +7333,12 @@ checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 name = "safe_arith"
 version = "0.1.0"
 source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
+source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
 
 [[package]]
 name = "safe_arith"
 version = "0.1.0"
+source = "git+https://github.com/sigp/lighthouse?branch=unstable#fec502db9f93923f5fa965aad970ac244930c321"
 source = "git+https://github.com/sigp/lighthouse?branch=unstable#fec502db9f93923f5fa965aad970ac244930c321"
 
 [[package]]
@@ -6853,7 +7353,9 @@ dependencies = [
 [[package]]
 name = "scale-info"
 version = "2.11.6"
+version = "2.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346a3b32eba2640d17a9cb5927056b08f3de90f65b72fe09402c2ad07d684d0b"
 checksum = "346a3b32eba2640d17a9cb5927056b08f3de90f65b72fe09402c2ad07d684d0b"
 dependencies = [
  "cfg-if",
@@ -6865,19 +7367,24 @@ dependencies = [
 [[package]]
 name = "scale-info-derive"
 version = "2.11.6"
+version = "2.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6630024bf739e2179b91fb424b28898baf819414262c5d376677dbff1fe7ebf"
 checksum = "c6630024bf739e2179b91fb424b28898baf819414262c5d376677dbff1fe7ebf"
 dependencies = [
  "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
  "syn 2.0.90",
+ "syn 2.0.90",
 ]
 
 [[package]]
 name = "schannel"
 version = "0.1.27"
+version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f29ebaa345f945cec9fbbc532eb307f0fdad8161f281b6369539c8d84876b3d"
 checksum = "1f29ebaa345f945cec9fbbc532eb307f0fdad8161f281b6369539c8d84876b3d"
 dependencies = [
  "windows-sys 0.59.0",
@@ -6970,7 +7477,9 @@ dependencies = [
 [[package]]
 name = "security-framework-sys"
 version = "2.12.1"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa39c7303dc58b5543c94d22c1766b0d31f2ee58306363ea622b10bbc075eaa2"
 checksum = "fa39c7303dc58b5543c94d22c1766b0d31f2ee58306363ea622b10bbc075eaa2"
 dependencies = [
  "core-foundation-sys",
@@ -6995,7 +7504,9 @@ checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
 [[package]]
 name = "semver-parser"
 version = "0.10.3"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9900206b54a3527fdc7b8a938bffd94a568bac4f4aa8113b209df75a09c0dec2"
 checksum = "9900206b54a3527fdc7b8a938bffd94a568bac4f4aa8113b209df75a09c0dec2"
 dependencies = [
  "pest",
@@ -7004,6 +7515,7 @@ dependencies = [
 [[package]]
 name = "sensitive_url"
 version = "0.1.0"
+source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
 source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
 dependencies = [
  "serde",
@@ -7014,6 +7526,7 @@ dependencies = [
 name = "sensitive_url"
 version = "0.1.0"
 source = "git+https://github.com/sigp/lighthouse?branch=unstable#fec502db9f93923f5fa965aad970ac244930c321"
+source = "git+https://github.com/sigp/lighthouse?branch=unstable#fec502db9f93923f5fa965aad970ac244930c321"
 dependencies = [
  "serde",
  "url",
@@ -7022,7 +7535,9 @@ dependencies = [
 [[package]]
 name = "serde"
 version = "1.0.215"
+version = "1.0.215"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6513c1ad0b11a9376da888e3e0baa0077f1aed55c17f50e7b2397136129fb88f"
 checksum = "6513c1ad0b11a9376da888e3e0baa0077f1aed55c17f50e7b2397136129fb88f"
 dependencies = [
  "serde_derive",
@@ -7041,18 +7556,23 @@ dependencies = [
 [[package]]
 name = "serde_derive"
 version = "1.0.215"
+version = "1.0.215"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad1e866f866923f252f05c889987993144fb74e722403468a4ebd70c3cd756c0"
 checksum = "ad1e866f866923f252f05c889987993144fb74e722403468a4ebd70c3cd756c0"
 dependencies = [
  "proc-macro2",
  "quote",
+ "syn 2.0.90",
  "syn 2.0.90",
 ]
 
 [[package]]
 name = "serde_json"
 version = "1.0.133"
+version = "1.0.133"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7fceb2473b9166b2294ef05efcb65a3db80803f0b03ef86a5fc88a2b85ee377"
 checksum = "c7fceb2473b9166b2294ef05efcb65a3db80803f0b03ef86a5fc88a2b85ee377"
 dependencies = [
  "itoa",
@@ -7079,6 +7599,7 @@ checksum = "6c64451ba24fc7a6a2d60fc75dd9c83c90903b19028d4eff35e88fc1e86564e9"
 dependencies = [
  "proc-macro2",
  "quote",
+ "syn 2.0.90",
  "syn 2.0.90",
 ]
 
@@ -7227,6 +7748,7 @@ dependencies = [
  "num-bigint",
  "num-traits",
  "thiserror 1.0.69",
+ "thiserror 1.0.69",
  "time",
 ]
 
@@ -7242,6 +7764,7 @@ dependencies = [
 [[package]]
 name = "slasher"
 version = "0.1.0"
+source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
 source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
 dependencies = [
  "bincode",
@@ -7268,6 +7791,7 @@ dependencies = [
 [[package]]
 name = "slashing_protection"
 version = "0.1.0"
+source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
 source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
 dependencies = [
  "arbitrary",
@@ -7388,6 +7912,7 @@ dependencies = [
 name = "slot_clock"
 version = "0.2.0"
 source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
+source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
 dependencies = [
  "metrics 0.2.0 (git+https://github.com/agemanning/lighthouse?branch=modularize-vc)",
  "parking_lot 0.12.3",
@@ -7439,7 +7964,9 @@ dependencies = [
 [[package]]
 name = "socket2"
 version = "0.5.8"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c970269d99b64e60ec3bd6ad27270092a5394c4e309314b18ae3fe575695fbe8"
 checksum = "c970269d99b64e60ec3bd6ad27270092a5394c4e309314b18ae3fe575695fbe8"
 dependencies = [
  "libc",
@@ -7506,6 +8033,7 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 name = "state_processing"
 version = "0.2.0"
 source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
+source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
 dependencies = [
  "arbitrary",
  "bls 0.2.0 (git+https://github.com/agemanning/lighthouse?branch=modularize-vc)",
@@ -7537,6 +8065,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 [[package]]
 name = "store"
 version = "0.2.0"
+source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
 source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
 dependencies = [
  "db-key",
@@ -7615,6 +8144,7 @@ dependencies = [
 name = "swap_or_not_shuffle"
 version = "0.2.0"
 source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
+source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
 dependencies = [
  "alloy-primitives",
  "ethereum_hashing",
@@ -7624,6 +8154,7 @@ dependencies = [
 [[package]]
 name = "swap_or_not_shuffle"
 version = "0.2.0"
+source = "git+https://github.com/sigp/lighthouse?branch=unstable#fec502db9f93923f5fa965aad970ac244930c321"
 source = "git+https://github.com/sigp/lighthouse?branch=unstable#fec502db9f93923f5fa965aad970ac244930c321"
 dependencies = [
  "alloy-primitives",
@@ -7645,7 +8176,9 @@ dependencies = [
 [[package]]
 name = "syn"
 version = "2.0.90"
+version = "2.0.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "919d3b74a5dd0ccd15aeb8f93e7006bd9e14c295087c9896a110f490752bcf31"
 checksum = "919d3b74a5dd0ccd15aeb8f93e7006bd9e14c295087c9896a110f490752bcf31"
 dependencies = [
  "proc-macro2",
@@ -7662,7 +8195,9 @@ checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 [[package]]
 name = "sync_wrapper"
 version = "1.0.2"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
 
 [[package]]
@@ -7673,6 +8208,7 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
+ "syn 2.0.90",
  "syn 2.0.90",
 ]
 
@@ -7696,6 +8232,18 @@ dependencies = [
  "bitflags 2.6.0",
  "core-foundation",
  "system-configuration-sys 0.6.0",
+ "system-configuration-sys 0.5.0",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
+dependencies = [
+ "bitflags 2.6.0",
+ "core-foundation",
+ "system-configuration-sys 0.6.0",
 ]
 
 [[package]]
@@ -7703,6 +8251,16 @@ name = "system-configuration-sys"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -7740,6 +8298,7 @@ checksum = "c63f48baada5c52e65a29eef93ab4f8982681b67f9e8d29c7b05abcfec2b9ffe"
 name = "task_executor"
 version = "0.1.0"
 source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
+source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
 dependencies = [
  "async-channel",
  "futures",
@@ -7753,6 +8312,7 @@ dependencies = [
 [[package]]
 name = "task_executor"
 version = "0.1.0"
+source = "git+https://github.com/sigp/lighthouse?branch=unstable#fec502db9f93923f5fa965aad970ac244930c321"
 source = "git+https://github.com/sigp/lighthouse?branch=unstable#fec502db9f93923f5fa965aad970ac244930c321"
 dependencies = [
  "async-channel",
@@ -7768,12 +8328,15 @@ dependencies = [
 [[package]]
 name = "tempfile"
 version = "3.14.0"
+version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28cce251fcbc87fac86a866eeb0d6c2d536fc16d06f184bb61aeae11aa4cee0c"
 checksum = "28cce251fcbc87fac86a866eeb0d6c2d536fc16d06f184bb61aeae11aa4cee0c"
 dependencies = [
  "cfg-if",
  "fastrand",
  "once_cell",
+ "rustix 0.38.41",
  "rustix 0.38.41",
  "windows-sys 0.59.0",
 ]
@@ -7792,9 +8355,12 @@ dependencies = [
 [[package]]
 name = "terminal_size"
 version = "0.4.1"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5352447f921fda68cf61b4101566c0bdb5104eff6804d0678e5227580ab6a4e9"
+checksum = "5352447f921fda68cf61b4101566c0bdb5104eff6804d0678e5227580ab6a4e9"
 dependencies = [
+ "rustix 0.38.41",
  "rustix 0.38.41",
  "windows-sys 0.59.0",
 ]
@@ -7802,6 +8368,7 @@ dependencies = [
 [[package]]
 name = "test_random_derive"
 version = "0.2.0"
+source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
 source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
 dependencies = [
  "quote",
@@ -7812,6 +8379,7 @@ dependencies = [
 name = "test_random_derive"
 version = "0.2.0"
 source = "git+https://github.com/sigp/lighthouse?branch=unstable#fec502db9f93923f5fa965aad970ac244930c321"
+source = "git+https://github.com/sigp/lighthouse?branch=unstable#fec502db9f93923f5fa965aad970ac244930c321"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -7820,7 +8388,9 @@ dependencies = [
 [[package]]
 name = "thiserror"
 version = "1.0.69"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
  "thiserror-impl 1.0.69",
@@ -7833,12 +8403,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c006c85c7651b3cf2ada4584faa36773bd07bac24acfb39f3c431b36d7e667aa"
 dependencies = [
  "thiserror-impl 2.0.3",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec2a1820ebd077e2b90c4df007bebf344cd394098a13c563957d0afc83ea47"
+dependencies = [
+ "thiserror-impl 2.0.6",
 ]
 
 [[package]]
 name = "thiserror-impl"
 version = "1.0.69"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
@@ -7851,6 +8433,18 @@ name = "thiserror-impl"
 version = "2.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f077553d607adc1caf65430528a576c757a71ed73944b66ebb58ef2bbd243568"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
+ "syn 2.0.90",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d65750cab40f4ff1929fb1ba509e9914eb756131cef4210da8d5d700d26f6312"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7879,7 +8473,9 @@ dependencies = [
 [[package]]
 name = "time"
 version = "0.3.37"
+version = "0.3.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35e7868883861bd0e56d9ac6efcaaca0d6d5d82a2a7ec8209ff492c07cf37b21"
 checksum = "35e7868883861bd0e56d9ac6efcaaca0d6d5d82a2a7ec8209ff492c07cf37b21"
 dependencies = [
  "deranged",
@@ -7900,7 +8496,9 @@ checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 [[package]]
 name = "time-macros"
 version = "0.2.19"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2834e6017e3e5e4b9834939793b282bc03b37a3336245fa820e35e233e2a85de"
 checksum = "2834e6017e3e5e4b9834939793b282bc03b37a3336245fa820e35e233e2a85de"
 dependencies = [
  "num-conv",
@@ -7921,6 +8519,7 @@ dependencies = [
  "rustc-hash 1.1.0",
  "sha2 0.10.8",
  "thiserror 1.0.69",
+ "thiserror 1.0.69",
  "unicode-normalization",
  "wasm-bindgen",
  "zeroize",
@@ -7933,6 +8532,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
 dependencies = [
  "crunchy",
+]
+
+[[package]]
+name = "tinystr"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f"
+dependencies = [
+ "displaydoc",
+ "zerovec",
 ]
 
 [[package]]
@@ -7963,7 +8572,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 [[package]]
 name = "tokio"
 version = "1.42.0"
+version = "1.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cec9b21b0450273377fc97bd4c33a8acffc8c996c987a7c5b319a0083707551"
 checksum = "5cec9b21b0450273377fc97bd4c33a8acffc8c996c987a7c5b319a0083707551"
 dependencies = [
  "backtrace",
@@ -7972,6 +8583,7 @@ dependencies = [
  "mio",
  "pin-project-lite",
  "signal-hook-registry",
+ "socket2 0.5.8",
  "socket2 0.5.8",
  "tokio-macros",
  "windows-sys 0.52.0",
@@ -7995,6 +8607,7 @@ checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
+ "syn 2.0.90",
  "syn 2.0.90",
 ]
 
@@ -8031,9 +8644,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f4e6ce100d0eb49a2734f8c0812bcd324cf357d21810932c5df6b96ef2b86f1"
+checksum = "eca58d7bba4a75707817a2c44174253f9236b2d5fbd055602e9d5c07c139a047"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -8043,9 +8656,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.12"
+version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61e7c3654c13bcd040d4a03abee2c75b1d14a37b423cf5a813ceae1cc903ec6a"
+checksum = "d7fcaa8d55a2bdd6b83ace262b016eca0d79ee02818c5c1bcdf0305114081078"
 dependencies = [
  "bytes",
  "futures-core",
@@ -8103,12 +8716,14 @@ dependencies = [
 [[package]]
 name = "tower-http"
 version = "0.6.2"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "403fa3b783d4b626a8ad51d766ab03cb6d2dbfc46b1c5d4448395e6628dc9697"
 checksum = "403fa3b783d4b626a8ad51d766ab03cb6d2dbfc46b1c5d4448395e6628dc9697"
 dependencies = [
  "bitflags 2.6.0",
  "bytes",
- "http 1.1.0",
+ "http 1.2.0",
  "pin-project-lite",
  "tower-layer",
  "tower-service",
@@ -8129,7 +8744,9 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 [[package]]
 name = "tracing"
 version = "0.1.41"
+version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
  "log",
@@ -8146,6 +8763,7 @@ checksum = "3566e8ce28cc0a3fe42519fc80e6b4c943cc4c8cef275620eb8dac2d3d4e06cf"
 dependencies = [
  "crossbeam-channel",
  "thiserror 1.0.69",
+ "thiserror 1.0.69",
  "time",
  "tracing-subscriber",
 ]
@@ -8153,18 +8771,23 @@ dependencies = [
 [[package]]
 name = "tracing-attributes"
 version = "0.1.28"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
 checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
 dependencies = [
  "proc-macro2",
  "quote",
+ "syn 2.0.90",
  "syn 2.0.90",
 ]
 
 [[package]]
 name = "tracing-core"
 version = "0.1.33"
+version = "0.1.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
 checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
 dependencies = [
  "once_cell",
@@ -8185,7 +8808,9 @@ dependencies = [
 [[package]]
 name = "tracing-subscriber"
 version = "0.3.19"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
 checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
 dependencies = [
  "matchers",
@@ -8240,6 +8865,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.90",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -8255,7 +8881,9 @@ dependencies = [
 [[package]]
 name = "triomphe"
 version = "0.1.14"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef8f7726da4807b58ea5c96fdc122f80702030edc33b35aff9190a51148ccc85"
 checksum = "ef8f7726da4807b58ea5c96fdc122f80702030edc33b35aff9190a51148ccc85"
 dependencies = [
  "serde",
@@ -8277,6 +8905,7 @@ checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 [[package]]
 name = "types"
 version = "0.2.1"
+source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
 source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
 dependencies = [
  "alloy-primitives",
@@ -8326,6 +8955,7 @@ dependencies = [
 [[package]]
 name = "types"
 version = "0.2.1"
+source = "git+https://github.com/sigp/lighthouse?branch=unstable#fec502db9f93923f5fa965aad970ac244930c321"
 source = "git+https://github.com/sigp/lighthouse?branch=unstable#fec502db9f93923f5fa965aad970ac244930c321"
 dependencies = [
  "alloy-primitives",
@@ -8423,13 +9053,17 @@ checksum = "7e51b68083f157f853b6379db119d1c1be0e6e4dec98101079dec41f6f5cf6df"
 [[package]]
 name = "unicode-bidi"
 version = "0.3.17"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ab17db44d7388991a428b2ee655ce0c212e862eff1768a455c58f9aad6e7893"
 checksum = "5ab17db44d7388991a428b2ee655ce0c212e862eff1768a455c58f9aad6e7893"
 
 [[package]]
 name = "unicode-ident"
 version = "1.0.14"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
 checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
 
 [[package]]
@@ -8502,6 +9136,7 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 name = "unused_port"
 version = "0.1.0"
 source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
+source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
 dependencies = [
  "lru_cache 0.1.0 (git+https://github.com/agemanning/lighthouse?branch=modularize-vc)",
  "parking_lot 0.12.3",
@@ -8511,6 +9146,7 @@ dependencies = [
 name = "unused_port"
 version = "0.1.0"
 source = "git+https://github.com/sigp/lighthouse?branch=unstable#fec502db9f93923f5fa965aad970ac244930c321"
+source = "git+https://github.com/sigp/lighthouse?branch=unstable#fec502db9f93923f5fa965aad970ac244930c321"
 dependencies = [
  "lru_cache 0.1.0 (git+https://github.com/sigp/lighthouse?branch=unstable)",
  "parking_lot 0.12.3",
@@ -8519,13 +9155,28 @@ dependencies = [
 [[package]]
 name = "url"
 version = "2.5.4"
+version = "2.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60"
 checksum = "32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60"
 dependencies = [
  "form_urlencoded",
  "idna 1.0.3",
+ "idna 1.0.3",
  "percent-encoding",
 ]
+
+[[package]]
+name = "utf16_iter"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246"
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "utf16_iter"
@@ -8559,6 +9210,7 @@ dependencies = [
 name = "validator_dir"
 version = "0.1.0"
 source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
+source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
 dependencies = [
  "bls 0.2.0 (git+https://github.com/agemanning/lighthouse?branch=modularize-vc)",
  "deposit_contract",
@@ -8576,6 +9228,7 @@ dependencies = [
 [[package]]
 name = "validator_metrics"
 version = "0.1.0"
+source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
 source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
 dependencies = [
  "metrics 0.2.0 (git+https://github.com/agemanning/lighthouse?branch=modularize-vc)",
@@ -8671,6 +9324,7 @@ dependencies = [
 name = "warp_utils"
 version = "0.1.0"
 source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
+source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
 dependencies = [
  "beacon_chain",
  "bytes",
@@ -8696,8 +9350,10 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 [[package]]
 name = "wasm-bindgen"
 version = "0.2.97"
+version = "0.2.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d15e63b4482863c109d70a7b8706c1e364eb6ea449b201a76c5b89cedcec2d5c"
+checksum = "a474f6281d1d70c17ae7aa6a613c87fce69a127e2624002df63dcb39d6cf6396"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -8707,14 +9363,16 @@ dependencies = [
 [[package]]
 name = "wasm-bindgen-backend"
 version = "0.2.97"
+version = "0.2.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d36ef12e3aaca16ddd3f67922bc63e48e953f126de60bd33ccc0101ef9998cd"
+checksum = "5f89bb38646b4f81674e8f5c3fb81b562be1fd936d84320f3264486418519c79"
 dependencies = [
  "bumpalo",
  "log",
- "once_cell",
  "proc-macro2",
  "quote",
+ "syn 2.0.90",
  "syn 2.0.90",
  "wasm-bindgen-shared",
 ]
@@ -8722,11 +9380,14 @@ dependencies = [
 [[package]]
 name = "wasm-bindgen-futures"
 version = "0.4.47"
+version = "0.4.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9dfaf8f50e5f293737ee323940c7d8b08a66a95a419223d9f41610ca08b0833d"
+checksum = "38176d9b44ea84e9184eff0bc34cc167ed044f816accfe5922e54d84cf48eca2"
 dependencies = [
  "cfg-if",
  "js-sys",
+ "once_cell",
  "once_cell",
  "wasm-bindgen",
  "web-sys",
@@ -8735,8 +9396,10 @@ dependencies = [
 [[package]]
 name = "wasm-bindgen-macro"
 version = "0.2.97"
+version = "0.2.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "705440e08b42d3e4b36de7d66c944be628d579796b8090bfa3471478a2260051"
+checksum = "2cc6181fd9a7492eef6fef1f33961e3695e4579b9872a6f7c83aee556666d4fe"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -8745,11 +9408,14 @@ dependencies = [
 [[package]]
 name = "wasm-bindgen-macro-support"
 version = "0.2.97"
+version = "0.2.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98c9ae5a76e46f4deecd0f0255cc223cfa18dc9b261213b8aa0c7b36f61b3f1d"
+checksum = "30d7a95b763d3c45903ed6c81f156801839e5ee968bb07e534c44df0fcd330c2"
 dependencies = [
  "proc-macro2",
  "quote",
+ "syn 2.0.90",
  "syn 2.0.90",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
@@ -8758,13 +9424,17 @@ dependencies = [
 [[package]]
 name = "wasm-bindgen-shared"
 version = "0.2.97"
+version = "0.2.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ee99da9c5ba11bd675621338ef6fa52296b76b83305e9b6e5c77d4c286d6d49"
+checksum = "943aab3fdaaa029a6e0271b35ea10b72b943135afe9bffca82384098ad0e06a6"
 
 [[package]]
 name = "wasm-streams"
 version = "0.4.2"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
 checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
 dependencies = [
  "futures-util",
@@ -8777,8 +9447,10 @@ dependencies = [
 [[package]]
 name = "web-sys"
 version = "0.3.74"
+version = "0.3.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a98bc3c33f0fe7e59ad7cd041b89034fa82a7c2d4365ca538dda6cdaf513863c"
+checksum = "04dd7223427d52553d3702c004d3b2fe07c148165faa56313cb00211e31c12bc"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -8837,9 +9509,13 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 [[package]]
 name = "windows"
 version = "0.53.0"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "efc5cf48f83140dcaab716eeaea345f9e93d0018fb81162753a3f76c3397b538"
+checksum = "efc5cf48f83140dcaab716eeaea345f9e93d0018fb81162753a3f76c3397b538"
 dependencies = [
+ "windows-core 0.53.0",
+ "windows-targets 0.52.6",
  "windows-core 0.53.0",
  "windows-targets 0.52.6",
 ]
@@ -8859,9 +9535,31 @@ dependencies = [
 [[package]]
 name = "windows-core"
 version = "0.52.0"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dcc5b895a6377f1ab9fa55acedab1fd5ac0db66ad1e6c7f47e28a22e446a5dd"
+dependencies = [
+ "windows-result",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
+dependencies = [
+ "windows-targets 0.52.6",
  "windows-targets 0.52.6",
 ]
 
@@ -9139,6 +9837,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
 
 [[package]]
+name = "write16"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936"
+
+[[package]]
+name = "writeable"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
+
+[[package]]
 name = "wyz"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9179,14 +9889,17 @@ dependencies = [
  "oid-registry",
  "rusticata-macros",
  "thiserror 1.0.69",
+ "thiserror 1.0.69",
  "time",
 ]
 
 [[package]]
 name = "xml-rs"
 version = "0.8.23"
+version = "0.8.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af310deaae937e48a26602b730250b4949e125f468f11e6990be3e5304ddd96f"
+checksum = "ea8b391c9a790b496184c29f7f93b9ed5b16abb306c05415b68bcc16e4d06432"
 
 [[package]]
 name = "xmltree"
@@ -9215,7 +9928,9 @@ dependencies = [
 [[package]]
 name = "yamux"
 version = "0.13.4"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17610762a1207ee816c6fadc29220904753648aba0a9ed61c7b8336e80a559c4"
 checksum = "17610762a1207ee816c6fadc29220904753648aba0a9ed61c7b8336e80a559c4"
 dependencies = [
  "futures",
@@ -9235,6 +9950,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
 dependencies = [
  "time",
+]
+
+[[package]]
+name = "yoke"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "120e6aef9aa629e3d4f52dc8cc43a015c7724194c97dfaf45180d2daf2b77f40"
+dependencies = [
+ "serde",
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
+ "synstructure",
 ]
 
 [[package]]
@@ -9301,6 +10040,28 @@ dependencies = [
  "quote",
  "syn 2.0.90",
  "synstructure",
+ "syn 2.0.90",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cff3ee08c995dee1859d998dea82f7374f2826091dd9cd47def953cae446cd2e"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "595eed982f7d355beb85837f651fa22e90b3c044842dc7f2c2842c086f295808"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
+ "synstructure",
 ]
 
 [[package]]
@@ -9320,6 +10081,29 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
+ "syn 2.0.90",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa2b893d79df23bfb12d5461018d408ea19dfafe76c2c7ef6d4eba614f8ff079"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
  "syn 2.0.90",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,9 +25,7 @@ dependencies = [
 [[package]]
 name = "addr2line"
 version = "0.24.2"
-version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
 checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
 dependencies = [
  "gimli",
@@ -117,9 +115,7 @@ dependencies = [
 [[package]]
 name = "allocator-api2"
 version = "0.2.21"
-version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
@@ -174,9 +170,7 @@ dependencies = [
 [[package]]
 name = "alloy-primitives"
 version = "0.8.14"
-version = "0.8.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9db948902dfbae96a73c2fbf1f7abec62af034ab883e4c777c3fd29702bd6e2c"
 checksum = "9db948902dfbae96a73c2fbf1f7abec62af034ab883e4c777c3fd29702bd6e2c"
 dependencies = [
  "alloy-rlp",
@@ -187,9 +181,7 @@ dependencies = [
  "derive_arbitrary",
  "derive_more 1.0.0",
  "foldhash",
- "foldhash",
  "getrandom",
- "hashbrown 0.15.2",
  "hashbrown 0.15.2",
  "hex-literal",
  "indexmap",
@@ -202,7 +194,6 @@ dependencies = [
  "rand",
  "ruint",
  "rustc-hash 2.1.0",
- "rustc-hash 2.1.0",
  "serde",
  "sha3 0.10.8",
  "tiny-keccak",
@@ -211,10 +202,8 @@ dependencies = [
 [[package]]
 name = "alloy-rlp"
 version = "0.3.9"
-version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da0822426598f95e45dd1ea32a738dac057529a709ee645fcc516ffa4cbde08f"
-checksum = "f542548a609dca89fcd72b3b9f355928cf844d4363c5eed9c5273a3dd225e097"
 dependencies = [
  "alloy-rlp-derive",
  "arrayvec",
@@ -224,14 +213,11 @@ dependencies = [
 [[package]]
 name = "alloy-rlp-derive"
 version = "0.3.9"
-version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b09cae092c27b6f1bde952653a22708691802e57bfef4a2973b80bea21efd3f"
-checksum = "5a833d97bf8a5f0f878daf2c8451fff7de7f9de38baa5a45d936ec718d81255a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
  "syn 2.0.90",
 ]
 
@@ -271,9 +257,7 @@ dependencies = [
 [[package]]
 name = "anstream"
 version = "0.6.18"
-version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8acc5369981196006228e28809f761875c0327210a891e941f4c683b3a99529b"
 checksum = "8acc5369981196006228e28809f761875c0327210a891e941f4c683b3a99529b"
 dependencies = [
  "anstyle",
@@ -288,17 +272,13 @@ dependencies = [
 [[package]]
 name = "anstyle"
 version = "1.0.10"
-version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
 checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
 
 [[package]]
 name = "anstyle-parse"
 version = "0.2.6"
-version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
 checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
 dependencies = [
  "utf8parse",
@@ -307,42 +287,32 @@ dependencies = [
 [[package]]
 name = "anstyle-query"
 version = "1.1.2"
-version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
-checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
 dependencies = [
- "windows-sys 0.59.0",
  "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "anstyle-wincon"
 version = "3.0.6"
-version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2109dbce0e72be3ec00bed26e6a7479ca384ad226efdd66db8fa2e3a38c83125"
 checksum = "2109dbce0e72be3ec00bed26e6a7479ca384ad226efdd66db8fa2e3a38c83125"
 dependencies = [
  "anstyle",
- "windows-sys 0.59.0",
  "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "anyhow"
 version = "1.0.93"
-version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c95c10ba0b00a02636238b814946408b1322d5ac4760326e6fb8ec956d85775"
-checksum = "c1fd03a028ef38ba2276dce7e33fcd6369c158a1bca17946c4b1b701891c1ff7"
 
 [[package]]
 name = "arbitrary"
 version = "1.4.1"
-version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dde20b3d026af13f561bdd0f15edf01fc734f0dafcedbaf42bba506a9517f223"
 checksum = "dde20b3d026af13f561bdd0f15edf01fc734f0dafcedbaf42bba506a9517f223"
 dependencies = [
  "derive_arbitrary",
@@ -512,7 +482,6 @@ dependencies = [
  "num-traits",
  "rusticata-macros",
  "thiserror 1.0.69",
- "thiserror 1.0.69",
  "time",
 ]
 
@@ -525,7 +494,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.90",
- "syn 2.0.90",
  "synstructure",
 ]
 
@@ -537,7 +505,6 @@ checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
  "syn 2.0.90",
 ]
 
@@ -561,9 +528,7 @@ dependencies = [
 [[package]]
 name = "async-io"
 version = "2.4.0"
-version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a2b323ccce0a1d90b449fd71f2a06ca7faa7c54c2751f06c9bd851fc061059"
 checksum = "43a2b323ccce0a1d90b449fd71f2a06ca7faa7c54c2751f06c9bd851fc061059"
 dependencies = [
  "async-lock",
@@ -573,7 +538,6 @@ dependencies = [
  "futures-lite",
  "parking",
  "polling",
- "rustix 0.38.41",
  "rustix 0.38.41",
  "slab",
  "tracing",
@@ -599,7 +563,6 @@ checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
  "syn 2.0.90",
 ]
 
@@ -636,7 +599,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.90",
- "syn 2.0.90",
 ]
 
 [[package]]
@@ -648,19 +610,16 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 [[package]]
 name = "axum"
 version = "0.7.9"
-version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
 checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
 dependencies = [
  "async-trait",
  "axum-core",
  "bytes",
  "futures-util",
- "http 1.2.0",
+ "http 1.1.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.5.1",
  "hyper 1.5.1",
  "hyper-util",
  "itoa",
@@ -674,7 +633,6 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
- "sync_wrapper 1.0.2",
  "sync_wrapper 1.0.2",
  "tokio",
  "tower",
@@ -692,13 +650,12 @@ dependencies = [
  "async-trait",
  "bytes",
  "futures-util",
- "http 1.2.0",
+ "http 1.1.0",
  "http-body 1.0.1",
  "http-body-util",
  "mime",
  "pin-project-lite",
  "rustversion",
- "sync_wrapper 1.0.2",
  "sync_wrapper 1.0.2",
  "tower-layer",
  "tower-service",
@@ -765,7 +722,6 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 [[package]]
 name = "beacon_chain"
 version = "0.2.0"
-source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
 source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
 dependencies = [
  "alloy-primitives",
@@ -921,7 +877,6 @@ checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
 name = "bls"
 version = "0.2.0"
 source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
-source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -941,7 +896,6 @@ dependencies = [
 [[package]]
 name = "bls"
 version = "0.2.0"
-source = "git+https://github.com/sigp/lighthouse?branch=unstable#fec502db9f93923f5fa965aad970ac244930c321"
 source = "git+https://github.com/sigp/lighthouse?branch=unstable#fec502db9f93923f5fa965aad970ac244930c321"
 dependencies = [
  "alloy-primitives",
@@ -1000,7 +954,6 @@ dependencies = [
 name = "builder_client"
 version = "0.1.0"
 source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
-source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
 dependencies = [
  "eth2",
  "lighthouse_version 0.1.0 (git+https://github.com/agemanning/lighthouse?branch=modularize-vc)",
@@ -1030,9 +983,7 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 [[package]]
 name = "bytes"
 version = "1.9.0"
-version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
 checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
 dependencies = [
  "serde",
@@ -1077,10 +1028,8 @@ dependencies = [
 [[package]]
 name = "cc"
 version = "1.2.2"
-version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f34d93e62b03caf570cccc334cbc6c2fceca82f39211051345108adcba3eebdc"
-checksum = "27f657647bcff5394bf56c7317665bbf790a137a50eaaa5c6bfbb9e27a518f2d"
 dependencies = [
  "jobserver",
  "libc",
@@ -1158,10 +1107,8 @@ dependencies = [
 [[package]]
 name = "clap"
 version = "4.5.21"
-version = "4.5.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb3b4b9e5a7c7514dfa52869339ee98b3156b0bfb4e8a77c4ff4babb64b1604f"
-checksum = "3135e7ec2ef7b10c6ed8950f0f792ed96ee093fa088608f1c76e569722700c84"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1170,10 +1117,8 @@ dependencies = [
 [[package]]
 name = "clap_builder"
 version = "4.5.21"
-version = "4.5.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b17a95aa67cc7b5ebd32aa5370189aa0d79069ef1c64ce893bd30fb24bff20ec"
-checksum = "30582fc632330df2bd26877bde0c1f4470d57c582bbc070376afcd04d8cb4838"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1192,21 +1137,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.90",
- "syn 2.0.90",
 ]
 
 [[package]]
 name = "clap_lex"
 version = "0.7.3"
-version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "afb84c814227b90d6895e01398aee0d8033c00e7466aca416fb6a8e0eb19d8a7"
-checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
 name = "clap_utils"
 version = "0.1.0"
-source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
 source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
 dependencies = [
  "alloy-primitives",
@@ -1224,7 +1165,6 @@ dependencies = [
 [[package]]
 name = "clap_utils"
 version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?branch=unstable#fec502db9f93923f5fa965aad970ac244930c321"
 source = "git+https://github.com/sigp/lighthouse?branch=unstable#fec502db9f93923f5fa965aad970ac244930c321"
 dependencies = [
  "alloy-primitives",
@@ -1250,7 +1190,6 @@ dependencies = [
  "http_api",
  "http_metrics",
  "hyper 1.5.1",
- "hyper 1.5.1",
  "network",
  "parking_lot 0.12.3",
  "sensitive_url 0.1.0 (git+https://github.com/agemanning/lighthouse?branch=modularize-vc)",
@@ -1266,9 +1205,7 @@ dependencies = [
 [[package]]
 name = "cmake"
 version = "0.1.52"
-version = "0.1.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c682c223677e0e5b6b7f63a64b9351844c3f1b1678a68b7ee617e30fb082620e"
 checksum = "c682c223677e0e5b6b7f63a64b9351844c3f1b1678a68b7ee617e30fb082620e"
 dependencies = [
  "cc",
@@ -1277,15 +1214,12 @@ dependencies = [
 [[package]]
 name = "colorchoice"
 version = "1.0.3"
-version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
 name = "compare_fields"
 version = "0.2.0"
-source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
 source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
 dependencies = [
  "itertools 0.10.5",
@@ -1294,7 +1228,6 @@ dependencies = [
 [[package]]
 name = "compare_fields"
 version = "0.2.0"
-source = "git+https://github.com/sigp/lighthouse?branch=unstable#fec502db9f93923f5fa965aad970ac244930c321"
 source = "git+https://github.com/sigp/lighthouse?branch=unstable#fec502db9f93923f5fa965aad970ac244930c321"
 dependencies = [
  "itertools 0.10.5",
@@ -1303,7 +1236,6 @@ dependencies = [
 [[package]]
 name = "compare_fields_derive"
 version = "0.2.0"
-source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
 source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
 dependencies = [
  "quote",
@@ -1313,7 +1245,6 @@ dependencies = [
 [[package]]
 name = "compare_fields_derive"
 version = "0.2.0"
-source = "git+https://github.com/sigp/lighthouse?branch=unstable#fec502db9f93923f5fa965aad970ac244930c321"
 source = "git+https://github.com/sigp/lighthouse?branch=unstable#fec502db9f93923f5fa965aad970ac244930c321"
 dependencies = [
  "quote",
@@ -1332,9 +1263,7 @@ dependencies = [
 [[package]]
 name = "const-hex"
 version = "1.14.0"
-version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b0485bab839b018a8f1723fc5391819fea5f8f0f32288ef8a735fd096b6160c"
 checksum = "4b0485bab839b018a8f1723fc5391819fea5f8f0f32288ef8a735fd096b6160c"
 dependencies = [
  "cfg-if",
@@ -1393,9 +1322,7 @@ dependencies = [
 [[package]]
 name = "cpufeatures"
 version = "0.2.16"
-version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16b80225097f2e5ae4e7179dd2266824648f3e2f49d9134d584b76389d31c4c3"
 checksum = "16b80225097f2e5ae4e7179dd2266824648f3e2f49d9134d584b76389d31c4c3"
 dependencies = [
  "libc",
@@ -1610,7 +1537,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.90",
- "syn 2.0.90",
 ]
 
 [[package]]
@@ -1659,7 +1585,6 @@ dependencies = [
  "quote",
  "strsim 0.11.1",
  "syn 2.0.90",
- "syn 2.0.90",
 ]
 
 [[package]]
@@ -1681,7 +1606,6 @@ checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core 0.20.10",
  "quote",
- "syn 2.0.90",
  "syn 2.0.90",
 ]
 
@@ -1768,7 +1692,6 @@ dependencies = [
 name = "deposit_contract"
 version = "0.2.0"
 source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
-source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
 dependencies = [
  "ethabi 16.0.0",
  "ethereum_ssz",
@@ -1838,14 +1761,11 @@ dependencies = [
 [[package]]
 name = "derive_arbitrary"
 version = "1.4.1"
-version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30542c1ad912e0e3d22a1935c290e12e8a29d704a420177a31faad4a601a0800"
 checksum = "30542c1ad912e0e3d22a1935c290e12e8a29d704a420177a31faad4a601a0800"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
  "syn 2.0.90",
 ]
 
@@ -1857,7 +1777,6 @@ checksum = "5f33878137e4dafd7fa914ad4e259e18a4e8e532b9617a2d0150262bf53abfce"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
  "syn 2.0.90",
 ]
 
@@ -1879,7 +1798,6 @@ dependencies = [
  "convert_case",
  "proc-macro2",
  "quote",
- "syn 2.0.90",
  "syn 2.0.90",
  "unicode-xid",
 ]
@@ -1909,7 +1827,6 @@ dependencies = [
 name = "directory"
 version = "0.1.0"
 source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
-source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
 dependencies = [
  "clap",
  "clap_utils 0.1.0 (git+https://github.com/agemanning/lighthouse?branch=modularize-vc)",
@@ -1919,7 +1836,6 @@ dependencies = [
 [[package]]
 name = "directory"
 version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?branch=unstable#fec502db9f93923f5fa965aad970ac244930c321"
 source = "git+https://github.com/sigp/lighthouse?branch=unstable#fec502db9f93923f5fa965aad970ac244930c321"
 dependencies = [
  "clap",
@@ -2002,7 +1918,6 @@ dependencies = [
  "ctr 0.9.2",
  "delay_map 0.3.0",
  "enr 0.12.1",
- "enr 0.12.1",
  "fnv",
  "futures",
  "hashlink 0.8.4",
@@ -2036,7 +1951,6 @@ dependencies = [
  "ctr 0.9.2",
  "delay_map 0.4.0",
  "enr 0.12.1",
- "enr 0.12.1",
  "fnv",
  "futures",
  "hashlink 0.9.1",
@@ -2048,40 +1962,6 @@ dependencies = [
  "parking_lot 0.12.3",
  "rand",
  "smallvec",
- "socket2 0.5.8",
- "tokio",
- "tracing",
- "uint 0.10.0",
- "zeroize",
-]
-
-[[package]]
-name = "discv5"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "898d136ecb64116ec68aecf14d889bd30f8b1fe0c19e262953f7388dbe77052e"
-dependencies = [
- "aes 0.8.4",
- "aes-gcm",
- "alloy-rlp",
- "arrayvec",
- "ctr 0.9.2",
- "delay_map 0.4.0",
- "enr 0.13.0",
- "fnv",
- "futures",
- "hashlink 0.9.1",
- "hex",
- "hkdf",
- "lazy_static",
- "libp2p-identity",
- "lru",
- "more-asserts",
- "multiaddr",
- "parking_lot 0.12.3",
- "rand",
- "smallvec",
- "socket2 0.5.8",
  "socket2 0.5.8",
  "tokio",
  "tracing",
@@ -2130,7 +2010,6 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
  "syn 2.0.90",
 ]
 
@@ -2284,25 +2163,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "enr"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "851bd664a3d3a3c175cff92b2f0df02df3c541b4895d0ae307611827aae46152"
-dependencies = [
- "alloy-rlp",
- "base64 0.22.1",
- "bytes",
- "ed25519-dalek",
- "hex",
- "k256 0.13.4",
- "log",
- "rand",
- "serde",
- "sha3 0.10.8",
- "zeroize",
-]
-
-[[package]]
 name = "enum-as-inner"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2312,13 +2172,11 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.90",
- "syn 2.0.90",
 ]
 
 [[package]]
 name = "environment"
 version = "0.1.2"
-source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
 source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
 dependencies = [
  "async-channel",
@@ -2356,13 +2214,10 @@ dependencies = [
 [[package]]
 name = "errno"
 version = "0.3.10"
-version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
  "windows-sys 0.59.0",
 ]
 
@@ -2379,7 +2234,6 @@ dependencies = [
 [[package]]
 name = "eth1"
 version = "0.2.0"
-source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
 source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
 dependencies = [
  "eth2",
@@ -2405,7 +2259,6 @@ dependencies = [
 [[package]]
 name = "eth2"
 version = "0.1.0"
-source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
 source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
 dependencies = [
  "account_utils",
@@ -2439,7 +2292,6 @@ dependencies = [
 name = "eth2_config"
 version = "0.2.0"
 source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
-source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
 dependencies = [
  "paste",
  "types 0.2.1 (git+https://github.com/agemanning/lighthouse?branch=modularize-vc)",
@@ -2449,7 +2301,6 @@ dependencies = [
 name = "eth2_config"
 version = "0.2.0"
 source = "git+https://github.com/sigp/lighthouse?branch=unstable#fec502db9f93923f5fa965aad970ac244930c321"
-source = "git+https://github.com/sigp/lighthouse?branch=unstable#fec502db9f93923f5fa965aad970ac244930c321"
 dependencies = [
  "paste",
  "types 0.2.1 (git+https://github.com/sigp/lighthouse?branch=unstable)",
@@ -2458,7 +2309,6 @@ dependencies = [
 [[package]]
 name = "eth2_interop_keypairs"
 version = "0.2.0"
-source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
 source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
 dependencies = [
  "bls 0.2.0 (git+https://github.com/agemanning/lighthouse?branch=modularize-vc)",
@@ -2472,7 +2322,6 @@ dependencies = [
 [[package]]
 name = "eth2_interop_keypairs"
 version = "0.2.0"
-source = "git+https://github.com/sigp/lighthouse?branch=unstable#fec502db9f93923f5fa965aad970ac244930c321"
 source = "git+https://github.com/sigp/lighthouse?branch=unstable#fec502db9f93923f5fa965aad970ac244930c321"
 dependencies = [
  "bls 0.2.0 (git+https://github.com/sigp/lighthouse?branch=unstable)",
@@ -2487,7 +2336,6 @@ dependencies = [
 name = "eth2_key_derivation"
 version = "0.1.0"
 source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
-source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
 dependencies = [
  "bls 0.2.0 (git+https://github.com/agemanning/lighthouse?branch=modularize-vc)",
  "num-bigint-dig",
@@ -2499,7 +2347,6 @@ dependencies = [
 [[package]]
 name = "eth2_keystore"
 version = "0.1.0"
-source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
 source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
 dependencies = [
  "aes 0.7.5",
@@ -2523,7 +2370,6 @@ dependencies = [
 name = "eth2_network_config"
 version = "0.2.0"
 source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
-source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
 dependencies = [
  "bytes",
  "discv5 0.7.0",
@@ -2545,10 +2391,8 @@ dependencies = [
 name = "eth2_network_config"
 version = "0.2.0"
 source = "git+https://github.com/sigp/lighthouse?branch=unstable#fec502db9f93923f5fa965aad970ac244930c321"
-source = "git+https://github.com/sigp/lighthouse?branch=unstable#fec502db9f93923f5fa965aad970ac244930c321"
 dependencies = [
  "bytes",
- "discv5 0.9.0",
  "discv5 0.9.0",
  "eth2_config 0.2.0 (git+https://github.com/sigp/lighthouse?branch=unstable)",
  "kzg 0.1.0 (git+https://github.com/sigp/lighthouse?branch=unstable)",
@@ -2567,7 +2411,6 @@ dependencies = [
 [[package]]
 name = "eth2_wallet"
 version = "0.1.0"
-source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
 source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
 dependencies = [
  "eth2_key_derivation",
@@ -2592,7 +2435,6 @@ dependencies = [
  "serde_json",
  "sha3 0.9.1",
  "thiserror 1.0.69",
- "thiserror 1.0.69",
  "uint 0.9.5",
 ]
 
@@ -2609,7 +2451,6 @@ dependencies = [
  "serde",
  "serde_json",
  "sha3 0.10.8",
- "thiserror 1.0.69",
  "thiserror 1.0.69",
  "uint 0.9.5",
 ]
@@ -2717,7 +2558,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.90",
- "syn 2.0.90",
 ]
 
 [[package]]
@@ -2741,7 +2581,6 @@ dependencies = [
  "serde",
  "serde_json",
  "strum",
- "thiserror 1.0.69",
  "thiserror 1.0.69",
  "tiny-keccak",
  "unicode-xid",
@@ -2767,9 +2606,7 @@ dependencies = [
 [[package]]
 name = "event-listener-strategy"
 version = "0.5.3"
-version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c3e4e0dd3673c1139bf041f3008816d9cf2946bbfac2945c09e523b8d7b05b2"
 checksum = "3c3e4e0dd3673c1139bf041f3008816d9cf2946bbfac2945c09e523b8d7b05b2"
 dependencies = [
  "event-listener 5.3.1",
@@ -2779,7 +2616,6 @@ dependencies = [
 [[package]]
 name = "execution_layer"
 version = "0.1.0"
-source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
 source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
 dependencies = [
  "alloy-consensus",
@@ -2846,10 +2682,8 @@ checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 [[package]]
 name = "fastrand"
 version = "2.2.0"
-version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "486f806e73c5707928240ddc295403b1b93c96a02038563881c4a2fd84b81ac4"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "fastrlp"
@@ -2869,7 +2703,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e182f7dbc2ef73d9ef67351c5fbbea084729c48362d3ce9dd44c28e32e277fe5"
 dependencies = [
  "libc",
- "thiserror 1.0.69",
  "thiserror 1.0.69",
 ]
 
@@ -2920,7 +2753,6 @@ dependencies = [
 name = "filesystem"
 version = "0.1.0"
 source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
-source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
 dependencies = [
  "winapi",
  "windows-acl",
@@ -2954,7 +2786,6 @@ dependencies = [
 name = "fixed_bytes"
 version = "0.1.0"
 source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
-source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
 dependencies = [
  "alloy-primitives",
  "safe_arith 0.1.0 (git+https://github.com/agemanning/lighthouse?branch=modularize-vc)",
@@ -2964,7 +2795,6 @@ dependencies = [
 name = "fixed_bytes"
 version = "0.1.0"
 source = "git+https://github.com/sigp/lighthouse?branch=unstable#fec502db9f93923f5fa965aad970ac244930c321"
-source = "git+https://github.com/sigp/lighthouse?branch=unstable#fec502db9f93923f5fa965aad970ac244930c321"
 dependencies = [
  "alloy-primitives",
  "safe_arith 0.1.0 (git+https://github.com/sigp/lighthouse?branch=unstable)",
@@ -2973,9 +2803,7 @@ dependencies = [
 [[package]]
 name = "flate2"
 version = "1.0.35"
-version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c936bfdafb507ebbf50b8074c54fa31c5be9a1e7e5f467dd659697041407d07c"
 checksum = "c936bfdafb507ebbf50b8074c54fa31c5be9a1e7e5f467dd659697041407d07c"
 dependencies = [
  "crc32fast",
@@ -3013,7 +2841,6 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 [[package]]
 name = "fork_choice"
 version = "0.1.0"
-source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
 source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
 dependencies = [
  "ethereum_ssz",
@@ -3118,9 +2945,7 @@ checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 [[package]]
 name = "futures-lite"
 version = "2.5.0"
-version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cef40d21ae2c515b51041df9ed313ed21e572df340ea58a922a0aefe7e8891a1"
 checksum = "cef40d21ae2c515b51041df9ed313ed21e572df340ea58a922a0aefe7e8891a1"
 dependencies = [
  "futures-core",
@@ -3136,7 +2961,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.90",
- "syn 2.0.90",
 ]
 
 [[package]]
@@ -3146,7 +2970,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f2f12607f92c69b12ed746fabf9ca4f5c482cba46679c1a75b874ed7c26adb"
 dependencies = [
  "futures-io",
- "rustls 0.23.19",
  "rustls 0.23.19",
  "rustls-pki-types",
 ]
@@ -3213,7 +3036,6 @@ dependencies = [
 name = "genesis"
 version = "0.2.0"
 source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
-source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
 dependencies = [
  "environment",
  "eth1",
@@ -3256,9 +3078,7 @@ dependencies = [
 [[package]]
 name = "gimli"
 version = "0.31.1"
-version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
@@ -3279,7 +3099,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.90",
- "syn 2.0.90",
 ]
 
 [[package]]
@@ -3291,7 +3110,6 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 [[package]]
 name = "gossipsub"
 version = "0.5.0"
-source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
 source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
 dependencies = [
  "async-channel",
@@ -3322,7 +3140,6 @@ dependencies = [
 [[package]]
 name = "gossipsub"
 version = "0.5.0"
-source = "git+https://github.com/sigp/lighthouse?branch=unstable#fec502db9f93923f5fa965aad970ac244930c321"
 source = "git+https://github.com/sigp/lighthouse?branch=unstable#fec502db9f93923f5fa965aad970ac244930c321"
 dependencies = [
  "async-channel",
@@ -3420,15 +3237,12 @@ dependencies = [
 [[package]]
 name = "hashbrown"
 version = "0.15.2"
-version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
 checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
 dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash",
- "serde",
  "serde",
 ]
 
@@ -3538,8 +3352,6 @@ dependencies = [
  "rand",
  "socket2 0.5.8",
  "thiserror 1.0.69",
- "socket2 0.5.8",
- "thiserror 1.0.69",
  "tinyvec",
  "tokio",
  "tracing",
@@ -3562,7 +3374,6 @@ dependencies = [
  "rand",
  "resolv-conf",
  "smallvec",
- "thiserror 1.0.69",
  "thiserror 1.0.69",
  "tokio",
  "tracing",
@@ -3641,9 +3452,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.2.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f16ca2af56261c99fba8bac40a10251ce8188205a4c448fbb745a2e4daa76fea"
+checksum = "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258"
 dependencies = [
  "bytes",
  "fnv",
@@ -3668,7 +3479,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http 1.2.0",
+ "http 1.1.0",
 ]
 
 [[package]]
@@ -3679,7 +3490,7 @@ checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
 dependencies = [
  "bytes",
  "futures-util",
- "http 1.2.0",
+ "http 1.1.0",
  "http-body 1.0.1",
  "pin-project-lite",
 ]
@@ -3741,7 +3552,6 @@ dependencies = [
  "itoa",
  "pin-project-lite",
  "socket2 0.5.8",
- "socket2 0.5.8",
  "tokio",
  "tower-service",
  "tracing",
@@ -3751,15 +3561,13 @@ dependencies = [
 [[package]]
 name = "hyper"
 version = "1.5.1"
-version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97818827ef4f364230e16705d4706e2897df2bb60617d6ca15d598025a3c481f"
 checksum = "97818827ef4f364230e16705d4706e2897df2bb60617d6ca15d598025a3c481f"
 dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http 1.2.0",
+ "http 1.1.0",
  "http-body 1.0.1",
  "httparse",
  "httpdate",
@@ -3799,16 +3607,13 @@ dependencies = [
 [[package]]
 name = "hyper-util"
 version = "0.1.10"
-version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df2dcfbe0677734ab2f3ffa7fa7bfd4706bfdc1ef393f2ee30184aed67e631b4"
 checksum = "df2dcfbe0677734ab2f3ffa7fa7bfd4706bfdc1ef393f2ee30184aed67e631b4"
 dependencies = [
  "bytes",
  "futures-util",
- "http 1.2.0",
+ "http 1.1.0",
  "http-body 1.0.1",
- "hyper 1.5.1",
  "hyper 1.5.1",
  "pin-project-lite",
  "tokio",
@@ -3827,7 +3632,6 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
  "windows-core 0.52.0",
- "windows-core 0.52.0",
 ]
 
 [[package]]
@@ -3837,124 +3641,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
 dependencies = [
  "cc",
-]
-
-[[package]]
-name = "icu_collections"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db2fa452206ebee18c4b5c2274dbf1de17008e874b4dc4f0aea9d01ca79e4526"
-dependencies = [
- "displaydoc",
- "yoke",
- "zerofrom",
- "zerovec",
-]
-
-[[package]]
-name = "icu_locid"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13acbb8371917fc971be86fc8057c41a64b521c184808a698c02acc242dbf637"
-dependencies = [
- "displaydoc",
- "litemap",
- "tinystr",
- "writeable",
- "zerovec",
-]
-
-[[package]]
-name = "icu_locid_transform"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01d11ac35de8e40fdeda00d9e1e9d92525f3f9d887cdd7aa81d727596788b54e"
-dependencies = [
- "displaydoc",
- "icu_locid",
- "icu_locid_transform_data",
- "icu_provider",
- "tinystr",
- "zerovec",
-]
-
-[[package]]
-name = "icu_locid_transform_data"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdc8ff3388f852bede6b579ad4e978ab004f139284d7b28715f773507b946f6e"
-
-[[package]]
-name = "icu_normalizer"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19ce3e0da2ec68599d193c93d088142efd7f9c5d6fc9b803774855747dc6a84f"
-dependencies = [
- "displaydoc",
- "icu_collections",
- "icu_normalizer_data",
- "icu_properties",
- "icu_provider",
- "smallvec",
- "utf16_iter",
- "utf8_iter",
- "write16",
- "zerovec",
-]
-
-[[package]]
-name = "icu_normalizer_data"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8cafbf7aa791e9b22bec55a167906f9e1215fd475cd22adfcf660e03e989516"
-
-[[package]]
-name = "icu_properties"
-version = "1.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93d6020766cfc6302c15dbbc9c8778c37e62c14427cb7f6e601d849e092aeef5"
-dependencies = [
- "displaydoc",
- "icu_collections",
- "icu_locid_transform",
- "icu_properties_data",
- "icu_provider",
- "tinystr",
- "zerovec",
-]
-
-[[package]]
-name = "icu_properties_data"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67a8effbc3dd3e4ba1afa8ad918d5684b8868b3b26500753effea8d2eed19569"
-
-[[package]]
-name = "icu_provider"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ed421c8a8ef78d3e2dbc98a973be2f3770cb42b606e3ab18d6237c4dfde68d9"
-dependencies = [
- "displaydoc",
- "icu_locid",
- "icu_provider_macros",
- "stable_deref_trait",
- "tinystr",
- "writeable",
- "yoke",
- "zerofrom",
- "zerovec",
-]
-
-[[package]]
-name = "icu_provider_macros"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.90",
 ]
 
 [[package]]
@@ -4094,24 +3780,9 @@ dependencies = [
 [[package]]
 name = "idna"
 version = "1.0.3"
-version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e"
-checksum = "686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e"
 dependencies = [
- "idna_adapter",
- "smallvec",
- "utf8_iter",
-]
-
-[[package]]
-name = "idna_adapter"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daca1df1c957320b2cf139ac61e7bd64fed304c5040df000a745aa1de3b4ef71"
-dependencies = [
- "icu_normalizer",
- "icu_properties",
  "idna_adapter",
  "smallvec",
  "utf8_iter",
@@ -4140,9 +3811,7 @@ dependencies = [
 [[package]]
 name = "if-watch"
 version = "3.2.1"
-version = "3.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdf9d64cfcf380606e64f9a0bcf493616b65331199f984151a6fa11a7b3cde38"
 checksum = "cdf9d64cfcf380606e64f9a0bcf493616b65331199f984151a6fa11a7b3cde38"
 dependencies = [
  "async-io",
@@ -4156,12 +3825,7 @@ dependencies = [
  "netlink-packet-route",
  "netlink-proto",
  "netlink-sys",
- "netlink-packet-core",
- "netlink-packet-route",
- "netlink-proto",
- "netlink-sys",
  "rtnetlink",
- "system-configuration 0.6.1",
  "system-configuration 0.6.1",
  "tokio",
  "windows",
@@ -4234,28 +3898,22 @@ dependencies = [
 [[package]]
 name = "impl-trait-for-tuples"
 version = "0.2.3"
-version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0eb5a3343abf848c0984fe4604b2b105da9539376e24fc0a3b0007411ae4fd9"
 checksum = "a0eb5a3343abf848c0984fe4604b2b105da9539376e24fc0a3b0007411ae4fd9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
  "syn 2.0.90",
 ]
 
 [[package]]
 name = "indexmap"
 version = "2.7.0"
-version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62f822373a4fe84d4bb149bf54e584a7f4abec90e072ed49cda0edea5b95471f"
 checksum = "62f822373a4fe84d4bb149bf54e584a7f4abec90e072ed49cda0edea5b95471f"
 dependencies = [
  "arbitrary",
  "equivalent",
- "hashbrown 0.15.2",
  "hashbrown 0.15.2",
  "serde",
 ]
@@ -4282,7 +3940,6 @@ dependencies = [
 name = "int_to_bytes"
 version = "0.2.0"
 source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
-source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
 dependencies = [
  "bytes",
 ]
@@ -4290,7 +3947,6 @@ dependencies = [
 [[package]]
 name = "int_to_bytes"
 version = "0.2.0"
-source = "git+https://github.com/sigp/lighthouse?branch=unstable#fec502db9f93923f5fa965aad970ac244930c321"
 source = "git+https://github.com/sigp/lighthouse?branch=unstable#fec502db9f93923f5fa965aad970ac244930c321"
 dependencies = [
  "bytes",
@@ -4322,7 +3978,6 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b58db92f96b720de98181bbbe63c831e87005ab460c1bf306eb2622b4707997f"
 dependencies = [
- "socket2 0.5.8",
  "socket2 0.5.8",
  "widestring 1.1.0",
  "windows-sys 0.48.0",
@@ -4373,9 +4028,7 @@ dependencies = [
 [[package]]
 name = "itoa"
 version = "1.0.14"
-version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
 checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
 
 [[package]]
@@ -4390,12 +4043,9 @@ dependencies = [
 [[package]]
 name = "js-sys"
 version = "0.3.74"
-version = "0.3.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a865e038f7f6ed956f788f0d7d60c541fff74c7bd74272c5d4cf15c63743e705"
-checksum = "6717b6b5b077764fb5966237269cb3c64edddde4b14ce42647430a78ced9e7b7"
 dependencies = [
- "once_cell",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -4475,7 +4125,6 @@ dependencies = [
 name = "kzg"
 version = "0.1.0"
 source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
-source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
 dependencies = [
  "arbitrary",
  "c-kzg",
@@ -4494,7 +4143,6 @@ dependencies = [
 [[package]]
 name = "kzg"
 version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?branch=unstable#fec502db9f93923f5fa965aad970ac244930c321"
 source = "git+https://github.com/sigp/lighthouse?branch=unstable#fec502db9f93923f5fa965aad970ac244930c321"
 dependencies = [
  "arbitrary",
@@ -4546,9 +4194,7 @@ dependencies = [
 [[package]]
 name = "libc"
 version = "0.2.167"
-version = "0.2.167"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09d6582e104315a817dff97f75133544b2e094ee22447d2acf4a74e189ba06fc"
 checksum = "09d6582e104315a817dff97f75133544b2e094ee22447d2acf4a74e189ba06fc"
 
 [[package]]
@@ -4578,9 +4224,7 @@ dependencies = [
 [[package]]
 name = "libm"
 version = "0.2.11"
-version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8355be11b20d696c8f18f6cc018c4e372165b1fa8126cef092399c9951984ffa"
 checksum = "8355be11b20d696c8f18f6cc018c4e372165b1fa8126cef092399c9951984ffa"
 
 [[package]]
@@ -4614,7 +4258,6 @@ dependencies = [
  "multiaddr",
  "pin-project",
  "rw-stream-sink",
- "thiserror 1.0.69",
  "thiserror 1.0.69",
 ]
 
@@ -4663,7 +4306,6 @@ dependencies = [
  "rand",
  "rw-stream-sink",
  "smallvec",
- "thiserror 1.0.69",
  "thiserror 1.0.69",
  "tracing",
  "unsigned-varint 0.8.0",
@@ -4737,7 +4379,6 @@ dependencies = [
  "quick-protobuf-codec",
  "smallvec",
  "thiserror 1.0.69",
- "thiserror 1.0.69",
  "tracing",
  "void",
 ]
@@ -4745,9 +4386,7 @@ dependencies = [
 [[package]]
 name = "libp2p-identity"
 version = "0.2.10"
-version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "257b5621d159b32282eac446bed6670c39c7dc68a200a992d8f056afa0066f6d"
 checksum = "257b5621d159b32282eac446bed6670c39c7dc68a200a992d8f056afa0066f6d"
 dependencies = [
  "asn1_der",
@@ -4761,7 +4400,6 @@ dependencies = [
  "rand",
  "sec1 0.7.3",
  "sha2 0.10.8",
- "thiserror 1.0.69",
  "thiserror 1.0.69",
  "tracing",
  "zeroize",
@@ -4782,7 +4420,6 @@ dependencies = [
  "libp2p-swarm",
  "rand",
  "smallvec",
- "socket2 0.5.8",
  "socket2 0.5.8",
  "tokio",
  "tracing",
@@ -4847,7 +4484,6 @@ dependencies = [
  "snow",
  "static_assertions",
  "thiserror 1.0.69",
- "thiserror 1.0.69",
  "tracing",
  "x25519-dalek",
  "zeroize",
@@ -4907,9 +4543,6 @@ dependencies = [
  "rustls 0.23.19",
  "socket2 0.5.8",
  "thiserror 1.0.69",
- "rustls 0.23.19",
- "socket2 0.5.8",
- "thiserror 1.0.69",
  "tokio",
  "tracing",
 ]
@@ -4948,7 +4581,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.90",
- "syn 2.0.90",
 ]
 
 [[package]]
@@ -4963,7 +4595,6 @@ dependencies = [
  "libc",
  "libp2p-core",
  "libp2p-identity",
- "socket2 0.5.8",
  "socket2 0.5.8",
  "tokio",
  "tracing",
@@ -4982,9 +4613,7 @@ dependencies = [
  "rcgen",
  "ring 0.17.8",
  "rustls 0.23.19",
- "rustls 0.23.19",
  "rustls-webpki 0.101.7",
- "thiserror 1.0.69",
  "thiserror 1.0.69",
  "x509-parser",
  "yasna",
@@ -5016,10 +4645,8 @@ dependencies = [
  "futures",
  "libp2p-core",
  "thiserror 1.0.69",
- "thiserror 1.0.69",
  "tracing",
  "yamux 0.12.1",
- "yamux 0.13.4",
  "yamux 0.13.4",
 ]
 
@@ -5107,7 +4734,6 @@ dependencies = [
 name = "lighthouse_network"
 version = "0.2.0"
 source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
-source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -5158,16 +4784,13 @@ dependencies = [
 name = "lighthouse_network"
 version = "0.2.0"
 source = "git+https://github.com/sigp/lighthouse?branch=unstable#fec502db9f93923f5fa965aad970ac244930c321"
-source = "git+https://github.com/sigp/lighthouse?branch=unstable#fec502db9f93923f5fa965aad970ac244930c321"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "bytes",
  "delay_map 0.4.0",
- "delay_map 0.4.0",
  "directory 0.1.0 (git+https://github.com/sigp/lighthouse?branch=unstable)",
  "dirs 3.0.2",
- "discv5 0.9.0",
  "discv5 0.9.0",
  "either",
  "ethereum_ssz",
@@ -5210,7 +4833,6 @@ dependencies = [
 name = "lighthouse_version"
 version = "0.1.0"
 source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
-source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
 dependencies = [
  "git-version",
  "target_info",
@@ -5219,7 +4841,6 @@ dependencies = [
 [[package]]
 name = "lighthouse_version"
 version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?branch=unstable#fec502db9f93923f5fa965aad970ac244930c321"
 source = "git+https://github.com/sigp/lighthouse?branch=unstable#fec502db9f93923f5fa965aad970ac244930c321"
 dependencies = [
  "git-version",
@@ -5251,12 +4872,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ee93343901ab17bd981295f2cf0026d4ad018c7c31ba84549a4ddbb47a45104"
 
 [[package]]
-name = "litemap"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ee93343901ab17bd981295f2cf0026d4ad018c7c31ba84549a4ddbb47a45104"
-
-[[package]]
 name = "lock_api"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5269,7 +4884,6 @@ dependencies = [
 [[package]]
 name = "lockfile"
 version = "0.1.0"
-source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
 source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
 dependencies = [
  "fs2",
@@ -5284,7 +4898,6 @@ checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 [[package]]
 name = "logging"
 version = "0.2.0"
-source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
 source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
 dependencies = [
  "chrono",
@@ -5307,7 +4920,6 @@ dependencies = [
 [[package]]
 name = "logging"
 version = "0.2.0"
-source = "git+https://github.com/sigp/lighthouse?branch=unstable#fec502db9f93923f5fa965aad970ac244930c321"
 source = "git+https://github.com/sigp/lighthouse?branch=unstable#fec502db9f93923f5fa965aad970ac244930c321"
 dependencies = [
  "chrono",
@@ -5334,7 +4946,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
 dependencies = [
  "hashbrown 0.15.2",
- "hashbrown 0.15.2",
 ]
 
 [[package]]
@@ -5350,7 +4961,6 @@ dependencies = [
 name = "lru_cache"
 version = "0.1.0"
 source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
-source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
 dependencies = [
  "fnv",
 ]
@@ -5358,7 +4968,6 @@ dependencies = [
 [[package]]
 name = "lru_cache"
 version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?branch=unstable#fec502db9f93923f5fa965aad970ac244930c321"
 source = "git+https://github.com/sigp/lighthouse?branch=unstable#fec502db9f93923f5fa965aad970ac244930c321"
 dependencies = [
  "fnv",
@@ -5425,7 +5034,6 @@ dependencies = [
 name = "merkle_proof"
 version = "0.2.0"
 source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
-source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
 dependencies = [
  "alloy-primitives",
  "ethereum_hashing",
@@ -5437,7 +5045,6 @@ dependencies = [
 name = "merkle_proof"
 version = "0.2.0"
 source = "git+https://github.com/sigp/lighthouse?branch=unstable#fec502db9f93923f5fa965aad970ac244930c321"
-source = "git+https://github.com/sigp/lighthouse?branch=unstable#fec502db9f93923f5fa965aad970ac244930c321"
 dependencies = [
  "alloy-primitives",
  "ethereum_hashing",
@@ -5448,9 +5055,7 @@ dependencies = [
 [[package]]
 name = "metastruct"
 version = "0.1.3"
-version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d74f54f231f9a18d77393ecc5cc7ab96709b2a61ee326c2b2b291009b0cc5a07"
 checksum = "d74f54f231f9a18d77393ecc5cc7ab96709b2a61ee326c2b2b291009b0cc5a07"
 dependencies = [
  "metastruct_macro",
@@ -5459,9 +5064,7 @@ dependencies = [
 [[package]]
 name = "metastruct_macro"
 version = "0.1.3"
-version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "985e7225f3a4dfbec47a0c6a730a874185fda840d365d7bbd6ba199dd81796d5"
 checksum = "985e7225f3a4dfbec47a0c6a730a874185fda840d365d7bbd6ba199dd81796d5"
 dependencies = [
  "darling 0.13.4",
@@ -5476,7 +5079,6 @@ dependencies = [
 name = "metrics"
 version = "0.2.0"
 source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
-source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
 dependencies = [
  "prometheus",
 ]
@@ -5484,7 +5086,6 @@ dependencies = [
 [[package]]
 name = "metrics"
 version = "0.2.0"
-source = "git+https://github.com/sigp/lighthouse?branch=unstable#fec502db9f93923f5fa965aad970ac244930c321"
 source = "git+https://github.com/sigp/lighthouse?branch=unstable#fec502db9f93923f5fa965aad970ac244930c321"
 dependencies = [
  "prometheus",
@@ -5547,9 +5148,7 @@ dependencies = [
 [[package]]
 name = "mio"
 version = "1.0.3"
-version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
 checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
 dependencies = [
  "libc",
@@ -5596,13 +5195,10 @@ dependencies = [
 [[package]]
 name = "multihash"
 version = "0.19.2"
-version = "0.19.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc41f430805af9d1cf4adae4ed2149c759b877b01d909a1f40256188d09345d2"
-checksum = "6b430e7953c29dd6a09afc29ff0bb69c6e306329ee6794700aee27b76a1aea8d"
 dependencies = [
  "core2",
- "unsigned-varint 0.8.0",
  "unsigned-varint 0.8.0",
 ]
 
@@ -5640,9 +5236,7 @@ dependencies = [
 [[package]]
 name = "netlink-packet-core"
 version = "0.7.0"
-version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72724faf704479d67b388da142b186f916188505e7e0b26719019c525882eda4"
 checksum = "72724faf704479d67b388da142b186f916188505e7e0b26719019c525882eda4"
 dependencies = [
  "anyhow",
@@ -5653,9 +5247,7 @@ dependencies = [
 [[package]]
 name = "netlink-packet-route"
 version = "0.17.1"
-version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053998cea5a306971f88580d0829e90f270f940befd7cf928da179d4187a5a66"
 checksum = "053998cea5a306971f88580d0829e90f270f940befd7cf928da179d4187a5a66"
 dependencies = [
  "anyhow",
@@ -5676,15 +5268,12 @@ dependencies = [
  "byteorder",
  "paste",
  "thiserror 1.0.69",
- "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "netlink-proto"
 version = "0.11.3"
-version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b33524dc0968bfad349684447bfce6db937a9ac3332a1fe60c0c5a5ce63f21"
 checksum = "86b33524dc0968bfad349684447bfce6db937a9ac3332a1fe60c0c5a5ce63f21"
 dependencies = [
  "bytes",
@@ -5692,7 +5281,6 @@ dependencies = [
  "log",
  "netlink-packet-core",
  "netlink-sys",
- "thiserror 1.0.69",
  "thiserror 1.0.69",
  "tokio",
 ]
@@ -5732,17 +5320,6 @@ name = "nix"
 version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa52e972a9a719cecb6864fb88568781eb706bac2cd1d4f04a648542dbf78069"
-dependencies = [
- "bitflags 1.3.2",
- "cfg-if",
- "libc",
-]
-
-[[package]]
-name = "nix"
-version = "0.26.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
 dependencies = [
  "bitflags 1.3.2",
  "cfg-if",
@@ -5875,9 +5452,7 @@ dependencies = [
 [[package]]
 name = "object"
 version = "0.36.5"
-version = "0.36.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aedf0a2d09c573ed1d8d85b30c119153926a2b36dce0ab28322c09a117a4683e"
 checksum = "aedf0a2d09c573ed1d8d85b30c119153926a2b36dce0ab28322c09a117a4683e"
 dependencies = [
  "memchr",
@@ -5895,15 +5470,12 @@ dependencies = [
 [[package]]
 name = "once_cell"
 version = "1.20.2"
-version = "1.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 
 [[package]]
 name = "oneshot_broadcast"
 version = "0.1.0"
-source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
 source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
 dependencies = [
  "parking_lot 0.12.3",
@@ -5964,7 +5536,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.90",
- "syn 2.0.90",
 ]
 
 [[package]]
@@ -5976,9 +5547,7 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 [[package]]
 name = "openssl-src"
 version = "300.4.1+3.4.0"
-version = "300.4.1+3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "faa4eac4138c62414b5622d1b31c5c304f34b406b013c079c2bbc652fdd6678c"
 checksum = "faa4eac4138c62414b5622d1b31c5c304f34b406b013c079c2bbc652fdd6678c"
 dependencies = [
  "cc",
@@ -6000,7 +5569,6 @@ dependencies = [
 [[package]]
 name = "operation_pool"
 version = "0.2.0"
-source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
 source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
 dependencies = [
  "bitvec 1.0.1",
@@ -6223,23 +5791,18 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 [[package]]
 name = "pest"
 version = "2.7.14"
-version = "2.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879952a81a83930934cbf1786752d6dedc3b1f29e8f8fb2ad1d0a36f377cf442"
-checksum = "8b7cafe60d6cf8e62e1b9b2ea516a089c008945bb5a275416789e7db0bc199dc"
 dependencies = [
  "memchr",
  "thiserror 1.0.69",
- "thiserror 2.0.6",
  "ucd-trie",
 ]
 
 [[package]]
 name = "pin-project"
 version = "1.1.7"
-version = "1.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be57f64e946e500c8ee36ef6331845d40a93055567ec57e8fae13efd33759b95"
 checksum = "be57f64e946e500c8ee36ef6331845d40a93055567ec57e8fae13efd33759b95"
 dependencies = [
  "pin-project-internal",
@@ -6248,23 +5811,18 @@ dependencies = [
 [[package]]
 name = "pin-project-internal"
 version = "1.1.7"
-version = "1.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c0f5fad0874fc7abcd4d750e76917eaebbecaa2c20bde22e1dbeeba8beb758c"
 checksum = "3c0f5fad0874fc7abcd4d750e76917eaebbecaa2c20bde22e1dbeeba8beb758c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
  "syn 2.0.90",
 ]
 
 [[package]]
 name = "pin-project-lite"
 version = "0.2.15"
-version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "915a1e146535de9163f3987b8944ed8cf49a18bb0056bcebcdcece385cece4ff"
 checksum = "915a1e146535de9163f3987b8944ed8cf49a18bb0056bcebcdcece385cece4ff"
 
 [[package]]
@@ -6308,16 +5866,13 @@ checksum = "e8d0eef3571242013a0d5dc84861c3ae4a652e56e12adf8bdc26ff5f8cb34c94"
 [[package]]
 name = "polling"
 version = "3.7.4"
-version = "3.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a604568c3202727d1507653cb121dbd627a58684eb09a820fd746bee38b4442f"
 checksum = "a604568c3202727d1507653cb121dbd627a58684eb09a820fd746bee38b4442f"
 dependencies = [
  "cfg-if",
  "concurrent-queue",
  "hermit-abi 0.4.0",
  "pin-project-lite",
- "rustix 0.38.41",
  "rustix 0.38.41",
  "tracing",
  "windows-sys 0.59.0",
@@ -6365,7 +5920,6 @@ dependencies = [
 name = "pretty_reqwest_error"
 version = "0.1.0"
 source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
-source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
 dependencies = [
  "reqwest",
  "sensitive_url 0.1.0 (git+https://github.com/agemanning/lighthouse?branch=modularize-vc)",
@@ -6374,7 +5928,6 @@ dependencies = [
 [[package]]
 name = "pretty_reqwest_error"
 version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?branch=unstable#fec502db9f93923f5fa965aad970ac244930c321"
 source = "git+https://github.com/sigp/lighthouse?branch=unstable#fec502db9f93923f5fa965aad970ac244930c321"
 dependencies = [
  "reqwest",
@@ -6439,9 +5992,7 @@ dependencies = [
 [[package]]
 name = "proc-macro2"
 version = "1.0.92"
-version = "1.0.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0"
 checksum = "37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0"
 dependencies = [
  "unicode-ident",
@@ -6475,7 +6026,6 @@ dependencies = [
  "parking_lot 0.12.3",
  "protobuf",
  "thiserror 1.0.69",
- "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -6498,7 +6048,6 @@ checksum = "440f724eba9f6996b75d63681b0a92b06947f1457076d503a4d2e2c8f56442b8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
  "syn 2.0.90",
 ]
 
@@ -6531,13 +6080,11 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.90",
- "syn 2.0.90",
 ]
 
 [[package]]
 name = "proto_array"
 version = "0.2.0"
-source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
 source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
 dependencies = [
  "ethereum_ssz",
@@ -6570,7 +6117,6 @@ dependencies = [
  "num_cpus",
  "once_cell",
  "platforms",
- "thiserror 1.0.69",
  "thiserror 1.0.69",
  "unescape",
 ]
@@ -6611,16 +6157,13 @@ dependencies = [
  "bytes",
  "quick-protobuf",
  "thiserror 1.0.69",
- "thiserror 1.0.69",
  "unsigned-varint 0.8.0",
 ]
 
 [[package]]
 name = "quinn"
 version = "0.11.6"
-version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62e96808277ec6f97351a2380e6c25114bc9e67037775464979f3037c92d05ef"
 checksum = "62e96808277ec6f97351a2380e6c25114bc9e67037775464979f3037c92d05ef"
 dependencies = [
  "bytes",
@@ -6632,10 +6175,6 @@ dependencies = [
  "rustls 0.23.19",
  "socket2 0.5.8",
  "thiserror 2.0.3",
- "rustc-hash 2.1.0",
- "rustls 0.23.19",
- "socket2 0.5.8",
- "thiserror 2.0.6",
  "tokio",
  "tracing",
 ]
@@ -6643,44 +6182,32 @@ dependencies = [
 [[package]]
 name = "quinn-proto"
 version = "0.11.9"
-version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2fe5ef3495d7d2e377ff17b1a8ce2ee2ec2a18cde8b6ad6619d65d0701c135d"
 checksum = "a2fe5ef3495d7d2e377ff17b1a8ce2ee2ec2a18cde8b6ad6619d65d0701c135d"
 dependencies = [
  "bytes",
- "getrandom",
  "getrandom",
  "rand",
  "ring 0.17.8",
  "rustc-hash 2.1.0",
  "rustls 0.23.19",
  "rustls-pki-types",
- "rustc-hash 2.1.0",
- "rustls 0.23.19",
- "rustls-pki-types",
  "slab",
  "thiserror 2.0.3",
- "thiserror 2.0.6",
  "tinyvec",
  "tracing",
- "web-time",
  "web-time",
 ]
 
 [[package]]
 name = "quinn-udp"
 version = "0.5.7"
-version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d5a626c6807713b15cac82a6acaccd6043c9a5408c24baae07611fec3f243da"
 checksum = "7d5a626c6807713b15cac82a6acaccd6043c9a5408c24baae07611fec3f243da"
 dependencies = [
  "cfg_aliases",
- "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.8",
  "socket2 0.5.8",
  "tracing",
  "windows-sys 0.59.0",
@@ -6827,7 +6354,6 @@ dependencies = [
  "getrandom",
  "libredox",
  "thiserror 1.0.69",
- "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -6838,7 +6364,6 @@ checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.9",
  "regex-automata 0.4.9",
  "regex-syntax 0.8.5",
 ]
@@ -6855,9 +6380,7 @@ dependencies = [
 [[package]]
 name = "regex-automata"
 version = "0.4.9"
-version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
 checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
 dependencies = [
  "aho-corasick",
@@ -6908,7 +6431,6 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper 0.1.2",
- "system-configuration 0.5.1",
  "system-configuration 0.5.1",
  "tokio",
  "tokio-native-tls",
@@ -7034,22 +6556,15 @@ dependencies = [
 [[package]]
 name = "rtnetlink"
 version = "0.13.1"
-version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a552eb82d19f38c3beed3f786bd23aa434ceb9ac43ab44419ca6d67a7e186c0"
 checksum = "7a552eb82d19f38c3beed3f786bd23aa434ceb9ac43ab44419ca6d67a7e186c0"
 dependencies = [
  "futures",
  "log",
  "netlink-packet-core",
- "netlink-packet-core",
  "netlink-packet-route",
  "netlink-packet-utils",
- "netlink-packet-utils",
  "netlink-proto",
- "netlink-sys",
- "nix 0.26.4",
- "thiserror 1.0.69",
  "netlink-sys",
  "nix 0.26.4",
  "thiserror 1.0.69",
@@ -7104,9 +6619,7 @@ dependencies = [
 [[package]]
 name = "rust_eth_kzg"
 version = "0.5.1"
-version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3291fd0d9c629a56537d74bbc1e7bcaf5be610f2f7b55af85c4fea843c6aeca3"
 checksum = "3291fd0d9c629a56537d74bbc1e7bcaf5be610f2f7b55af85c4fea843c6aeca3"
 dependencies = [
  "crate_crypto_internal_eth_kzg_bls12_381",
@@ -7132,9 +6645,7 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 [[package]]
 name = "rustc-hash"
 version = "2.1.0"
-version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7fb8039b3032c191086b10f11f319a6e99e1e82889c5cc6046f515c9db1d497"
 checksum = "c7fb8039b3032c191086b10f11f319a6e99e1e82889c5cc6046f515c9db1d497"
 
 [[package]]
@@ -7187,9 +6698,7 @@ dependencies = [
 [[package]]
 name = "rustix"
 version = "0.38.41"
-version = "0.38.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7f649912bc1495e167a6edee79151c84b1bad49748cb4f1f1167f459f6224f6"
 checksum = "d7f649912bc1495e167a6edee79151c84b1bad49748cb4f1f1167f459f6224f6"
 dependencies = [
  "bitflags 2.6.0",
@@ -7228,9 +6737,7 @@ dependencies = [
 [[package]]
 name = "rustls"
 version = "0.23.19"
-version = "0.23.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "934b404430bb06b3fae2cba809eb45a1ab1aecd64491213d7c3301b88393f8d1"
 checksum = "934b404430bb06b3fae2cba809eb45a1ab1aecd64491213d7c3301b88393f8d1"
 dependencies = [
  "once_cell",
@@ -7267,9 +6774,6 @@ checksum = "16f1201b3c9a7ee8039bcadc17b7e605e2945b27eee7631788c1bd2b0643674b"
 dependencies = [
  "web-time",
 ]
-dependencies = [
- "web-time",
-]
 
 [[package]]
 name = "rustls-webpki"
@@ -7295,9 +6799,7 @@ dependencies = [
 [[package]]
 name = "rustversion"
 version = "1.0.18"
-version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e819f2bc632f285be6d7cd36e25940d45b2391dd6d9b939e79de557f7014248"
 checksum = "0e819f2bc632f285be6d7cd36e25940d45b2391dd6d9b939e79de557f7014248"
 
 [[package]]
@@ -7333,12 +6835,10 @@ checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 name = "safe_arith"
 version = "0.1.0"
 source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
-source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
 
 [[package]]
 name = "safe_arith"
 version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?branch=unstable#fec502db9f93923f5fa965aad970ac244930c321"
 source = "git+https://github.com/sigp/lighthouse?branch=unstable#fec502db9f93923f5fa965aad970ac244930c321"
 
 [[package]]
@@ -7353,9 +6853,7 @@ dependencies = [
 [[package]]
 name = "scale-info"
 version = "2.11.6"
-version = "2.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "346a3b32eba2640d17a9cb5927056b08f3de90f65b72fe09402c2ad07d684d0b"
 checksum = "346a3b32eba2640d17a9cb5927056b08f3de90f65b72fe09402c2ad07d684d0b"
 dependencies = [
  "cfg-if",
@@ -7367,24 +6865,19 @@ dependencies = [
 [[package]]
 name = "scale-info-derive"
 version = "2.11.6"
-version = "2.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6630024bf739e2179b91fb424b28898baf819414262c5d376677dbff1fe7ebf"
 checksum = "c6630024bf739e2179b91fb424b28898baf819414262c5d376677dbff1fe7ebf"
 dependencies = [
  "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
  "syn 2.0.90",
- "syn 2.0.90",
 ]
 
 [[package]]
 name = "schannel"
 version = "0.1.27"
-version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f29ebaa345f945cec9fbbc532eb307f0fdad8161f281b6369539c8d84876b3d"
 checksum = "1f29ebaa345f945cec9fbbc532eb307f0fdad8161f281b6369539c8d84876b3d"
 dependencies = [
  "windows-sys 0.59.0",
@@ -7477,9 +6970,7 @@ dependencies = [
 [[package]]
 name = "security-framework-sys"
 version = "2.12.1"
-version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa39c7303dc58b5543c94d22c1766b0d31f2ee58306363ea622b10bbc075eaa2"
 checksum = "fa39c7303dc58b5543c94d22c1766b0d31f2ee58306363ea622b10bbc075eaa2"
 dependencies = [
  "core-foundation-sys",
@@ -7504,9 +6995,7 @@ checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
 [[package]]
 name = "semver-parser"
 version = "0.10.3"
-version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9900206b54a3527fdc7b8a938bffd94a568bac4f4aa8113b209df75a09c0dec2"
 checksum = "9900206b54a3527fdc7b8a938bffd94a568bac4f4aa8113b209df75a09c0dec2"
 dependencies = [
  "pest",
@@ -7516,7 +7005,6 @@ dependencies = [
 name = "sensitive_url"
 version = "0.1.0"
 source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
-source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
 dependencies = [
  "serde",
  "url",
@@ -7526,7 +7014,6 @@ dependencies = [
 name = "sensitive_url"
 version = "0.1.0"
 source = "git+https://github.com/sigp/lighthouse?branch=unstable#fec502db9f93923f5fa965aad970ac244930c321"
-source = "git+https://github.com/sigp/lighthouse?branch=unstable#fec502db9f93923f5fa965aad970ac244930c321"
 dependencies = [
  "serde",
  "url",
@@ -7535,9 +7022,7 @@ dependencies = [
 [[package]]
 name = "serde"
 version = "1.0.215"
-version = "1.0.215"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6513c1ad0b11a9376da888e3e0baa0077f1aed55c17f50e7b2397136129fb88f"
 checksum = "6513c1ad0b11a9376da888e3e0baa0077f1aed55c17f50e7b2397136129fb88f"
 dependencies = [
  "serde_derive",
@@ -7556,23 +7041,18 @@ dependencies = [
 [[package]]
 name = "serde_derive"
 version = "1.0.215"
-version = "1.0.215"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad1e866f866923f252f05c889987993144fb74e722403468a4ebd70c3cd756c0"
 checksum = "ad1e866f866923f252f05c889987993144fb74e722403468a4ebd70c3cd756c0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
  "syn 2.0.90",
 ]
 
 [[package]]
 name = "serde_json"
 version = "1.0.133"
-version = "1.0.133"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7fceb2473b9166b2294ef05efcb65a3db80803f0b03ef86a5fc88a2b85ee377"
 checksum = "c7fceb2473b9166b2294ef05efcb65a3db80803f0b03ef86a5fc88a2b85ee377"
 dependencies = [
  "itoa",
@@ -7599,7 +7079,6 @@ checksum = "6c64451ba24fc7a6a2d60fc75dd9c83c90903b19028d4eff35e88fc1e86564e9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
  "syn 2.0.90",
 ]
 
@@ -7748,7 +7227,6 @@ dependencies = [
  "num-bigint",
  "num-traits",
  "thiserror 1.0.69",
- "thiserror 1.0.69",
  "time",
 ]
 
@@ -7764,7 +7242,6 @@ dependencies = [
 [[package]]
 name = "slasher"
 version = "0.1.0"
-source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
 source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
 dependencies = [
  "bincode",
@@ -7791,7 +7268,6 @@ dependencies = [
 [[package]]
 name = "slashing_protection"
 version = "0.1.0"
-source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
 source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
 dependencies = [
  "arbitrary",
@@ -7912,7 +7388,6 @@ dependencies = [
 name = "slot_clock"
 version = "0.2.0"
 source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
-source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
 dependencies = [
  "metrics 0.2.0 (git+https://github.com/agemanning/lighthouse?branch=modularize-vc)",
  "parking_lot 0.12.3",
@@ -7964,9 +7439,7 @@ dependencies = [
 [[package]]
 name = "socket2"
 version = "0.5.8"
-version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c970269d99b64e60ec3bd6ad27270092a5394c4e309314b18ae3fe575695fbe8"
 checksum = "c970269d99b64e60ec3bd6ad27270092a5394c4e309314b18ae3fe575695fbe8"
 dependencies = [
  "libc",
@@ -8033,7 +7506,6 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 name = "state_processing"
 version = "0.2.0"
 source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
-source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
 dependencies = [
  "arbitrary",
  "bls 0.2.0 (git+https://github.com/agemanning/lighthouse?branch=modularize-vc)",
@@ -8065,7 +7537,6 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 [[package]]
 name = "store"
 version = "0.2.0"
-source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
 source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
 dependencies = [
  "db-key",
@@ -8144,7 +7615,6 @@ dependencies = [
 name = "swap_or_not_shuffle"
 version = "0.2.0"
 source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
-source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
 dependencies = [
  "alloy-primitives",
  "ethereum_hashing",
@@ -8154,7 +7624,6 @@ dependencies = [
 [[package]]
 name = "swap_or_not_shuffle"
 version = "0.2.0"
-source = "git+https://github.com/sigp/lighthouse?branch=unstable#fec502db9f93923f5fa965aad970ac244930c321"
 source = "git+https://github.com/sigp/lighthouse?branch=unstable#fec502db9f93923f5fa965aad970ac244930c321"
 dependencies = [
  "alloy-primitives",
@@ -8176,9 +7645,7 @@ dependencies = [
 [[package]]
 name = "syn"
 version = "2.0.90"
-version = "2.0.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "919d3b74a5dd0ccd15aeb8f93e7006bd9e14c295087c9896a110f490752bcf31"
 checksum = "919d3b74a5dd0ccd15aeb8f93e7006bd9e14c295087c9896a110f490752bcf31"
 dependencies = [
  "proc-macro2",
@@ -8195,9 +7662,7 @@ checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 [[package]]
 name = "sync_wrapper"
 version = "1.0.2"
-version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
 
 [[package]]
@@ -8208,7 +7673,6 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
  "syn 2.0.90",
 ]
 
@@ -8232,18 +7696,6 @@ dependencies = [
  "bitflags 2.6.0",
  "core-foundation",
  "system-configuration-sys 0.6.0",
- "system-configuration-sys 0.5.0",
-]
-
-[[package]]
-name = "system-configuration"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
-dependencies = [
- "bitflags 2.6.0",
- "core-foundation",
- "system-configuration-sys 0.6.0",
 ]
 
 [[package]]
@@ -8251,16 +7703,6 @@ name = "system-configuration-sys"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
-name = "system-configuration-sys"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -8298,7 +7740,6 @@ checksum = "c63f48baada5c52e65a29eef93ab4f8982681b67f9e8d29c7b05abcfec2b9ffe"
 name = "task_executor"
 version = "0.1.0"
 source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
-source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
 dependencies = [
  "async-channel",
  "futures",
@@ -8312,7 +7753,6 @@ dependencies = [
 [[package]]
 name = "task_executor"
 version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?branch=unstable#fec502db9f93923f5fa965aad970ac244930c321"
 source = "git+https://github.com/sigp/lighthouse?branch=unstable#fec502db9f93923f5fa965aad970ac244930c321"
 dependencies = [
  "async-channel",
@@ -8328,15 +7768,12 @@ dependencies = [
 [[package]]
 name = "tempfile"
 version = "3.14.0"
-version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28cce251fcbc87fac86a866eeb0d6c2d536fc16d06f184bb61aeae11aa4cee0c"
 checksum = "28cce251fcbc87fac86a866eeb0d6c2d536fc16d06f184bb61aeae11aa4cee0c"
 dependencies = [
  "cfg-if",
  "fastrand",
  "once_cell",
- "rustix 0.38.41",
  "rustix 0.38.41",
  "windows-sys 0.59.0",
 ]
@@ -8355,12 +7792,9 @@ dependencies = [
 [[package]]
 name = "terminal_size"
 version = "0.4.1"
-version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5352447f921fda68cf61b4101566c0bdb5104eff6804d0678e5227580ab6a4e9"
-checksum = "5352447f921fda68cf61b4101566c0bdb5104eff6804d0678e5227580ab6a4e9"
 dependencies = [
- "rustix 0.38.41",
  "rustix 0.38.41",
  "windows-sys 0.59.0",
 ]
@@ -8368,7 +7802,6 @@ dependencies = [
 [[package]]
 name = "test_random_derive"
 version = "0.2.0"
-source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
 source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
 dependencies = [
  "quote",
@@ -8378,7 +7811,6 @@ dependencies = [
 [[package]]
 name = "test_random_derive"
 version = "0.2.0"
-source = "git+https://github.com/sigp/lighthouse?branch=unstable#fec502db9f93923f5fa965aad970ac244930c321"
 source = "git+https://github.com/sigp/lighthouse?branch=unstable#fec502db9f93923f5fa965aad970ac244930c321"
 dependencies = [
  "quote",
@@ -8388,9 +7820,7 @@ dependencies = [
 [[package]]
 name = "thiserror"
 version = "1.0.69"
-version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
  "thiserror-impl 1.0.69",
@@ -8403,24 +7833,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c006c85c7651b3cf2ada4584faa36773bd07bac24acfb39f3c431b36d7e667aa"
 dependencies = [
  "thiserror-impl 2.0.3",
- "thiserror-impl 1.0.69",
-]
-
-[[package]]
-name = "thiserror"
-version = "2.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fec2a1820ebd077e2b90c4df007bebf344cd394098a13c563957d0afc83ea47"
-dependencies = [
- "thiserror-impl 2.0.6",
 ]
 
 [[package]]
 name = "thiserror-impl"
 version = "1.0.69"
-version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
@@ -8433,18 +7851,6 @@ name = "thiserror-impl"
 version = "2.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f077553d607adc1caf65430528a576c757a71ed73944b66ebb58ef2bbd243568"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.90",
- "syn 2.0.90",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "2.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d65750cab40f4ff1929fb1ba509e9914eb756131cef4210da8d5d700d26f6312"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8473,9 +7879,7 @@ dependencies = [
 [[package]]
 name = "time"
 version = "0.3.37"
-version = "0.3.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35e7868883861bd0e56d9ac6efcaaca0d6d5d82a2a7ec8209ff492c07cf37b21"
 checksum = "35e7868883861bd0e56d9ac6efcaaca0d6d5d82a2a7ec8209ff492c07cf37b21"
 dependencies = [
  "deranged",
@@ -8496,9 +7900,7 @@ checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 [[package]]
 name = "time-macros"
 version = "0.2.19"
-version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2834e6017e3e5e4b9834939793b282bc03b37a3336245fa820e35e233e2a85de"
 checksum = "2834e6017e3e5e4b9834939793b282bc03b37a3336245fa820e35e233e2a85de"
 dependencies = [
  "num-conv",
@@ -8519,7 +7921,6 @@ dependencies = [
  "rustc-hash 1.1.0",
  "sha2 0.10.8",
  "thiserror 1.0.69",
- "thiserror 1.0.69",
  "unicode-normalization",
  "wasm-bindgen",
  "zeroize",
@@ -8532,16 +7933,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
 dependencies = [
  "crunchy",
-]
-
-[[package]]
-name = "tinystr"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f"
-dependencies = [
- "displaydoc",
- "zerovec",
 ]
 
 [[package]]
@@ -8572,9 +7963,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 [[package]]
 name = "tokio"
 version = "1.42.0"
-version = "1.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cec9b21b0450273377fc97bd4c33a8acffc8c996c987a7c5b319a0083707551"
 checksum = "5cec9b21b0450273377fc97bd4c33a8acffc8c996c987a7c5b319a0083707551"
 dependencies = [
  "backtrace",
@@ -8583,7 +7972,6 @@ dependencies = [
  "mio",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.5.8",
  "socket2 0.5.8",
  "tokio-macros",
  "windows-sys 0.52.0",
@@ -8607,7 +7995,6 @@ checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
  "syn 2.0.90",
 ]
 
@@ -8644,9 +8031,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.17"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eca58d7bba4a75707817a2c44174253f9236b2d5fbd055602e9d5c07c139a047"
+checksum = "4f4e6ce100d0eb49a2734f8c0812bcd324cf357d21810932c5df6b96ef2b86f1"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -8656,9 +8043,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.13"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7fcaa8d55a2bdd6b83ace262b016eca0d79ee02818c5c1bcdf0305114081078"
+checksum = "61e7c3654c13bcd040d4a03abee2c75b1d14a37b423cf5a813ceae1cc903ec6a"
 dependencies = [
  "bytes",
  "futures-core",
@@ -8716,14 +8103,12 @@ dependencies = [
 [[package]]
 name = "tower-http"
 version = "0.6.2"
-version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "403fa3b783d4b626a8ad51d766ab03cb6d2dbfc46b1c5d4448395e6628dc9697"
 checksum = "403fa3b783d4b626a8ad51d766ab03cb6d2dbfc46b1c5d4448395e6628dc9697"
 dependencies = [
  "bitflags 2.6.0",
  "bytes",
- "http 1.2.0",
+ "http 1.1.0",
  "pin-project-lite",
  "tower-layer",
  "tower-service",
@@ -8744,9 +8129,7 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 [[package]]
 name = "tracing"
 version = "0.1.41"
-version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
  "log",
@@ -8763,7 +8146,6 @@ checksum = "3566e8ce28cc0a3fe42519fc80e6b4c943cc4c8cef275620eb8dac2d3d4e06cf"
 dependencies = [
  "crossbeam-channel",
  "thiserror 1.0.69",
- "thiserror 1.0.69",
  "time",
  "tracing-subscriber",
 ]
@@ -8771,23 +8153,18 @@ dependencies = [
 [[package]]
 name = "tracing-attributes"
 version = "0.1.28"
-version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
 checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
  "syn 2.0.90",
 ]
 
 [[package]]
 name = "tracing-core"
 version = "0.1.33"
-version = "0.1.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
 checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
 dependencies = [
  "once_cell",
@@ -8808,9 +8185,7 @@ dependencies = [
 [[package]]
 name = "tracing-subscriber"
 version = "0.3.19"
-version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
 checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
 dependencies = [
  "matchers",
@@ -8865,7 +8240,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.90",
- "syn 2.0.90",
 ]
 
 [[package]]
@@ -8881,9 +8255,7 @@ dependencies = [
 [[package]]
 name = "triomphe"
 version = "0.1.14"
-version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef8f7726da4807b58ea5c96fdc122f80702030edc33b35aff9190a51148ccc85"
 checksum = "ef8f7726da4807b58ea5c96fdc122f80702030edc33b35aff9190a51148ccc85"
 dependencies = [
  "serde",
@@ -8905,7 +8277,6 @@ checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 [[package]]
 name = "types"
 version = "0.2.1"
-source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
 source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
 dependencies = [
  "alloy-primitives",
@@ -8955,7 +8326,6 @@ dependencies = [
 [[package]]
 name = "types"
 version = "0.2.1"
-source = "git+https://github.com/sigp/lighthouse?branch=unstable#fec502db9f93923f5fa965aad970ac244930c321"
 source = "git+https://github.com/sigp/lighthouse?branch=unstable#fec502db9f93923f5fa965aad970ac244930c321"
 dependencies = [
  "alloy-primitives",
@@ -9053,17 +8423,13 @@ checksum = "7e51b68083f157f853b6379db119d1c1be0e6e4dec98101079dec41f6f5cf6df"
 [[package]]
 name = "unicode-bidi"
 version = "0.3.17"
-version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ab17db44d7388991a428b2ee655ce0c212e862eff1768a455c58f9aad6e7893"
 checksum = "5ab17db44d7388991a428b2ee655ce0c212e862eff1768a455c58f9aad6e7893"
 
 [[package]]
 name = "unicode-ident"
 version = "1.0.14"
-version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
 checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
 
 [[package]]
@@ -9136,7 +8502,6 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 name = "unused_port"
 version = "0.1.0"
 source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
-source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
 dependencies = [
  "lru_cache 0.1.0 (git+https://github.com/agemanning/lighthouse?branch=modularize-vc)",
  "parking_lot 0.12.3",
@@ -9146,7 +8511,6 @@ dependencies = [
 name = "unused_port"
 version = "0.1.0"
 source = "git+https://github.com/sigp/lighthouse?branch=unstable#fec502db9f93923f5fa965aad970ac244930c321"
-source = "git+https://github.com/sigp/lighthouse?branch=unstable#fec502db9f93923f5fa965aad970ac244930c321"
 dependencies = [
  "lru_cache 0.1.0 (git+https://github.com/sigp/lighthouse?branch=unstable)",
  "parking_lot 0.12.3",
@@ -9155,28 +8519,13 @@ dependencies = [
 [[package]]
 name = "url"
 version = "2.5.4"
-version = "2.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60"
 checksum = "32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60"
 dependencies = [
  "form_urlencoded",
  "idna 1.0.3",
- "idna 1.0.3",
  "percent-encoding",
 ]
-
-[[package]]
-name = "utf16_iter"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246"
-
-[[package]]
-name = "utf8_iter"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "utf16_iter"
@@ -9210,7 +8559,6 @@ dependencies = [
 name = "validator_dir"
 version = "0.1.0"
 source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
-source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
 dependencies = [
  "bls 0.2.0 (git+https://github.com/agemanning/lighthouse?branch=modularize-vc)",
  "deposit_contract",
@@ -9228,7 +8576,6 @@ dependencies = [
 [[package]]
 name = "validator_metrics"
 version = "0.1.0"
-source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
 source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
 dependencies = [
  "metrics 0.2.0 (git+https://github.com/agemanning/lighthouse?branch=modularize-vc)",
@@ -9324,7 +8671,6 @@ dependencies = [
 name = "warp_utils"
 version = "0.1.0"
 source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
-source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
 dependencies = [
  "beacon_chain",
  "bytes",
@@ -9350,10 +8696,8 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 [[package]]
 name = "wasm-bindgen"
 version = "0.2.97"
-version = "0.2.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d15e63b4482863c109d70a7b8706c1e364eb6ea449b201a76c5b89cedcec2d5c"
-checksum = "a474f6281d1d70c17ae7aa6a613c87fce69a127e2624002df63dcb39d6cf6396"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -9363,16 +8707,14 @@ dependencies = [
 [[package]]
 name = "wasm-bindgen-backend"
 version = "0.2.97"
-version = "0.2.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d36ef12e3aaca16ddd3f67922bc63e48e953f126de60bd33ccc0101ef9998cd"
-checksum = "5f89bb38646b4f81674e8f5c3fb81b562be1fd936d84320f3264486418519c79"
 dependencies = [
  "bumpalo",
  "log",
+ "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.90",
  "syn 2.0.90",
  "wasm-bindgen-shared",
 ]
@@ -9380,14 +8722,11 @@ dependencies = [
 [[package]]
 name = "wasm-bindgen-futures"
 version = "0.4.47"
-version = "0.4.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9dfaf8f50e5f293737ee323940c7d8b08a66a95a419223d9f41610ca08b0833d"
-checksum = "38176d9b44ea84e9184eff0bc34cc167ed044f816accfe5922e54d84cf48eca2"
 dependencies = [
  "cfg-if",
  "js-sys",
- "once_cell",
  "once_cell",
  "wasm-bindgen",
  "web-sys",
@@ -9396,10 +8735,8 @@ dependencies = [
 [[package]]
 name = "wasm-bindgen-macro"
 version = "0.2.97"
-version = "0.2.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "705440e08b42d3e4b36de7d66c944be628d579796b8090bfa3471478a2260051"
-checksum = "2cc6181fd9a7492eef6fef1f33961e3695e4579b9872a6f7c83aee556666d4fe"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -9408,14 +8745,11 @@ dependencies = [
 [[package]]
 name = "wasm-bindgen-macro-support"
 version = "0.2.97"
-version = "0.2.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98c9ae5a76e46f4deecd0f0255cc223cfa18dc9b261213b8aa0c7b36f61b3f1d"
-checksum = "30d7a95b763d3c45903ed6c81f156801839e5ee968bb07e534c44df0fcd330c2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
  "syn 2.0.90",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
@@ -9424,17 +8758,13 @@ dependencies = [
 [[package]]
 name = "wasm-bindgen-shared"
 version = "0.2.97"
-version = "0.2.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ee99da9c5ba11bd675621338ef6fa52296b76b83305e9b6e5c77d4c286d6d49"
-checksum = "943aab3fdaaa029a6e0271b35ea10b72b943135afe9bffca82384098ad0e06a6"
 
 [[package]]
 name = "wasm-streams"
 version = "0.4.2"
-version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
 checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
 dependencies = [
  "futures-util",
@@ -9447,10 +8777,8 @@ dependencies = [
 [[package]]
 name = "web-sys"
 version = "0.3.74"
-version = "0.3.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a98bc3c33f0fe7e59ad7cd041b89034fa82a7c2d4365ca538dda6cdaf513863c"
-checksum = "04dd7223427d52553d3702c004d3b2fe07c148165faa56313cb00211e31c12bc"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -9509,13 +8837,9 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 [[package]]
 name = "windows"
 version = "0.53.0"
-version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "efc5cf48f83140dcaab716eeaea345f9e93d0018fb81162753a3f76c3397b538"
-checksum = "efc5cf48f83140dcaab716eeaea345f9e93d0018fb81162753a3f76c3397b538"
 dependencies = [
- "windows-core 0.53.0",
- "windows-targets 0.52.6",
  "windows-core 0.53.0",
  "windows-targets 0.52.6",
 ]
@@ -9535,31 +8859,9 @@ dependencies = [
 [[package]]
 name = "windows-core"
 version = "0.52.0"
-version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
-checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dcc5b895a6377f1ab9fa55acedab1fd5ac0db66ad1e6c7f47e28a22e446a5dd"
-dependencies = [
- "windows-result",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-result"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
-dependencies = [
- "windows-targets 0.52.6",
  "windows-targets 0.52.6",
 ]
 
@@ -9837,18 +9139,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
 
 [[package]]
-name = "write16"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936"
-
-[[package]]
-name = "writeable"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
-
-[[package]]
 name = "wyz"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9889,17 +9179,14 @@ dependencies = [
  "oid-registry",
  "rusticata-macros",
  "thiserror 1.0.69",
- "thiserror 1.0.69",
  "time",
 ]
 
 [[package]]
 name = "xml-rs"
 version = "0.8.23"
-version = "0.8.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af310deaae937e48a26602b730250b4949e125f468f11e6990be3e5304ddd96f"
-checksum = "ea8b391c9a790b496184c29f7f93b9ed5b16abb306c05415b68bcc16e4d06432"
 
 [[package]]
 name = "xmltree"
@@ -9928,9 +9215,7 @@ dependencies = [
 [[package]]
 name = "yamux"
 version = "0.13.4"
-version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17610762a1207ee816c6fadc29220904753648aba0a9ed61c7b8336e80a559c4"
 checksum = "17610762a1207ee816c6fadc29220904753648aba0a9ed61c7b8336e80a559c4"
 dependencies = [
  "futures",
@@ -9950,30 +9235,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
 dependencies = [
  "time",
-]
-
-[[package]]
-name = "yoke"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "120e6aef9aa629e3d4f52dc8cc43a015c7724194c97dfaf45180d2daf2b77f40"
-dependencies = [
- "serde",
- "stable_deref_trait",
- "yoke-derive",
- "zerofrom",
-]
-
-[[package]]
-name = "yoke-derive"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.90",
- "synstructure",
 ]
 
 [[package]]
@@ -10040,28 +9301,6 @@ dependencies = [
  "quote",
  "syn 2.0.90",
  "synstructure",
- "syn 2.0.90",
-]
-
-[[package]]
-name = "zerofrom"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cff3ee08c995dee1859d998dea82f7374f2826091dd9cd47def953cae446cd2e"
-dependencies = [
- "zerofrom-derive",
-]
-
-[[package]]
-name = "zerofrom-derive"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "595eed982f7d355beb85837f651fa22e90b3c044842dc7f2c2842c086f295808"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.90",
- "synstructure",
 ]
 
 [[package]]
@@ -10081,29 +9320,6 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
-]
-
-[[package]]
-name = "zerovec"
-version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa2b893d79df23bfb12d5461018d408ea19dfafe76c2c7ef6d4eba614f8ff079"
-dependencies = [
- "yoke",
- "zerofrom",
- "zerovec-derive",
-]
-
-[[package]]
-name = "zerovec-derive"
-version = "0.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.90",
  "syn 2.0.90",
 ]
 

--- a/anchor/src/environment.rs
+++ b/anchor/src/environment.rs
@@ -151,8 +151,11 @@ impl Environment {
             .signal_rx
             .take()
             .ok_or("Inner shutdown already received")?;
-        
-        match self.runtime().block_on(environment_windows::handle_shutdown_signals(signal_rx)) {
+
+        match self
+            .runtime()
+            .block_on(environment_windows::handle_shutdown_signals(signal_rx))
+        {
             Ok(reason) => {
                 info!(reason = reason.message(), "Internal shutdown received");
                 Ok(reason)

--- a/anchor/src/environment.rs
+++ b/anchor/src/environment.rs
@@ -14,6 +14,10 @@ use {
     tokio::signal::unix::{signal, Signal, SignalKind},
 };
 
+#[cfg(target_family = "windows")]
+#[path = "environment_windows.rs"]
+mod environment_windows;
+
 /// The maximum time in seconds the client will wait for all internal tasks to shutdown.
 const MAXIMUM_SHUTDOWN_TIME: u64 = 15;
 
@@ -138,6 +142,22 @@ impl Environment {
             future::Either::Right(((res, _, _), _)) => {
                 res.ok_or_else(|| "Handler channel closed".to_string())
             }
+        }
+    }
+
+    #[cfg(target_family = "windows")]
+    pub fn block_until_shutdown_requested(&mut self) -> Result<ShutdownReason, String> {
+        let signal_rx = self
+            .signal_rx
+            .take()
+            .ok_or("Inner shutdown already received")?;
+        
+        match self.runtime().block_on(environment_windows::handle_shutdown_signals(signal_rx)) {
+            Ok(reason) => {
+                info!(reason = reason.message(), "Internal shutdown received");
+                Ok(reason)
+            }
+            Err(e) => Err(e),
         }
     }
 

--- a/anchor/src/environment_windows.rs
+++ b/anchor/src/environment_windows.rs
@@ -34,7 +34,9 @@ pub(crate) async fn handle_shutdown_signals(
     match register_handlers.await {
         future::Either::Left((Ok(reason), _)) => Ok(reason),
         future::Either::Left((Err(e), _)) => Err(e.into()),
-        future::Either::Right(((res, _, _), _)) => res.ok_or_else(|| "Handler channel closed".to_string()),
+        future::Either::Right(((res, _, _), _)) => {
+            res.ok_or_else(|| "Handler channel closed".to_string())
+        }
     }
 }
 

--- a/anchor/src/environment_windows.rs
+++ b/anchor/src/environment_windows.rs
@@ -1,0 +1,62 @@
+use futures::channel::mpsc::Receiver;
+use futures::{future, Future, StreamExt};
+use std::{pin::Pin, task::Context, task::Poll};
+use task_executor::ShutdownReason;
+use tokio::signal::windows::{ctrl_c, CtrlC};
+use tracing::error;
+
+pub(crate) async fn handle_shutdown_signals(
+    mut signal_rx: Receiver<ShutdownReason>,
+) -> Result<ShutdownReason, String> {
+    let inner_shutdown = async move {
+        signal_rx
+            .next()
+            .await
+            .ok_or("Internal shutdown channel exhausted")
+    };
+    futures::pin_mut!(inner_shutdown);
+
+    let register_handlers = async {
+        let mut handles = vec![];
+
+        // Setup for handling Ctrl+C
+        match ctrl_c() {
+            Ok(ctrl_c) => {
+                let ctrl_c = SignalFuture::new(ctrl_c, "Received Ctrl+C");
+                handles.push(ctrl_c);
+            }
+            Err(e) => error!(error = ?e, "Could not register Ctrl+C handler"),
+        }
+
+        future::select(inner_shutdown, future::select_all(handles.into_iter())).await
+    };
+
+    match register_handlers.await {
+        future::Either::Left((Ok(reason), _)) => Ok(reason),
+        future::Either::Left((Err(e), _)) => Err(e.into()),
+        future::Either::Right(((res, _, _), _)) => res.ok_or_else(|| "Handler channel closed".to_string()),
+    }
+}
+
+struct SignalFuture {
+    signal: CtrlC,
+    message: &'static str,
+}
+
+impl SignalFuture {
+    pub fn new(signal: CtrlC, message: &'static str) -> SignalFuture {
+        SignalFuture { signal, message }
+    }
+}
+
+impl Future for SignalFuture {
+    type Output = Option<ShutdownReason>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        match self.signal.poll_recv(cx) {
+            Poll::Pending => Poll::Pending,
+            Poll::Ready(Some(_)) => Poll::Ready(Some(ShutdownReason::Success(self.message))),
+            Poll::Ready(None) => Poll::Ready(None),
+        }
+    }
+}


### PR DESCRIPTION
## Issue Addressed

While working on the multi-arch release I was running into this compilation issue:

```
error[E0599]: no method named `block_until_shutdown_requested` found for struct `Environment` in the current scope
  --> anchor\src/main.rs:55:45
   |
55 |     let shutdown_reason = match environment.block_until_shutdown_requested() {
   |                                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ method not found in `Environment`
   |
  ::: anchor\src\environment.rs:22:1
   |
22 | pub struct Environment {
   | ---------------------- method `block_until_shutdown_requested` not found for this struct

warning: unused import: `StreamExt`
 --> anchor\src\environment.rs:5:23
  |
5 | use futures::{future, StreamExt};
  |                       ^^^^^^^^^

For more information about this error, try `rustc --explain E0599`.
```

This is due to the unix compilation flags, and no equivalent for windows. 




https://github.com/magick93/anchor/actions/runs/12192178883/job/34012355238#step:10:1345

## Proposed Changes

- Implement a windows specific impl of `handle_shutdown_signals()`
- Add `anchor/src/environment_windows.rs` - this is only used when compiling for win. 



## Additional Info

- This PR compiles, but has not been tested on a windows os. 
- The original compiler output - https://github.com/magick93/anchor/actions/runs/12192178883/job/34012355238#step:10:1345
- https://docs.rs/tokio/latest/i686-unknown-linux-gnu/tokio/signal/windows/index.html