### PR TITLE
Ensure the "workspace.dependencies" table is sorted

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -210,6 +210,6 @@ jobs:
         with:
           channel: stable
           cache-target: release
-          bins: cargo-sort
+          bins: cargo-sort, taplo-cli
       - name: Run cargo sort to check if Cargo.toml files are sorted
-        run: cargo sort --check --workspace
+        run: make sort

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -641,7 +641,7 @@ dependencies = [
  "dirs 5.0.1",
  "futures",
  "regex",
- "sensitive_url 0.1.0 (git+https://github.com/agemanning/lighthouse?branch=modularize-vc)",
+ "sensitive_url",
  "serde",
  "task_executor",
  "tokio",
@@ -1246,50 +1246,10 @@ dependencies = [
  "ethereum_hashing",
  "ethereum_serde_utils",
  "ethereum_ssz",
- "fixed_bytes 0.1.0 (git+https://github.com/sigp/lighthouse?branch=anchor)",
+ "fixed_bytes",
  "hex",
  "rand",
- "safe_arith 0.1.0 (git+https://github.com/sigp/lighthouse?branch=anchor)",
- "serde",
- "tree_hash",
- "zeroize",
-]
-
-[[package]]
-name = "bls"
-version = "0.2.0"
-source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
-dependencies = [
- "alloy-primitives",
- "arbitrary",
- "blst",
- "ethereum_hashing",
- "ethereum_serde_utils",
- "ethereum_ssz",
- "fixed_bytes 0.1.0 (git+https://github.com/agemanning/lighthouse?branch=modularize-vc)",
- "hex",
- "rand",
- "safe_arith 0.1.0 (git+https://github.com/agemanning/lighthouse?branch=modularize-vc)",
- "serde",
- "tree_hash",
- "zeroize",
-]
-
-[[package]]
-name = "bls"
-version = "0.2.0"
-source = "git+https://github.com/sigp/lighthouse?branch=unstable#06e4d22d4954807ddc755feaea7518ad2ce06f35"
-dependencies = [
- "alloy-primitives",
- "arbitrary",
- "blst",
- "ethereum_hashing",
- "ethereum_serde_utils",
- "ethereum_ssz",
- "fixed_bytes 0.1.0 (git+https://github.com/sigp/lighthouse?branch=unstable)",
- "hex",
- "rand",
- "safe_arith 0.1.0 (git+https://github.com/sigp/lighthouse?branch=unstable)",
+ "safe_arith",
  "serde",
  "tree_hash",
  "zeroize",
@@ -1518,7 +1478,7 @@ checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 [[package]]
 name = "clap_utils"
 version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?branch=unstable#06e4d22d4954807ddc755feaea7518ad2ce06f35"
+source = "git+https://github.com/sigp/lighthouse?branch=anchor#997991f5513f22bb240816c2e2400cf6a1819a0c"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -1529,7 +1489,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
- "types 0.2.1 (git+https://github.com/sigp/lighthouse?branch=unstable)",
+ "types",
 ]
 
 [[package]]
@@ -1546,7 +1506,7 @@ dependencies = [
  "network",
  "parking_lot",
  "processor",
- "sensitive_url 0.1.0 (git+https://github.com/agemanning/lighthouse?branch=modularize-vc)",
+ "sensitive_url",
  "serde",
  "strum 0.24.1",
  "task_executor",
@@ -1571,43 +1531,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "compare_fields"
-version = "0.2.0"
-source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
-dependencies = [
- "itertools 0.10.5",
-]
-
-[[package]]
-name = "compare_fields"
-version = "0.2.0"
-source = "git+https://github.com/sigp/lighthouse?branch=unstable#06e4d22d4954807ddc755feaea7518ad2ce06f35"
-dependencies = [
- "itertools 0.10.5",
-]
-
-[[package]]
 name = "compare_fields_derive"
 version = "0.2.0"
 source = "git+https://github.com/sigp/lighthouse?branch=anchor#997991f5513f22bb240816c2e2400cf6a1819a0c"
-dependencies = [
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "compare_fields_derive"
-version = "0.2.0"
-source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
-dependencies = [
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "compare_fields_derive"
-version = "0.2.0"
-source = "git+https://github.com/sigp/lighthouse?branch=unstable#06e4d22d4954807ddc755feaea7518ad2ce06f35"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -2029,7 +1955,7 @@ dependencies = [
  "rusqlite",
  "ssv_types",
  "tempfile",
- "types 0.2.1 (git+https://github.com/sigp/lighthouse?branch=unstable)",
+ "types",
 ]
 
 [[package]]
@@ -2156,7 +2082,7 @@ dependencies = [
 [[package]]
 name = "directory"
 version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?branch=unstable#06e4d22d4954807ddc755feaea7518ad2ce06f35"
+source = "git+https://github.com/sigp/lighthouse?branch=anchor#997991f5513f22bb240816c2e2400cf6a1819a0c"
 dependencies = [
  "clap",
  "clap_utils",
@@ -2428,7 +2354,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "types 0.2.1 (git+https://github.com/sigp/lighthouse?branch=unstable)",
+ "types",
 ]
 
 [[package]]
@@ -2447,26 +2373,26 @@ dependencies = [
  "libp2p-identity",
  "mediatype",
  "multiaddr",
- "pretty_reqwest_error 0.1.0 (git+https://github.com/sigp/lighthouse?branch=anchor)",
+ "pretty_reqwest_error",
  "proto_array",
  "reqwest 0.11.27",
  "reqwest-eventsource",
- "sensitive_url 0.1.0 (git+https://github.com/sigp/lighthouse?branch=anchor)",
+ "sensitive_url",
  "serde",
  "serde_json",
  "slashing_protection",
  "ssz_types",
- "types 0.2.1 (git+https://github.com/sigp/lighthouse?branch=anchor)",
+ "types",
  "zeroize",
 ]
 
 [[package]]
 name = "eth2_config"
 version = "0.2.0"
-source = "git+https://github.com/sigp/lighthouse?branch=unstable#06e4d22d4954807ddc755feaea7518ad2ce06f35"
+source = "git+https://github.com/sigp/lighthouse?branch=anchor#997991f5513f22bb240816c2e2400cf6a1819a0c"
 dependencies = [
  "paste",
- "types 0.2.1 (git+https://github.com/sigp/lighthouse?branch=unstable)",
+ "types",
 ]
 
 [[package]]
@@ -2474,33 +2400,7 @@ name = "eth2_interop_keypairs"
 version = "0.2.0"
 source = "git+https://github.com/sigp/lighthouse?branch=anchor#997991f5513f22bb240816c2e2400cf6a1819a0c"
 dependencies = [
- "bls 0.2.0 (git+https://github.com/sigp/lighthouse?branch=anchor)",
- "ethereum_hashing",
- "hex",
- "num-bigint",
- "serde",
- "serde_yaml",
-]
-
-[[package]]
-name = "eth2_interop_keypairs"
-version = "0.2.0"
-source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
-dependencies = [
- "bls 0.2.0 (git+https://github.com/agemanning/lighthouse?branch=modularize-vc)",
- "ethereum_hashing",
- "hex",
- "num-bigint",
- "serde",
- "serde_yaml",
-]
-
-[[package]]
-name = "eth2_interop_keypairs"
-version = "0.2.0"
-source = "git+https://github.com/sigp/lighthouse?branch=unstable#06e4d22d4954807ddc755feaea7518ad2ce06f35"
-dependencies = [
- "bls 0.2.0 (git+https://github.com/sigp/lighthouse?branch=unstable)",
+ "bls",
  "ethereum_hashing",
  "hex",
  "num-bigint",
@@ -2513,7 +2413,7 @@ name = "eth2_key_derivation"
 version = "0.1.0"
 source = "git+https://github.com/sigp/lighthouse?branch=anchor#997991f5513f22bb240816c2e2400cf6a1819a0c"
 dependencies = [
- "bls 0.2.0 (git+https://github.com/sigp/lighthouse?branch=anchor)",
+ "bls",
  "num-bigint-dig",
  "ring 0.16.20",
  "sha2 0.9.9",
@@ -2526,7 +2426,7 @@ version = "0.1.0"
 source = "git+https://github.com/sigp/lighthouse?branch=anchor#997991f5513f22bb240816c2e2400cf6a1819a0c"
 dependencies = [
  "aes 0.7.5",
- "bls 0.2.0 (git+https://github.com/sigp/lighthouse?branch=anchor)",
+ "bls",
  "eth2_key_derivation",
  "hex",
  "hmac 0.11.0",
@@ -2545,20 +2445,20 @@ dependencies = [
 [[package]]
 name = "eth2_network_config"
 version = "0.2.0"
-source = "git+https://github.com/sigp/lighthouse?branch=unstable#06e4d22d4954807ddc755feaea7518ad2ce06f35"
+source = "git+https://github.com/sigp/lighthouse?branch=anchor#997991f5513f22bb240816c2e2400cf6a1819a0c"
 dependencies = [
  "bytes",
  "discv5",
  "eth2_config",
- "kzg 0.1.0 (git+https://github.com/sigp/lighthouse?branch=unstable)",
+ "kzg",
  "logging",
- "pretty_reqwest_error 0.1.0 (git+https://github.com/sigp/lighthouse?branch=unstable)",
+ "pretty_reqwest_error",
  "reqwest 0.11.27",
- "sensitive_url 0.1.0 (git+https://github.com/sigp/lighthouse?branch=unstable)",
+ "sensitive_url",
  "serde_yaml",
  "sha2 0.9.9",
  "slog",
- "types 0.2.1 (git+https://github.com/sigp/lighthouse?branch=unstable)",
+ "types",
  "url",
  "zip",
 ]
@@ -2752,25 +2652,7 @@ version = "0.1.0"
 source = "git+https://github.com/sigp/lighthouse?branch=anchor#997991f5513f22bb240816c2e2400cf6a1819a0c"
 dependencies = [
  "alloy-primitives",
- "safe_arith 0.1.0 (git+https://github.com/sigp/lighthouse?branch=anchor)",
-]
-
-[[package]]
-name = "fixed_bytes"
-version = "0.1.0"
-source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
-dependencies = [
- "alloy-primitives",
- "safe_arith 0.1.0 (git+https://github.com/agemanning/lighthouse?branch=modularize-vc)",
-]
-
-[[package]]
-name = "fixed_bytes"
-version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?branch=unstable#06e4d22d4954807ddc755feaea7518ad2ce06f35"
-dependencies = [
- "alloy-primitives",
- "safe_arith 0.1.0 (git+https://github.com/sigp/lighthouse?branch=unstable)",
+ "safe_arith",
 ]
 
 [[package]]
@@ -3038,7 +2920,7 @@ checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 [[package]]
 name = "gossipsub"
 version = "0.5.0"
-source = "git+https://github.com/sigp/lighthouse?branch=unstable#06e4d22d4954807ddc755feaea7518ad2ce06f35"
+source = "git+https://github.com/sigp/lighthouse?branch=anchor#997991f5513f22bb240816c2e2400cf6a1819a0c"
 dependencies = [
  "async-channel",
  "asynchronous-codec",
@@ -3167,7 +3049,7 @@ version = "0.1.0"
 source = "git+https://github.com/sigp/lighthouse?branch=anchor#997991f5513f22bb240816c2e2400cf6a1819a0c"
 dependencies = [
  "eth2",
- "metrics 0.2.0 (git+https://github.com/sigp/lighthouse?branch=anchor)",
+ "metrics",
  "procfs",
  "psutil",
 ]
@@ -3391,7 +3273,7 @@ version = "0.1.0"
 dependencies = [
  "axum",
  "health_metrics",
- "metrics 0.2.0 (git+https://github.com/agemanning/lighthouse?branch=modularize-vc)",
+ "metrics",
  "parking_lot",
  "serde",
  "tokio",
@@ -3815,22 +3697,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "int_to_bytes"
-version = "0.2.0"
-source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
-dependencies = [
- "bytes",
-]
-
-[[package]]
-name = "int_to_bytes"
-version = "0.2.0"
-source = "git+https://github.com/sigp/lighthouse?branch=unstable#06e4d22d4954807ddc755feaea7518ad2ce06f35"
-dependencies = [
- "bytes",
-]
-
-[[package]]
 name = "io-lifetimes"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3956,44 +3822,6 @@ dependencies = [
 name = "kzg"
 version = "0.1.0"
 source = "git+https://github.com/sigp/lighthouse?branch=anchor#997991f5513f22bb240816c2e2400cf6a1819a0c"
-dependencies = [
- "arbitrary",
- "c-kzg",
- "derivative",
- "ethereum_hashing",
- "ethereum_serde_utils",
- "ethereum_ssz",
- "ethereum_ssz_derive",
- "hex",
- "rust_eth_kzg",
- "serde",
- "serde_json",
- "tree_hash",
-]
-
-[[package]]
-name = "kzg"
-version = "0.1.0"
-source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
-dependencies = [
- "arbitrary",
- "c-kzg",
- "derivative",
- "ethereum_hashing",
- "ethereum_serde_utils",
- "ethereum_ssz",
- "ethereum_ssz_derive",
- "hex",
- "rust_eth_kzg",
- "serde",
- "serde_json",
- "tree_hash",
-]
-
-[[package]]
-name = "kzg"
-version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?branch=unstable#06e4d22d4954807ddc755feaea7518ad2ce06f35"
 dependencies = [
  "arbitrary",
  "c-kzg",
@@ -4549,7 +4377,7 @@ dependencies = [
 [[package]]
 name = "lighthouse_network"
 version = "0.2.0"
-source = "git+https://github.com/sigp/lighthouse?branch=unstable#06e4d22d4954807ddc755feaea7518ad2ce06f35"
+source = "git+https://github.com/sigp/lighthouse?branch=anchor#997991f5513f22bb240816c2e2400cf6a1819a0c"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -4559,6 +4387,7 @@ dependencies = [
  "dirs 3.0.2",
  "discv5",
  "either",
+ "eth2",
  "ethereum_ssz",
  "ethereum_ssz_derive",
  "fnv",
@@ -4571,7 +4400,7 @@ dependencies = [
  "lighthouse_version",
  "lru",
  "lru_cache",
- "metrics 0.2.0 (git+https://github.com/sigp/lighthouse?branch=unstable)",
+ "metrics",
  "parking_lot",
  "prometheus-client",
  "rand",
@@ -4589,7 +4418,7 @@ dependencies = [
  "tokio",
  "tokio-io-timeout",
  "tokio-util",
- "types 0.2.1 (git+https://github.com/sigp/lighthouse?branch=unstable)",
+ "types",
  "unsigned-varint 0.8.0",
  "unused_port",
  "void",
@@ -4598,7 +4427,7 @@ dependencies = [
 [[package]]
 name = "lighthouse_version"
 version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?branch=unstable#06e4d22d4954807ddc755feaea7518ad2ce06f35"
+source = "git+https://github.com/sigp/lighthouse?branch=anchor#997991f5513f22bb240816c2e2400cf6a1819a0c"
 dependencies = [
  "git-version",
  "target_info",
@@ -4647,10 +4476,10 @@ checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 [[package]]
 name = "logging"
 version = "0.2.0"
-source = "git+https://github.com/sigp/lighthouse?branch=unstable#06e4d22d4954807ddc755feaea7518ad2ce06f35"
+source = "git+https://github.com/sigp/lighthouse?branch=anchor#997991f5513f22bb240816c2e2400cf6a1819a0c"
 dependencies = [
  "chrono",
- "metrics 0.2.0 (git+https://github.com/sigp/lighthouse?branch=unstable)",
+ "metrics",
  "parking_lot",
  "serde",
  "serde_json",
@@ -4687,7 +4516,7 @@ dependencies = [
 [[package]]
 name = "lru_cache"
 version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?branch=unstable#06e4d22d4954807ddc755feaea7518ad2ce06f35"
+source = "git+https://github.com/sigp/lighthouse?branch=anchor#997991f5513f22bb240816c2e2400cf6a1819a0c"
 dependencies = [
  "fnv",
 ]
@@ -4756,30 +4585,8 @@ source = "git+https://github.com/sigp/lighthouse?branch=anchor#997991f5513f22bb2
 dependencies = [
  "alloy-primitives",
  "ethereum_hashing",
- "fixed_bytes 0.1.0 (git+https://github.com/sigp/lighthouse?branch=anchor)",
- "safe_arith 0.1.0 (git+https://github.com/sigp/lighthouse?branch=anchor)",
-]
-
-[[package]]
-name = "merkle_proof"
-version = "0.2.0"
-source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
-dependencies = [
- "alloy-primitives",
- "ethereum_hashing",
- "fixed_bytes 0.1.0 (git+https://github.com/agemanning/lighthouse?branch=modularize-vc)",
- "safe_arith 0.1.0 (git+https://github.com/agemanning/lighthouse?branch=modularize-vc)",
-]
-
-[[package]]
-name = "merkle_proof"
-version = "0.2.0"
-source = "git+https://github.com/sigp/lighthouse?branch=unstable#06e4d22d4954807ddc755feaea7518ad2ce06f35"
-dependencies = [
- "alloy-primitives",
- "ethereum_hashing",
- "fixed_bytes 0.1.0 (git+https://github.com/sigp/lighthouse?branch=unstable)",
- "safe_arith 0.1.0 (git+https://github.com/sigp/lighthouse?branch=unstable)",
+ "fixed_bytes",
+ "safe_arith",
 ]
 
 [[package]]
@@ -4809,22 +4616,6 @@ dependencies = [
 name = "metrics"
 version = "0.2.0"
 source = "git+https://github.com/sigp/lighthouse?branch=anchor#997991f5513f22bb240816c2e2400cf6a1819a0c"
-dependencies = [
- "prometheus",
-]
-
-[[package]]
-name = "metrics"
-version = "0.2.0"
-source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
-dependencies = [
- "prometheus",
-]
-
-[[package]]
-name = "metrics"
-version = "0.2.0"
-source = "git+https://github.com/sigp/lighthouse?branch=unstable#06e4d22d4954807ddc755feaea7518ad2ce06f35"
 dependencies = [
  "prometheus",
 ]
@@ -5040,7 +4831,7 @@ dependencies = [
  "task_executor",
  "tokio",
  "tracing",
- "types 0.2.1 (git+https://github.com/sigp/lighthouse?branch=unstable)",
+ "types",
  "version",
 ]
 
@@ -5555,16 +5346,7 @@ version = "0.1.0"
 source = "git+https://github.com/sigp/lighthouse?branch=anchor#997991f5513f22bb240816c2e2400cf6a1819a0c"
 dependencies = [
  "reqwest 0.11.27",
- "sensitive_url 0.1.0 (git+https://github.com/sigp/lighthouse?branch=anchor)",
-]
-
-[[package]]
-name = "pretty_reqwest_error"
-version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?branch=unstable#06e4d22d4954807ddc755feaea7518ad2ce06f35"
-dependencies = [
- "reqwest 0.11.27",
- "sensitive_url 0.1.0 (git+https://github.com/sigp/lighthouse?branch=unstable)",
+ "sensitive_url",
 ]
 
 [[package]]
@@ -5633,7 +5415,7 @@ version = "0.1.0"
 dependencies = [
  "async-channel",
  "futures",
- "metrics 0.2.0 (git+https://github.com/agemanning/lighthouse?branch=modularize-vc)",
+ "metrics",
  "num_cpus",
  "serde",
  "task_executor",
@@ -5732,11 +5514,11 @@ source = "git+https://github.com/sigp/lighthouse?branch=anchor#997991f5513f22bb2
 dependencies = [
  "ethereum_ssz",
  "ethereum_ssz_derive",
- "safe_arith 0.1.0 (git+https://github.com/sigp/lighthouse?branch=anchor)",
+ "safe_arith",
  "serde",
  "serde_yaml",
  "superstruct",
- "types 0.2.1 (git+https://github.com/sigp/lighthouse?branch=anchor)",
+ "types",
 ]
 
 [[package]]
@@ -5785,7 +5567,7 @@ dependencies = [
  "ssv_types",
  "tokio",
  "tracing",
- "types 0.2.1 (git+https://github.com/sigp/lighthouse?branch=unstable)",
+ "types",
 ]
 
 [[package]]
@@ -6488,16 +6270,6 @@ version = "0.1.0"
 source = "git+https://github.com/sigp/lighthouse?branch=anchor#997991f5513f22bb240816c2e2400cf6a1819a0c"
 
 [[package]]
-name = "safe_arith"
-version = "0.1.0"
-source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
-
-[[package]]
-name = "safe_arith"
-version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?branch=unstable#06e4d22d4954807ddc755feaea7518ad2ce06f35"
-
-[[package]]
 name = "salsa20"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6634,24 +6406,6 @@ checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
 name = "sensitive_url"
 version = "0.1.0"
 source = "git+https://github.com/sigp/lighthouse?branch=anchor#997991f5513f22bb240816c2e2400cf6a1819a0c"
-dependencies = [
- "serde",
- "url",
-]
-
-[[package]]
-name = "sensitive_url"
-version = "0.1.0"
-source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
-dependencies = [
- "serde",
- "url",
-]
-
-[[package]]
-name = "sensitive_url"
-version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?branch=unstable#06e4d22d4954807ddc755feaea7518ad2ce06f35"
 dependencies = [
  "serde",
  "url",
@@ -6833,7 +6587,7 @@ dependencies = [
  "ssv_types",
  "tokio",
  "tracing",
- "types 0.2.1 (git+https://github.com/sigp/lighthouse?branch=unstable)",
+ "types",
 ]
 
 [[package]]
@@ -6859,7 +6613,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "types 0.2.1 (git+https://github.com/sigp/lighthouse?branch=anchor)",
+ "types",
 ]
 
 [[package]]
@@ -6967,11 +6721,11 @@ dependencies = [
 [[package]]
 name = "slot_clock"
 version = "0.2.0"
-source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
+source = "git+https://github.com/sigp/lighthouse?branch=anchor#997991f5513f22bb240816c2e2400cf6a1819a0c"
 dependencies = [
- "metrics 0.2.0 (git+https://github.com/agemanning/lighthouse?branch=modularize-vc)",
+ "metrics",
  "parking_lot",
- "types 0.2.1 (git+https://github.com/agemanning/lighthouse?branch=modularize-vc)",
+ "types",
 ]
 
 [[package]]
@@ -7049,7 +6803,7 @@ dependencies = [
  "rusqlite",
  "tree_hash",
  "tree_hash_derive",
- "types 0.2.1 (git+https://github.com/sigp/lighthouse?branch=unstable)",
+ "types",
 ]
 
 [[package]]
@@ -7165,27 +6919,7 @@ source = "git+https://github.com/sigp/lighthouse?branch=anchor#997991f5513f22bb2
 dependencies = [
  "alloy-primitives",
  "ethereum_hashing",
- "fixed_bytes 0.1.0 (git+https://github.com/sigp/lighthouse?branch=anchor)",
-]
-
-[[package]]
-name = "swap_or_not_shuffle"
-version = "0.2.0"
-source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
-dependencies = [
- "alloy-primitives",
- "ethereum_hashing",
- "fixed_bytes 0.1.0 (git+https://github.com/agemanning/lighthouse?branch=modularize-vc)",
-]
-
-[[package]]
-name = "swap_or_not_shuffle"
-version = "0.2.0"
-source = "git+https://github.com/sigp/lighthouse?branch=unstable#06e4d22d4954807ddc755feaea7518ad2ce06f35"
-dependencies = [
- "alloy-primitives",
- "ethereum_hashing",
- "fixed_bytes 0.1.0 (git+https://github.com/sigp/lighthouse?branch=unstable)",
+ "fixed_bytes",
 ]
 
 [[package]]
@@ -7311,12 +7045,12 @@ checksum = "c63f48baada5c52e65a29eef93ab4f8982681b67f9e8d29c7b05abcfec2b9ffe"
 [[package]]
 name = "task_executor"
 version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?branch=unstable#06e4d22d4954807ddc755feaea7518ad2ce06f35"
+source = "git+https://github.com/sigp/lighthouse?branch=anchor#997991f5513f22bb240816c2e2400cf6a1819a0c"
 dependencies = [
  "async-channel",
  "futures",
  "logging",
- "metrics 0.2.0 (git+https://github.com/sigp/lighthouse?branch=unstable)",
+ "metrics",
  "slog",
  "sloggers",
  "tokio",
@@ -7362,24 +7096,6 @@ dependencies = [
 name = "test_random_derive"
 version = "0.2.0"
 source = "git+https://github.com/sigp/lighthouse?branch=anchor#997991f5513f22bb240816c2e2400cf6a1819a0c"
-dependencies = [
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "test_random_derive"
-version = "0.2.0"
-source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
-dependencies = [
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "test_random_derive"
-version = "0.2.0"
-source = "git+https://github.com/sigp/lighthouse?branch=unstable#06e4d22d4954807ddc755feaea7518ad2ce06f35"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -7845,23 +7561,23 @@ dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "arbitrary",
- "bls 0.2.0 (git+https://github.com/sigp/lighthouse?branch=anchor)",
- "compare_fields 0.2.0 (git+https://github.com/sigp/lighthouse?branch=anchor)",
- "compare_fields_derive 0.2.0 (git+https://github.com/sigp/lighthouse?branch=anchor)",
+ "bls",
+ "compare_fields",
+ "compare_fields_derive",
  "derivative",
- "eth2_interop_keypairs 0.2.0 (git+https://github.com/sigp/lighthouse?branch=anchor)",
+ "eth2_interop_keypairs",
  "ethereum_hashing",
  "ethereum_serde_utils",
  "ethereum_ssz",
  "ethereum_ssz_derive",
- "fixed_bytes 0.1.0 (git+https://github.com/sigp/lighthouse?branch=anchor)",
+ "fixed_bytes",
  "hex",
- "int_to_bytes 0.2.0 (git+https://github.com/sigp/lighthouse?branch=anchor)",
+ "int_to_bytes",
  "itertools 0.10.5",
- "kzg 0.1.0 (git+https://github.com/sigp/lighthouse?branch=anchor)",
+ "kzg",
  "log",
  "maplit",
- "merkle_proof 0.2.0 (git+https://github.com/sigp/lighthouse?branch=anchor)",
+ "merkle_proof",
  "metastruct",
  "milhouse",
  "parking_lot",
@@ -7871,7 +7587,7 @@ dependencies = [
  "regex",
  "rpds",
  "rusqlite",
- "safe_arith 0.1.0 (git+https://github.com/sigp/lighthouse?branch=anchor)",
+ "safe_arith",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -7879,107 +7595,9 @@ dependencies = [
  "smallvec",
  "ssz_types",
  "superstruct",
- "swap_or_not_shuffle 0.2.0 (git+https://github.com/sigp/lighthouse?branch=anchor)",
+ "swap_or_not_shuffle",
  "tempfile",
- "test_random_derive 0.2.0 (git+https://github.com/sigp/lighthouse?branch=anchor)",
- "tree_hash",
- "tree_hash_derive",
-]
-
-[[package]]
-name = "types"
-version = "0.2.1"
-source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
-dependencies = [
- "alloy-primitives",
- "alloy-rlp",
- "arbitrary",
- "bls 0.2.0 (git+https://github.com/agemanning/lighthouse?branch=modularize-vc)",
- "compare_fields 0.2.0 (git+https://github.com/agemanning/lighthouse?branch=modularize-vc)",
- "compare_fields_derive 0.2.0 (git+https://github.com/agemanning/lighthouse?branch=modularize-vc)",
- "derivative",
- "eth2_interop_keypairs 0.2.0 (git+https://github.com/agemanning/lighthouse?branch=modularize-vc)",
- "ethereum_hashing",
- "ethereum_serde_utils",
- "ethereum_ssz",
- "ethereum_ssz_derive",
- "fixed_bytes 0.1.0 (git+https://github.com/agemanning/lighthouse?branch=modularize-vc)",
- "hex",
- "int_to_bytes 0.2.0 (git+https://github.com/agemanning/lighthouse?branch=modularize-vc)",
- "itertools 0.10.5",
- "kzg 0.1.0 (git+https://github.com/agemanning/lighthouse?branch=modularize-vc)",
- "log",
- "maplit",
- "merkle_proof 0.2.0 (git+https://github.com/agemanning/lighthouse?branch=modularize-vc)",
- "metastruct",
- "milhouse",
- "parking_lot",
- "rand",
- "rand_xorshift",
- "rayon",
- "regex",
- "rpds",
- "rusqlite",
- "safe_arith 0.1.0 (git+https://github.com/agemanning/lighthouse?branch=modularize-vc)",
- "serde",
- "serde_json",
- "serde_yaml",
- "slog",
- "smallvec",
- "ssz_types",
- "superstruct",
- "swap_or_not_shuffle 0.2.0 (git+https://github.com/agemanning/lighthouse?branch=modularize-vc)",
- "tempfile",
- "test_random_derive 0.2.0 (git+https://github.com/agemanning/lighthouse?branch=modularize-vc)",
- "tree_hash",
- "tree_hash_derive",
-]
-
-[[package]]
-name = "types"
-version = "0.2.1"
-source = "git+https://github.com/sigp/lighthouse?branch=unstable#06e4d22d4954807ddc755feaea7518ad2ce06f35"
-dependencies = [
- "alloy-primitives",
- "alloy-rlp",
- "arbitrary",
- "bls 0.2.0 (git+https://github.com/sigp/lighthouse?branch=unstable)",
- "compare_fields 0.2.0 (git+https://github.com/sigp/lighthouse?branch=unstable)",
- "compare_fields_derive 0.2.0 (git+https://github.com/sigp/lighthouse?branch=unstable)",
- "derivative",
- "eth2_interop_keypairs 0.2.0 (git+https://github.com/sigp/lighthouse?branch=unstable)",
- "ethereum_hashing",
- "ethereum_serde_utils",
- "ethereum_ssz",
- "ethereum_ssz_derive",
- "fixed_bytes 0.1.0 (git+https://github.com/sigp/lighthouse?branch=unstable)",
- "hex",
- "int_to_bytes 0.2.0 (git+https://github.com/sigp/lighthouse?branch=unstable)",
- "itertools 0.10.5",
- "kzg 0.1.0 (git+https://github.com/sigp/lighthouse?branch=unstable)",
- "log",
- "maplit",
- "merkle_proof 0.2.0 (git+https://github.com/sigp/lighthouse?branch=unstable)",
- "metastruct",
- "milhouse",
- "parking_lot",
- "rand",
- "rand_xorshift",
- "rayon",
- "regex",
- "rpds",
- "rusqlite",
- "safe_arith 0.1.0 (git+https://github.com/sigp/lighthouse?branch=unstable)",
- "serde",
- "serde_json",
- "serde_yaml",
- "slog",
- "smallvec",
- "ssz_types",
- "superstruct",
- "swap_or_not_shuffle 0.2.0 (git+https://github.com/sigp/lighthouse?branch=unstable)",
- "tempfile",
- "test_random_derive 0.2.0 (git+https://github.com/sigp/lighthouse?branch=unstable)",
+ "test_random_derive",
  "tree_hash",
  "tree_hash_derive",
 ]
@@ -8101,7 +7719,7 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 [[package]]
 name = "unused_port"
 version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?branch=unstable#06e4d22d4954807ddc755feaea7518ad2ce06f35"
+source = "git+https://github.com/sigp/lighthouse?branch=anchor#997991f5513f22bb240816c2e2400cf6a1819a0c"
 dependencies = [
  "lru_cache",
  "parking_lot",
@@ -8155,9 +7773,9 @@ dependencies = [
 [[package]]
 name = "validator_metrics"
 version = "0.1.0"
-source = "git+https://github.com/agemanning/lighthouse?branch=modularize-vc#75a58586623f84f0fd4b0a5c1de43edfc8010a78"
+source = "git+https://github.com/sigp/lighthouse?branch=anchor#997991f5513f22bb240816c2e2400cf6a1819a0c"
 dependencies = [
- "metrics 0.2.0 (git+https://github.com/agemanning/lighthouse?branch=modularize-vc)",
+ "metrics",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,47 +1,61 @@
 [workspace]
 # Extra tooling projects will be added.
 members = [
-  "anchor",
-  "anchor/client",
-  "anchor/common/qbft",
-  "anchor/common/ssv_types",
-  "anchor/common/version",
-  "anchor/database",
-  "anchor/eth",
-  "anchor/http_api",
-  "anchor/http_metrics",
-  "anchor/network",
-  "anchor/processor",
+    "anchor",
+    "anchor/client",
+    "anchor/common/qbft",
+    "anchor/common/ssv_types",
+    "anchor/common/version",
+    "anchor/database",
+    "anchor/eth",
+    "anchor/http_api",
+    "anchor/http_metrics",
+    "anchor/network",
+    "anchor/processor",
     "anchor/qbft_manager",
-  "anchor/signature_collector",
+    "anchor/signature_collector",
 ]
 resolver = "2"
 
 [workspace.package]
 edition = "2021"
 
-# NOTE: The block below is currently not sorted by `cargo sort`. Please keep sorted manually, especially during merges!
+# This table has three subsections: first the internal dependencies, then the lighthouse dependencies, then all other.
 [workspace.dependencies]
 client = { path = "anchor/client" }
+database = { path = "anchor/database" }
 eth = { path = "anchor/eth" }
-qbft = { path = "anchor/common/qbft" }
 http_api = { path = "anchor/http_api" }
 http_metrics = { path = "anchor/http_metrics" }
-database = { path = "anchor/database" }
 network = { path = "anchor/network" }
-version = { path = "anchor/common/version" }
 processor = { path = "anchor/processor" }
+qbft = { path = "anchor/common/qbft" }
+qbft_manager = { path = "anchor/common/qbft" }
 ssv_types = { path = "anchor/common/ssv_types" }
-lighthouse_network = { git = "https://github.com/sigp/lighthouse", branch = "unstable" }
-task_executor = { git = "https://github.com/sigp/lighthouse", branch = "unstable", default-features = false, features = [
-  "tracing",
+version = { path = "anchor/common/version" }
+
+health_metrics = { git = "https://github.com/sigp/lighthouse", branch = "anchor" }
+lighthouse_network = { git = "https://github.com/sigp/lighthouse", branch = "anchor" }
+metrics = { git = "https://github.com/sigp/lighthouse", branch = "anchor" }
+sensitive_url = { git = "https://github.com/sigp/lighthouse", branch = "anchor" }
+slot_clock = { git = "https://github.com/sigp/lighthouse", branch = "anchor" }
+task_executor = { git = "https://github.com/sigp/lighthouse", branch = "anchor", default-features = false, features = [
+    "tracing",
 ] }
-metrics = { git = "https://github.com/agemanning/lighthouse", branch = "modularize-vc" }
-validator_metrics = { git = "https://github.com/agemanning/lighthouse", branch = "modularize-vc" }
-sensitive_url = { git = "https://github.com/agemanning/lighthouse", branch = "modularize-vc" }
-slot_clock = { git = "https://github.com/agemanning/lighthouse", branch = "modularize-vc" }
-unused_port = { git = "https://github.com/sigp/lighthouse", branch = "unstable" }
-types = { git = "https://github.com/sigp/lighthouse", branch = "unstable" }
+types = { git = "https://github.com/sigp/lighthouse", branch = "anchor" }
+unused_port = { git = "https://github.com/sigp/lighthouse", branch = "anchor" }
+validator_metrics = { git = "https://github.com/sigp/lighthouse", branch = "anchor" }
+
+alloy = { version = "0.6.4", features = [
+    "sol-types",
+    "transports",
+    "json",
+    "contract",
+    "pubsub",
+    "provider-ws",
+    "rpc-types",
+    "rlp",
+] }
 async-channel = "1.9"
 axum = "0.7.7"
 base64 = "0.22.1"
@@ -52,43 +66,32 @@ dirs = "5.0.1"
 discv5 = "0.9.0"
 either = "1.13.0"
 futures = "0.3.30"
-health_metrics = { git = "https://github.com/sigp/lighthouse", branch = "anchor" }
+hex = "0.4.3"
 hyper = "1.4"
 indexmap = "2.7.0"
 num_cpus = "1"
 openssl = "0.10.68"
 parking_lot = "0.12"
-qbft_manager = { path = "anchor/common/qbft" }
+reqwest = "0.12.12"
 rusqlite = "0.28.0"
 serde = { version = "1.0.208", features = ["derive"] }
 strum = { version = "0.24", features = ["derive"] }
 tokio = { version = "1.39.2", features = [
-  "rt",
-  "rt-multi-thread",
-  "time",
-  "signal",
-  "macros",
+    "rt",
+    "rt-multi-thread",
+    "time",
+    "signal",
+    "macros",
 ] }
 tower-http = { version = "0.6", features = ["cors"] }
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["fmt", "env-filter"] }
 tree_hash = "0.8"
 tree_hash_derive = "0.8"
-hex = "0.4.3"
-alloy = { version = "0.6.4", features = [
-  "sol-types",
-  "transports",
-  "json",
-  "contract",
-  "pubsub",
-  "provider-ws",
-  "rpc-types",
-  "rlp",
-] }
-reqwest = "0.12.12"
 
 [profile.maxperf]
 inherits = "release"
-lto = "fat"
+
 codegen-units = 1
 incremental = false
+lto = "fat"

--- a/Makefile
+++ b/Makefile
@@ -150,3 +150,9 @@ udeps:
 # Performs a `cargo` clean
 clean:
 	cargo clean
+
+# Check if dependencies are sorted (requires cargo-sort and taplo-cli)
+sort:
+	cargo sort --check --workspace
+	# separate check for root Cargo toml to check workspace dependencies
+	taplo fmt -o reorder_keys=true -o "indent_string=    " Cargo.toml --diff --check


### PR DESCRIPTION
## Issue Addressed

- #88

## Proposed Changes

As a workaround, use Taplo to check during CI whether the dependencies are sorted. 

## Additional Info

Taplo allows empty lines for different sorted subsections, so I categorized the dependencies: Anchor internal, Lighthouse dependencies, other dependencies

Yes, this is annoying, but it ensures easy and clean merges once we are all on the same page.
