### PR TITLE
add signature collector cleanup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6651,6 +6651,7 @@ version = "0.1.0"
 dependencies = [
  "dashmap",
  "processor",
+ "slot_clock",
  "ssv_types",
  "tokio",
  "tracing",

--- a/anchor/signature_collector/Cargo.toml
+++ b/anchor/signature_collector/Cargo.toml
@@ -7,6 +7,7 @@ authors = ["Sigma Prime <contact@sigmaprime.io>"]
 [dependencies]
 dashmap = { workspace = true }
 processor = { workspace = true }
+slot_clock = { workspace = true }
 ssv_types = { workspace = true }
 tokio = { workspace = true, features = ["sync"] }
 tracing = { workspace = true }

--- a/anchor/validator_store/src/lib.rs
+++ b/anchor/validator_store/src/lib.rs
@@ -20,6 +20,7 @@ use ssv_types::message::{
 use ssv_types::{Cluster, OperatorId, ValidatorMetadata};
 use std::fmt::Debug;
 use std::sync::Arc;
+use std::time::Duration;
 use tracing::{error, info, warn};
 use types::attestation::Attestation;
 use types::beacon_block::BeaconBlock;
@@ -29,6 +30,7 @@ use types::signed_aggregate_and_proof::SignedAggregateAndProof;
 use types::signed_beacon_block::SignedBeaconBlock;
 use types::signed_contribution_and_proof::SignedContributionAndProof;
 use types::signed_voluntary_exit::SignedVoluntaryExit;
+use types::slot_data::SlotData;
 use types::slot_epoch::{Epoch, Slot};
 use types::sync_committee_contribution::SyncCommitteeContribution;
 use types::sync_committee_message::SyncCommitteeMessage;
@@ -62,10 +64,11 @@ struct InitializedCluster {
 
 pub struct AnchorValidatorStore<T: SlotClock + 'static, E: EthSpec> {
     clusters: DashMap<PublicKeyBytes, InitializedCluster>,
-    signature_collector: Arc<SignatureCollectorManager>,
+    signature_collector: Arc<SignatureCollectorManager<T>>,
     qbft_manager: Arc<QbftManager<T, E>>,
     slashing_protection: SlashingDatabase,
     slashing_protection_last_prune: Mutex<Epoch>,
+    slot_clock: T,
     spec: Arc<ChainSpec>,
     genesis_validators_root: Hash256,
     operator_id: OperatorId,
@@ -73,9 +76,10 @@ pub struct AnchorValidatorStore<T: SlotClock + 'static, E: EthSpec> {
 
 impl<T: SlotClock, E: EthSpec> AnchorValidatorStore<T, E> {
     pub fn new(
-        signature_collector: Arc<SignatureCollectorManager>,
+        signature_collector: Arc<SignatureCollectorManager<T>>,
         qbft_manager: Arc<QbftManager<T, E>>,
         slashing_protection: SlashingDatabase,
+        slot_clock: T,
         spec: Arc<ChainSpec>,
         genesis_validators_root: Hash256,
         operator_id: OperatorId,
@@ -86,6 +90,7 @@ impl<T: SlotClock, E: EthSpec> AnchorValidatorStore<T, E> {
             qbft_manager,
             slashing_protection,
             slashing_protection_last_prune: Mutex::new(Epoch::new(0)),
+            slot_clock,
             spec,
             genesis_validators_root,
             operator_id,
@@ -132,6 +137,7 @@ impl<T: SlotClock, E: EthSpec> AnchorValidatorStore<T, E> {
         &self,
         cluster: InitializedCluster,
         signing_root: Hash256,
+        for_slot: Slot,
     ) -> Result<Signature, Error> {
         let collector = self.signature_collector.sign_and_collect(
             SignatureRequest {
@@ -143,6 +149,7 @@ impl<T: SlotClock, E: EthSpec> AnchorValidatorStore<T, E> {
                     .safe_mul(2)
                     .and_then(|x| x.safe_add(1))
                     .map_err(SpecificError::from)?,
+                slot: for_slot,
             },
             self.operator_id,
             cluster.decrypted_key_share,
@@ -237,7 +244,7 @@ impl<T: SlotClock, E: EthSpec> AnchorValidatorStore<T, E> {
 
         let signing_root = block.signing_root(domain_hash);
         let signature = self
-            .collect_signature(self.cluster(validator_pubkey)?, signing_root)
+            .collect_signature(self.cluster(validator_pubkey)?, signing_root, block.slot())
             .await?;
         Ok(SignedBeaconBlock::from_block(block, signature))
     }
@@ -272,7 +279,7 @@ impl<T: SlotClock, E: EthSpec> AnchorValidatorStore<T, E> {
 
         let domain = self.get_domain(epoch, Domain::SyncCommittee);
         let signing_root = data.block_root.signing_root(domain);
-        let signature = self.collect_signature(cluster, signing_root).await?;
+        let signature = self.collect_signature(cluster, signing_root, slot).await?;
 
         Ok(SyncCommitteeMessage {
             slot,
@@ -354,13 +361,14 @@ impl<T: SlotClock, E: EthSpec> AnchorValidatorStore<T, E> {
             .map(|contribution| {
                 let cluster = cluster.clone();
                 async move {
+                    let slot = contribution.contribution.slot;
                     let message = ContributionAndProof {
                         aggregator_index,
                         contribution: contribution.contribution,
                         selection_proof: contribution.selection_proof_sig,
                     };
                     let signing_root = message.signing_root(domain_hash);
-                    self.collect_signature(cluster, signing_root)
+                    self.collect_signature(cluster, signing_root, slot)
                         .await
                         .map(|signature| SignedContributionAndProof { message, signature })
                 }
@@ -500,8 +508,12 @@ impl<T: SlotClock, E: EthSpec> ValidatorStore for AnchorValidatorStore<T, E> {
     ) -> Result<Signature, Error> {
         let domain_hash = self.get_domain(signing_epoch, Domain::Randao);
         let signing_root = signing_epoch.signing_root(domain_hash);
-        self.collect_signature(self.cluster(validator_pubkey)?, signing_root)
-            .await
+        self.collect_signature(
+            self.cluster(validator_pubkey)?,
+            signing_root,
+            signing_epoch.end_slot(E::slots_per_epoch()),
+        )
+        .await
     }
 
     fn set_validator_index(&self, validator_pubkey: &PublicKeyBytes, index: u64) {
@@ -620,7 +632,9 @@ impl<T: SlotClock, E: EthSpec> ValidatorStore for AnchorValidatorStore<T, E> {
         )?;
 
         let signing_root = attestation.data().signing_root(domain_hash);
-        let signature = self.collect_signature(cluster, signing_root).await?;
+        let signature = self
+            .collect_signature(cluster, signing_root, attestation.data().slot)
+            .await?;
         attestation
             .add_signature(&signature, validator_committee_position)
             .map_err(Error::UnableToSignAttestation)?;
@@ -639,15 +653,28 @@ impl<T: SlotClock, E: EthSpec> ValidatorStore for AnchorValidatorStore<T, E> {
 
     async fn sign_validator_registration_data(
         &self,
-        validator_registration_data: ValidatorRegistrationData,
+        mut validator_registration_data: ValidatorRegistrationData,
     ) -> Result<SignedValidatorRegistrationData, Error> {
         let domain_hash = self.spec.get_builder_domain();
         let signing_root = validator_registration_data.signing_root(domain_hash);
+
+        // SSV always uses the start of the current epoch, so we need to convert to that
+        let epoch = self
+            .slot_clock
+            .slot_of(Duration::from_secs(validator_registration_data.timestamp))
+            .unwrap_or(self.spec.genesis_slot)
+            .epoch(E::slots_per_epoch());
+        let sign_slot = epoch.start_slot(E::slots_per_epoch());
+        let validity_slot = epoch.end_slot(E::slots_per_epoch());
+        if let Some(duration) = self.slot_clock.start_of(sign_slot) {
+            validator_registration_data.timestamp = duration.as_secs();
+        }
 
         let signature = self
             .collect_signature(
                 self.cluster(validator_registration_data.pubkey)?,
                 signing_root,
+                validity_slot,
             )
             .await?;
 
@@ -710,7 +737,9 @@ impl<T: SlotClock, E: EthSpec> ValidatorStore for AnchorValidatorStore<T, E> {
 
         let domain_hash = self.get_domain(signing_epoch, Domain::AggregateAndProof);
         let signing_root = message.signing_root(domain_hash);
-        let signature = self.collect_signature(cluster, signing_root).await?;
+        let signature = self
+            .collect_signature(cluster, signing_root, message.aggregate().get_slot())
+            .await?;
 
         Ok(SignedAggregateAndProof::from_aggregate_and_proof(
             message, signature,
@@ -726,7 +755,7 @@ impl<T: SlotClock, E: EthSpec> ValidatorStore for AnchorValidatorStore<T, E> {
         let domain_hash = self.get_domain(epoch, Domain::SelectionProof);
         let signing_root = slot.signing_root(domain_hash);
 
-        self.collect_signature(self.cluster(validator_pubkey)?, signing_root)
+        self.collect_signature(self.cluster(validator_pubkey)?, signing_root, slot)
             .await
             .map(SelectionProof::from)
     }
@@ -745,7 +774,7 @@ impl<T: SlotClock, E: EthSpec> ValidatorStore for AnchorValidatorStore<T, E> {
         }
         .signing_root(domain_hash);
 
-        self.collect_signature(self.cluster(*validator_pubkey)?, signing_root)
+        self.collect_signature(self.cluster(*validator_pubkey)?, signing_root, slot)
             .await
             .map(SyncSelectionProof::from)
     }


### PR DESCRIPTION
## Issue Addressed

Signature Collector never cleans up, causing a memory leak.

## Proposed Changes

Introduce an expiry slot to the `SignatureRequest`. The signature collector removes all requests older than this expiry slot, plus a safety margin (which is 1 slot for now, we'll see if that is sufficient)

## Additional Info

The design of this is very similar to how clean up is done in the QBFT manager.

Along the way, I noticed that the `sign_validator_registration_data` logic is incorrect, as LH passes the current timestamp, but in SSV we need the epoch timestamp, so I fixed that as well.
