### PR TITLE
Replace `warp_utils` with `health_metrics` 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,26 +3,6 @@
 version = 3
 
 [[package]]
-name = "account_utils"
-version = "0.1.0"
-source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
-dependencies = [
- "directory 0.1.0 (git+https://github.com/agemanning/lighthouse?branch=modularize-vc)",
- "eth2_keystore",
- "eth2_wallet",
- "filesystem",
- "rand",
- "regex",
- "rpassword",
- "serde",
- "serde_yaml",
- "slog",
- "types 0.2.1 (git+https://github.com/agemanning/lighthouse?branch=modularize-vc)",
- "validator_dir",
- "zeroize",
-]
-
-[[package]]
 name = "addr2line"
 version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -119,55 +99,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
-name = "alloy-consensus"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "629b62e38d471cc15fea534eb7283d2f8a4e8bdb1811bcc5d66dda6cfce6fae1"
-dependencies = [
- "alloy-eips",
- "alloy-primitives",
- "alloy-rlp",
- "c-kzg",
-]
-
-[[package]]
-name = "alloy-eip2930"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0069cf0642457f87a01a014f6dc29d5d893cd4fd8fddf0c3cdfad1bb3ebafc41"
-dependencies = [
- "alloy-primitives",
- "alloy-rlp",
-]
-
-[[package]]
-name = "alloy-eip7702"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea59dc42102bc9a1905dc57901edc6dd48b9f38115df86c7d252acba70d71d04"
-dependencies = [
- "alloy-primitives",
- "alloy-rlp",
-]
-
-[[package]]
-name = "alloy-eips"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f923dd5fca5f67a43d81ed3ebad0880bd41f6dd0ada930030353ac356c54cd0f"
-dependencies = [
- "alloy-eip2930",
- "alloy-eip7702",
- "alloy-primitives",
- "alloy-rlp",
- "c-kzg",
- "derive_more 1.0.0",
- "once_cell",
- "serde",
- "sha2 0.10.8",
-]
-
-[[package]]
 name = "alloy-primitives"
 version = "0.8.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -186,7 +117,7 @@ dependencies = [
  "hex-literal",
  "indexmap",
  "itoa",
- "k256 0.13.4",
+ "k256",
  "keccak-asm",
  "paste",
  "proptest",
@@ -195,7 +126,7 @@ dependencies = [
  "ruint",
  "rustc-hash 2.1.0",
  "serde",
- "sha3 0.10.8",
+ "sha3",
  "tiny-keccak",
 ]
 
@@ -685,12 +616,6 @@ checksum = "4cbbc9d0964165b47557570cce6c952866c2678457aca742aafc9fb771d30270"
 
 [[package]]
 name = "base16ct"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349a06037c7bf932dd7e7d1f653678b2038b9ad46a74102f1fc7bd7872678cce"
-
-[[package]]
-name = "base16ct"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
@@ -720,72 +645,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
-name = "beacon_chain"
-version = "0.2.0"
-source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
-dependencies = [
- "alloy-primitives",
- "bitvec 1.0.1",
- "bls 0.2.0 (git+https://github.com/agemanning/lighthouse?branch=modularize-vc)",
- "derivative",
- "eth1",
- "eth2",
- "eth2_network_config 0.2.0 (git+https://github.com/agemanning/lighthouse?branch=modularize-vc)",
- "ethereum_hashing",
- "ethereum_serde_utils",
- "ethereum_ssz",
- "ethereum_ssz_derive",
- "execution_layer",
- "fork_choice",
- "futures",
- "genesis",
- "hex",
- "int_to_bytes 0.2.0 (git+https://github.com/agemanning/lighthouse?branch=modularize-vc)",
- "itertools 0.10.5",
- "kzg 0.1.0 (git+https://github.com/agemanning/lighthouse?branch=modularize-vc)",
- "lighthouse_version 0.1.0 (git+https://github.com/agemanning/lighthouse?branch=modularize-vc)",
- "logging 0.2.0 (git+https://github.com/agemanning/lighthouse?branch=modularize-vc)",
- "lru",
- "merkle_proof 0.2.0 (git+https://github.com/agemanning/lighthouse?branch=modularize-vc)",
- "metrics 0.2.0 (git+https://github.com/agemanning/lighthouse?branch=modularize-vc)",
- "oneshot_broadcast",
- "operation_pool",
- "parking_lot 0.12.3",
- "proto_array",
- "rand",
- "rayon",
- "safe_arith 0.1.0 (git+https://github.com/agemanning/lighthouse?branch=modularize-vc)",
- "sensitive_url 0.1.0 (git+https://github.com/agemanning/lighthouse?branch=modularize-vc)",
- "serde",
- "serde_json",
- "slasher",
- "slog",
- "slog-async",
- "slog-term",
- "sloggers",
- "slot_clock",
- "smallvec",
- "ssz_types",
- "state_processing",
- "store",
- "strum",
- "superstruct",
- "task_executor 0.1.0 (git+https://github.com/agemanning/lighthouse?branch=modularize-vc)",
- "tempfile",
- "tokio",
- "tokio-stream",
- "tree_hash",
- "tree_hash_derive",
- "types 0.2.1 (git+https://github.com/agemanning/lighthouse?branch=modularize-vc)",
-]
-
-[[package]]
-name = "bincode"
-version = "1.3.3"
+name = "bindgen"
+version = "0.69.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
 dependencies = [
- "serde",
+ "bitflags 2.6.0",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.10.5",
+ "lazy_static",
+ "lazycell",
+ "log",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash 1.1.0",
+ "shlex",
+ "syn 2.0.90",
+ "which",
 ]
 
 [[package]]
@@ -817,26 +696,14 @@ checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 
 [[package]]
 name = "bitvec"
-version = "0.20.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7774144344a4faa177370406a7ff5f1da24303817368584c6206c8303eb07848"
-dependencies = [
- "funty 1.1.0",
- "radium 0.6.2",
- "tap",
- "wyz 0.2.0",
-]
-
-[[package]]
-name = "bitvec"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
 dependencies = [
- "funty 2.0.0",
- "radium 0.7.0",
+ "funty",
+ "radium",
  "tap",
- "wyz 0.5.1",
+ "wyz",
 ]
 
 [[package]]
@@ -854,7 +721,6 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
 dependencies = [
- "block-padding",
  "generic-array",
 ]
 
@@ -868,10 +734,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "block-padding"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
+name = "bls"
+version = "0.2.0"
+source = "git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup#39b5dfd1d277ac4ea4b5ac90f60f34bf0f937ca6"
+dependencies = [
+ "alloy-primitives",
+ "arbitrary",
+ "blst",
+ "ethereum_hashing",
+ "ethereum_serde_utils",
+ "ethereum_ssz",
+ "fixed_bytes 0.1.0 (git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup)",
+ "hex",
+ "rand",
+ "safe_arith 0.1.0 (git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup)",
+ "serde",
+ "tree_hash",
+ "zeroize",
+]
 
 [[package]]
 name = "bls"
@@ -933,8 +813,8 @@ checksum = "7a8a8ed6fefbeef4a8c7b460e4110e12c5e22a5b7cf32621aae6ad650c4dcf29"
 dependencies = [
  "blst",
  "byte-slice-cast",
- "ff 0.13.0",
- "group 0.13.0",
+ "ff",
+ "group",
  "pairing",
  "rand_core",
  "serde",
@@ -948,18 +828,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
 dependencies = [
  "tinyvec",
-]
-
-[[package]]
-name = "builder_client"
-version = "0.1.0"
-source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
-dependencies = [
- "eth2",
- "lighthouse_version 0.1.0 (git+https://github.com/agemanning/lighthouse?branch=modularize-vc)",
- "reqwest",
- "sensitive_url 0.1.0 (git+https://github.com/agemanning/lighthouse?branch=modularize-vc)",
- "serde",
 ]
 
 [[package]]
@@ -1021,8 +889,6 @@ dependencies = [
  "glob",
  "hex",
  "libc",
- "once_cell",
- "serde",
 ]
 
 [[package]]
@@ -1034,6 +900,15 @@ dependencies = [
  "jobserver",
  "libc",
  "shlex",
+]
+
+[[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
 ]
 
 [[package]]
@@ -1105,6 +980,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
+]
+
+[[package]]
 name = "clap"
 version = "4.5.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1148,18 +1034,18 @@ checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 [[package]]
 name = "clap_utils"
 version = "0.1.0"
-source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
+source = "git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup#39b5dfd1d277ac4ea4b5ac90f60f34bf0f937ca6"
 dependencies = [
  "alloy-primitives",
  "clap",
  "dirs 3.0.2",
- "eth2_network_config 0.2.0 (git+https://github.com/agemanning/lighthouse?branch=modularize-vc)",
+ "eth2_network_config 0.2.0 (git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup)",
  "ethereum_ssz",
  "hex",
  "serde",
  "serde_json",
  "serde_yaml",
- "types 0.2.1 (git+https://github.com/agemanning/lighthouse?branch=modularize-vc)",
+ "types 0.2.1 (git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup)",
 ]
 
 [[package]]
@@ -1191,7 +1077,7 @@ dependencies = [
  "http_metrics",
  "hyper 1.5.1",
  "network",
- "parking_lot 0.12.3",
+ "parking_lot",
  "processor",
  "sensitive_url 0.1.0 (git+https://github.com/agemanning/lighthouse?branch=modularize-vc)",
  "serde",
@@ -1221,6 +1107,14 @@ checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 [[package]]
 name = "compare_fields"
 version = "0.2.0"
+source = "git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup#39b5dfd1d277ac4ea4b5ac90f60f34bf0f937ca6"
+dependencies = [
+ "itertools 0.10.5",
+]
+
+[[package]]
+name = "compare_fields"
+version = "0.2.0"
 source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
 dependencies = [
  "itertools 0.10.5",
@@ -1232,6 +1126,15 @@ version = "0.2.0"
 source = "git+https://github.com/sigp/lighthouse?branch=unstable#c5a48a9dffc82e5e18d24ca7f2ab3671c9ad8469"
 dependencies = [
  "itertools 0.10.5",
+]
+
+[[package]]
+name = "compare_fields_derive"
+version = "0.2.0"
+source = "git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup#39b5dfd1d277ac4ea4b5ac90f60f34bf0f937ca6"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1337,8 +1240,8 @@ checksum = "319cb241b1ad37f8c376b2ebcd7233f53e033a50de6f0a9cf38e6cc545554de4"
 dependencies = [
  "blst",
  "blstrs",
- "ff 0.13.0",
- "group 0.13.0",
+ "ff",
+ "group",
  "pairing",
  "subtle",
 ]
@@ -1432,18 +1335,6 @@ checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "crypto-bigint"
-version = "0.4.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef2b4b23cddf68b89b8f8069890e8c270d54e2d5fe1b143820234805e4cb17ef"
-dependencies = [
- "generic-array",
- "rand_core",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "crypto-bigint"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
@@ -1501,16 +1392,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
 dependencies = [
  "cipher 0.4.4",
-]
-
-[[package]]
-name = "ctrlc"
-version = "3.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90eeab0aa92f3f9b4e87f258c72b139c207d251f9cbc1080a0086b86a8870dd3"
-dependencies = [
- "nix 0.29.0",
- "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1670,16 +1551,6 @@ checksum = "b72465f46d518f6015d9cf07f7f3013a95dd6b9c2747c3d65ae0cce43929d14f"
 
 [[package]]
 name = "delay_map"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4355c25cbf99edcb6b4a0e906f6bdc6956eda149e84455bea49696429b2f8e8"
-dependencies = [
- "futures",
- "tokio-util",
-]
-
-[[package]]
-name = "delay_map"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df941644b671f05f59433e481ba0d31ac10e3667de725236a4c0d587c496fba1"
@@ -1687,31 +1558,6 @@ dependencies = [
  "futures",
  "tokio",
  "tokio-util",
-]
-
-[[package]]
-name = "deposit_contract"
-version = "0.2.0"
-source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
-dependencies = [
- "ethabi 16.0.0",
- "ethereum_ssz",
- "hex",
- "reqwest",
- "serde_json",
- "sha2 0.9.9",
- "tree_hash",
- "types 0.2.1 (git+https://github.com/agemanning/lighthouse?branch=modularize-vc)",
-]
-
-[[package]]
-name = "der"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1a467a65c5e759bce6e65eaf91cc29f466cdc57cb65777bd646872a8a1fd4de"
-dependencies = [
- "const-oid",
- "zeroize",
 ]
 
 [[package]]
@@ -1827,11 +1673,11 @@ dependencies = [
 [[package]]
 name = "directory"
 version = "0.1.0"
-source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
+source = "git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup#39b5dfd1d277ac4ea4b5ac90f60f34bf0f937ca6"
 dependencies = [
  "clap",
- "clap_utils 0.1.0 (git+https://github.com/agemanning/lighthouse?branch=modularize-vc)",
- "eth2_network_config 0.2.0 (git+https://github.com/agemanning/lighthouse?branch=modularize-vc)",
+ "clap_utils 0.1.0 (git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup)",
+ "eth2_network_config 0.2.0 (git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup)",
 ]
 
 [[package]]
@@ -1908,39 +1754,6 @@ dependencies = [
 
 [[package]]
 name = "discv5"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f569b8c367554666c8652305621e8bae3634a2ff5c6378081d5bd8c399c99f23"
-dependencies = [
- "aes 0.8.4",
- "aes-gcm",
- "alloy-rlp",
- "arrayvec",
- "ctr 0.9.2",
- "delay_map 0.3.0",
- "enr 0.12.1",
- "fnv",
- "futures",
- "hashlink 0.8.4",
- "hex",
- "hkdf",
- "lazy_static",
- "libp2p-identity",
- "lru",
- "more-asserts",
- "multiaddr",
- "parking_lot 0.11.2",
- "rand",
- "smallvec",
- "socket2 0.4.10",
- "tokio",
- "tracing",
- "uint 0.9.5",
- "zeroize",
-]
-
-[[package]]
-name = "discv5"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "898d136ecb64116ec68aecf14d889bd30f8b1fe0c19e262953f7388dbe77052e"
@@ -1950,8 +1763,8 @@ dependencies = [
  "alloy-rlp",
  "arrayvec",
  "ctr 0.9.2",
- "delay_map 0.4.0",
- "enr 0.13.0",
+ "delay_map",
+ "enr",
  "fnv",
  "futures",
  "hashlink 0.9.1",
@@ -1962,10 +1775,10 @@ dependencies = [
  "lru",
  "more-asserts",
  "multiaddr",
- "parking_lot 0.12.3",
+ "parking_lot",
  "rand",
  "smallvec",
- "socket2 0.5.8",
+ "socket2",
  "tokio",
  "tracing",
  "uint 0.10.0",
@@ -1991,28 +1804,16 @@ checksum = "dcbb2bf8e87535c23f7a8a321e364ce21462d0ff10cb6407820e8e96dfff6653"
 
 [[package]]
 name = "ecdsa"
-version = "0.14.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413301934810f597c1d19ca71c8710e99a3f1ba28a0d2ebc01551a2daeea3c5c"
-dependencies = [
- "der 0.6.1",
- "elliptic-curve 0.12.3",
- "rfc6979 0.3.1",
- "signature 1.6.4",
-]
-
-[[package]]
-name = "ecdsa"
 version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
- "der 0.7.9",
+ "der",
  "digest 0.10.7",
- "elliptic-curve 0.13.8",
- "rfc6979 0.4.0",
- "signature 2.2.0",
- "spki 0.7.3",
+ "elliptic-curve",
+ "rfc6979",
+ "signature",
+ "spki",
 ]
 
 [[package]]
@@ -2021,8 +1822,8 @@ version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
 dependencies = [
- "pkcs8 0.10.2",
- "signature 2.2.0",
+ "pkcs8",
+ "signature",
 ]
 
 [[package]]
@@ -2048,39 +1849,20 @@ checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 
 [[package]]
 name = "elliptic-curve"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7bb888ab5300a19b8e5bceef25ac745ad065f3c9f7efc6de1b91958110891d3"
-dependencies = [
- "base16ct 0.1.1",
- "crypto-bigint 0.4.9",
- "der 0.6.1",
- "digest 0.10.7",
- "ff 0.12.1",
- "generic-array",
- "group 0.12.1",
- "rand_core",
- "sec1 0.3.0",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "elliptic-curve"
 version = "0.13.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
- "base16ct 0.2.0",
- "crypto-bigint 0.5.5",
+ "base16ct",
+ "crypto-bigint",
  "digest 0.10.7",
- "ff 0.13.0",
+ "ff",
  "generic-array",
- "group 0.13.0",
+ "group",
  "pem-rfc7468",
- "pkcs8 0.10.2",
+ "pkcs8",
  "rand_core",
- "sec1 0.7.3",
+ "sec1",
  "subtle",
  "zeroize",
 ]
@@ -2096,25 +1878,6 @@ dependencies = [
 
 [[package]]
 name = "enr"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "972070166c68827e64bd1ebc8159dd8e32d9bc2da7ebe8f20b61308f7974ad30"
-dependencies = [
- "alloy-rlp",
- "base64 0.21.7",
- "bytes",
- "ed25519-dalek",
- "hex",
- "k256 0.13.4",
- "log",
- "rand",
- "serde",
- "sha3 0.10.8",
- "zeroize",
-]
-
-[[package]]
-name = "enr"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "851bd664a3d3a3c175cff92b2f0df02df3c541b4895d0ae307611827aae46152"
@@ -2124,11 +1887,11 @@ dependencies = [
  "bytes",
  "ed25519-dalek",
  "hex",
- "k256 0.13.4",
+ "k256",
  "log",
  "rand",
  "serde",
- "sha3 0.10.8",
+ "sha3",
  "zeroize",
 ]
 
@@ -2142,28 +1905,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.90",
-]
-
-[[package]]
-name = "environment"
-version = "0.1.2"
-source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
-dependencies = [
- "async-channel",
- "ctrlc",
- "eth2_config 0.2.0 (git+https://github.com/agemanning/lighthouse?branch=modularize-vc)",
- "eth2_network_config 0.2.0 (git+https://github.com/agemanning/lighthouse?branch=modularize-vc)",
- "futures",
- "logging 0.2.0 (git+https://github.com/agemanning/lighthouse?branch=modularize-vc)",
- "serde",
- "slog",
- "slog-async",
- "slog-json",
- "slog-term",
- "sloggers",
- "task_executor 0.1.0 (git+https://github.com/agemanning/lighthouse?branch=modularize-vc)",
- "tokio",
- "types 0.2.1 (git+https://github.com/agemanning/lighthouse?branch=modularize-vc)",
 ]
 
 [[package]]
@@ -2192,47 +1933,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "error-chain"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d2f06b9cac1506ece98fe3231e3cc9c4410ec3d5b1f24ae1c8946f0742cdefc"
-dependencies = [
- "backtrace",
- "version_check",
-]
-
-[[package]]
-name = "eth1"
-version = "0.2.0"
-source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
-dependencies = [
- "eth2",
- "ethereum_ssz",
- "ethereum_ssz_derive",
- "execution_layer",
- "futures",
- "logging 0.2.0 (git+https://github.com/agemanning/lighthouse?branch=modularize-vc)",
- "merkle_proof 0.2.0 (git+https://github.com/agemanning/lighthouse?branch=modularize-vc)",
- "metrics 0.2.0 (git+https://github.com/agemanning/lighthouse?branch=modularize-vc)",
- "parking_lot 0.12.3",
- "sensitive_url 0.1.0 (git+https://github.com/agemanning/lighthouse?branch=modularize-vc)",
- "serde",
- "slog",
- "state_processing",
- "superstruct",
- "task_executor 0.1.0 (git+https://github.com/agemanning/lighthouse?branch=modularize-vc)",
- "tokio",
- "tree_hash",
- "types 0.2.1 (git+https://github.com/agemanning/lighthouse?branch=modularize-vc)",
-]
-
-[[package]]
 name = "eth2"
 version = "0.1.0"
-source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
+source = "git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup#39b5dfd1d277ac4ea4b5ac90f60f34bf0f937ca6"
 dependencies = [
- "account_utils",
- "bytes",
  "derivative",
  "eth2_keystore",
  "ethereum_serde_utils",
@@ -2240,31 +1944,29 @@ dependencies = [
  "ethereum_ssz_derive",
  "futures",
  "futures-util",
- "libsecp256k1",
- "lighthouse_network 0.2.0 (git+https://github.com/agemanning/lighthouse?branch=modularize-vc)",
+ "lighthouse_network 0.2.0 (git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup)",
  "mediatype",
- "pretty_reqwest_error 0.1.0 (git+https://github.com/agemanning/lighthouse?branch=modularize-vc)",
- "procfs",
+ "pretty_reqwest_error 0.1.0 (git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup)",
  "proto_array",
- "psutil",
  "reqwest",
- "ring 0.16.20",
- "sensitive_url 0.1.0 (git+https://github.com/agemanning/lighthouse?branch=modularize-vc)",
+ "reqwest-eventsource",
+ "sensitive_url 0.1.0 (git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup)",
  "serde",
  "serde_json",
  "slashing_protection",
  "ssz_types",
  "store",
- "types 0.2.1 (git+https://github.com/agemanning/lighthouse?branch=modularize-vc)",
+ "types 0.2.1 (git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup)",
+ "zeroize",
 ]
 
 [[package]]
 name = "eth2_config"
 version = "0.2.0"
-source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
+source = "git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup#39b5dfd1d277ac4ea4b5ac90f60f34bf0f937ca6"
 dependencies = [
  "paste",
- "types 0.2.1 (git+https://github.com/agemanning/lighthouse?branch=modularize-vc)",
+ "types 0.2.1 (git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup)",
 ]
 
 [[package]]
@@ -2274,6 +1976,19 @@ source = "git+https://github.com/sigp/lighthouse?branch=unstable#c5a48a9dffc82e5
 dependencies = [
  "paste",
  "types 0.2.1 (git+https://github.com/sigp/lighthouse?branch=unstable)",
+]
+
+[[package]]
+name = "eth2_interop_keypairs"
+version = "0.2.0"
+source = "git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup#39b5dfd1d277ac4ea4b5ac90f60f34bf0f937ca6"
+dependencies = [
+ "bls 0.2.0 (git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup)",
+ "ethereum_hashing",
+ "hex",
+ "num-bigint",
+ "serde",
+ "serde_yaml",
 ]
 
 [[package]]
@@ -2305,9 +2020,9 @@ dependencies = [
 [[package]]
 name = "eth2_key_derivation"
 version = "0.1.0"
-source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
+source = "git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup#39b5dfd1d277ac4ea4b5ac90f60f34bf0f937ca6"
 dependencies = [
- "bls 0.2.0 (git+https://github.com/agemanning/lighthouse?branch=modularize-vc)",
+ "bls 0.2.0 (git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup)",
  "num-bigint-dig",
  "ring 0.16.20",
  "sha2 0.9.9",
@@ -2317,10 +2032,10 @@ dependencies = [
 [[package]]
 name = "eth2_keystore"
 version = "0.1.0"
-source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
+source = "git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup#39b5dfd1d277ac4ea4b5ac90f60f34bf0f937ca6"
 dependencies = [
  "aes 0.7.5",
- "bls 0.2.0 (git+https://github.com/agemanning/lighthouse?branch=modularize-vc)",
+ "bls 0.2.0 (git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup)",
  "eth2_key_derivation",
  "hex",
  "hmac 0.11.0",
@@ -2339,20 +2054,20 @@ dependencies = [
 [[package]]
 name = "eth2_network_config"
 version = "0.2.0"
-source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
+source = "git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup#39b5dfd1d277ac4ea4b5ac90f60f34bf0f937ca6"
 dependencies = [
  "bytes",
- "discv5 0.7.0",
- "eth2_config 0.2.0 (git+https://github.com/agemanning/lighthouse?branch=modularize-vc)",
- "kzg 0.1.0 (git+https://github.com/agemanning/lighthouse?branch=modularize-vc)",
- "logging 0.2.0 (git+https://github.com/agemanning/lighthouse?branch=modularize-vc)",
- "pretty_reqwest_error 0.1.0 (git+https://github.com/agemanning/lighthouse?branch=modularize-vc)",
+ "discv5",
+ "eth2_config 0.2.0 (git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup)",
+ "kzg 0.1.0 (git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup)",
+ "logging 0.2.0 (git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup)",
+ "pretty_reqwest_error 0.1.0 (git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup)",
  "reqwest",
- "sensitive_url 0.1.0 (git+https://github.com/agemanning/lighthouse?branch=modularize-vc)",
+ "sensitive_url 0.1.0 (git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup)",
  "serde_yaml",
  "sha2 0.9.9",
  "slog",
- "types 0.2.1 (git+https://github.com/agemanning/lighthouse?branch=modularize-vc)",
+ "types 0.2.1 (git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup)",
  "url",
  "zip",
 ]
@@ -2363,7 +2078,7 @@ version = "0.2.0"
 source = "git+https://github.com/sigp/lighthouse?branch=unstable#c5a48a9dffc82e5e18d24ca7f2ab3671c9ad8469"
 dependencies = [
  "bytes",
- "discv5 0.9.0",
+ "discv5",
  "eth2_config 0.2.0 (git+https://github.com/sigp/lighthouse?branch=unstable)",
  "kzg 0.1.0 (git+https://github.com/sigp/lighthouse?branch=unstable)",
  "logging 0.2.0 (git+https://github.com/sigp/lighthouse?branch=unstable)",
@@ -2376,111 +2091,6 @@ dependencies = [
  "types 0.2.1 (git+https://github.com/sigp/lighthouse?branch=unstable)",
  "url",
  "zip",
-]
-
-[[package]]
-name = "eth2_wallet"
-version = "0.1.0"
-source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
-dependencies = [
- "eth2_key_derivation",
- "eth2_keystore",
- "rand",
- "serde",
- "serde_json",
- "serde_repr",
- "tiny-bip39",
- "uuid",
-]
-
-[[package]]
-name = "ethabi"
-version = "16.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4c98847055d934070b90e806e12d3936b787d0a115068981c1d8dfd5dfef5a5"
-dependencies = [
- "ethereum-types 0.12.1",
- "hex",
- "serde",
- "serde_json",
- "sha3 0.9.1",
- "thiserror 1.0.69",
- "uint 0.9.5",
-]
-
-[[package]]
-name = "ethabi"
-version = "18.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7413c5f74cc903ea37386a8965a936cbeb334bd270862fdece542c1b2dcbc898"
-dependencies = [
- "ethereum-types 0.14.1",
- "hex",
- "once_cell",
- "regex",
- "serde",
- "serde_json",
- "sha3 0.10.8",
- "thiserror 1.0.69",
- "uint 0.9.5",
-]
-
-[[package]]
-name = "ethbloom"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfb684ac8fa8f6c5759f788862bb22ec6fe3cb392f6bfd08e3c64b603661e3f8"
-dependencies = [
- "crunchy",
- "fixed-hash 0.7.0",
- "impl-rlp",
- "impl-serde 0.3.2",
- "tiny-keccak",
-]
-
-[[package]]
-name = "ethbloom"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c22d4b5885b6aa2fe5e8b9329fb8d232bf739e434e6b87347c63bdd00c120f60"
-dependencies = [
- "crunchy",
- "fixed-hash 0.8.0",
- "impl-codec 0.6.0",
- "impl-rlp",
- "impl-serde 0.4.0",
- "scale-info",
- "tiny-keccak",
-]
-
-[[package]]
-name = "ethereum-types"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05136f7057fe789f06e6d41d07b34e6f70d8c86e5693b60f97aaa6553553bdaf"
-dependencies = [
- "ethbloom 0.11.1",
- "fixed-hash 0.7.0",
- "impl-rlp",
- "impl-serde 0.3.2",
- "primitive-types 0.10.1",
- "uint 0.9.5",
-]
-
-[[package]]
-name = "ethereum-types"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02d215cbf040552efcbe99a38372fe80ab9d00268e20012b79fcd0f073edd8ee"
-dependencies = [
- "ethbloom 0.13.0",
- "fixed-hash 0.8.0",
- "impl-codec 0.6.0",
- "impl-rlp",
- "impl-serde 0.4.0",
- "primitive-types 0.12.2",
- "scale-info",
- "uint 0.9.5",
 ]
 
 [[package]]
@@ -2531,32 +2141,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ethers-core"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ade3e9c97727343984e1ceada4fdab11142d2ee3472d2c67027d56b1251d4f15"
-dependencies = [
- "arrayvec",
- "bytes",
- "chrono",
- "elliptic-curve 0.12.3",
- "ethabi 18.0.0",
- "generic-array",
- "hex",
- "k256 0.11.6",
- "open-fastrlp",
- "rand",
- "rlp",
- "rlp-derive",
- "serde",
- "serde_json",
- "strum",
- "thiserror 1.0.69",
- "tiny-keccak",
- "unicode-xid",
-]
-
-[[package]]
 name = "event-listener"
 version = "2.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2584,57 +2168,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "execution_layer"
-version = "0.1.0"
-source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
+name = "eventsource-stream"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74fef4569247a5f429d9156b9d0a2599914385dd189c539334c625d8099d90ab"
 dependencies = [
- "alloy-consensus",
- "alloy-primitives",
- "alloy-rlp",
- "arc-swap",
- "builder_client",
- "bytes",
- "eth2",
- "eth2_network_config 0.2.0 (git+https://github.com/agemanning/lighthouse?branch=modularize-vc)",
- "ethereum_serde_utils",
- "ethereum_ssz",
- "ethers-core",
- "fixed_bytes 0.1.0 (git+https://github.com/agemanning/lighthouse?branch=modularize-vc)",
- "fork_choice",
- "hash-db",
- "hash256-std-hasher",
- "hex",
- "jsonwebtoken",
- "keccak-hash",
- "kzg 0.1.0 (git+https://github.com/agemanning/lighthouse?branch=modularize-vc)",
- "lighthouse_version 0.1.0 (git+https://github.com/agemanning/lighthouse?branch=modularize-vc)",
- "logging 0.2.0 (git+https://github.com/agemanning/lighthouse?branch=modularize-vc)",
- "lru",
- "metrics 0.2.0 (git+https://github.com/agemanning/lighthouse?branch=modularize-vc)",
- "parking_lot 0.12.3",
- "pretty_reqwest_error 0.1.0 (git+https://github.com/agemanning/lighthouse?branch=modularize-vc)",
- "rand",
- "reqwest",
- "sensitive_url 0.1.0 (git+https://github.com/agemanning/lighthouse?branch=modularize-vc)",
- "serde",
- "serde_json",
- "sha2 0.9.9",
- "slog",
- "slot_clock",
- "ssz_types",
- "state_processing",
- "strum",
- "superstruct",
- "task_executor 0.1.0 (git+https://github.com/agemanning/lighthouse?branch=modularize-vc)",
- "tempfile",
- "tokio",
- "tokio-stream",
- "tree_hash",
- "tree_hash_derive",
- "triehash",
- "types 0.2.1 (git+https://github.com/agemanning/lighthouse?branch=modularize-vc)",
- "warp",
- "zeroize",
+ "futures-core",
+ "nom",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -2678,21 +2219,11 @@ dependencies = [
 
 [[package]]
 name = "ff"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d013fc25338cc558c5c2cfbad646908fb23591e2404481826742b651c9af7160"
-dependencies = [
- "rand_core",
- "subtle",
-]
-
-[[package]]
-name = "ff"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ded41244b729663b1e574f1b4fb731469f69f79c17667b5d776b16cda0479449"
 dependencies = [
- "bitvec 1.0.1",
+ "bitvec",
  "rand_core",
  "subtle",
 ]
@@ -2722,22 +2253,10 @@ dependencies = [
 [[package]]
 name = "filesystem"
 version = "0.1.0"
-source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
+source = "git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup#39b5dfd1d277ac4ea4b5ac90f60f34bf0f937ca6"
 dependencies = [
  "winapi",
  "windows-acl",
-]
-
-[[package]]
-name = "fixed-hash"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfcf0ed7fe52a17a03854ec54a9f76d6d84508d1c0e66bc1793301c73fc8493c"
-dependencies = [
- "byteorder",
- "rand",
- "rustc-hex",
- "static_assertions",
 ]
 
 [[package]]
@@ -2750,6 +2269,15 @@ dependencies = [
  "rand",
  "rustc-hex",
  "static_assertions",
+]
+
+[[package]]
+name = "fixed_bytes"
+version = "0.1.0"
+source = "git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup#39b5dfd1d277ac4ea4b5ac90f60f34bf0f937ca6"
+dependencies = [
+ "alloy-primitives",
+ "safe_arith 0.1.0 (git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup)",
 ]
 
 [[package]]
@@ -2777,7 +2305,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c936bfdafb507ebbf50b8074c54fa31c5be9a1e7e5f467dd659697041407d07c"
 dependencies = [
  "crc32fast",
- "libz-sys",
  "miniz_oxide",
 ]
 
@@ -2809,20 +2336,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
-name = "fork_choice"
-version = "0.1.0"
-source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
-dependencies = [
- "ethereum_ssz",
- "ethereum_ssz_derive",
- "metrics 0.2.0 (git+https://github.com/agemanning/lighthouse?branch=modularize-vc)",
- "proto_array",
- "slog",
- "state_processing",
- "types 0.2.1 (git+https://github.com/agemanning/lighthouse?branch=modularize-vc)",
-]
-
-[[package]]
 name = "form_urlencoded"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2830,22 +2343,6 @@ checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
 ]
-
-[[package]]
-name = "fs2"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
-dependencies = [
- "libc",
- "winapi",
-]
-
-[[package]]
-name = "funty"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fed34cd105917e91daa4da6b3728c47b068749d6a62c59811f06ed2ac71d9da7"
 
 [[package]]
 name = "funty"
@@ -3003,26 +2500,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "genesis"
-version = "0.2.0"
-source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
-dependencies = [
- "environment",
- "eth1",
- "ethereum_hashing",
- "ethereum_ssz",
- "futures",
- "int_to_bytes 0.2.0 (git+https://github.com/agemanning/lighthouse?branch=modularize-vc)",
- "merkle_proof 0.2.0 (git+https://github.com/agemanning/lighthouse?branch=modularize-vc)",
- "rayon",
- "slog",
- "state_processing",
- "tokio",
- "tree_hash",
- "types 0.2.1 (git+https://github.com/agemanning/lighthouse?branch=modularize-vc)",
-]
-
-[[package]]
 name = "getrandom"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3080,7 +2557,7 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 [[package]]
 name = "gossipsub"
 version = "0.5.0"
-source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
+source = "git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup#39b5dfd1d277ac4ea4b5ac90f60f34bf0f937ca6"
 dependencies = [
  "async-channel",
  "asynchronous-codec",
@@ -3090,7 +2567,6 @@ dependencies = [
  "either",
  "fnv",
  "futures",
- "futures-ticker",
  "futures-timer",
  "getrandom",
  "hashlink 0.9.1",
@@ -3138,22 +2614,11 @@ dependencies = [
 
 [[package]]
 name = "group"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dfbfb3a6cfbd390d5c9564ab283a0349b9b9fcd46a706c1eb10e0db70bfbac7"
-dependencies = [
- "ff 0.12.1",
- "rand_core",
- "subtle",
-]
-
-[[package]]
-name = "group"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
- "ff 0.13.0",
+ "ff",
  "rand",
  "rand_core",
  "rand_xorshift",
@@ -3177,21 +2642,6 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
-]
-
-[[package]]
-name = "hash-db"
-version = "0.15.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d23bd4e7b5eda0d0f3a307e8b381fdc8ba9000f26fbe912250c0a4cc3956364a"
-
-[[package]]
-name = "hash256-std-hasher"
-version = "0.15.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92c171d55b98633f4ed3860808f004099b36c1cc29c42cfc53aa8591b21efcf2"
-dependencies = [
- "crunchy",
 ]
 
 [[package]]
@@ -3235,27 +2685,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "headers"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06683b93020a07e3dbcf5f8c0f6d40080d725bea7936fc01ad345c01b97dc270"
+name = "health_metrics"
+version = "0.1.0"
+source = "git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup#39b5dfd1d277ac4ea4b5ac90f60f34bf0f937ca6"
 dependencies = [
- "base64 0.21.7",
- "bytes",
- "headers-core",
- "http 0.2.12",
- "httpdate",
- "mime",
- "sha1",
-]
-
-[[package]]
-name = "headers-core"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7f66481bfee273957b1f20485a4ff3362987f85b2c236580d81b4eb7a326429"
-dependencies = [
- "http 0.2.12",
+ "eth2",
+ "metrics 0.2.0 (git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup)",
+ "procfs",
+ "psutil",
 ]
 
 [[package]]
@@ -3320,7 +2757,7 @@ dependencies = [
  "ipnet",
  "once_cell",
  "rand",
- "socket2 0.5.8",
+ "socket2",
  "thiserror 1.0.69",
  "tinyvec",
  "tokio",
@@ -3340,7 +2777,7 @@ dependencies = [
  "ipconfig",
  "lru-cache",
  "once_cell",
- "parking_lot 0.12.3",
+ "parking_lot",
  "rand",
  "resolv-conf",
  "smallvec",
@@ -3396,6 +2833,15 @@ dependencies = [
  "digest 0.9.0",
  "generic-array",
  "hmac 0.8.1",
+]
+
+[[package]]
+name = "home"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
+dependencies = [
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3482,14 +2928,14 @@ name = "http_metrics"
 version = "0.1.0"
 dependencies = [
  "axum",
+ "health_metrics",
  "metrics 0.2.0 (git+https://github.com/agemanning/lighthouse?branch=modularize-vc)",
- "parking_lot 0.12.3",
+ "parking_lot",
  "serde",
  "tokio",
  "tower-http",
  "tracing",
  "validator_metrics",
- "warp_utils",
 ]
 
 [[package]]
@@ -3521,7 +2967,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.5.8",
+ "socket2",
  "tokio",
  "tower-service",
  "tracing",
@@ -3558,7 +3004,7 @@ dependencies = [
  "hyper 0.14.31",
  "rustls 0.21.12",
  "tokio",
- "tokio-rustls 0.24.1",
+ "tokio-rustls",
 ]
 
 [[package]]
@@ -3812,47 +3258,11 @@ dependencies = [
 
 [[package]]
 name = "impl-codec"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "161ebdfec3c8e3b52bf61c4f3550a1eea4f9579d10dc1b936f3171ebdcd6c443"
-dependencies = [
- "parity-scale-codec 2.3.1",
-]
-
-[[package]]
-name = "impl-codec"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba6a270039626615617f3f36d15fc827041df3b78c439da2cadfa47455a77f2f"
 dependencies = [
- "parity-scale-codec 3.6.12",
-]
-
-[[package]]
-name = "impl-rlp"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f28220f89297a075ddc7245cd538076ee98b01f2a9c23a53a4f1105d5a322808"
-dependencies = [
- "rlp",
-]
-
-[[package]]
-name = "impl-serde"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4551f042f3438e64dbd6226b20527fc84a6e1fe65688b58746a2f53623f25f5c"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "impl-serde"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc88fc67028ae3db0c853baa36269d398d5f45b6982f95549ff5def78c935cd"
-dependencies = [
- "serde",
+ "parity-scale-codec",
 ]
 
 [[package]]
@@ -3899,6 +3309,14 @@ dependencies = [
 [[package]]
 name = "int_to_bytes"
 version = "0.2.0"
+source = "git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup#39b5dfd1d277ac4ea4b5ac90f60f34bf0f937ca6"
+dependencies = [
+ "bytes",
+]
+
+[[package]]
+name = "int_to_bytes"
+version = "0.2.0"
 source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
 dependencies = [
  "bytes",
@@ -3938,7 +3356,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b58db92f96b720de98181bbbe63c831e87005ab460c1bf306eb2622b4707997f"
 dependencies = [
- "socket2 0.5.8",
+ "socket2",
  "widestring 1.1.0",
  "windows-sys 0.48.0",
  "winreg",
@@ -4011,45 +3429,17 @@ dependencies = [
 ]
 
 [[package]]
-name = "jsonwebtoken"
-version = "9.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9ae10193d25051e74945f1ea2d0b42e03cc3b890f7e4cc5faa44997d808193f"
-dependencies = [
- "base64 0.21.7",
- "js-sys",
- "pem",
- "ring 0.17.8",
- "serde",
- "serde_json",
- "simple_asn1",
-]
-
-[[package]]
-name = "k256"
-version = "0.11.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72c1e0b51e7ec0a97369623508396067a486bd0cbed95a2659a4b863d28cfc8b"
-dependencies = [
- "cfg-if",
- "ecdsa 0.14.8",
- "elliptic-curve 0.12.3",
- "sha2 0.10.8",
- "sha3 0.10.8",
-]
-
-[[package]]
 name = "k256"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6e3919bbaa2945715f0bb6d3934a173d1e9a59ac23767fbaaef277265a7411b"
 dependencies = [
  "cfg-if",
- "ecdsa 0.16.9",
- "elliptic-curve 0.13.8",
+ "ecdsa",
+ "elliptic-curve",
  "once_cell",
  "sha2 0.10.8",
- "signature 2.2.0",
+ "signature",
 ]
 
 [[package]]
@@ -4072,13 +3462,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "keccak-hash"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b286e6b663fb926e1eeb68528e69cb70ed46c6d65871a21b2215ae8154c6d3c"
+name = "kzg"
+version = "0.1.0"
+source = "git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup#39b5dfd1d277ac4ea4b5ac90f60f34bf0f937ca6"
 dependencies = [
- "primitive-types 0.12.2",
- "tiny-keccak",
+ "arbitrary",
+ "c-kzg",
+ "derivative",
+ "ethereum_hashing",
+ "ethereum_serde_utils",
+ "ethereum_ssz",
+ "ethereum_ssz_derive",
+ "hex",
+ "rust_eth_kzg",
+ "serde",
+ "serde_json",
+ "tree_hash",
 ]
 
 [[package]]
@@ -4127,6 +3526,12 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 dependencies = [
  "spin 0.9.8",
 ]
+
+[[package]]
+name = "lazycell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "leveldb"
@@ -4179,6 +3584,16 @@ dependencies = [
  "core2",
  "hashbrown 0.14.5",
  "rle-decode-fast",
+]
+
+[[package]]
+name = "libloading"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
+dependencies = [
+ "cfg-if",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -4260,7 +3675,7 @@ dependencies = [
  "multihash",
  "multistream-select",
  "once_cell",
- "parking_lot 0.12.3",
+ "parking_lot",
  "pin-project",
  "quick-protobuf",
  "rand",
@@ -4284,7 +3699,7 @@ dependencies = [
  "hickory-resolver",
  "libp2p-core",
  "libp2p-identity",
- "parking_lot 0.12.3",
+ "parking_lot",
  "smallvec",
  "tracing",
 ]
@@ -4358,7 +3773,7 @@ dependencies = [
  "p256",
  "quick-protobuf",
  "rand",
- "sec1 0.7.3",
+ "sec1",
  "sha2 0.10.8",
  "thiserror 1.0.69",
  "tracing",
@@ -4380,7 +3795,7 @@ dependencies = [
  "libp2p-swarm",
  "rand",
  "smallvec",
- "socket2 0.5.8",
+ "socket2",
  "tokio",
  "tracing",
  "void",
@@ -4416,7 +3831,7 @@ dependencies = [
  "libp2p-core",
  "libp2p-identity",
  "nohash-hasher",
- "parking_lot 0.12.3",
+ "parking_lot",
  "rand",
  "smallvec",
  "tracing",
@@ -4496,12 +3911,12 @@ dependencies = [
  "libp2p-core",
  "libp2p-identity",
  "libp2p-tls",
- "parking_lot 0.12.3",
+ "parking_lot",
  "quinn",
  "rand",
  "ring 0.17.8",
  "rustls 0.23.19",
- "socket2 0.5.8",
+ "socket2",
  "thiserror 1.0.69",
  "tokio",
  "tracing",
@@ -4555,7 +3970,7 @@ dependencies = [
  "libc",
  "libp2p-core",
  "libp2p-identity",
- "socket2 0.5.8",
+ "socket2",
  "tokio",
  "tracing",
 ]
@@ -4680,44 +4095,32 @@ dependencies = [
 ]
 
 [[package]]
-name = "libz-sys"
-version = "1.1.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2d16453e800a8cf6dd2fc3eb4bc99b786a9b90c663b8559a5b1a041bf89e472"
-dependencies = [
- "cc",
- "pkg-config",
- "vcpkg",
-]
-
-[[package]]
 name = "lighthouse_network"
 version = "0.2.0"
-source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
+source = "git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup#39b5dfd1d277ac4ea4b5ac90f60f34bf0f937ca6"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "bytes",
- "delay_map 0.3.0",
- "directory 0.1.0 (git+https://github.com/agemanning/lighthouse?branch=modularize-vc)",
+ "delay_map",
+ "directory 0.1.0 (git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup)",
  "dirs 3.0.2",
- "discv5 0.7.0",
+ "discv5",
  "either",
- "error-chain",
  "ethereum_ssz",
  "ethereum_ssz_derive",
  "fnv",
  "futures",
- "gossipsub 0.5.0 (git+https://github.com/agemanning/lighthouse?branch=modularize-vc)",
+ "gossipsub 0.5.0 (git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup)",
  "hex",
  "itertools 0.10.5",
  "libp2p",
  "libp2p-mplex",
- "lighthouse_version 0.1.0 (git+https://github.com/agemanning/lighthouse?branch=modularize-vc)",
+ "lighthouse_version 0.1.0 (git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup)",
  "lru",
- "lru_cache 0.1.0 (git+https://github.com/agemanning/lighthouse?branch=modularize-vc)",
- "metrics 0.2.0 (git+https://github.com/agemanning/lighthouse?branch=modularize-vc)",
- "parking_lot 0.12.3",
+ "lru_cache 0.1.0 (git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup)",
+ "metrics 0.2.0 (git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup)",
+ "parking_lot",
  "prometheus-client",
  "rand",
  "regex",
@@ -4729,14 +4132,14 @@ dependencies = [
  "ssz_types",
  "strum",
  "superstruct",
- "task_executor 0.1.0 (git+https://github.com/agemanning/lighthouse?branch=modularize-vc)",
+ "task_executor 0.1.0 (git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup)",
  "tiny-keccak",
  "tokio",
  "tokio-io-timeout",
  "tokio-util",
- "types 0.2.1 (git+https://github.com/agemanning/lighthouse?branch=modularize-vc)",
+ "types 0.2.1 (git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup)",
  "unsigned-varint 0.8.0",
- "unused_port 0.1.0 (git+https://github.com/agemanning/lighthouse?branch=modularize-vc)",
+ "unused_port 0.1.0 (git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup)",
  "void",
 ]
 
@@ -4748,10 +4151,10 @@ dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "bytes",
- "delay_map 0.4.0",
+ "delay_map",
  "directory 0.1.0 (git+https://github.com/sigp/lighthouse?branch=unstable)",
  "dirs 3.0.2",
- "discv5 0.9.0",
+ "discv5",
  "either",
  "ethereum_ssz",
  "ethereum_ssz_derive",
@@ -4766,7 +4169,7 @@ dependencies = [
  "lru",
  "lru_cache 0.1.0 (git+https://github.com/sigp/lighthouse?branch=unstable)",
  "metrics 0.2.0 (git+https://github.com/sigp/lighthouse?branch=unstable)",
- "parking_lot 0.12.3",
+ "parking_lot",
  "prometheus-client",
  "rand",
  "regex",
@@ -4792,7 +4195,7 @@ dependencies = [
 [[package]]
 name = "lighthouse_version"
 version = "0.1.0"
-source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
+source = "git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup#39b5dfd1d277ac4ea4b5ac90f60f34bf0f937ca6"
 dependencies = [
  "git-version",
  "target_info",
@@ -4842,14 +4245,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lockfile"
-version = "0.1.0"
-source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
-dependencies = [
- "fs2",
-]
-
-[[package]]
 name = "log"
 version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4858,11 +4253,11 @@ checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 [[package]]
 name = "logging"
 version = "0.2.0"
-source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
+source = "git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup#39b5dfd1d277ac4ea4b5ac90f60f34bf0f937ca6"
 dependencies = [
  "chrono",
- "metrics 0.2.0 (git+https://github.com/agemanning/lighthouse?branch=modularize-vc)",
- "parking_lot 0.12.3",
+ "metrics 0.2.0 (git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup)",
+ "parking_lot",
  "serde",
  "serde_json",
  "slog",
@@ -4884,7 +4279,7 @@ source = "git+https://github.com/sigp/lighthouse?branch=unstable#c5a48a9dffc82e5
 dependencies = [
  "chrono",
  "metrics 0.2.0 (git+https://github.com/sigp/lighthouse?branch=unstable)",
- "parking_lot 0.12.3",
+ "parking_lot",
  "serde",
  "serde_json",
  "slog",
@@ -4920,7 +4315,7 @@ dependencies = [
 [[package]]
 name = "lru_cache"
 version = "0.1.0"
-source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
+source = "git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup#39b5dfd1d277ac4ea4b5ac90f60f34bf0f937ca6"
 dependencies = [
  "fnv",
 ]
@@ -4993,6 +4388,17 @@ dependencies = [
 [[package]]
 name = "merkle_proof"
 version = "0.2.0"
+source = "git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup#39b5dfd1d277ac4ea4b5ac90f60f34bf0f937ca6"
+dependencies = [
+ "alloy-primitives",
+ "ethereum_hashing",
+ "fixed_bytes 0.1.0 (git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup)",
+ "safe_arith 0.1.0 (git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup)",
+]
+
+[[package]]
+name = "merkle_proof"
+version = "0.2.0"
 source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
 dependencies = [
  "alloy-primitives",
@@ -5038,6 +4444,14 @@ dependencies = [
 [[package]]
 name = "metrics"
 version = "0.2.0"
+source = "git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup#39b5dfd1d277ac4ea4b5ac90f60f34bf0f937ca6"
+dependencies = [
+ "prometheus",
+]
+
+[[package]]
+name = "metrics"
+version = "0.2.0"
 source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
 dependencies = [
  "prometheus",
@@ -5064,7 +4478,7 @@ dependencies = [
  "ethereum_ssz",
  "ethereum_ssz_derive",
  "itertools 0.13.0",
- "parking_lot 0.12.3",
+ "parking_lot",
  "rayon",
  "serde",
  "smallvec",
@@ -5079,16 +4493,6 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
-
-[[package]]
-name = "mime_guess"
-version = "2.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
-dependencies = [
- "mime",
- "unicase",
-]
 
 [[package]]
 name = "minimal-lexical"
@@ -5264,7 +4668,7 @@ version = "0.1.0"
 dependencies = [
  "async-channel",
  "dirs 5.0.1",
- "discv5 0.9.0",
+ "discv5",
  "futures",
  "libp2p",
  "lighthouse_network 0.2.0 (git+https://github.com/sigp/lighthouse?branch=unstable)",
@@ -5294,18 +4698,6 @@ checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
 dependencies = [
  "bitflags 1.3.2",
  "cfg-if",
- "libc",
-]
-
-[[package]]
-name = "nix"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
-dependencies = [
- "bitflags 2.6.0",
- "cfg-if",
- "cfg_aliases",
  "libc",
 ]
 
@@ -5434,43 +4826,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 
 [[package]]
-name = "oneshot_broadcast"
-version = "0.1.0"
-source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
-dependencies = [
- "parking_lot 0.12.3",
-]
-
-[[package]]
 name = "opaque-debug"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
-
-[[package]]
-name = "open-fastrlp"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "786393f80485445794f6043fd3138854dd109cc6c4bd1a6383db304c9ce9b9ce"
-dependencies = [
- "arrayvec",
- "auto_impl",
- "bytes",
- "ethereum-types 0.14.1",
- "open-fastrlp-derive",
-]
-
-[[package]]
-name = "open-fastrlp-derive"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "003b2be5c6c53c1cfeb0a238b8a1c3915cd410feb684457a36c10038f764bb1c"
-dependencies = [
- "bytes",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
 
 [[package]]
 name = "openssl"
@@ -5527,26 +4886,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "operation_pool"
-version = "0.2.0"
-source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
-dependencies = [
- "bitvec 1.0.1",
- "derivative",
- "ethereum_ssz",
- "ethereum_ssz_derive",
- "itertools 0.10.5",
- "metrics 0.2.0 (git+https://github.com/agemanning/lighthouse?branch=modularize-vc)",
- "parking_lot 0.12.3",
- "rand",
- "rayon",
- "serde",
- "state_processing",
- "store",
- "types 0.2.1 (git+https://github.com/agemanning/lighthouse?branch=modularize-vc)",
-]
-
-[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5564,8 +4903,8 @@ version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
 dependencies = [
- "ecdsa 0.16.9",
- "elliptic-curve 0.13.8",
+ "ecdsa",
+ "elliptic-curve",
  "primeorder",
  "sha2 0.10.8",
 ]
@@ -5576,21 +4915,7 @@ version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81fec4625e73cf41ef4bb6846cafa6d44736525f442ba45e407c4a000a13996f"
 dependencies = [
- "group 0.13.0",
-]
-
-[[package]]
-name = "parity-scale-codec"
-version = "2.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "373b1a4c1338d9cd3d1fa53b3a11bdab5ab6bd80a20f7f7becd76953ae2be909"
-dependencies = [
- "arrayvec",
- "bitvec 0.20.4",
- "byte-slice-cast",
- "impl-trait-for-tuples",
- "parity-scale-codec-derive 2.3.1",
- "serde",
+ "group",
 ]
 
 [[package]]
@@ -5600,23 +4925,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "306800abfa29c7f16596b5970a588435e3d5b3149683d00c12b699cc19f895ee"
 dependencies = [
  "arrayvec",
- "bitvec 1.0.1",
+ "bitvec",
  "byte-slice-cast",
  "impl-trait-for-tuples",
- "parity-scale-codec-derive 3.6.12",
+ "parity-scale-codec-derive",
  "serde",
-]
-
-[[package]]
-name = "parity-scale-codec-derive"
-version = "2.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1557010476e0595c9b568d16dcfb81b93cdeb157612726f5170d31aa707bed27"
-dependencies = [
- "proc-macro-crate 1.3.1",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -5625,7 +4938,7 @@ version = "3.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d830939c76d294956402033aee57a6da7b438f2294eb94864c37b0569053a42c"
 dependencies = [
- "proc-macro-crate 3.2.0",
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -5639,37 +4952,12 @@ checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
-dependencies = [
- "instant",
- "lock_api",
- "parking_lot_core 0.8.6",
-]
-
-[[package]]
-name = "parking_lot"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
 dependencies = [
  "lock_api",
- "parking_lot_core 0.9.10",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60a2cfe6f0ad2bfc16aefa463b497d5c7a5ecd44a23efa72aa342d90177356dc"
-dependencies = [
- "cfg-if",
- "instant",
- "libc",
- "redox_syscall 0.2.16",
- "smallvec",
- "winapi",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -5680,7 +4968,7 @@ checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.7",
+ "redox_syscall",
  "smallvec",
  "windows-targets 0.52.6",
 ]
@@ -5793,22 +5081,12 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkcs8"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9eca2c590a5f85da82668fa685c09ce2888b9430e83299debf1f34b65fd4a4ba"
-dependencies = [
- "der 0.6.1",
- "spki 0.6.0",
-]
-
-[[package]]
-name = "pkcs8"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
- "der 0.7.9",
- "spki 0.7.3",
+ "der",
+ "spki",
 ]
 
 [[package]]
@@ -5879,10 +5157,10 @@ dependencies = [
 [[package]]
 name = "pretty_reqwest_error"
 version = "0.1.0"
-source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
+source = "git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup#39b5dfd1d277ac4ea4b5ac90f60f34bf0f937ca6"
 dependencies = [
  "reqwest",
- "sensitive_url 0.1.0 (git+https://github.com/agemanning/lighthouse?branch=modularize-vc)",
+ "sensitive_url 0.1.0 (git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup)",
 ]
 
 [[package]]
@@ -5895,25 +5173,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettyplease"
+version = "0.2.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64d1ec885c64d0457d564db4ec299b2dae3f9c02808b8ad9c3a089c591b18033"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.90",
+]
+
+[[package]]
 name = "primeorder"
 version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
 dependencies = [
- "elliptic-curve 0.13.8",
-]
-
-[[package]]
-name = "primitive-types"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05e4722c697a58a99d5d06a08c30821d7c082a4632198de1eaa5a6c22ef42373"
-dependencies = [
- "fixed-hash 0.7.0",
- "impl-codec 0.5.1",
- "impl-rlp",
- "impl-serde 0.3.2",
- "uint 0.9.5",
+ "elliptic-curve",
 ]
 
 [[package]]
@@ -5922,22 +5197,9 @@ version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b34d9fd68ae0b74a41b21c03c2f62847aa0ffea044eee893b4c140b37e244e2"
 dependencies = [
- "fixed-hash 0.8.0",
- "impl-codec 0.6.0",
- "impl-rlp",
- "impl-serde 0.4.0",
- "scale-info",
+ "fixed-hash",
+ "impl-codec",
  "uint 0.9.5",
-]
-
-[[package]]
-name = "proc-macro-crate"
-version = "1.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
-dependencies = [
- "once_cell",
- "toml_edit 0.19.15",
 ]
 
 [[package]]
@@ -5946,7 +5208,7 @@ version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecf48c7ca261d60b74ab1a7b20da18bede46776b2e55535cb958eb595c5fa7b"
 dependencies = [
- "toml_edit 0.22.22",
+ "toml_edit",
 ]
 
 [[package]]
@@ -5998,7 +5260,7 @@ dependencies = [
  "fnv",
  "lazy_static",
  "memchr",
- "parking_lot 0.12.3",
+ "parking_lot",
  "protobuf",
  "thiserror 1.0.69",
 ]
@@ -6011,7 +5273,7 @@ checksum = "504ee9ff529add891127c4827eb481bd69dc0ebc72e9a682e187db4caa60c3ca"
 dependencies = [
  "dtoa",
  "itoa",
- "parking_lot 0.12.3",
+ "parking_lot",
  "prometheus-client-derive-encode",
 ]
 
@@ -6060,15 +5322,15 @@ dependencies = [
 [[package]]
 name = "proto_array"
 version = "0.2.0"
-source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
+source = "git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup#39b5dfd1d277ac4ea4b5ac90f60f34bf0f937ca6"
 dependencies = [
  "ethereum_ssz",
  "ethereum_ssz_derive",
- "safe_arith 0.1.0 (git+https://github.com/agemanning/lighthouse?branch=modularize-vc)",
+ "safe_arith 0.1.0 (git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup)",
  "serde",
  "serde_yaml",
  "superstruct",
- "types 0.2.1 (git+https://github.com/agemanning/lighthouse?branch=modularize-vc)",
+ "types 0.2.1 (git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup)",
 ]
 
 [[package]]
@@ -6148,7 +5410,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.0",
  "rustls 0.23.19",
- "socket2 0.5.8",
+ "socket2",
  "thiserror 2.0.6",
  "tokio",
  "tracing",
@@ -6183,7 +5445,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.8",
+ "socket2",
  "tracing",
  "windows-sys 0.59.0",
 ]
@@ -6204,7 +5466,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51de85fb3fb6524929c8a2eb85e6b6d363de4e8c48f9e2c2eac4944abc181c93"
 dependencies = [
  "log",
- "parking_lot 0.12.3",
+ "parking_lot",
  "scheduled-thread-pool",
 ]
 
@@ -6217,12 +5479,6 @@ dependencies = [
  "r2d2",
  "rusqlite",
 ]
-
-[[package]]
-name = "radium"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "643f8f41a8ebc4c5dc4515c82bb8abd397b527fc20fd681b7c011c2aee5d44fb"
 
 [[package]]
 name = "radium"
@@ -6300,15 +5556,6 @@ dependencies = [
  "ring 0.16.20",
  "time",
  "yasna",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
-dependencies = [
- "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -6401,7 +5648,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "rustls 0.21.12",
- "rustls-pemfile 1.0.4",
+ "rustls-pemfile",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -6409,7 +5656,7 @@ dependencies = [
  "system-configuration 0.5.1",
  "tokio",
  "tokio-native-tls",
- "tokio-rustls 0.24.1",
+ "tokio-rustls",
  "tokio-util",
  "tower-service",
  "url",
@@ -6422,6 +5669,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "reqwest-eventsource"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f529a5ff327743addc322af460761dff5b50e0c826b9e6ac44c3195c50bb2026"
+dependencies = [
+ "eventsource-stream",
+ "futures-core",
+ "futures-timer",
+ "mime",
+ "nom",
+ "pin-project-lite",
+ "reqwest",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "resolv-conf"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6429,17 +5692,6 @@ checksum = "52e44394d2086d010551b14b53b1f24e31647570cd1deb0379e2c21b329aba00"
 dependencies = [
  "hostname",
  "quick-error",
-]
-
-[[package]]
-name = "rfc6979"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7743f17af12fa0b03b803ba12cd6a8d9483a587e89c69445e3909655c0b9fabb"
-dependencies = [
- "crypto-bigint 0.4.9",
- "hmac 0.12.1",
- "zeroize",
 ]
 
 [[package]]
@@ -6499,27 +5751,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rlp-derive"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e33d7b2abe0c340d8797fe2907d3f20d3b5ea5908683618bfe80df7f621f672a"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "rpassword"
-version = "5.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffc936cf8a7ea60c58f030fd36a612a48f440610214dc54bc36431f9ea0c3efb"
-dependencies = [
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "rpds"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6560,8 +5791,8 @@ dependencies = [
  "fastrlp",
  "num-bigint",
  "num-traits",
- "parity-scale-codec 3.6.12",
- "primitive-types 0.12.2",
+ "parity-scale-codec",
+ "primitive-types",
  "proptest",
  "rand",
  "rlp",
@@ -6697,20 +5928,6 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.22.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf4ef73721ac7bcd79b2b315da7779d8fc09718c6b3d2d1b2d94850eb8c18432"
-dependencies = [
- "log",
- "ring 0.17.8",
- "rustls-pki-types",
- "rustls-webpki 0.102.8",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "rustls"
 version = "0.23.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "934b404430bb06b3fae2cba809eb45a1ab1aecd64491213d7c3301b88393f8d1"
@@ -6730,15 +5947,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
 dependencies = [
  "base64 0.21.7",
-]
-
-[[package]]
-name = "rustls-pemfile"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
-dependencies = [
- "rustls-pki-types",
 ]
 
 [[package]]
@@ -6809,6 +6017,11 @@ checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 [[package]]
 name = "safe_arith"
 version = "0.1.0"
+source = "git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup#39b5dfd1d277ac4ea4b5ac90f60f34bf0f937ca6"
+
+[[package]]
+name = "safe_arith"
+version = "0.1.0"
 source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
 
 [[package]]
@@ -6826,30 +6039,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "scale-info"
-version = "2.11.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "346a3b32eba2640d17a9cb5927056b08f3de90f65b72fe09402c2ad07d684d0b"
-dependencies = [
- "cfg-if",
- "derive_more 1.0.0",
- "parity-scale-codec 3.6.12",
- "scale-info-derive",
-]
-
-[[package]]
-name = "scale-info-derive"
-version = "2.11.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6630024bf739e2179b91fb424b28898baf819414262c5d376677dbff1fe7ebf"
-dependencies = [
- "proc-macro-crate 3.2.0",
- "proc-macro2",
- "quote",
- "syn 2.0.90",
-]
-
-[[package]]
 name = "schannel"
 version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6864,14 +6053,8 @@ version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3cbc66816425a074528352f5789333ecff06ca41b36b0b0efdfbb29edc391a19"
 dependencies = [
- "parking_lot 0.12.3",
+ "parking_lot",
 ]
-
-[[package]]
-name = "scoped-tls"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
 name = "scopeguard"
@@ -6903,28 +6086,14 @@ dependencies = [
 
 [[package]]
 name = "sec1"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3be24c1842290c45df0a7bf069e0c268a747ad05a192f2fd7dcfdbc1cba40928"
-dependencies = [
- "base16ct 0.1.1",
- "der 0.6.1",
- "generic-array",
- "pkcs8 0.9.0",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "sec1"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
 dependencies = [
- "base16ct 0.2.0",
- "der 0.7.9",
+ "base16ct",
+ "der",
  "generic-array",
- "pkcs8 0.10.2",
+ "pkcs8",
  "subtle",
  "zeroize",
 ]
@@ -6979,6 +6148,15 @@ dependencies = [
 [[package]]
 name = "sensitive_url"
 version = "0.1.0"
+source = "git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup#39b5dfd1d277ac4ea4b5ac90f60f34bf0f937ca6"
+dependencies = [
+ "serde",
+ "url",
+]
+
+[[package]]
+name = "sensitive_url"
+version = "0.1.0"
 source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
 dependencies = [
  "serde",
@@ -7001,16 +6179,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b9781016e935a97e8beecf0c933758c97a5520d32930e460142b4cd80c6338e"
 dependencies = [
  "serde_derive",
-]
-
-[[package]]
-name = "serde_array_query"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d89c6e82b1005b33d5b2bbc47096800e5ad6b67ef5636f9c13ad29a6935734a7"
-dependencies = [
- "serde",
- "serde_urlencoded",
 ]
 
 [[package]]
@@ -7119,18 +6287,6 @@ dependencies = [
 
 [[package]]
 name = "sha3"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f81199417d4e5de3f04b1e871023acea7389672c4135918f05aa9cbf2f2fa809"
-dependencies = [
- "block-buffer 0.9.0",
- "digest 0.9.0",
- "keccak",
- "opaque-debug",
-]
-
-[[package]]
-name = "sha3"
 version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
@@ -7175,34 +6331,12 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "1.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
-dependencies = [
- "digest 0.10.7",
- "rand_core",
-]
-
-[[package]]
-name = "signature"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest 0.10.7",
  "rand_core",
-]
-
-[[package]]
-name = "simple_asn1"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adc4e5204eb1910f40f9cfa375f6f05b68c3abac4b6fd879c8ff5e7ae8a0a085"
-dependencies = [
- "num-bigint",
- "num-traits",
- "thiserror 1.0.69",
- "time",
 ]
 
 [[package]]
@@ -7215,35 +6349,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "slasher"
-version = "0.1.0"
-source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
-dependencies = [
- "bincode",
- "byteorder",
- "derivative",
- "ethereum_ssz",
- "ethereum_ssz_derive",
- "filesystem",
- "flate2",
- "lru",
- "metrics 0.2.0 (git+https://github.com/agemanning/lighthouse?branch=modularize-vc)",
- "parking_lot 0.12.3",
- "rand",
- "safe_arith 0.1.0 (git+https://github.com/agemanning/lighthouse?branch=modularize-vc)",
- "serde",
- "slog",
- "ssz_types",
- "strum",
- "tree_hash",
- "tree_hash_derive",
- "types 0.2.1 (git+https://github.com/agemanning/lighthouse?branch=modularize-vc)",
-]
-
-[[package]]
 name = "slashing_protection"
 version = "0.1.0"
-source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
+source = "git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup#39b5dfd1d277ac4ea4b5ac90f60f34bf0f937ca6"
 dependencies = [
  "arbitrary",
  "ethereum_serde_utils",
@@ -7254,7 +6362,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "types 0.2.1 (git+https://github.com/agemanning/lighthouse?branch=modularize-vc)",
+ "types 0.2.1 (git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup)",
 ]
 
 [[package]]
@@ -7365,7 +6473,7 @@ version = "0.2.0"
 source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
 dependencies = [
  "metrics 0.2.0 (git+https://github.com/agemanning/lighthouse?branch=modularize-vc)",
- "parking_lot 0.12.3",
+ "parking_lot",
  "types 0.2.1 (git+https://github.com/agemanning/lighthouse?branch=modularize-vc)",
 ]
 
@@ -7403,16 +6511,6 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.4.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f7916fc008ca5542385b89a3d3ce689953c143e9304a9bf8beec1de48994c0d"
-dependencies = [
- "libc",
- "winapi",
-]
-
-[[package]]
-name = "socket2"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c970269d99b64e60ec3bd6ad27270092a5394c4e309314b18ae3fe575695fbe8"
@@ -7435,22 +6533,12 @@ checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "spki"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67cf02bbac7a337dc36e4f5a693db6c21e7863f45070f7064577eb4367a3212b"
-dependencies = [
- "base64ct",
- "der 0.6.1",
-]
-
-[[package]]
-name = "spki"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
- "der 0.7.9",
+ "der",
 ]
 
 [[package]]
@@ -7490,27 +6578,27 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 [[package]]
 name = "state_processing"
 version = "0.2.0"
-source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
+source = "git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup#39b5dfd1d277ac4ea4b5ac90f60f34bf0f937ca6"
 dependencies = [
  "arbitrary",
- "bls 0.2.0 (git+https://github.com/agemanning/lighthouse?branch=modularize-vc)",
+ "bls 0.2.0 (git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup)",
  "derivative",
  "ethereum_hashing",
  "ethereum_ssz",
  "ethereum_ssz_derive",
- "int_to_bytes 0.2.0 (git+https://github.com/agemanning/lighthouse?branch=modularize-vc)",
+ "int_to_bytes 0.2.0 (git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup)",
  "integer-sqrt",
  "itertools 0.10.5",
- "merkle_proof 0.2.0 (git+https://github.com/agemanning/lighthouse?branch=modularize-vc)",
- "metrics 0.2.0 (git+https://github.com/agemanning/lighthouse?branch=modularize-vc)",
+ "merkle_proof 0.2.0 (git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup)",
+ "metrics 0.2.0 (git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup)",
  "rand",
  "rayon",
- "safe_arith 0.1.0 (git+https://github.com/agemanning/lighthouse?branch=modularize-vc)",
+ "safe_arith 0.1.0 (git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup)",
  "smallvec",
  "ssz_types",
- "test_random_derive 0.2.0 (git+https://github.com/agemanning/lighthouse?branch=modularize-vc)",
+ "test_random_derive 0.2.0 (git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup)",
  "tree_hash",
- "types 0.2.1 (git+https://github.com/agemanning/lighthouse?branch=modularize-vc)",
+ "types 0.2.1 (git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup)",
 ]
 
 [[package]]
@@ -7522,24 +6610,30 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 [[package]]
 name = "store"
 version = "0.2.0"
-source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
+source = "git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup#39b5dfd1d277ac4ea4b5ac90f60f34bf0f937ca6"
 dependencies = [
+ "bls 0.2.0 (git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup)",
  "db-key",
- "directory 0.1.0 (git+https://github.com/agemanning/lighthouse?branch=modularize-vc)",
+ "directory 0.1.0 (git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup)",
  "ethereum_ssz",
  "ethereum_ssz_derive",
  "itertools 0.10.5",
  "leveldb",
+ "logging 0.2.0 (git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup)",
  "lru",
- "metrics 0.2.0 (git+https://github.com/agemanning/lighthouse?branch=modularize-vc)",
- "parking_lot 0.12.3",
- "safe_arith 0.1.0 (git+https://github.com/agemanning/lighthouse?branch=modularize-vc)",
+ "metrics 0.2.0 (git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup)",
+ "parking_lot",
+ "safe_arith 0.1.0 (git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup)",
  "serde",
  "slog",
  "sloggers",
+ "smallvec",
  "state_processing",
  "strum",
- "types 0.2.1 (git+https://github.com/agemanning/lighthouse?branch=modularize-vc)",
+ "superstruct",
+ "types 0.2.1 (git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup)",
+ "xdelta3",
+ "zstd 0.13.2",
 ]
 
 [[package]]
@@ -7594,6 +6688,16 @@ dependencies = [
  "quote",
  "smallvec",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "swap_or_not_shuffle"
+version = "0.2.0"
+source = "git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup#39b5dfd1d277ac4ea4b5ac90f60f34bf0f937ca6"
+dependencies = [
+ "alloy-primitives",
+ "ethereum_hashing",
+ "fixed_bytes 0.1.0 (git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup)",
 ]
 
 [[package]]
@@ -7724,12 +6828,12 @@ checksum = "c63f48baada5c52e65a29eef93ab4f8982681b67f9e8d29c7b05abcfec2b9ffe"
 [[package]]
 name = "task_executor"
 version = "0.1.0"
-source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
+source = "git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup#39b5dfd1d277ac4ea4b5ac90f60f34bf0f937ca6"
 dependencies = [
  "async-channel",
  "futures",
- "logging 0.2.0 (git+https://github.com/agemanning/lighthouse?branch=modularize-vc)",
- "metrics 0.2.0 (git+https://github.com/agemanning/lighthouse?branch=modularize-vc)",
+ "logging 0.2.0 (git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup)",
+ "metrics 0.2.0 (git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup)",
  "slog",
  "sloggers",
  "tokio",
@@ -7782,6 +6886,15 @@ checksum = "5352447f921fda68cf61b4101566c0bdb5104eff6804d0678e5227580ab6a4e9"
 dependencies = [
  "rustix 0.38.42",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "test_random_derive"
+version = "0.2.0"
+source = "git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup#39b5dfd1d277ac4ea4b5ac90f60f34bf0f937ca6"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -7893,25 +7006,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tiny-bip39"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62cc94d358b5a1e84a5cb9109f559aa3c4d634d2b1b4de3d0fa4adc7c78e2861"
-dependencies = [
- "anyhow",
- "hmac 0.12.1",
- "once_cell",
- "pbkdf2 0.11.0",
- "rand",
- "rustc-hash 1.1.0",
- "sha2 0.10.8",
- "thiserror 1.0.69",
- "unicode-normalization",
- "wasm-bindgen",
- "zeroize",
-]
-
-[[package]]
 name = "tiny-keccak"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7957,7 +7051,7 @@ dependencies = [
  "mio",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.5.8",
+ "socket2",
  "tokio-macros",
  "windows-sys 0.52.0",
 ]
@@ -8004,29 +7098,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-rustls"
-version = "0.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f"
-dependencies = [
- "rustls 0.22.4",
- "rustls-pki-types",
- "tokio",
-]
-
-[[package]]
-name = "tokio-stream"
-version = "0.1.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eca58d7bba4a75707817a2c44174253f9236b2d5fbd055602e9d5c07c139a047"
-dependencies = [
- "futures-core",
- "pin-project-lite",
- "tokio",
- "tokio-util",
-]
-
-[[package]]
 name = "tokio-util"
 version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8049,24 +7120,13 @@ checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
 
 [[package]]
 name = "toml_edit"
-version = "0.19.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
-dependencies = [
- "indexmap",
- "toml_datetime",
- "winnow 0.5.40",
-]
-
-[[package]]
-name = "toml_edit"
 version = "0.22.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
 dependencies = [
  "indexmap",
  "toml_datetime",
- "winnow 0.6.20",
+ "winnow",
 ]
 
 [[package]]
@@ -8228,16 +7288,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "triehash"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1631b201eb031b563d2e85ca18ec8092508e262a3196ce9bd10a67ec87b9f5c"
-dependencies = [
- "hash-db",
- "rlp",
-]
-
-[[package]]
 name = "triomphe"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8258,6 +7308,55 @@ name = "typenum"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+
+[[package]]
+name = "types"
+version = "0.2.1"
+source = "git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup#39b5dfd1d277ac4ea4b5ac90f60f34bf0f937ca6"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
+ "arbitrary",
+ "bls 0.2.0 (git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup)",
+ "compare_fields 0.2.0 (git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup)",
+ "compare_fields_derive 0.2.0 (git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup)",
+ "derivative",
+ "eth2_interop_keypairs 0.2.0 (git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup)",
+ "ethereum_hashing",
+ "ethereum_serde_utils",
+ "ethereum_ssz",
+ "ethereum_ssz_derive",
+ "fixed_bytes 0.1.0 (git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup)",
+ "hex",
+ "int_to_bytes 0.2.0 (git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup)",
+ "itertools 0.10.5",
+ "kzg 0.1.0 (git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup)",
+ "log",
+ "maplit",
+ "merkle_proof 0.2.0 (git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup)",
+ "metastruct",
+ "milhouse",
+ "parking_lot",
+ "rand",
+ "rand_xorshift",
+ "rayon",
+ "regex",
+ "rpds",
+ "rusqlite",
+ "safe_arith 0.1.0 (git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup)",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "slog",
+ "smallvec",
+ "ssz_types",
+ "superstruct",
+ "swap_or_not_shuffle 0.2.0 (git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup)",
+ "tempfile",
+ "test_random_derive 0.2.0 (git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup)",
+ "tree_hash",
+ "tree_hash_derive",
+]
 
 [[package]]
 name = "types"
@@ -8286,7 +7385,7 @@ dependencies = [
  "merkle_proof 0.2.0 (git+https://github.com/agemanning/lighthouse?branch=modularize-vc)",
  "metastruct",
  "milhouse",
- "parking_lot 0.12.3",
+ "parking_lot",
  "rand",
  "rand_xorshift",
  "rayon",
@@ -8335,7 +7434,7 @@ dependencies = [
  "merkle_proof 0.2.0 (git+https://github.com/sigp/lighthouse?branch=unstable)",
  "metastruct",
  "milhouse",
- "parking_lot 0.12.3",
+ "parking_lot",
  "rand",
  "rand_xorshift",
  "rayon",
@@ -8398,12 +7497,6 @@ name = "unescape"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccb97dac3243214f8d8507998906ca3e2e0b900bf9bf4870477f125b82e68f6e"
-
-[[package]]
-name = "unicase"
-version = "2.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e51b68083f157f853b6379db119d1c1be0e6e4dec98101079dec41f6f5cf6df"
 
 [[package]]
 name = "unicode-ident"
@@ -8480,10 +7573,10 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 [[package]]
 name = "unused_port"
 version = "0.1.0"
-source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
+source = "git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup#39b5dfd1d277ac4ea4b5ac90f60f34bf0f937ca6"
 dependencies = [
- "lru_cache 0.1.0 (git+https://github.com/agemanning/lighthouse?branch=modularize-vc)",
- "parking_lot 0.12.3",
+ "lru_cache 0.1.0 (git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup)",
+ "parking_lot",
 ]
 
 [[package]]
@@ -8492,7 +7585,7 @@ version = "0.1.0"
 source = "git+https://github.com/sigp/lighthouse?branch=unstable#c5a48a9dffc82e5e18d24ca7f2ab3671c9ad8469"
 dependencies = [
  "lru_cache 0.1.0 (git+https://github.com/sigp/lighthouse?branch=unstable)",
- "parking_lot 0.12.3",
+ "parking_lot",
 ]
 
 [[package]]
@@ -8532,24 +7625,6 @@ checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
 dependencies = [
  "getrandom",
  "serde",
-]
-
-[[package]]
-name = "validator_dir"
-version = "0.1.0"
-source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
-dependencies = [
- "bls 0.2.0 (git+https://github.com/agemanning/lighthouse?branch=modularize-vc)",
- "deposit_contract",
- "derivative",
- "directory 0.1.0 (git+https://github.com/agemanning/lighthouse?branch=modularize-vc)",
- "eth2_keystore",
- "filesystem",
- "hex",
- "lockfile",
- "rand",
- "tree_hash",
- "types 0.2.1 (git+https://github.com/agemanning/lighthouse?branch=modularize-vc)",
 ]
 
 [[package]]
@@ -8615,55 +7690,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
 dependencies = [
  "try-lock",
-]
-
-[[package]]
-name = "warp"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4378d202ff965b011c64817db11d5829506d3404edeadb61f190d111da3f231c"
-dependencies = [
- "bytes",
- "futures-channel",
- "futures-util",
- "headers",
- "http 0.2.12",
- "hyper 0.14.31",
- "log",
- "mime",
- "mime_guess",
- "percent-encoding",
- "pin-project",
- "rustls-pemfile 2.2.0",
- "scoped-tls",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "tokio",
- "tokio-rustls 0.25.0",
- "tokio-util",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "warp_utils"
-version = "0.1.0"
-source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
-dependencies = [
- "beacon_chain",
- "bytes",
- "eth2",
- "headers",
- "metrics 0.2.0 (git+https://github.com/agemanning/lighthouse?branch=modularize-vc)",
- "safe_arith 0.1.0 (git+https://github.com/agemanning/lighthouse?branch=modularize-vc)",
- "serde",
- "serde_array_query",
- "serde_json",
- "state_processing",
- "tokio",
- "types 0.2.1 (git+https://github.com/agemanning/lighthouse?branch=modularize-vc)",
- "warp",
 ]
 
 [[package]]
@@ -8777,6 +7803,18 @@ name = "webpki-roots"
 version = "0.25.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
+
+[[package]]
+name = "which"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
+dependencies = [
+ "either",
+ "home",
+ "once_cell",
+ "rustix 0.38.42",
+]
 
 [[package]]
 name = "widestring"
@@ -9078,15 +8116,6 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.5.40"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "winnow"
 version = "0.6.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36c1fec1a2bb5866f07c25f68c26e565c4c200aebb96d7e55710c19d3e8ac49b"
@@ -9115,12 +8144,6 @@ name = "writeable"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
-
-[[package]]
-name = "wyz"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85e60b0d1b5f99db2556934e21937020776a5d31520bf169e851ac44e6420214"
 
 [[package]]
 name = "wyz"
@@ -9161,6 +8184,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "xdelta3"
+version = "0.1.5"
+source = "git+http://github.com/sigp/xdelta3-rs?rev=50d63cdf1878e5cf3538e9aae5eed34a22c64e4a#50d63cdf1878e5cf3538e9aae5eed34a22c64e4a"
+dependencies = [
+ "bindgen",
+ "cc",
+ "futures-io",
+ "futures-util",
+ "libc",
+ "log",
+ "rand",
+]
+
+[[package]]
 name = "xml-rs"
 version = "0.8.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9184,7 +8221,7 @@ dependencies = [
  "futures",
  "log",
  "nohash-hasher",
- "parking_lot 0.12.3",
+ "parking_lot",
  "pin-project",
  "rand",
  "static_assertions",
@@ -9199,7 +8236,7 @@ dependencies = [
  "futures",
  "log",
  "nohash-hasher",
- "parking_lot 0.12.3",
+ "parking_lot",
  "pin-project",
  "rand",
  "static_assertions",
@@ -9287,6 +8324,7 @@ version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
 dependencies = [
+ "serde",
  "zeroize_derive",
 ]
 
@@ -9340,7 +8378,7 @@ dependencies = [
  "pbkdf2 0.11.0",
  "sha1",
  "time",
- "zstd",
+ "zstd 0.11.2+zstd.1.5.2",
 ]
 
 [[package]]
@@ -9349,7 +8387,16 @@ version = "0.11.2+zstd.1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20cc960326ece64f010d2d2107537f26dc589a6573a316bd5b1dba685fa5fde4"
 dependencies = [
- "zstd-safe",
+ "zstd-safe 5.0.2+zstd.1.5.2",
+]
+
+[[package]]
+name = "zstd"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcf2b778a664581e31e389454a7072dab1647606d44f7feea22cd5abb9c9f3f9"
+dependencies = [
+ "zstd-safe 7.2.1",
 ]
 
 [[package]]
@@ -9359,6 +8406,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d2a5585e04f9eea4b2a3d1eca508c4dee9592a89ef6f450c11719da0726f4db"
 dependencies = [
  "libc",
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54a3ab4db68cea366acc5c897c7b4d4d1b8994a9cd6e6f841f8964566a419059"
+dependencies = [
  "zstd-sys",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -736,7 +736,7 @@ dependencies = [
 [[package]]
 name = "bls"
 version = "0.2.0"
-source = "git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup#39b5dfd1d277ac4ea4b5ac90f60f34bf0f937ca6"
+source = "git+https://github.com/dknopik/lighthouse?branch=dependency-cleanup#39b5dfd1d277ac4ea4b5ac90f60f34bf0f937ca6"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -744,10 +744,10 @@ dependencies = [
  "ethereum_hashing",
  "ethereum_serde_utils",
  "ethereum_ssz",
- "fixed_bytes 0.1.0 (git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup)",
+ "fixed_bytes 0.1.0 (git+https://github.com/dknopik/lighthouse?branch=dependency-cleanup)",
  "hex",
  "rand",
- "safe_arith 0.1.0 (git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup)",
+ "safe_arith 0.1.0 (git+https://github.com/dknopik/lighthouse?branch=dependency-cleanup)",
  "serde",
  "tree_hash",
  "zeroize",
@@ -1034,18 +1034,18 @@ checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 [[package]]
 name = "clap_utils"
 version = "0.1.0"
-source = "git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup#39b5dfd1d277ac4ea4b5ac90f60f34bf0f937ca6"
+source = "git+https://github.com/dknopik/lighthouse?branch=dependency-cleanup#39b5dfd1d277ac4ea4b5ac90f60f34bf0f937ca6"
 dependencies = [
  "alloy-primitives",
  "clap",
  "dirs 3.0.2",
- "eth2_network_config 0.2.0 (git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup)",
+ "eth2_network_config 0.2.0 (git+https://github.com/dknopik/lighthouse?branch=dependency-cleanup)",
  "ethereum_ssz",
  "hex",
  "serde",
  "serde_json",
  "serde_yaml",
- "types 0.2.1 (git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup)",
+ "types 0.2.1 (git+https://github.com/dknopik/lighthouse?branch=dependency-cleanup)",
 ]
 
 [[package]]
@@ -1107,7 +1107,7 @@ checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 [[package]]
 name = "compare_fields"
 version = "0.2.0"
-source = "git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup#39b5dfd1d277ac4ea4b5ac90f60f34bf0f937ca6"
+source = "git+https://github.com/dknopik/lighthouse?branch=dependency-cleanup#39b5dfd1d277ac4ea4b5ac90f60f34bf0f937ca6"
 dependencies = [
  "itertools 0.10.5",
 ]
@@ -1131,7 +1131,7 @@ dependencies = [
 [[package]]
 name = "compare_fields_derive"
 version = "0.2.0"
-source = "git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup#39b5dfd1d277ac4ea4b5ac90f60f34bf0f937ca6"
+source = "git+https://github.com/dknopik/lighthouse?branch=dependency-cleanup#39b5dfd1d277ac4ea4b5ac90f60f34bf0f937ca6"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -1673,11 +1673,11 @@ dependencies = [
 [[package]]
 name = "directory"
 version = "0.1.0"
-source = "git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup#39b5dfd1d277ac4ea4b5ac90f60f34bf0f937ca6"
+source = "git+https://github.com/dknopik/lighthouse?branch=dependency-cleanup#39b5dfd1d277ac4ea4b5ac90f60f34bf0f937ca6"
 dependencies = [
  "clap",
- "clap_utils 0.1.0 (git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup)",
- "eth2_network_config 0.2.0 (git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup)",
+ "clap_utils 0.1.0 (git+https://github.com/dknopik/lighthouse?branch=dependency-cleanup)",
+ "eth2_network_config 0.2.0 (git+https://github.com/dknopik/lighthouse?branch=dependency-cleanup)",
 ]
 
 [[package]]
@@ -1935,7 +1935,7 @@ dependencies = [
 [[package]]
 name = "eth2"
 version = "0.1.0"
-source = "git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup#39b5dfd1d277ac4ea4b5ac90f60f34bf0f937ca6"
+source = "git+https://github.com/dknopik/lighthouse?branch=dependency-cleanup#39b5dfd1d277ac4ea4b5ac90f60f34bf0f937ca6"
 dependencies = [
  "derivative",
  "eth2_keystore",
@@ -1944,29 +1944,29 @@ dependencies = [
  "ethereum_ssz_derive",
  "futures",
  "futures-util",
- "lighthouse_network 0.2.0 (git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup)",
+ "lighthouse_network 0.2.0 (git+https://github.com/dknopik/lighthouse?branch=dependency-cleanup)",
  "mediatype",
- "pretty_reqwest_error 0.1.0 (git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup)",
+ "pretty_reqwest_error 0.1.0 (git+https://github.com/dknopik/lighthouse?branch=dependency-cleanup)",
  "proto_array",
  "reqwest",
  "reqwest-eventsource",
- "sensitive_url 0.1.0 (git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup)",
+ "sensitive_url 0.1.0 (git+https://github.com/dknopik/lighthouse?branch=dependency-cleanup)",
  "serde",
  "serde_json",
  "slashing_protection",
  "ssz_types",
  "store",
- "types 0.2.1 (git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup)",
+ "types 0.2.1 (git+https://github.com/dknopik/lighthouse?branch=dependency-cleanup)",
  "zeroize",
 ]
 
 [[package]]
 name = "eth2_config"
 version = "0.2.0"
-source = "git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup#39b5dfd1d277ac4ea4b5ac90f60f34bf0f937ca6"
+source = "git+https://github.com/dknopik/lighthouse?branch=dependency-cleanup#39b5dfd1d277ac4ea4b5ac90f60f34bf0f937ca6"
 dependencies = [
  "paste",
- "types 0.2.1 (git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup)",
+ "types 0.2.1 (git+https://github.com/dknopik/lighthouse?branch=dependency-cleanup)",
 ]
 
 [[package]]
@@ -1981,9 +1981,9 @@ dependencies = [
 [[package]]
 name = "eth2_interop_keypairs"
 version = "0.2.0"
-source = "git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup#39b5dfd1d277ac4ea4b5ac90f60f34bf0f937ca6"
+source = "git+https://github.com/dknopik/lighthouse?branch=dependency-cleanup#39b5dfd1d277ac4ea4b5ac90f60f34bf0f937ca6"
 dependencies = [
- "bls 0.2.0 (git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup)",
+ "bls 0.2.0 (git+https://github.com/dknopik/lighthouse?branch=dependency-cleanup)",
  "ethereum_hashing",
  "hex",
  "num-bigint",
@@ -2020,9 +2020,9 @@ dependencies = [
 [[package]]
 name = "eth2_key_derivation"
 version = "0.1.0"
-source = "git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup#39b5dfd1d277ac4ea4b5ac90f60f34bf0f937ca6"
+source = "git+https://github.com/dknopik/lighthouse?branch=dependency-cleanup#39b5dfd1d277ac4ea4b5ac90f60f34bf0f937ca6"
 dependencies = [
- "bls 0.2.0 (git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup)",
+ "bls 0.2.0 (git+https://github.com/dknopik/lighthouse?branch=dependency-cleanup)",
  "num-bigint-dig",
  "ring 0.16.20",
  "sha2 0.9.9",
@@ -2032,10 +2032,10 @@ dependencies = [
 [[package]]
 name = "eth2_keystore"
 version = "0.1.0"
-source = "git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup#39b5dfd1d277ac4ea4b5ac90f60f34bf0f937ca6"
+source = "git+https://github.com/dknopik/lighthouse?branch=dependency-cleanup#39b5dfd1d277ac4ea4b5ac90f60f34bf0f937ca6"
 dependencies = [
  "aes 0.7.5",
- "bls 0.2.0 (git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup)",
+ "bls 0.2.0 (git+https://github.com/dknopik/lighthouse?branch=dependency-cleanup)",
  "eth2_key_derivation",
  "hex",
  "hmac 0.11.0",
@@ -2054,20 +2054,20 @@ dependencies = [
 [[package]]
 name = "eth2_network_config"
 version = "0.2.0"
-source = "git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup#39b5dfd1d277ac4ea4b5ac90f60f34bf0f937ca6"
+source = "git+https://github.com/dknopik/lighthouse?branch=dependency-cleanup#39b5dfd1d277ac4ea4b5ac90f60f34bf0f937ca6"
 dependencies = [
  "bytes",
  "discv5",
- "eth2_config 0.2.0 (git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup)",
- "kzg 0.1.0 (git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup)",
- "logging 0.2.0 (git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup)",
- "pretty_reqwest_error 0.1.0 (git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup)",
+ "eth2_config 0.2.0 (git+https://github.com/dknopik/lighthouse?branch=dependency-cleanup)",
+ "kzg 0.1.0 (git+https://github.com/dknopik/lighthouse?branch=dependency-cleanup)",
+ "logging 0.2.0 (git+https://github.com/dknopik/lighthouse?branch=dependency-cleanup)",
+ "pretty_reqwest_error 0.1.0 (git+https://github.com/dknopik/lighthouse?branch=dependency-cleanup)",
  "reqwest",
- "sensitive_url 0.1.0 (git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup)",
+ "sensitive_url 0.1.0 (git+https://github.com/dknopik/lighthouse?branch=dependency-cleanup)",
  "serde_yaml",
  "sha2 0.9.9",
  "slog",
- "types 0.2.1 (git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup)",
+ "types 0.2.1 (git+https://github.com/dknopik/lighthouse?branch=dependency-cleanup)",
  "url",
  "zip",
 ]
@@ -2253,7 +2253,7 @@ dependencies = [
 [[package]]
 name = "filesystem"
 version = "0.1.0"
-source = "git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup#39b5dfd1d277ac4ea4b5ac90f60f34bf0f937ca6"
+source = "git+https://github.com/dknopik/lighthouse?branch=dependency-cleanup#39b5dfd1d277ac4ea4b5ac90f60f34bf0f937ca6"
 dependencies = [
  "winapi",
  "windows-acl",
@@ -2274,10 +2274,10 @@ dependencies = [
 [[package]]
 name = "fixed_bytes"
 version = "0.1.0"
-source = "git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup#39b5dfd1d277ac4ea4b5ac90f60f34bf0f937ca6"
+source = "git+https://github.com/dknopik/lighthouse?branch=dependency-cleanup#39b5dfd1d277ac4ea4b5ac90f60f34bf0f937ca6"
 dependencies = [
  "alloy-primitives",
- "safe_arith 0.1.0 (git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup)",
+ "safe_arith 0.1.0 (git+https://github.com/dknopik/lighthouse?branch=dependency-cleanup)",
 ]
 
 [[package]]
@@ -2557,7 +2557,7 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 [[package]]
 name = "gossipsub"
 version = "0.5.0"
-source = "git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup#39b5dfd1d277ac4ea4b5ac90f60f34bf0f937ca6"
+source = "git+https://github.com/dknopik/lighthouse?branch=dependency-cleanup#39b5dfd1d277ac4ea4b5ac90f60f34bf0f937ca6"
 dependencies = [
  "async-channel",
  "asynchronous-codec",
@@ -2687,10 +2687,10 @@ dependencies = [
 [[package]]
 name = "health_metrics"
 version = "0.1.0"
-source = "git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup#39b5dfd1d277ac4ea4b5ac90f60f34bf0f937ca6"
+source = "git+https://github.com/dknopik/lighthouse?branch=dependency-cleanup#39b5dfd1d277ac4ea4b5ac90f60f34bf0f937ca6"
 dependencies = [
  "eth2",
- "metrics 0.2.0 (git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup)",
+ "metrics 0.2.0 (git+https://github.com/dknopik/lighthouse?branch=dependency-cleanup)",
  "procfs",
  "psutil",
 ]
@@ -3309,7 +3309,7 @@ dependencies = [
 [[package]]
 name = "int_to_bytes"
 version = "0.2.0"
-source = "git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup#39b5dfd1d277ac4ea4b5ac90f60f34bf0f937ca6"
+source = "git+https://github.com/dknopik/lighthouse?branch=dependency-cleanup#39b5dfd1d277ac4ea4b5ac90f60f34bf0f937ca6"
 dependencies = [
  "bytes",
 ]
@@ -3464,7 +3464,7 @@ dependencies = [
 [[package]]
 name = "kzg"
 version = "0.1.0"
-source = "git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup#39b5dfd1d277ac4ea4b5ac90f60f34bf0f937ca6"
+source = "git+https://github.com/dknopik/lighthouse?branch=dependency-cleanup#39b5dfd1d277ac4ea4b5ac90f60f34bf0f937ca6"
 dependencies = [
  "arbitrary",
  "c-kzg",
@@ -4097,13 +4097,13 @@ dependencies = [
 [[package]]
 name = "lighthouse_network"
 version = "0.2.0"
-source = "git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup#39b5dfd1d277ac4ea4b5ac90f60f34bf0f937ca6"
+source = "git+https://github.com/dknopik/lighthouse?branch=dependency-cleanup#39b5dfd1d277ac4ea4b5ac90f60f34bf0f937ca6"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "bytes",
  "delay_map",
- "directory 0.1.0 (git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup)",
+ "directory 0.1.0 (git+https://github.com/dknopik/lighthouse?branch=dependency-cleanup)",
  "dirs 3.0.2",
  "discv5",
  "either",
@@ -4111,15 +4111,15 @@ dependencies = [
  "ethereum_ssz_derive",
  "fnv",
  "futures",
- "gossipsub 0.5.0 (git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup)",
+ "gossipsub 0.5.0 (git+https://github.com/dknopik/lighthouse?branch=dependency-cleanup)",
  "hex",
  "itertools 0.10.5",
  "libp2p",
  "libp2p-mplex",
- "lighthouse_version 0.1.0 (git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup)",
+ "lighthouse_version 0.1.0 (git+https://github.com/dknopik/lighthouse?branch=dependency-cleanup)",
  "lru",
- "lru_cache 0.1.0 (git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup)",
- "metrics 0.2.0 (git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup)",
+ "lru_cache 0.1.0 (git+https://github.com/dknopik/lighthouse?branch=dependency-cleanup)",
+ "metrics 0.2.0 (git+https://github.com/dknopik/lighthouse?branch=dependency-cleanup)",
  "parking_lot",
  "prometheus-client",
  "rand",
@@ -4132,14 +4132,14 @@ dependencies = [
  "ssz_types",
  "strum",
  "superstruct",
- "task_executor 0.1.0 (git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup)",
+ "task_executor 0.1.0 (git+https://github.com/dknopik/lighthouse?branch=dependency-cleanup)",
  "tiny-keccak",
  "tokio",
  "tokio-io-timeout",
  "tokio-util",
- "types 0.2.1 (git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup)",
+ "types 0.2.1 (git+https://github.com/dknopik/lighthouse?branch=dependency-cleanup)",
  "unsigned-varint 0.8.0",
- "unused_port 0.1.0 (git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup)",
+ "unused_port 0.1.0 (git+https://github.com/dknopik/lighthouse?branch=dependency-cleanup)",
  "void",
 ]
 
@@ -4195,7 +4195,7 @@ dependencies = [
 [[package]]
 name = "lighthouse_version"
 version = "0.1.0"
-source = "git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup#39b5dfd1d277ac4ea4b5ac90f60f34bf0f937ca6"
+source = "git+https://github.com/dknopik/lighthouse?branch=dependency-cleanup#39b5dfd1d277ac4ea4b5ac90f60f34bf0f937ca6"
 dependencies = [
  "git-version",
  "target_info",
@@ -4253,10 +4253,10 @@ checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 [[package]]
 name = "logging"
 version = "0.2.0"
-source = "git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup#39b5dfd1d277ac4ea4b5ac90f60f34bf0f937ca6"
+source = "git+https://github.com/dknopik/lighthouse?branch=dependency-cleanup#39b5dfd1d277ac4ea4b5ac90f60f34bf0f937ca6"
 dependencies = [
  "chrono",
- "metrics 0.2.0 (git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup)",
+ "metrics 0.2.0 (git+https://github.com/dknopik/lighthouse?branch=dependency-cleanup)",
  "parking_lot",
  "serde",
  "serde_json",
@@ -4315,7 +4315,7 @@ dependencies = [
 [[package]]
 name = "lru_cache"
 version = "0.1.0"
-source = "git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup#39b5dfd1d277ac4ea4b5ac90f60f34bf0f937ca6"
+source = "git+https://github.com/dknopik/lighthouse?branch=dependency-cleanup#39b5dfd1d277ac4ea4b5ac90f60f34bf0f937ca6"
 dependencies = [
  "fnv",
 ]
@@ -4388,12 +4388,12 @@ dependencies = [
 [[package]]
 name = "merkle_proof"
 version = "0.2.0"
-source = "git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup#39b5dfd1d277ac4ea4b5ac90f60f34bf0f937ca6"
+source = "git+https://github.com/dknopik/lighthouse?branch=dependency-cleanup#39b5dfd1d277ac4ea4b5ac90f60f34bf0f937ca6"
 dependencies = [
  "alloy-primitives",
  "ethereum_hashing",
- "fixed_bytes 0.1.0 (git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup)",
- "safe_arith 0.1.0 (git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup)",
+ "fixed_bytes 0.1.0 (git+https://github.com/dknopik/lighthouse?branch=dependency-cleanup)",
+ "safe_arith 0.1.0 (git+https://github.com/dknopik/lighthouse?branch=dependency-cleanup)",
 ]
 
 [[package]]
@@ -4444,7 +4444,7 @@ dependencies = [
 [[package]]
 name = "metrics"
 version = "0.2.0"
-source = "git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup#39b5dfd1d277ac4ea4b5ac90f60f34bf0f937ca6"
+source = "git+https://github.com/dknopik/lighthouse?branch=dependency-cleanup#39b5dfd1d277ac4ea4b5ac90f60f34bf0f937ca6"
 dependencies = [
  "prometheus",
 ]
@@ -5157,10 +5157,10 @@ dependencies = [
 [[package]]
 name = "pretty_reqwest_error"
 version = "0.1.0"
-source = "git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup#39b5dfd1d277ac4ea4b5ac90f60f34bf0f937ca6"
+source = "git+https://github.com/dknopik/lighthouse?branch=dependency-cleanup#39b5dfd1d277ac4ea4b5ac90f60f34bf0f937ca6"
 dependencies = [
  "reqwest",
- "sensitive_url 0.1.0 (git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup)",
+ "sensitive_url 0.1.0 (git+https://github.com/dknopik/lighthouse?branch=dependency-cleanup)",
 ]
 
 [[package]]
@@ -5322,15 +5322,15 @@ dependencies = [
 [[package]]
 name = "proto_array"
 version = "0.2.0"
-source = "git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup#39b5dfd1d277ac4ea4b5ac90f60f34bf0f937ca6"
+source = "git+https://github.com/dknopik/lighthouse?branch=dependency-cleanup#39b5dfd1d277ac4ea4b5ac90f60f34bf0f937ca6"
 dependencies = [
  "ethereum_ssz",
  "ethereum_ssz_derive",
- "safe_arith 0.1.0 (git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup)",
+ "safe_arith 0.1.0 (git+https://github.com/dknopik/lighthouse?branch=dependency-cleanup)",
  "serde",
  "serde_yaml",
  "superstruct",
- "types 0.2.1 (git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup)",
+ "types 0.2.1 (git+https://github.com/dknopik/lighthouse?branch=dependency-cleanup)",
 ]
 
 [[package]]
@@ -6017,7 +6017,7 @@ checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 [[package]]
 name = "safe_arith"
 version = "0.1.0"
-source = "git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup#39b5dfd1d277ac4ea4b5ac90f60f34bf0f937ca6"
+source = "git+https://github.com/dknopik/lighthouse?branch=dependency-cleanup#39b5dfd1d277ac4ea4b5ac90f60f34bf0f937ca6"
 
 [[package]]
 name = "safe_arith"
@@ -6148,7 +6148,7 @@ dependencies = [
 [[package]]
 name = "sensitive_url"
 version = "0.1.0"
-source = "git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup#39b5dfd1d277ac4ea4b5ac90f60f34bf0f937ca6"
+source = "git+https://github.com/dknopik/lighthouse?branch=dependency-cleanup#39b5dfd1d277ac4ea4b5ac90f60f34bf0f937ca6"
 dependencies = [
  "serde",
  "url",
@@ -6351,7 +6351,7 @@ dependencies = [
 [[package]]
 name = "slashing_protection"
 version = "0.1.0"
-source = "git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup#39b5dfd1d277ac4ea4b5ac90f60f34bf0f937ca6"
+source = "git+https://github.com/dknopik/lighthouse?branch=dependency-cleanup#39b5dfd1d277ac4ea4b5ac90f60f34bf0f937ca6"
 dependencies = [
  "arbitrary",
  "ethereum_serde_utils",
@@ -6362,7 +6362,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "types 0.2.1 (git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup)",
+ "types 0.2.1 (git+https://github.com/dknopik/lighthouse?branch=dependency-cleanup)",
 ]
 
 [[package]]
@@ -6578,27 +6578,27 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 [[package]]
 name = "state_processing"
 version = "0.2.0"
-source = "git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup#39b5dfd1d277ac4ea4b5ac90f60f34bf0f937ca6"
+source = "git+https://github.com/dknopik/lighthouse?branch=dependency-cleanup#39b5dfd1d277ac4ea4b5ac90f60f34bf0f937ca6"
 dependencies = [
  "arbitrary",
- "bls 0.2.0 (git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup)",
+ "bls 0.2.0 (git+https://github.com/dknopik/lighthouse?branch=dependency-cleanup)",
  "derivative",
  "ethereum_hashing",
  "ethereum_ssz",
  "ethereum_ssz_derive",
- "int_to_bytes 0.2.0 (git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup)",
+ "int_to_bytes 0.2.0 (git+https://github.com/dknopik/lighthouse?branch=dependency-cleanup)",
  "integer-sqrt",
  "itertools 0.10.5",
- "merkle_proof 0.2.0 (git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup)",
- "metrics 0.2.0 (git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup)",
+ "merkle_proof 0.2.0 (git+https://github.com/dknopik/lighthouse?branch=dependency-cleanup)",
+ "metrics 0.2.0 (git+https://github.com/dknopik/lighthouse?branch=dependency-cleanup)",
  "rand",
  "rayon",
- "safe_arith 0.1.0 (git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup)",
+ "safe_arith 0.1.0 (git+https://github.com/dknopik/lighthouse?branch=dependency-cleanup)",
  "smallvec",
  "ssz_types",
- "test_random_derive 0.2.0 (git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup)",
+ "test_random_derive 0.2.0 (git+https://github.com/dknopik/lighthouse?branch=dependency-cleanup)",
  "tree_hash",
- "types 0.2.1 (git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup)",
+ "types 0.2.1 (git+https://github.com/dknopik/lighthouse?branch=dependency-cleanup)",
 ]
 
 [[package]]
@@ -6610,20 +6610,20 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 [[package]]
 name = "store"
 version = "0.2.0"
-source = "git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup#39b5dfd1d277ac4ea4b5ac90f60f34bf0f937ca6"
+source = "git+https://github.com/dknopik/lighthouse?branch=dependency-cleanup#39b5dfd1d277ac4ea4b5ac90f60f34bf0f937ca6"
 dependencies = [
- "bls 0.2.0 (git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup)",
+ "bls 0.2.0 (git+https://github.com/dknopik/lighthouse?branch=dependency-cleanup)",
  "db-key",
- "directory 0.1.0 (git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup)",
+ "directory 0.1.0 (git+https://github.com/dknopik/lighthouse?branch=dependency-cleanup)",
  "ethereum_ssz",
  "ethereum_ssz_derive",
  "itertools 0.10.5",
  "leveldb",
- "logging 0.2.0 (git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup)",
+ "logging 0.2.0 (git+https://github.com/dknopik/lighthouse?branch=dependency-cleanup)",
  "lru",
- "metrics 0.2.0 (git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup)",
+ "metrics 0.2.0 (git+https://github.com/dknopik/lighthouse?branch=dependency-cleanup)",
  "parking_lot",
- "safe_arith 0.1.0 (git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup)",
+ "safe_arith 0.1.0 (git+https://github.com/dknopik/lighthouse?branch=dependency-cleanup)",
  "serde",
  "slog",
  "sloggers",
@@ -6631,7 +6631,7 @@ dependencies = [
  "state_processing",
  "strum",
  "superstruct",
- "types 0.2.1 (git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup)",
+ "types 0.2.1 (git+https://github.com/dknopik/lighthouse?branch=dependency-cleanup)",
  "xdelta3",
  "zstd 0.13.2",
 ]
@@ -6693,11 +6693,11 @@ dependencies = [
 [[package]]
 name = "swap_or_not_shuffle"
 version = "0.2.0"
-source = "git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup#39b5dfd1d277ac4ea4b5ac90f60f34bf0f937ca6"
+source = "git+https://github.com/dknopik/lighthouse?branch=dependency-cleanup#39b5dfd1d277ac4ea4b5ac90f60f34bf0f937ca6"
 dependencies = [
  "alloy-primitives",
  "ethereum_hashing",
- "fixed_bytes 0.1.0 (git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup)",
+ "fixed_bytes 0.1.0 (git+https://github.com/dknopik/lighthouse?branch=dependency-cleanup)",
 ]
 
 [[package]]
@@ -6828,12 +6828,12 @@ checksum = "c63f48baada5c52e65a29eef93ab4f8982681b67f9e8d29c7b05abcfec2b9ffe"
 [[package]]
 name = "task_executor"
 version = "0.1.0"
-source = "git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup#39b5dfd1d277ac4ea4b5ac90f60f34bf0f937ca6"
+source = "git+https://github.com/dknopik/lighthouse?branch=dependency-cleanup#39b5dfd1d277ac4ea4b5ac90f60f34bf0f937ca6"
 dependencies = [
  "async-channel",
  "futures",
- "logging 0.2.0 (git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup)",
- "metrics 0.2.0 (git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup)",
+ "logging 0.2.0 (git+https://github.com/dknopik/lighthouse?branch=dependency-cleanup)",
+ "metrics 0.2.0 (git+https://github.com/dknopik/lighthouse?branch=dependency-cleanup)",
  "slog",
  "sloggers",
  "tokio",
@@ -6891,7 +6891,7 @@ dependencies = [
 [[package]]
 name = "test_random_derive"
 version = "0.2.0"
-source = "git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup#39b5dfd1d277ac4ea4b5ac90f60f34bf0f937ca6"
+source = "git+https://github.com/dknopik/lighthouse?branch=dependency-cleanup#39b5dfd1d277ac4ea4b5ac90f60f34bf0f937ca6"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -7312,28 +7312,28 @@ checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 [[package]]
 name = "types"
 version = "0.2.1"
-source = "git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup#39b5dfd1d277ac4ea4b5ac90f60f34bf0f937ca6"
+source = "git+https://github.com/dknopik/lighthouse?branch=dependency-cleanup#39b5dfd1d277ac4ea4b5ac90f60f34bf0f937ca6"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "arbitrary",
- "bls 0.2.0 (git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup)",
- "compare_fields 0.2.0 (git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup)",
- "compare_fields_derive 0.2.0 (git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup)",
+ "bls 0.2.0 (git+https://github.com/dknopik/lighthouse?branch=dependency-cleanup)",
+ "compare_fields 0.2.0 (git+https://github.com/dknopik/lighthouse?branch=dependency-cleanup)",
+ "compare_fields_derive 0.2.0 (git+https://github.com/dknopik/lighthouse?branch=dependency-cleanup)",
  "derivative",
- "eth2_interop_keypairs 0.2.0 (git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup)",
+ "eth2_interop_keypairs 0.2.0 (git+https://github.com/dknopik/lighthouse?branch=dependency-cleanup)",
  "ethereum_hashing",
  "ethereum_serde_utils",
  "ethereum_ssz",
  "ethereum_ssz_derive",
- "fixed_bytes 0.1.0 (git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup)",
+ "fixed_bytes 0.1.0 (git+https://github.com/dknopik/lighthouse?branch=dependency-cleanup)",
  "hex",
- "int_to_bytes 0.2.0 (git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup)",
+ "int_to_bytes 0.2.0 (git+https://github.com/dknopik/lighthouse?branch=dependency-cleanup)",
  "itertools 0.10.5",
- "kzg 0.1.0 (git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup)",
+ "kzg 0.1.0 (git+https://github.com/dknopik/lighthouse?branch=dependency-cleanup)",
  "log",
  "maplit",
- "merkle_proof 0.2.0 (git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup)",
+ "merkle_proof 0.2.0 (git+https://github.com/dknopik/lighthouse?branch=dependency-cleanup)",
  "metastruct",
  "milhouse",
  "parking_lot",
@@ -7343,7 +7343,7 @@ dependencies = [
  "regex",
  "rpds",
  "rusqlite",
- "safe_arith 0.1.0 (git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup)",
+ "safe_arith 0.1.0 (git+https://github.com/dknopik/lighthouse?branch=dependency-cleanup)",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -7351,9 +7351,9 @@ dependencies = [
  "smallvec",
  "ssz_types",
  "superstruct",
- "swap_or_not_shuffle 0.2.0 (git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup)",
+ "swap_or_not_shuffle 0.2.0 (git+https://github.com/dknopik/lighthouse?branch=dependency-cleanup)",
  "tempfile",
- "test_random_derive 0.2.0 (git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup)",
+ "test_random_derive 0.2.0 (git+https://github.com/dknopik/lighthouse?branch=dependency-cleanup)",
  "tree_hash",
  "tree_hash_derive",
 ]
@@ -7573,9 +7573,9 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 [[package]]
 name = "unused_port"
 version = "0.1.0"
-source = "git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup#39b5dfd1d277ac4ea4b5ac90f60f34bf0f937ca6"
+source = "git+https://github.com/dknopik/lighthouse?branch=dependency-cleanup#39b5dfd1d277ac4ea4b5ac90f60f34bf0f937ca6"
 dependencies = [
- "lru_cache 0.1.0 (git+https://github.com/dknopik/lighthouse.git?branch=dependency-cleanup)",
+ "lru_cache 0.1.0 (git+https://github.com/dknopik/lighthouse?branch=dependency-cleanup)",
  "parking_lot",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ edition = "2021"
 [workspace.dependencies]
 client = { path = "anchor/client" }
 qbft = { path = "anchor/qbft" }
+health_metrics = { git = "https://github.com/dknopik/lighthouse.git" , branch = "dependency-cleanup" }
 http_api = { path = "anchor/http_api" }
 http_metrics = { path = "anchor/http_metrics" }
 network = { path = "anchor/network" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ edition = "2021"
 [workspace.dependencies]
 client = { path = "anchor/client" }
 qbft = { path = "anchor/qbft" }
-health_metrics = { git = "https://github.com/dknopik/lighthouse.git" , branch = "dependency-cleanup" }
+health_metrics = { git = "https://github.com/dknopik/lighthouse", branch = "dependency-cleanup" }
 http_api = { path = "anchor/http_api" }
 http_metrics = { path = "anchor/http_metrics" }
 network = { path = "anchor/network" }

--- a/anchor/http_metrics/Cargo.toml
+++ b/anchor/http_metrics/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 [dependencies]
 axum = { workspace = true }
+health_metrics = { workspace = true }
 metrics = { workspace = true }
 parking_lot = { workspace = true }
 serde = { workspace = true }
@@ -12,5 +13,4 @@ tokio = { workspace = true }
 tower-http = { workspace = true }
 tracing = { workspace = true }
 validator_metrics = { workspace = true }
-# Group dependencies
-warp_utils = { git = "https://github.com/agemanning/lighthouse", branch = "modularize-vc" }
+

--- a/anchor/http_metrics/src/lib.rs
+++ b/anchor/http_metrics/src/lib.rs
@@ -106,7 +106,7 @@ async fn metrics_handler(State(state): State<Arc<RwLock<Shared>>>) -> Response<B
         */
     }
 
-    warp_utils::metrics::scrape_health_metrics();
+    health_metrics::metrics::scrape_health_metrics();
 
     encoder.encode(&metrics::gather(), &mut buffer).unwrap();
 


### PR DESCRIPTION
## Proposed Changes

use `scrape_health_metrics` from [`health_metrics`](https://github.com/dknopik/lighthouse/tree/dependency-cleanup/common/health_metrics) instead of `warp_utils`. 

## Additional Info
this should help us avoid unnecessarily pulling `beacon_chain`

currently using [this branch](https://github.com/dknopik/lighthouse/tree/dependency-cleanup) for `health_metrics`. will have to wait till `dependency-cleanup` changes get merged in lighthouse.