### PR TITLE
Fix: Remove duplicate 'Validator' in SSV Validator Client

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Anchor :anchor:
-#### Secret Share Validator (SSV) Validator Client
+#### Secret Share Validator (SSV) Client
 
 [![Book Status]][Book Link] [![CI status]][gh-ci]
 


### PR DESCRIPTION
#### Secret Share Validator (SSV) Validator Client - #### Secret Share Validator (SSV) Client
**Removed duplicate 'Validator' in 'Secret Share Validator (SSV) Validator Client**