### PR TITLE
Remove `ssv_types` dependency on `qbft`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5619,6 +5619,7 @@ version = "0.1.0"
 dependencies = [
  "derive_more 1.0.0",
  "indexmap",
+ "ssv_types",
  "tracing",
  "tracing-subscriber",
 ]
@@ -6866,7 +6867,6 @@ dependencies = [
  "base64 0.22.1",
  "derive_more 1.0.0",
  "openssl",
- "qbft",
  "rusqlite",
  "tree_hash",
  "tree_hash_derive",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,9 +171,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-core"
-version = "0.8.18"
+version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0713007d14d88a6edb8e248cddab783b698dbb954a28b8eee4bab21cfb7e578"
+checksum = "648275bb59110f88cc5fa9a176845e52a554ebfebac2d21220bcda8c9220f797"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-json-abi",
@@ -184,9 +184,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-dyn-abi"
-version = "0.8.18"
+version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44e3b98c37b3218924cd1d2a8570666b89662be54e5b182643855f783ea68b33"
+checksum = "bc9138f4f0912793642d453523c3116bd5d9e11de73b70177aa7cb3e94b98ad2"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -253,9 +253,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-abi"
-version = "0.8.18"
+version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "731ea743b3d843bc657e120fb1d1e9cc94f5dab8107e35a82125a63e6420a102"
+checksum = "24acd2f5ba97c7a320e67217274bc81fe3c3174b8e6144ec875d9d54e760e278"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-type-parser",
@@ -315,9 +315,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-primitives"
-version = "0.8.18"
+version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "788bb18e8f61d5d9340b52143f27771daf7e1dccbaf2741621d2493f9debf52e"
+checksum = "ec878088ec6283ce1e90d280316aadd3d6ce3de06ff63d68953c855e7e447e92"
 dependencies = [
  "alloy-rlp",
  "arbitrary",
@@ -507,9 +507,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro"
-version = "0.8.18"
+version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a07b74d48661ab2e4b50bb5950d74dbff5e61dd8ed03bb822281b706d54ebacb"
+checksum = "8d039d267aa5cbb7732fa6ce1fd9b5e9e29368f580f80ba9d7a8450c794de4b2"
 dependencies = [
  "alloy-sol-macro-expander",
  "alloy-sol-macro-input",
@@ -521,9 +521,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro-expander"
-version = "0.8.18"
+version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19cc9c7f20b90f9be1a8f71a3d8e283a43745137b0837b1a1cb13159d37cad72"
+checksum = "620ae5eee30ee7216a38027dec34e0585c55099f827f92f50d11e3d2d3a4a954"
 dependencies = [
  "alloy-json-abi",
  "alloy-sol-macro-input",
@@ -540,9 +540,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro-input"
-version = "0.8.18"
+version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "713b7e6dfe1cb2f55c80fb05fd22ed085a1b4e48217611365ed0ae598a74c6ac"
+checksum = "ad9f7d057e00f8c5994e4ff4492b76532c51ead39353aa2ed63f8c50c0f4d52e"
 dependencies = [
  "alloy-json-abi",
  "const-hex",
@@ -557,9 +557,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-type-parser"
-version = "0.8.18"
+version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1eda2711ab2e1fb517fc6e2ffa9728c9a232e296d16810810e6957b781a1b8bc"
+checksum = "74e60b084fe1aef8acecda2743ff2d93c18ff3eb67a2d3b12f62582a1e66ef5e"
 dependencies = [
  "serde",
  "winnow",
@@ -567,9 +567,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-types"
-version = "0.8.18"
+version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3b478bc9c0c4737a04cd976accde4df7eba0bdc0d90ad6ff43d58bc93cf79c1"
+checksum = "c1382302752cd751efd275f4d6ef65877ddf61e0e6f5ac84ef4302b79a33a31a"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -1068,9 +1068,9 @@ dependencies = [
 
 [[package]]
 name = "auto_impl"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c87f3f15e7794432337fc718554eaa4dc8f04c9677a950ffe366f20a162ae42"
+checksum = "e12882f59de5360c748c4cbf569a042d5fb0eb515f7bea9c1f470b47f6ffbd73"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1236,9 +1236,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.7.0"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1be3f42a67d6d345ecd59f675f3f012d6974981560836e938c22b424b85ce1be"
+checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
 
 [[package]]
 name = "bitvec"
@@ -1973,15 +1973,15 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.6.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8566979429cf69b49a5c740c60791108e86440e8be149bbea4fe54d2c32d6e2"
+checksum = "0e60eed09d8c01d3cee5b7d30acb059b76614c918fa0f992e0dd6eeb10daad6f"
 
 [[package]]
 name = "data-encoding-macro"
-version = "0.1.15"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1559b6cba622276d6d63706db152618eeb15b89b3e4041446b05876e352e639"
+checksum = "5b16d9d0d88a5273d830dac8b78ceb217ffc9b1d5404e5597a3542515329405b"
 dependencies = [
  "data-encoding",
  "data-encoding-macro-internal",
@@ -1989,12 +1989,12 @@ dependencies = [
 
 [[package]]
 name = "data-encoding-macro-internal"
-version = "0.1.13"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "332d754c0af53bc87c108fed664d121ecf59207ec4196041f04d6ab9002ad33f"
+checksum = "1145d32e826a7748b69ee8fc62d3e6355ff7f1051df53141e7048162fc90481b"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -4378,7 +4378,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
- "bitflags 2.7.0",
+ "bitflags 2.8.0",
  "libc",
 ]
 
@@ -4536,9 +4536,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.22"
+version = "0.4.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
+checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
 
 [[package]]
 name = "logging"
@@ -5080,7 +5080,7 @@ version = "0.10.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6174bc48f102d208783c2c84bf931bb75927a617866870de8a4ea85597f871f5"
 dependencies = [
- "bitflags 2.7.0",
+ "bitflags 2.8.0",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -5551,7 +5551,7 @@ checksum = "b4c2511913b88df1637da85cc8d96ec8e43a3f8bb8ccb71ee1ac240d6f3df58d"
 dependencies = [
  "bit-set",
  "bit-vec",
- "bitflags 2.7.0",
+ "bitflags 2.8.0",
  "lazy_static",
  "num-traits",
  "rand",
@@ -5833,7 +5833,7 @@ version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03a862b389f93e68874fbf580b9de08dd02facb9a788ebadaf4a3fd33cf58834"
 dependencies = [
- "bitflags 2.7.0",
+ "bitflags 2.8.0",
 ]
 
 [[package]]
@@ -6216,7 +6216,7 @@ version = "0.38.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a78891ee6bf2340288408954ac787aa063d8e8817e9f53abb37c695c6d834ef6"
 dependencies = [
- "bitflags 2.7.0",
+ "bitflags 2.8.0",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -6423,7 +6423,7 @@ version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags 2.7.0",
+ "bitflags 2.8.0",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -7013,9 +7013,9 @@ dependencies = [
 
 [[package]]
 name = "syn-solidity"
-version = "0.8.18"
+version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31e89d8bf2768d277f40573c83a02a099e96d96dd3104e13ea676194e61ac4b0"
+checksum = "b84e4d83a0a6704561302b917a932484e1cae2d8c6354c64be8b7bac1c1fe057"
 dependencies = [
  "paste",
  "proc-macro2",
@@ -7066,7 +7066,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
 dependencies = [
- "bitflags 2.7.0",
+ "bitflags 2.8.0",
  "core-foundation",
  "system-configuration-sys 0.6.0",
 ]
@@ -7442,7 +7442,7 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "403fa3b783d4b626a8ad51d766ab03cb6d2dbfc46b1c5d4448395e6628dc9697"
 dependencies = [
- "bitflags 2.7.0",
+ "bitflags 2.8.0",
  "bytes",
  "http 1.2.0",
  "pin-project-lite",

--- a/anchor/common/qbft/Cargo.toml
+++ b/anchor/common/qbft/Cargo.toml
@@ -8,6 +8,7 @@ edition = { workspace = true }
 derive_more = { workspace = true }
 indexmap = { workspace = true }
 tracing = { workspace = true }
+ssv_types = { workspace = true }
 
 [dev-dependencies]
 tracing-subscriber = { workspace = true }

--- a/anchor/common/qbft/Cargo.toml
+++ b/anchor/common/qbft/Cargo.toml
@@ -7,8 +7,8 @@ edition = { workspace = true }
 [dependencies]
 derive_more = { workspace = true }
 indexmap = { workspace = true }
-tracing = { workspace = true }
 ssv_types = { workspace = true }
+tracing = { workspace = true }
 
 [dev-dependencies]
 tracing-subscriber = { workspace = true }

--- a/anchor/common/qbft/src/lib.rs
+++ b/anchor/common/qbft/src/lib.rs
@@ -1,8 +1,5 @@
 pub use config::{Config, ConfigBuilder};
-use std::cmp::Eq;
 use std::collections::{HashMap, HashSet};
-use std::fmt::Debug;
-use std::hash::Hash;
 use tracing::{debug, error, warn};
 pub use validation::{validate_consensus_data, ValidatedData, ValidationError};
 
@@ -11,6 +8,8 @@ pub use types::{
     Completed, ConsensusData, DefaultLeaderFunction, InstanceHeight, InstanceState, LeaderFunction,
     Message, OperatorId, Round,
 };
+
+use ssv_types::message::Data;
 
 mod config;
 mod error;
@@ -21,12 +20,6 @@ mod validation;
 mod tests;
 
 type RoundChangeMap<D> = HashMap<OperatorId, Option<ConsensusData<D>>>;
-
-pub trait Data: Debug + Clone {
-    type Hash: Debug + Clone + Eq + Hash;
-
-    fn hash(&self) -> Self::Hash;
-}
 
 /// The structure that defines the Quorum Based Fault Tolerance (QBFT) instance.
 ///

--- a/anchor/common/ssv_types/Cargo.toml
+++ b/anchor/common/ssv_types/Cargo.toml
@@ -8,7 +8,6 @@ authors = ["Sigma Prime <contact@sigmaprime.io>"]
 base64 = { workspace = true }
 derive_more = { workspace = true }
 openssl = { workspace = true }
-qbft = { workspace = true }
 rusqlite = { workspace = true }
 tree_hash = { workspace = true }
 tree_hash_derive = { workspace = true }

--- a/anchor/common/ssv_types/src/message.rs
+++ b/anchor/common/ssv_types/src/message.rs
@@ -7,10 +7,18 @@ use types::{
     AggregateAndProof, BeaconBlock, BlindedBeaconBlock, Checkpoint, CommitteeIndex, EthSpec,
     Hash256, PublicKeyBytes, Signature, Slot, SyncCommitteeContribution, VariableList,
 };
+use std::fmt::Debug;
+use std::hash::Hash;
 // todo - dear reader, this mainly serves as plain translation of the types found in the go code
 // there are a lot of byte[] there, and that got confusing, below should be more readable.
 // it needs some work to actually serialize to the same stuff on wire, and I feel like we can name
 // the fields better
+//
+pub trait Data: Debug + Clone {
+    type Hash: Debug + Clone + Eq + Hash;
+
+    fn hash(&self) -> Self::Hash;
+}
 
 #[derive(Clone, Debug)]
 pub struct SignedSsvMessage<E: EthSpec> {
@@ -24,7 +32,7 @@ pub struct SignedSsvMessage<E: EthSpec> {
 pub struct SsvMessage<E: EthSpec> {
     pub msg_type: MsgType,
     pub msg_id: MsgId,
-    pub data: Data<E>,
+    pub data: SsvData<E>,
 }
 
 #[derive(Clone, Debug)]
@@ -34,7 +42,7 @@ pub enum MsgType {
 }
 
 #[derive(Clone, Debug)]
-pub enum Data<E: EthSpec> {
+pub enum SsvData<E: EthSpec> {
     QbftMessage(QbftMessage<E>),
     PartialSignatureMessage(PartialSignatureMessage),
 }
@@ -80,7 +88,7 @@ pub struct ValidatorConsensusData<E: EthSpec> {
     pub data_ssz: Box<DataSsz<E>>,
 }
 
-impl<E: EthSpec> qbft::Data for ValidatorConsensusData<E> {
+impl<E: EthSpec> Data for ValidatorConsensusData<E> {
     type Hash = Hash256;
 
     fn hash(&self) -> Self::Hash {
@@ -181,7 +189,7 @@ pub struct BeaconVote {
     pub target: Checkpoint,
 }
 
-impl qbft::Data for BeaconVote {
+impl Data for BeaconVote {
     type Hash = Hash256;
 
     fn hash(&self) -> Self::Hash {

--- a/anchor/common/ssv_types/src/message.rs
+++ b/anchor/common/ssv_types/src/message.rs
@@ -1,5 +1,7 @@
 use crate::msgid::MsgId;
 use crate::{OperatorId, ValidatorIndex};
+use std::fmt::Debug;
+use std::hash::Hash;
 use tree_hash::{PackedEncoding, TreeHash, TreeHashType};
 use tree_hash_derive::TreeHash;
 use types::typenum::U13;
@@ -7,13 +9,11 @@ use types::{
     AggregateAndProof, BeaconBlock, BlindedBeaconBlock, Checkpoint, CommitteeIndex, EthSpec,
     Hash256, PublicKeyBytes, Signature, Slot, SyncCommitteeContribution, VariableList,
 };
-use std::fmt::Debug;
-use std::hash::Hash;
 // todo - dear reader, this mainly serves as plain translation of the types found in the go code
 // there are a lot of byte[] there, and that got confusing, below should be more readable.
 // it needs some work to actually serialize to the same stuff on wire, and I feel like we can name
 // the fields better
-//
+
 pub trait Data: Debug + Clone {
     type Hash: Debug + Clone + Eq + Hash;
 

--- a/anchor/qbft_manager/src/lib.rs
+++ b/anchor/qbft_manager/src/lib.rs
@@ -5,6 +5,7 @@ use qbft::{
     Message as NetworkMessage, OperatorId as QbftOperatorId,
 };
 use slot_clock::SlotClock;
+use ssv_types::message::Data;
 use ssv_types::message::{BeaconVote, ValidatorConsensusData};
 use ssv_types::{Cluster, ClusterId, OperatorId};
 use std::fmt::Debug;
@@ -47,13 +48,13 @@ pub enum ValidatorDutyKind {
 }
 
 #[derive(Debug)]
-pub struct QbftMessage<D: qbft::Data> {
+pub struct QbftMessage<D: Data> {
     pub kind: QbftMessageKind<D>,
     pub drop_on_finish: DropOnFinish,
 }
 
 #[derive(Debug)]
-pub enum QbftMessageKind<D: qbft::Data> {
+pub enum QbftMessageKind<D: Data> {
     Initialize {
         initial: D,
         config: qbft::Config<DefaultLeaderFunction>,
@@ -169,7 +170,7 @@ impl<T: SlotClock, E: EthSpec> QbftManager<T, E> {
 }
 
 pub trait QbftDecidable<T: SlotClock + 'static, E: EthSpec>:
-    qbft::Data<Hash = Hash256> + Send + 'static
+    Data<Hash = Hash256> + Send + 'static
 {
     type Id: Hash + Eq + Send;
 
@@ -220,7 +221,7 @@ impl<T: SlotClock + 'static, E: EthSpec> QbftDecidable<T, E> for BeaconVote {
     }
 }
 
-enum QbftInstance<D: qbft::Data, S: FnMut(NetworkMessage<D>)> {
+enum QbftInstance<D: Data, S: FnMut(NetworkMessage<D>)> {
     Uninitialized {
         // todo: proooobably limit this
         message_buffer: Vec<NetworkMessage<D>>,
@@ -235,7 +236,7 @@ enum QbftInstance<D: qbft::Data, S: FnMut(NetworkMessage<D>)> {
     },
 }
 
-async fn qbft_instance<D: qbft::Data>(mut rx: UnboundedReceiver<QbftMessage<D>>) {
+async fn qbft_instance<D: Data>(mut rx: UnboundedReceiver<QbftMessage<D>>) {
     let mut instance = QbftInstance::Uninitialized {
         message_buffer: Vec::new(),
     };


### PR DESCRIPTION
## Proposed Changes

`ssv_types` was importing the `qbft` crate which prevented us from using those types in qbft as it created a cyclic dependency. Types should ideally not depend on any other internal crates to prevent this from happening, so I moved the `Data` trait into types to keep it contained. 