### PR TITLE
Add basic peer manager

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2232,7 +2232,7 @@ dependencies = [
  "multiaddr",
  "parking_lot",
  "rand",
- "smallvec",
+ "smallvec 1.13.2",
  "socket2",
  "tokio",
  "tracing",
@@ -2591,7 +2591,7 @@ checksum = "1e999563461faea0ab9bc0024e5e66adcee35881f3d5062f52f31a4070fe1522"
 dependencies = [
  "alloy-primitives",
  "itertools 0.13.0",
- "smallvec",
+ "smallvec 1.13.2",
 ]
 
 [[package]]
@@ -2605,7 +2605,7 @@ dependencies = [
  "itertools 0.13.0",
  "serde",
  "serde_derive",
- "smallvec",
+ "smallvec 1.13.2",
  "typenum",
 ]
 
@@ -3267,7 +3267,7 @@ dependencies = [
  "parking_lot",
  "rand",
  "resolv-conf",
- "smallvec",
+ "smallvec 1.13.2",
  "thiserror 1.0.69",
  "tokio",
  "tracing",
@@ -3468,7 +3468,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "smallvec",
+ "smallvec 1.13.2",
  "tokio",
  "want",
 ]
@@ -3631,7 +3631,7 @@ dependencies = [
  "icu_normalizer_data",
  "icu_properties",
  "icu_provider",
- "smallvec",
+ "smallvec 1.13.2",
  "utf16_iter",
  "utf8_iter",
  "write16",
@@ -3706,7 +3706,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e"
 dependencies = [
  "idna_adapter",
- "smallvec",
+ "smallvec 1.13.2",
  "utf8_iter",
 ]
 
@@ -4112,7 +4112,7 @@ dependencies = [
  "quick-protobuf",
  "rand",
  "rw-stream-sink",
- "smallvec",
+ "smallvec 1.13.2",
  "thiserror 1.0.69",
  "tracing",
  "unsigned-varint 0.8.0",
@@ -4132,7 +4132,7 @@ dependencies = [
  "libp2p-core",
  "libp2p-identity",
  "parking_lot",
- "smallvec",
+ "smallvec 1.13.2",
  "tracing",
 ]
 
@@ -4161,7 +4161,7 @@ dependencies = [
  "rand",
  "regex",
  "sha2 0.10.8",
- "smallvec",
+ "smallvec 1.13.2",
  "tracing",
  "void",
  "web-time",
@@ -4184,7 +4184,7 @@ dependencies = [
  "lru",
  "quick-protobuf",
  "quick-protobuf-codec",
- "smallvec",
+ "smallvec 1.13.2",
  "thiserror 1.0.69",
  "tracing",
  "void",
@@ -4226,7 +4226,7 @@ dependencies = [
  "libp2p-identity",
  "libp2p-swarm",
  "rand",
- "smallvec",
+ "smallvec 1.13.2",
  "socket2",
  "tokio",
  "tracing",
@@ -4265,7 +4265,7 @@ dependencies = [
  "nohash-hasher",
  "parking_lot",
  "rand",
- "smallvec",
+ "smallvec 1.13.2",
  "tracing",
  "unsigned-varint 0.8.0",
 ]
@@ -4371,7 +4371,7 @@ dependencies = [
  "multistream-select",
  "once_cell",
  "rand",
- "smallvec",
+ "smallvec 1.13.2",
  "tokio",
  "tracing",
  "void",
@@ -4560,7 +4560,7 @@ dependencies = [
  "serde",
  "sha2 0.9.9",
  "slog",
- "smallvec",
+ "smallvec 1.13.2",
  "snap",
  "ssz_types 0.8.0",
  "strum 0.24.1",
@@ -4760,7 +4760,7 @@ dependencies = [
  "itertools 0.10.5",
  "proc-macro2",
  "quote",
- "smallvec",
+ "smallvec 1.13.2",
  "syn 1.0.109",
 ]
 
@@ -4788,7 +4788,7 @@ dependencies = [
  "parking_lot",
  "rayon",
  "serde",
- "smallvec",
+ "smallvec 1.13.2",
  "tree_hash 0.8.0",
  "triomphe",
  "typenum",
@@ -4883,7 +4883,7 @@ dependencies = [
  "futures",
  "log",
  "pin-project",
- "smallvec",
+ "smallvec 1.13.2",
  "unsigned-varint 0.7.2",
 ]
 
@@ -4972,7 +4972,9 @@ dependencies = [
 name = "network"
 version = "0.1.0"
 dependencies = [
+ "arbitrary",
  "async-channel",
+ "delay_map",
  "dirs 5.0.1",
  "discv5",
  "ethereum_serde_utils 1.0.0-beta.0",
@@ -4980,10 +4982,14 @@ dependencies = [
  "ethereum_ssz_derive 0.8.2",
  "futures",
  "hex",
+ "itertools 0.10.5",
  "libp2p",
  "lighthouse_network",
+ "parking_lot",
  "serde",
+ "smallvec 2.0.0-alpha.10",
  "ssz_types 0.10.0",
+ "strum 0.24.1",
  "task_executor",
  "tokio",
  "tracing",
@@ -5063,7 +5069,7 @@ dependencies = [
  "num-traits",
  "rand",
  "serde",
- "smallvec",
+ "smallvec 1.13.2",
  "zeroize",
 ]
 
@@ -5301,7 +5307,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
- "smallvec",
+ "smallvec 1.13.2",
  "windows-targets 0.52.6",
 ]
 
@@ -6225,7 +6231,7 @@ dependencies = [
  "fallible-streaming-iterator",
  "hashlink 0.8.4",
  "libsqlite3-sys",
- "smallvec",
+ "smallvec 1.13.2",
 ]
 
 [[package]]
@@ -6898,6 +6904,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "smallvec"
+version = "2.0.0-alpha.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d44cfb396c3caf6fbfd0ab422af02631b69ddd96d2eff0b0f0724f9024051b"
+
+[[package]]
 name = "snap"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6978,7 +6990,7 @@ dependencies = [
  "itertools 0.13.0",
  "serde",
  "serde_derive",
- "smallvec",
+ "smallvec 1.13.2",
  "tree_hash 0.8.0",
  "typenum",
 ]
@@ -6994,7 +7006,7 @@ dependencies = [
  "itertools 0.13.0",
  "serde",
  "serde_derive",
- "smallvec",
+ "smallvec 1.13.2",
  "tree_hash 0.9.0",
  "typenum",
 ]
@@ -7083,7 +7095,7 @@ dependencies = [
  "itertools 0.10.5",
  "proc-macro2",
  "quote",
- "smallvec",
+ "smallvec 1.13.2",
  "syn 1.0.109",
 ]
 
@@ -7637,7 +7649,7 @@ dependencies = [
  "once_cell",
  "regex",
  "sharded-slab",
- "smallvec",
+ "smallvec 1.13.2",
  "thread_local",
  "tracing",
  "tracing-core",
@@ -7671,7 +7683,7 @@ checksum = "373495c23db675a5192de8b610395e1bec324d596f9e6111192ce903dc11403a"
 dependencies = [
  "alloy-primitives",
  "ethereum_hashing",
- "smallvec",
+ "smallvec 1.13.2",
 ]
 
 [[package]]
@@ -7683,7 +7695,7 @@ dependencies = [
  "alloy-primitives",
  "ethereum_hashing",
  "ethereum_ssz 0.8.2",
- "smallvec",
+ "smallvec 1.13.2",
  "typenum",
 ]
 
@@ -7780,7 +7792,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "slog",
- "smallvec",
+ "smallvec 1.13.2",
  "ssz_types 0.8.0",
  "superstruct",
  "swap_or_not_shuffle",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2242,7 +2242,7 @@ dependencies = [
  "multiaddr",
  "parking_lot",
  "rand",
- "smallvec 1.13.2",
+ "smallvec",
  "socket2",
  "tokio",
  "tracing",
@@ -2601,7 +2601,7 @@ checksum = "1e999563461faea0ab9bc0024e5e66adcee35881f3d5062f52f31a4070fe1522"
 dependencies = [
  "alloy-primitives",
  "itertools 0.13.0",
- "smallvec 1.13.2",
+ "smallvec",
 ]
 
 [[package]]
@@ -2615,7 +2615,7 @@ dependencies = [
  "itertools 0.13.0",
  "serde",
  "serde_derive",
- "smallvec 1.13.2",
+ "smallvec",
  "typenum",
 ]
 
@@ -3277,7 +3277,7 @@ dependencies = [
  "parking_lot",
  "rand",
  "resolv-conf",
- "smallvec 1.13.2",
+ "smallvec",
  "thiserror 1.0.69",
  "tokio",
  "tracing",
@@ -3478,7 +3478,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "smallvec 1.13.2",
+ "smallvec",
  "tokio",
  "want",
 ]
@@ -3641,7 +3641,7 @@ dependencies = [
  "icu_normalizer_data",
  "icu_properties",
  "icu_provider",
- "smallvec 1.13.2",
+ "smallvec",
  "utf16_iter",
  "utf8_iter",
  "write16",
@@ -3716,7 +3716,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e"
 dependencies = [
  "idna_adapter",
- "smallvec 1.13.2",
+ "smallvec",
  "utf8_iter",
 ]
 
@@ -4122,7 +4122,7 @@ dependencies = [
  "quick-protobuf",
  "rand",
  "rw-stream-sink",
- "smallvec 1.13.2",
+ "smallvec",
  "thiserror 1.0.69",
  "tracing",
  "unsigned-varint 0.8.0",
@@ -4142,7 +4142,7 @@ dependencies = [
  "libp2p-core",
  "libp2p-identity",
  "parking_lot",
- "smallvec 1.13.2",
+ "smallvec",
  "tracing",
 ]
 
@@ -4171,7 +4171,7 @@ dependencies = [
  "rand",
  "regex",
  "sha2 0.10.8",
- "smallvec 1.13.2",
+ "smallvec",
  "tracing",
  "void",
  "web-time",
@@ -4194,7 +4194,7 @@ dependencies = [
  "lru",
  "quick-protobuf",
  "quick-protobuf-codec",
- "smallvec 1.13.2",
+ "smallvec",
  "thiserror 1.0.69",
  "tracing",
  "void",
@@ -4236,7 +4236,7 @@ dependencies = [
  "libp2p-identity",
  "libp2p-swarm",
  "rand",
- "smallvec 1.13.2",
+ "smallvec",
  "socket2",
  "tokio",
  "tracing",
@@ -4275,7 +4275,7 @@ dependencies = [
  "nohash-hasher",
  "parking_lot",
  "rand",
- "smallvec 1.13.2",
+ "smallvec",
  "tracing",
  "unsigned-varint 0.8.0",
 ]
@@ -4381,7 +4381,7 @@ dependencies = [
  "multistream-select",
  "once_cell",
  "rand",
- "smallvec 1.13.2",
+ "smallvec",
  "tokio",
  "tracing",
  "void",
@@ -4570,7 +4570,7 @@ dependencies = [
  "serde",
  "sha2 0.9.9",
  "slog",
- "smallvec 1.13.2",
+ "smallvec",
  "snap",
  "ssz_types 0.8.0",
  "strum 0.24.1",
@@ -4770,7 +4770,7 @@ dependencies = [
  "itertools 0.10.5",
  "proc-macro2",
  "quote",
- "smallvec 1.13.2",
+ "smallvec",
  "syn 1.0.109",
 ]
 
@@ -4798,7 +4798,7 @@ dependencies = [
  "parking_lot",
  "rayon",
  "serde",
- "smallvec 1.13.2",
+ "smallvec",
  "tree_hash 0.8.0",
  "triomphe",
  "typenum",
@@ -4893,7 +4893,7 @@ dependencies = [
  "futures",
  "log",
  "pin-project",
- "smallvec 1.13.2",
+ "smallvec",
  "unsigned-varint 0.7.2",
 ]
 
@@ -4997,7 +4997,7 @@ dependencies = [
  "lighthouse_network",
  "parking_lot",
  "serde",
- "smallvec 2.0.0-alpha.10",
+ "smallvec",
  "ssz_types 0.10.0",
  "strum 0.24.1",
  "task_executor",
@@ -5079,7 +5079,7 @@ dependencies = [
  "num-traits",
  "rand",
  "serde",
- "smallvec 1.13.2",
+ "smallvec",
  "zeroize",
 ]
 
@@ -5317,7 +5317,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
- "smallvec 1.13.2",
+ "smallvec",
  "windows-targets 0.52.6",
 ]
 
@@ -6241,7 +6241,7 @@ dependencies = [
  "fallible-streaming-iterator",
  "hashlink 0.8.4",
  "libsqlite3-sys",
- "smallvec 1.13.2",
+ "smallvec",
 ]
 
 [[package]]
@@ -6914,12 +6914,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "smallvec"
-version = "2.0.0-alpha.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d44cfb396c3caf6fbfd0ab422af02631b69ddd96d2eff0b0f0724f9024051b"
-
-[[package]]
 name = "snap"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7000,7 +6994,7 @@ dependencies = [
  "itertools 0.13.0",
  "serde",
  "serde_derive",
- "smallvec 1.13.2",
+ "smallvec",
  "tree_hash 0.8.0",
  "typenum",
 ]
@@ -7016,7 +7010,7 @@ dependencies = [
  "itertools 0.13.0",
  "serde",
  "serde_derive",
- "smallvec 1.13.2",
+ "smallvec",
  "tree_hash 0.9.0",
  "typenum",
 ]
@@ -7105,7 +7099,7 @@ dependencies = [
  "itertools 0.10.5",
  "proc-macro2",
  "quote",
- "smallvec 1.13.2",
+ "smallvec",
  "syn 1.0.109",
 ]
 
@@ -7659,7 +7653,7 @@ dependencies = [
  "once_cell",
  "regex",
  "sharded-slab",
- "smallvec 1.13.2",
+ "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
@@ -7693,7 +7687,7 @@ checksum = "373495c23db675a5192de8b610395e1bec324d596f9e6111192ce903dc11403a"
 dependencies = [
  "alloy-primitives",
  "ethereum_hashing",
- "smallvec 1.13.2",
+ "smallvec",
 ]
 
 [[package]]
@@ -7705,7 +7699,7 @@ dependencies = [
  "alloy-primitives",
  "ethereum_hashing",
  "ethereum_ssz 0.8.2",
- "smallvec 1.13.2",
+ "smallvec",
  "typenum",
 ]
 
@@ -7802,7 +7796,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "slog",
- "smallvec 1.13.2",
+ "smallvec",
  "ssz_types 0.8.0",
  "superstruct",
  "swap_or_not_shuffle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,6 +85,7 @@ parking_lot = "0.12"
 reqwest = "0.12.12"
 rusqlite = "0.28.0"
 serde = { version = "1.0.208", features = ["derive"] }
+smallvec = "2.0.0-alpha.9"
 strum = { version = "0.24", features = ["derive"] }
 tokio = { version = "1.39.2", features = [
     "rt",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,7 +86,7 @@ parking_lot = "0.12"
 reqwest = "0.12.12"
 rusqlite = "0.28.0"
 serde = { version = "1.0.208", features = ["derive"] }
-smallvec = "2.0.0-alpha.9"
+smallvec = "1.13.2"
 strum = { version = "0.24", features = ["derive"] }
 tokio = { version = "1.39.2", features = [
     "rt",

--- a/anchor/network/Cargo.toml
+++ b/anchor/network/Cargo.toml
@@ -5,6 +5,8 @@ edition = { workspace = true }
 authors = ["Sigma Prime <contact@sigmaprime.io>"]
 
 [dependencies]
+arbitrary = "1.4.1"
+delay_map = "0.4"
 dirs = { workspace = true }
 discv5 = { workspace = true }
 ethereum_serde_utils = "1.0.0-beta.0"
@@ -25,13 +27,17 @@ libp2p = { version = "0.54", default-features = false, features = [
   "ping",
 ] }
 lighthouse_network = { workspace = true }
+parking_lot = { workspace = true }
 serde = { workspace = true }
+smallvec = { workspace = true }
 ssz_types = "0.10"
 task_executor = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
 types = { workspace = true }
 version = { workspace = true }
+itertools = "0.10.5"
+strum = "0.24.1"
 
 [dev-dependencies]
 async-channel = { workspace = true }

--- a/anchor/network/Cargo.toml
+++ b/anchor/network/Cargo.toml
@@ -14,6 +14,7 @@ ethereum_ssz = "0.8.1"
 ethereum_ssz_derive = "0.8.1"
 futures = { workspace = true }
 hex = "0.4.3"
+itertools = "0.10.5"
 libp2p = { version = "0.54", default-features = false, features = [
   "identify",
   "yamux",
@@ -31,13 +32,12 @@ parking_lot = { workspace = true }
 serde = { workspace = true }
 smallvec = { workspace = true }
 ssz_types = "0.10"
+strum = "0.24.1"
 task_executor = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
 types = { workspace = true }
 version = { workspace = true }
-itertools = "0.10.5"
-strum = "0.24.1"
 
 [dev-dependencies]
 async-channel = { workspace = true }

--- a/anchor/network/src/behaviour.rs
+++ b/anchor/network/src/behaviour.rs
@@ -1,4 +1,5 @@
 use crate::discovery::Discovery;
+use crate::peer_manager::PeerManager;
 use libp2p::swarm::NetworkBehaviour;
 use libp2p::{gossipsub, identify, ping};
 
@@ -12,4 +13,6 @@ pub struct AnchorBehaviour {
     pub gossipsub: gossipsub::Behaviour,
     /// Discv5 Discovery protocol.
     pub discovery: Discovery,
+    /// The peer manager that keeps track of peer's reputation and status.
+    pub peer_manager: PeerManager,
 }

--- a/anchor/network/src/discovery.rs
+++ b/anchor/network/src/discovery.rs
@@ -3,6 +3,7 @@ use std::future::Future;
 use std::net::Ipv4Addr;
 use std::ops::Deref;
 use std::pin::Pin;
+use std::sync::Arc;
 use std::task::{Context, Poll};
 use std::time::Instant;
 
@@ -23,9 +24,9 @@ use libp2p::swarm::{
 };
 use lighthouse_network::discovery::enr_ext::{QUIC6_ENR_KEY, QUIC_ENR_KEY};
 use lighthouse_network::discovery::DiscoveredPeers;
-use lighthouse_network::CombinedKeyExt;
+use lighthouse_network::{CombinedKeyExt, SubnetDiscovery};
 use tokio::sync::mpsc;
-use tracing::{debug, error, warn};
+use tracing::{debug, error, trace, warn};
 
 use crate::Config;
 use lighthouse_network::EnrExt;

--- a/anchor/network/src/discovery.rs
+++ b/anchor/network/src/discovery.rs
@@ -3,7 +3,6 @@ use std::future::Future;
 use std::net::Ipv4Addr;
 use std::ops::Deref;
 use std::pin::Pin;
-use std::sync::Arc;
 use std::task::{Context, Poll};
 use std::time::Instant;
 
@@ -24,9 +23,9 @@ use libp2p::swarm::{
 };
 use lighthouse_network::discovery::enr_ext::{QUIC6_ENR_KEY, QUIC_ENR_KEY};
 use lighthouse_network::discovery::DiscoveredPeers;
-use lighthouse_network::{CombinedKeyExt, SubnetDiscovery};
+use lighthouse_network::{CombinedKeyExt};
 use tokio::sync::mpsc;
-use tracing::{debug, error, trace, warn};
+use tracing::{debug, error, warn};
 
 use crate::Config;
 use lighthouse_network::EnrExt;

--- a/anchor/network/src/discovery.rs
+++ b/anchor/network/src/discovery.rs
@@ -23,7 +23,7 @@ use libp2p::swarm::{
 };
 use lighthouse_network::discovery::enr_ext::{QUIC6_ENR_KEY, QUIC_ENR_KEY};
 use lighthouse_network::discovery::DiscoveredPeers;
-use lighthouse_network::{CombinedKeyExt};
+use lighthouse_network::CombinedKeyExt;
 use tokio::sync::mpsc;
 use tracing::{debug, error, warn};
 

--- a/anchor/network/src/lib.rs
+++ b/anchor/network/src/lib.rs
@@ -5,6 +5,7 @@ mod config;
 mod discovery;
 mod keypair_utils;
 mod network;
+mod peer_manager;
 mod transport;
 pub mod types;
 

--- a/anchor/network/src/network.rs
+++ b/anchor/network/src/network.rs
@@ -13,18 +13,17 @@ use libp2p::{futures, gossipsub, identify, ping, PeerId, Swarm, SwarmBuilder};
 use lighthouse_network::discovery::DiscoveredPeers;
 use lighthouse_network::discv5::enr::k256::sha2::{Digest, Sha256};
 use task_executor::TaskExecutor;
-use tracing::{debug, error, info, trace, warn};
+use tracing::{debug, error, info, warn};
 
 use crate::behaviour::AnchorBehaviour;
 use crate::behaviour::AnchorBehaviourEvent;
 use crate::discovery::{Discovery, FIND_NODE_QUERY_CLOSEST_PEERS};
 use crate::keypair_utils::load_private_key;
 use crate::transport::build_transport;
-use crate::{peer_manager, Config};
+use crate::Config;
 
 use crate::peer_manager::{PeerManager, PeerManagerEvent};
 use crate::types::ssv_message::SignedSSVMessage;
-use lighthouse_network::EnrExt;
 use ssz::Decode;
 
 pub struct Network {
@@ -136,7 +135,7 @@ impl Network {
                             // The peer manager will subsequently decide which peers need to be dialed and then dial
                             // them.
                             AnchorBehaviourEvent::Discovery(DiscoveredPeers { peers }) => {
-                                let mut peer_manager = &mut self.swarm.behaviour_mut().peer_manager;
+                                let peer_manager = &mut self.swarm.behaviour_mut().peer_manager;
                                 peer_manager.peers_discovered(peers.clone());
                                 debug!(peers =  ?peers, "Peers discovered");
                             }

--- a/anchor/network/src/peer_manager/mod.rs
+++ b/anchor/network/src/peer_manager/mod.rs
@@ -1,0 +1,500 @@
+mod peerdb;
+
+use crate::peer_manager::peerdb::PeerDB;
+use delay_map::HashSetDelay;
+use discv5::libp2p_identity::PeerId;
+use discv5::multiaddr::Multiaddr;
+use discv5::Enr;
+use futures::StreamExt;
+use libp2p::core::transport::PortUse;
+use libp2p::core::Endpoint;
+use libp2p::swarm::dial_opts::{DialOpts, PeerCondition};
+use libp2p::swarm::dummy::ConnectionHandler;
+use libp2p::swarm::{
+    ConnectionDenied, ConnectionId, FromSwarm, NetworkBehaviour, THandler, THandlerInEvent,
+    THandlerOutEvent, ToSwarm,
+};
+use lighthouse_network::peer_manager::config::Config;
+use lighthouse_network::rpc::GoodbyeReason;
+use lighthouse_network::{metrics, EnrExt, SubnetDiscovery};
+use parking_lot::RwLock;
+use smallvec::SmallVec;
+use std::collections::HashMap;
+use std::net::IpAddr;
+use std::task::{Context, Poll};
+use std::time::{Duration, Instant};
+use tracing::{debug, error};
+
+/// The heartbeat performs regular updates such as updating reputations and performing discovery
+/// requests. This defines the interval in seconds.
+const HEARTBEAT_INTERVAL: u64 = 30;
+
+/// A fraction of `PeerManager::target_peers_count` that we allow to connect to us in excess of
+/// `PeerManager::target_peers_count`. For clarity, if `PeerManager::target_peers_count` is 50 and
+/// PEER_EXCESS_FACTOR = 0.1 we allow 10% more nodes, i.e 55.
+pub const PEER_EXCESS_FACTOR: f32 = 0.1;
+
+/// A fraction of `PeerManager::target_peers` that we want to be outbound-only connections.
+pub const TARGET_OUTBOUND_ONLY_FACTOR: f32 = 0.3;
+
+/// A fraction of `PeerManager::target_peers` that if we get below, we start a discovery query to
+/// reach our target. MIN_OUTBOUND_ONLY_FACTOR must be < TARGET_OUTBOUND_ONLY_FACTOR.
+pub const MIN_OUTBOUND_ONLY_FACTOR: f32 = 0.2;
+
+/// The fraction of extra peers beyond the PEER_EXCESS_FACTOR that we allow us to dial for when
+/// requiring subnet peers. More specifically, if our target peer limit is 50, and our excess peer
+/// limit is 55, and we are at 55 peers, the following parameter provisions a few more slots of
+/// dialing priority peers we need for validator duties.
+pub const PRIORITY_PEER_EXCESS: f32 = 0.2;
+
+pub struct PeerManager {
+    /// The target number of peers we would like to connect to.
+    target_peers_count: usize,
+    /// Peers queued to be dialed.
+    peers_to_dial: Vec<Enr>,
+    /// A queue of events that the `PeerManager` is waiting to produce.
+    events: SmallVec<PeerManagerEvent, 16>,
+    /// A collection of inbound-connected peers awaiting to be Ping'd.
+    inbound_ping_peers: HashSetDelay<PeerId>,
+    /// A collection of outbound-connected peers awaiting to be Ping'd.
+    outbound_ping_peers: HashSetDelay<PeerId>,
+    /// A collection of peers awaiting to be Status'd.
+    status_peers: HashSetDelay<PeerId>,
+    /// The collection of known peers.
+    pub peers: RwLock<PeerDB>,
+    /// The heartbeat interval to perform routine maintenance.
+    heartbeat: tokio::time::Interval,
+    /// Keeps track of whether the discovery service is enabled or not.
+    discovery_enabled: bool,
+    /// Keeps track of whether the QUIC protocol is enabled or not.
+    quic_enabled: bool,
+}
+
+/// The events that the `PeerManager` outputs (requests).
+#[derive(Debug)]
+pub enum PeerManagerEvent {
+    /// A peer has dialed us.
+    PeerConnectedIncoming(PeerId),
+    /// A peer has been dialed.
+    PeerConnectedOutgoing(PeerId),
+    /// A peer has disconnected.
+    PeerDisconnected(PeerId),
+    /// Sends a STATUS to a peer.
+    Status(PeerId),
+    /// Sends a PING to a peer.
+    Ping(PeerId),
+    /// Request METADATA from a peer.
+    MetaData(PeerId),
+    /// The peer should be disconnected.
+    DisconnectPeer(PeerId, GoodbyeReason),
+    /// Inform the behaviour to ban this peer and associated ip addresses.
+    Banned(PeerId, Vec<IpAddr>),
+    /// The peer should be unbanned with the associated ip addresses.
+    UnBanned(PeerId, Vec<IpAddr>),
+    /// Request the behaviour to discover more peers and the amount of peers to discover.
+    DiscoverPeers(usize),
+    /// Request the behaviour to discover peers on subnets.
+    DiscoverSubnetPeers(Vec<SubnetDiscovery>),
+}
+
+impl PeerManager {
+    pub fn new(cfg: Config, trusted_peers: Vec<PeerId>, disable_peer_scoring: bool) -> Self {
+        // Set up the peer manager heartbeat interval
+        let heartbeat = tokio::time::interval(tokio::time::Duration::from_secs(HEARTBEAT_INTERVAL));
+        Self {
+            target_peers_count: cfg.target_peer_count,
+            peers_to_dial: Default::default(),
+            events: SmallVec::new(),
+            inbound_ping_peers: HashSetDelay::new(Duration::from_secs(cfg.ping_interval_inbound)),
+            outbound_ping_peers: HashSetDelay::new(Duration::from_secs(cfg.ping_interval_outbound)),
+            status_peers: HashSetDelay::new(Duration::from_secs(cfg.status_interval)),
+            peers: RwLock::new(PeerDB::new(trusted_peers, disable_peer_scoring)),
+            heartbeat,
+            discovery_enabled: cfg.discovery_enabled,
+            quic_enabled: true,
+        }
+    }
+
+    /// The maximum number of peers we allow to connect to us. This is `target_peers` * (1 +
+    /// PEER_EXCESS_FACTOR)
+    fn max_peers(&self) -> usize {
+        (self.target_peers_count as f32 * (1.0 + PEER_EXCESS_FACTOR)).ceil() as usize
+    }
+
+    /// The maximum number of peers we allow when dialing a priority peer (i.e a peer that is
+    /// subscribed to subnets that our validator requires. This is `target_peers` * (1 +
+    /// PEER_EXCESS_FACTOR + PRIORITY_PEER_EXCESS)
+    fn max_priority_peers(&self) -> usize {
+        (self.target_peers_count as f32 * (1.0 + PEER_EXCESS_FACTOR + PRIORITY_PEER_EXCESS)).ceil()
+            as usize
+    }
+
+    /// The minimum number of outbound peers that we reach before we start another discovery query.
+    fn min_outbound_only_peers(&self) -> usize {
+        (self.target_peers_count as f32 * MIN_OUTBOUND_ONLY_FACTOR).ceil() as usize
+    }
+
+    /// The minimum number of outbound peers that we reach before we start another discovery query.
+    fn target_outbound_peers(&self) -> usize {
+        (self.target_peers_count as f32 * TARGET_OUTBOUND_ONLY_FACTOR).ceil() as usize
+    }
+
+    /// The maximum number of peers that are connected or dialing before we refuse to do another
+    /// discovery search for more outbound peers. We can use up to half the priority peer excess allocation.
+    fn max_outbound_dialing_peers(&self) -> usize {
+        (self.target_peers_count as f32 * (1.0 + PEER_EXCESS_FACTOR + PRIORITY_PEER_EXCESS / 2.0))
+            .ceil() as usize
+    }
+
+    /// A peer is being dialed.
+    /// Returns true, if this peer will be dialed.
+    pub fn dial_peer(&mut self, peer: Enr) -> bool {
+        if self.peers.read().should_dial(&peer.peer_id()) {
+            self.peers_to_dial.push(peer);
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Peers that have been returned by discovery requests that are suitable for dialing are
+    /// returned here.
+    ///
+    /// This function decides whether or not to dial these peers.
+    pub fn peers_discovered(&mut self, results: HashMap<Enr, Option<Instant>>) {
+        let mut to_dial_peers = 0;
+        let results_count = results.len();
+        let connected_or_dialing = self.connected_or_dialing_peers();
+        for (enr, min_ttl) in results {
+            // There are two conditions in deciding whether to dial this peer.
+            // 1. If we are less than our max connections. Discovery queries are executed to reach
+            //    our target peers, so its fine to dial up to our max peers (which will get pruned
+            //    in the next heartbeat down to our target).
+            // 2. If the peer is one our validators require for a specific subnet, then it is
+            //    considered a priority. We have pre-allocated some extra priority slots for these
+            //    peers as specified by PRIORITY_PEER_EXCESS. Therefore we dial these peers, even
+            //    if we are already at our max_peer limit.
+            if !self.peers_to_dial.contains(&enr)
+                && (min_ttl.is_some()
+                // TODO && connected_or_dialing + to_dial_peers < self.max_priority_peers())
+                || connected_or_dialing + to_dial_peers < self.max_peers())
+            {
+                // This should be updated with the peer dialing. In fact created once the peer is
+                // dialed
+                let peer_id = enr.peer_id();
+                if let Some(min_ttl) = min_ttl {
+                    self.peers.write().update_min_ttl(&peer_id, min_ttl);
+                }
+                if self.dial_peer(enr) {
+                    debug!(
+                        %peer_id,
+                        "Added discovered ENR peer to dial queue"
+                    );
+                    to_dial_peers += 1;
+                }
+            }
+        }
+
+        // The heartbeat will attempt new discovery queries every N seconds if the node needs more
+        // peers. As an optimization, this function can recursively trigger new discovery queries
+        // immediatelly if we don't fulfill our peers needs after completing a query. This
+        // recursiveness results in an infinite loop in networks where there not enough peers to
+        // reach out target. To prevent the infinite loop, if a query returns no useful peers, we
+        // will cancel the recursiveness and wait for the heartbeat to trigger another query latter.
+        if results_count > 0 && to_dial_peers == 0 {
+            debug!(
+                results = results_count,
+                "Skipping recursive discovery query after finding no useful results"
+            );
+            metrics::inc_counter(&metrics::DISCOVERY_NO_USEFUL_ENRS);
+        } else {
+            // Queue another discovery if we need to
+            self.maintain_peer_count(to_dial_peers);
+        }
+    }
+
+    /// Returns the number of libp2p connected peers with outbound-only connections.
+    pub fn connected_outbound_only_peers(&self) -> usize {
+        self.peers.read().connected_outbound_only_peers().count()
+    }
+
+    /// Returns the number of libp2p peers that are either connected or being dialed.
+    pub fn connected_or_dialing_peers(&self) -> usize {
+        self.peers.read().connected_or_dialing_peers().count()
+    }
+
+    /// This function checks the status of our current peers and optionally requests a discovery
+    /// query if we need to find more peers to maintain the current number of peers
+    fn maintain_peer_count(&mut self, dialing_peers: usize) {
+        // Check if we need to do a discovery lookup
+        if self.discovery_enabled {
+            let peer_count = self.connected_or_dialing_peers();
+            let outbound_only_peer_count = self.connected_outbound_only_peers();
+            let wanted_peers = if peer_count < self.target_peers_count.saturating_sub(dialing_peers)
+            {
+                // We need more peers in general.
+                self.max_peers().saturating_sub(dialing_peers) - peer_count
+            } else if outbound_only_peer_count < self.min_outbound_only_peers()
+                && peer_count < self.max_outbound_dialing_peers()
+            {
+                self.max_outbound_dialing_peers()
+                    .saturating_sub(dialing_peers)
+                    .saturating_sub(peer_count)
+            } else {
+                0
+            };
+
+            if wanted_peers != 0 {
+                // We need more peers, re-queue a discovery lookup.
+                debug!(
+                    connected = peer_count,
+                    target = self.target_peers_count,
+                    outbound = outbound_only_peer_count,
+                    wanted = wanted_peers,
+                    "Starting a new peer discovery query"
+                );
+                self.events
+                    .push(PeerManagerEvent::DiscoverPeers(wanted_peers));
+            }
+        }
+    }
+
+    /// Registers a peer as connected. The `ingoing` parameter determines if the peer is being
+    /// dialed or connecting to us.
+    ///
+    /// This is called by `connect_ingoing` and `connect_outgoing`.
+    ///
+    /// Informs if the peer was accepted in to the db or not.
+    fn inject_peer_connection(
+        &mut self,
+        peer_id: &PeerId,
+        connection: ConnectingType,
+        enr: Option<Enr>,
+    ) -> bool {
+        {
+            let mut peerdb = self.peers.write();
+            if peerdb.ban_status(peer_id).is_some() {
+                // don't connect if the peer is banned
+                error!(
+                    peer_id = %peer_id,
+                    "Connection has been allowed to a banned peer"
+                );
+            }
+
+            match connection {
+                ConnectingType::Dialing => {
+                    peerdb.dialing_peer(peer_id, enr);
+                    return true;
+                }
+                ConnectingType::IngoingConnected { multiaddr } => {
+                    peerdb.connect_ingoing(peer_id, multiaddr, enr);
+                    // start a timer to ping inbound peers.
+                    self.inbound_ping_peers.insert(*peer_id);
+                }
+                ConnectingType::OutgoingConnected { multiaddr } => {
+                    peerdb.connect_outgoing(peer_id, multiaddr, enr);
+                    // start a timer for to ping outbound peers.
+                    self.outbound_ping_peers.insert(*peer_id);
+                }
+            }
+        }
+
+        // start a ping and status timer for the peer
+        self.status_peers.insert(*peer_id);
+
+        true
+    }
+
+    // Reduce memory footprint by routinely shrinking associating mappings.
+    fn shrink_mappings(&mut self) {
+        self.inbound_ping_peers.shrink_to(5);
+        self.outbound_ping_peers.shrink_to(5);
+        self.status_peers.shrink_to(5);
+        //self.temporary_banned_peers.shrink_to_fit();
+    }
+
+    /// The Peer manager's heartbeat maintains the peer count and maintains peer reputations.
+    ///
+    /// It will request discovery queries if the peer count has not reached the desired number of
+    /// overall peers, as well as the desired number of outbound-only peers.
+    ///
+    /// NOTE: Discovery will only add a new query if one isn't already queued.
+    fn heartbeat(&mut self) {
+        // Optionally run a discovery query if we need more peers.
+        self.maintain_peer_count(0);
+
+        // Cleans up the connection state of dialing peers.
+        // Libp2p dials peer-ids, but sometimes the response is from another peer-id or libp2p
+        // returns dial errors without a peer-id attached. This function reverts peers that have a
+        // dialing status long than DIAL_TIMEOUT seconds to a disconnected status. This is important because
+        // we count the number of dialing peers in our inbound connections.
+        self.peers.write().cleanup_dialing_peers();
+
+        // Updates peer's scores and unban any peers if required.
+        //let actions = self.peers.write().update_scores();
+        //for (peer_id, action) in actions {
+        //    self.handle_score_action(&peer_id, action, None);
+        //}
+
+        // Update peer score metrics;
+        //self.update_peer_score_metrics();
+
+        // Prune any excess peers back to our target in such a way that incentivises good scores and
+        // a uniform distribution of subnets.
+        //self.prune_excess_peers();
+
+        // Unban any peers that have served their temporary ban timeout
+        //self.unban_temporary_banned_peers();
+
+        // Maintains memory by shrinking mappings
+        self.shrink_mappings();
+    }
+}
+
+impl NetworkBehaviour for PeerManager {
+    type ConnectionHandler = ConnectionHandler;
+    type ToSwarm = PeerManagerEvent;
+
+    fn handle_established_inbound_connection(
+        &mut self,
+        _connection_id: ConnectionId,
+        peer: PeerId,
+        local_addr: &Multiaddr,
+        remote_addr: &Multiaddr,
+    ) -> Result<THandler<Self>, ConnectionDenied> {
+        // TODO check connection limits
+        Ok(ConnectionHandler)
+    }
+
+    fn handle_established_outbound_connection(
+        &mut self,
+        _connection_id: ConnectionId,
+        peer: PeerId,
+        addr: &Multiaddr,
+        role_override: Endpoint,
+        port_use: PortUse,
+    ) -> Result<THandler<Self>, ConnectionDenied> {
+        // TODO check connection limits
+        Ok(ConnectionHandler)
+    }
+
+    fn on_swarm_event(&mut self, event: FromSwarm) {}
+
+    fn on_connection_handler_event(
+        &mut self,
+        _peer_id: PeerId,
+        _connection_id: ConnectionId,
+        _event: THandlerOutEvent<Self>,
+    ) {
+        todo!()
+    }
+
+    fn poll(
+        &mut self,
+        cx: &mut Context<'_>,
+    ) -> Poll<ToSwarm<Self::ToSwarm, THandlerInEvent<Self>>> {
+        // perform the heartbeat when necessary
+        while self.heartbeat.poll_tick(cx).is_ready() {
+            self.heartbeat();
+        }
+
+        // poll the timeouts for pings and status'
+        loop {
+            match self.inbound_ping_peers.poll_next_unpin(cx) {
+                Poll::Ready(Some(Ok(peer_id))) => {
+                    self.inbound_ping_peers.insert(peer_id);
+                    self.events.push(PeerManagerEvent::Ping(peer_id));
+                }
+                Poll::Ready(Some(Err(e))) => {
+                    error!(
+                        error = e.to_string(),
+                        "Failed to check for inbound peers to ping"
+                    )
+                }
+                Poll::Ready(None) | Poll::Pending => break,
+            }
+        }
+
+        loop {
+            match self.outbound_ping_peers.poll_next_unpin(cx) {
+                Poll::Ready(Some(Ok(peer_id))) => {
+                    self.outbound_ping_peers.insert(peer_id);
+                    self.events.push(PeerManagerEvent::Ping(peer_id));
+                }
+                Poll::Ready(Some(Err(e))) => {
+                    error!(
+                        error = e.to_string(),
+                        "Failed to check for outbound peers to ping"
+                    )
+                }
+                Poll::Ready(None) | Poll::Pending => break,
+            }
+        }
+
+        // if !matches!(
+        //     self.network_globals.sync_state(),
+        //     SyncState::SyncingFinalized { .. } | SyncState::SyncingHead { .. }
+        // ) {
+        //     loop {
+        //         match self.status_peers.poll_next_unpin(cx) {
+        //             Poll::Ready(Some(Ok(peer_id))) => {
+        //                 self.status_peers.insert(peer_id);
+        //                 self.events.push(PeerManagerEvent::Status(peer_id))
+        //             }
+        //             Poll::Ready(Some(Err(e))) => {
+        //                 error!(self.log, "Failed to check for peers to ping"; "error" => e.to_string())
+        //             }
+        //             Poll::Ready(None) | Poll::Pending => break,
+        //         }
+        //     }
+        // }
+
+        if !self.events.is_empty() {
+            return Poll::Ready(ToSwarm::GenerateEvent(self.events.remove(0)));
+        } else {
+            self.events.shrink_to_fit();
+        }
+
+        if let Some(enr) = self.peers_to_dial.pop() {
+            self.inject_peer_connection(&enr.peer_id(), ConnectingType::Dialing, Some(enr.clone()));
+
+            // Prioritize Quic connections over Tcp ones.
+            let multiaddrs = [
+                self.quic_enabled
+                    .then_some(enr.multiaddr_quic())
+                    .unwrap_or_default(),
+                enr.multiaddr_tcp(),
+            ]
+            .concat();
+
+            debug!(
+                peer_id = %enr.peer_id(),
+                multiaddrs = ?multiaddrs,
+                "Dialing peer"
+            );
+            return Poll::Ready(ToSwarm::Dial {
+                opts: DialOpts::peer_id(enr.peer_id())
+                    .condition(PeerCondition::Disconnected)
+                    .addresses(multiaddrs)
+                    .build(),
+            });
+        }
+
+        Poll::Pending
+    }
+}
+
+enum ConnectingType {
+    /// We are in the process of dialing this peer.
+    Dialing,
+    /// A peer has dialed us.
+    IngoingConnected {
+        // The multiaddr the peer connected to us on.
+        multiaddr: Multiaddr,
+    },
+    /// We have successfully dialed a peer.
+    OutgoingConnected {
+        /// The multiaddr we dialed to reach the peer.
+        multiaddr: Multiaddr,
+    },
+}

--- a/anchor/network/src/peer_manager/mod.rs
+++ b/anchor/network/src/peer_manager/mod.rs
@@ -44,7 +44,7 @@ pub struct PeerManager {
     /// Peers queued to be dialed.
     peers_to_dial: Vec<Enr>,
     /// A queue of events that the `PeerManager` is waiting to produce.
-    events: SmallVec<PeerManagerEvent, 16>,
+    events: SmallVec<[PeerManagerEvent; 16]>,
     /// A collection of inbound-connected peers awaiting to be Ping'd.
     inbound_ping_peers: HashSetDelay<PeerId>,
     /// A collection of outbound-connected peers awaiting to be Ping'd.

--- a/anchor/network/src/peer_manager/mod.rs
+++ b/anchor/network/src/peer_manager/mod.rs
@@ -287,10 +287,7 @@ impl PeerManager {
     ///
     /// This is also called when dialing a peer fails.
     fn inject_disconnect(&mut self, peer_id: &PeerId) {
-        let (_ban_operation, purged_peers) = self
-            .peers
-            .write()
-            .inject_disconnect(peer_id);
+        let (_ban_operation, purged_peers) = self.peers.write().inject_disconnect(peer_id);
 
         // if let Some(ban_operation) = ban_operation {
         //     // The peer was awaiting a ban, continue to ban the peer.
@@ -307,7 +304,6 @@ impl PeerManager {
                 .map(|(peer_id, unbanned_ips)| PeerManagerEvent::UnBanned(peer_id, unbanned_ips)),
         );
     }
-
 
     /// Registers a peer as connected. The `ingoing` parameter determines if the peer is being
     /// dialed or connecting to us.

--- a/anchor/network/src/peer_manager/network_behaviour.rs
+++ b/anchor/network/src/peer_manager/network_behaviour.rs
@@ -1,0 +1,333 @@
+use crate::peer_manager::{ConnectingType, PeerManager, PeerManagerEvent};
+use discv5::libp2p_identity::PeerId;
+use discv5::multiaddr::{Multiaddr};
+use futures::StreamExt;
+use libp2p::core::transport::PortUse;
+use libp2p::core::{ConnectedPoint, Endpoint};
+use libp2p::swarm::behaviour::ConnectionEstablished;
+use libp2p::swarm::dial_opts::{DialOpts, PeerCondition};
+use libp2p::swarm::dummy::ConnectionHandler;
+use libp2p::swarm::{
+    ConnectionClosed, ConnectionDenied, ConnectionId, DialFailure, FromSwarm, NetworkBehaviour,
+    THandler, THandlerInEvent, THandlerOutEvent, ToSwarm,
+};
+use lighthouse_network::EnrExt;
+use std::task::{Context, Poll};
+use tracing::{debug, error, trace};
+
+impl NetworkBehaviour for PeerManager {
+    type ConnectionHandler = ConnectionHandler;
+    type ToSwarm = PeerManagerEvent;
+
+    fn handle_established_inbound_connection(
+        &mut self,
+        _connection_id: ConnectionId,
+        peer_id: PeerId,
+        _local_addr: &Multiaddr,
+        remote_addr: &Multiaddr,
+    ) -> Result<THandler<Self>, ConnectionDenied> {
+        trace!(
+            %peer_id,
+            %remote_addr,
+            "Inbound connection"
+        );
+        // We already checked if the peer was banned on `handle_pending_inbound_connection`.
+        // if self.ban_status(&peer_id).is_some() {
+        //     return Err(ConnectionDenied::new(
+        //         "Connection to peer rejected: peer has a bad score",
+        //     ));
+        // }
+
+        // Check the connection limits
+        if self.connected_or_dialing_peers() >= self.max_peers()
+            && self
+            .peers
+            .read()
+            .peer_info(&peer_id)
+            .map_or(true, |peer| !peer.has_future_duty())
+        {
+            return Err(ConnectionDenied::new(
+                "Connection to peer rejected: too many connections",
+            ));
+        }
+
+        // We have an inbound connection, this is indicative of having our libp2p NAT ports open. We
+        // distinguish between ipv4 and ipv6 here:
+        // match remote_addr.iter().next() {
+        //     Some(Protocol::Ip4(_)) => set_gauge_vec(&NAT_OPEN, &["libp2p_ipv4"], 1),
+        //     Some(Protocol::Ip6(_)) => set_gauge_vec(&NAT_OPEN, &["libp2p_ipv6"], 1),
+        //     _ => {}
+        // }
+
+        Ok(ConnectionHandler)
+    }
+
+    fn handle_established_outbound_connection(
+        &mut self,
+        _connection_id: ConnectionId,
+        peer_id: PeerId,
+        addr: &Multiaddr,
+        _role_override: Endpoint,
+        _port_use: PortUse,
+    ) -> Result<THandler<Self>, ConnectionDenied> {
+        trace!(
+            %peer_id,
+            multiaddr = %addr,
+            "Outbound connection");
+        // if let Some(cause) = self.ban_status(&peer_id) {
+        //     error!(
+        //         %peer_id,
+        //         "Connected a banned peer. Rejecting connection"
+        //     );
+        //     return Err(ConnectionDenied::new(cause));
+        // }
+
+        // Check the connection limits
+        if self.connected_peers() >= self.max_outbound_dialing_peers()
+            && self
+            .peers
+            .read()
+            .peer_info(&peer_id)
+            .map_or(true, |peer| !peer.has_future_duty())
+        {
+            return Err(ConnectionDenied::new(
+                "Connection to peer rejected: too many connections",
+            ));
+        }
+
+        Ok(ConnectionHandler)
+    }
+
+    fn on_swarm_event(&mut self, event: FromSwarm) {
+        match event {
+            FromSwarm::ConnectionEstablished(ConnectionEstablished {
+                peer_id,
+                endpoint,
+                other_established,
+                ..
+            }) => self.on_connection_established(peer_id, endpoint, other_established),
+            FromSwarm::ConnectionClosed(ConnectionClosed {
+                peer_id,
+                endpoint,
+
+                remaining_established,
+                ..
+            }) => self.on_connection_closed(peer_id, endpoint, remaining_established),
+            FromSwarm::DialFailure(DialFailure {
+                peer_id,
+                error,
+                connection_id: _,
+            }) => {
+                debug!(
+                    ?peer_id,
+                    %error,// = %ClearDialError(error),
+                    "Failed to dial peer"
+                );
+                self.on_dial_failure(peer_id);
+            }
+            _ => {
+                // NOTE: FromSwarm is a non exhaustive enum so updates should be based on release
+                // notes more than compiler feedback
+                // The rest of the events we ignore since they are handled in their associated
+                // `SwarmEvent`
+            }
+        }
+    }
+
+    fn on_connection_handler_event(
+        &mut self,
+        _peer_id: PeerId,
+        _connection_id: ConnectionId,
+        _event: THandlerOutEvent<Self>,
+    ) {
+        // no events from the dummy handler
+    }
+
+    fn poll(
+        &mut self,
+        cx: &mut Context<'_>,
+    ) -> Poll<ToSwarm<Self::ToSwarm, THandlerInEvent<Self>>> {
+        // perform the heartbeat when necessary
+        while self.heartbeat.poll_tick(cx).is_ready() {
+            self.heartbeat();
+        }
+
+        // poll the timeouts for pings and status'
+        loop {
+            match self.inbound_ping_peers.poll_next_unpin(cx) {
+                Poll::Ready(Some(Ok(peer_id))) => {
+                    self.inbound_ping_peers.insert(peer_id);
+                    self.events.push(PeerManagerEvent::Ping(peer_id));
+                }
+                Poll::Ready(Some(Err(e))) => {
+                    error!(
+                        error = e.to_string(),
+                        "Failed to check for inbound peers to ping"
+                    )
+                }
+                Poll::Ready(None) | Poll::Pending => break,
+            }
+        }
+
+        loop {
+            match self.outbound_ping_peers.poll_next_unpin(cx) {
+                Poll::Ready(Some(Ok(peer_id))) => {
+                    self.outbound_ping_peers.insert(peer_id);
+                    self.events.push(PeerManagerEvent::Ping(peer_id));
+                }
+                Poll::Ready(Some(Err(e))) => {
+                    error!(
+                        error = e.to_string(),
+                        "Failed to check for outbound peers to ping"
+                    )
+                }
+                Poll::Ready(None) | Poll::Pending => break,
+            }
+        }
+
+        // if !matches!(
+        //     self.network_globals.sync_state(),
+        //     SyncState::SyncingFinalized { .. } | SyncState::SyncingHead { .. }
+        // ) {
+        //     loop {
+        //         match self.status_peers.poll_next_unpin(cx) {
+        //             Poll::Ready(Some(Ok(peer_id))) => {
+        //                 self.status_peers.insert(peer_id);
+        //                 self.events.push(PeerManagerEvent::Status(peer_id))
+        //             }
+        //             Poll::Ready(Some(Err(e))) => {
+        //                 error!(self.log, "Failed to check for peers to ping"; "error" => e.to_string())
+        //             }
+        //             Poll::Ready(None) | Poll::Pending => break,
+        //         }
+        //     }
+        // }
+
+        if !self.events.is_empty() {
+            return Poll::Ready(ToSwarm::GenerateEvent(self.events.remove(0)));
+        } else {
+            self.events.shrink_to_fit();
+        }
+
+        if let Some(enr) = self.peers_to_dial.pop() {
+            self.inject_peer_connection(&enr.peer_id(), ConnectingType::Dialing, Some(enr.clone()));
+
+            // Prioritize Quic connections over Tcp ones.
+            let multiaddrs = [
+                self.quic_enabled
+                    .then_some(enr.multiaddr_quic())
+                    .unwrap_or_default(),
+                enr.multiaddr_tcp(),
+            ]
+            .concat();
+
+            debug!(
+                peer_id = %enr.peer_id(),
+                multiaddrs = ?multiaddrs,
+                "Dialing peer"
+            );
+            return Poll::Ready(ToSwarm::Dial {
+                opts: DialOpts::peer_id(enr.peer_id())
+                    .condition(PeerCondition::Disconnected)
+                    .addresses(multiaddrs)
+                    .build(),
+            });
+        }
+
+        Poll::Pending
+    }
+}
+
+impl PeerManager {
+    fn on_connection_established(
+        &mut self,
+        peer_id: PeerId,
+        endpoint: &ConnectedPoint,
+        _other_established: usize,
+    ) {
+        debug!(
+            %peer_id,
+            multiaddr = %endpoint.get_remote_address(),
+            connection = ?endpoint.to_endpoint(),
+            "Connection established"
+        );
+
+        // Update the prometheus metrics
+        // if self.metrics_enabled {
+        //     metrics::inc_counter(&metrics::PEER_CONNECT_EVENT_COUNT);
+        //
+        //     self.update_peer_count_metrics();
+        // }
+
+        // NOTE: We don't register peers that we are disconnecting immediately. The network service
+        // does not need to know about these peers.
+        match endpoint {
+            ConnectedPoint::Listener { send_back_addr, .. } => {
+                self.inject_connect_ingoing(&peer_id, send_back_addr.clone(), None);
+                self.events
+                    .push(PeerManagerEvent::PeerConnectedIncoming(peer_id));
+            }
+            ConnectedPoint::Dialer { address, .. } => {
+                self.inject_connect_outgoing(&peer_id, address.clone(), None);
+                self.events
+                    .push(PeerManagerEvent::PeerConnectedOutgoing(peer_id));
+            }
+        };
+    }
+
+    fn on_connection_closed(
+        &mut self,
+        peer_id: PeerId,
+        _endpoint: &ConnectedPoint,
+        remaining_established: usize,
+    ) {
+        if remaining_established > 0 {
+            return;
+        }
+
+        // There are no more connections
+        if self
+            .peers
+            .read()
+            .is_connected_or_disconnecting(&peer_id)
+        {
+            // We are disconnecting the peer or the peer has already been connected.
+            // Both these cases, the peer has been previously registered by the peer manager and
+            // potentially the application layer.
+            // Inform the application.
+            self.events
+                .push(PeerManagerEvent::PeerDisconnected(peer_id));
+            debug!(
+                %peer_id,
+                "Peer disconnected"
+            );
+        }
+
+        // NOTE: It may be the case that a rejected node, due to too many peers is disconnected
+        // here and the peer manager has no knowledge of its connection. We insert it here for
+        // reference so that peer manager can track this peer.
+        self.inject_disconnect(&peer_id);
+
+        // Update the prometheus metrics
+        // if self.metrics_enabled {
+        //     // Legacy standard metrics.
+        //     metrics::inc_counter(&metrics::PEER_DISCONNECT_EVENT_COUNT);
+        //
+        //     self.update_peer_count_metrics();
+        // }
+    }
+
+    /// A dial attempt has failed.
+    ///
+    /// NOTE: It can be the case that we are dialing a peer and during the dialing process the peer
+    /// connects and the dial attempt later fails. To handle this, we only update the peer_db if
+    /// the peer is not already connected.
+    fn on_dial_failure(&mut self, peer_id: Option<PeerId>) {
+        if let Some(peer_id) = peer_id {
+            if !self.peers.read().is_connected(&peer_id) {
+                self.inject_disconnect(&peer_id);
+            }
+        }
+    }
+}
+

--- a/anchor/network/src/peer_manager/network_behaviour.rs
+++ b/anchor/network/src/peer_manager/network_behaviour.rs
@@ -1,6 +1,6 @@
 use crate::peer_manager::{ConnectingType, PeerManager, PeerManagerEvent};
 use discv5::libp2p_identity::PeerId;
-use discv5::multiaddr::{Multiaddr};
+use discv5::multiaddr::Multiaddr;
 use futures::StreamExt;
 use libp2p::core::transport::PortUse;
 use libp2p::core::{ConnectedPoint, Endpoint};
@@ -41,10 +41,10 @@ impl NetworkBehaviour for PeerManager {
         // Check the connection limits
         if self.connected_or_dialing_peers() >= self.max_peers()
             && self
-            .peers
-            .read()
-            .peer_info(&peer_id)
-            .map_or(true, |peer| !peer.has_future_duty())
+                .peers
+                .read()
+                .peer_info(&peer_id)
+                .map_or(true, |peer| !peer.has_future_duty())
         {
             return Err(ConnectionDenied::new(
                 "Connection to peer rejected: too many connections",
@@ -85,10 +85,10 @@ impl NetworkBehaviour for PeerManager {
         // Check the connection limits
         if self.connected_peers() >= self.max_outbound_dialing_peers()
             && self
-            .peers
-            .read()
-            .peer_info(&peer_id)
-            .map_or(true, |peer| !peer.has_future_duty())
+                .peers
+                .read()
+                .peer_info(&peer_id)
+                .map_or(true, |peer| !peer.has_future_duty())
         {
             return Err(ConnectionDenied::new(
                 "Connection to peer rejected: too many connections",
@@ -286,11 +286,7 @@ impl PeerManager {
         }
 
         // There are no more connections
-        if self
-            .peers
-            .read()
-            .is_connected_or_disconnecting(&peer_id)
-        {
+        if self.peers.read().is_connected_or_disconnecting(&peer_id) {
             // We are disconnecting the peer or the peer has already been connected.
             // Both these cases, the peer has been previously registered by the peer manager and
             // potentially the application layer.
@@ -330,4 +326,3 @@ impl PeerManager {
         }
     }
 }
-

--- a/anchor/network/src/peer_manager/peerdb/client.rs
+++ b/anchor/network/src/peer_manager/peerdb/client.rs
@@ -1,0 +1,201 @@
+//! Known Ethereum 2.0 clients and their fingerprints.
+//!
+//! Currently using identify to fingerprint.
+
+use libp2p::identify::Info as IdentifyInfo;
+use serde::Serialize;
+use strum::{AsRefStr, EnumIter, IntoStaticStr};
+
+/// Various client and protocol information related to a node.
+#[derive(Clone, Debug, Serialize)]
+pub struct Client {
+    /// The client's name (Ex: lighthouse, prism, nimbus, etc)
+    pub kind: ClientKind,
+    /// The client's version.
+    pub version: String,
+    /// The OS version of the client.
+    pub os_version: String,
+    /// The libp2p protocol version.
+    pub protocol_version: String,
+    /// Identify agent string
+    pub agent_string: Option<String>,
+}
+
+#[derive(Clone, Copy, Debug, Serialize, PartialEq, AsRefStr, IntoStaticStr, EnumIter)]
+pub enum ClientKind {
+    /// A lighthouse node (the best kind).
+    Lighthouse,
+    /// A Nimbus node.
+    Nimbus,
+    /// A Teku node.
+    Teku,
+    /// A Prysm node.
+    Prysm,
+    /// A lodestar node.
+    Lodestar,
+    /// A Caplin node.
+    Caplin,
+    /// An unknown client.
+    Unknown,
+}
+
+impl Default for Client {
+    fn default() -> Self {
+        Client {
+            kind: ClientKind::Unknown,
+            version: "unknown".into(),
+            os_version: "unknown".into(),
+            protocol_version: "unknown".into(),
+            agent_string: None,
+        }
+    }
+}
+
+impl Client {
+    /// Builds a `Client` from `IdentifyInfo`.
+    pub fn from_identify_info(info: &IdentifyInfo) -> Self {
+        let (kind, version, os_version) = client_from_agent_version(&info.agent_version);
+
+        Client {
+            kind,
+            version,
+            os_version,
+            protocol_version: info.protocol_version.clone(),
+            agent_string: Some(info.agent_version.clone()),
+        }
+    }
+}
+
+impl std::fmt::Display for Client {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self.kind {
+            ClientKind::Lighthouse => write!(
+                f,
+                "Lighthouse: version: {}, os_version: {}",
+                self.version, self.os_version
+            ),
+            ClientKind::Teku => write!(
+                f,
+                "Teku: version: {}, os_version: {}",
+                self.version, self.os_version
+            ),
+            ClientKind::Nimbus => write!(
+                f,
+                "Nimbus: version: {}, os_version: {}",
+                self.version, self.os_version
+            ),
+            ClientKind::Prysm => write!(
+                f,
+                "Prysm: version: {}, os_version: {}",
+                self.version, self.os_version
+            ),
+            ClientKind::Lodestar => write!(f, "Lodestar: version: {}", self.version),
+            ClientKind::Caplin => write!(f, "Caplin"),
+            ClientKind::Unknown => {
+                if let Some(agent_string) = &self.agent_string {
+                    write!(f, "Unknown: {}", agent_string)
+                } else {
+                    write!(f, "Unknown")
+                }
+            }
+        }
+    }
+}
+
+impl std::fmt::Display for ClientKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_ref())
+    }
+}
+
+// helper function to identify clients from their agent_version. Returns the client
+// kind and it's associated version and the OS kind.
+fn client_from_agent_version(agent_version: &str) -> (ClientKind, String, String) {
+    let mut agent_split = agent_version.split('/');
+    let mut version = String::from("unknown");
+    let mut os_version = String::from("unknown");
+    match agent_split.next() {
+        Some("Lighthouse") => {
+            let kind = ClientKind::Lighthouse;
+            if let Some(agent_version) = agent_split.next() {
+                version = agent_version.into();
+                if let Some(agent_os_version) = agent_split.next() {
+                    os_version = agent_os_version.into();
+                }
+            }
+            (kind, version, os_version)
+        }
+        Some("teku") => {
+            let kind = ClientKind::Teku;
+            if agent_split.next().is_some() {
+                if let Some(agent_version) = agent_split.next() {
+                    version = agent_version.into();
+                    if let Some(agent_os_version) = agent_split.next() {
+                        os_version = agent_os_version.into();
+                    }
+                }
+            }
+            (kind, version, os_version)
+        }
+        Some("github.com") => {
+            let kind = ClientKind::Prysm;
+            (kind, version, os_version)
+        }
+        Some("Prysm") => {
+            let kind = ClientKind::Prysm;
+            if agent_split.next().is_some() {
+                if let Some(agent_version) = agent_split.next() {
+                    version = agent_version.into();
+                    if let Some(agent_os_version) = agent_split.next() {
+                        os_version = agent_os_version.into();
+                    }
+                }
+            }
+            (kind, version, os_version)
+        }
+        Some("nimbus") => {
+            let kind = ClientKind::Nimbus;
+            if agent_split.next().is_some() {
+                if let Some(agent_version) = agent_split.next() {
+                    version = agent_version.into();
+                    if let Some(agent_os_version) = agent_split.next() {
+                        os_version = agent_os_version.into();
+                    }
+                }
+            }
+            (kind, version, os_version)
+        }
+        Some("nim-libp2p") => {
+            let kind = ClientKind::Nimbus;
+            if let Some(agent_version) = agent_split.next() {
+                version = agent_version.into();
+                if let Some(agent_os_version) = agent_split.next() {
+                    os_version = agent_os_version.into();
+                }
+            }
+            (kind, version, os_version)
+        }
+        Some("js-libp2p") | Some("lodestar") => {
+            let kind = ClientKind::Lodestar;
+            if let Some(agent_version) = agent_split.next() {
+                version = agent_version.into();
+                if let Some(agent_os_version) = agent_split.next() {
+                    os_version = agent_os_version.into();
+                }
+            }
+            (kind, version, os_version)
+        }
+        Some("erigon") => {
+            let client_kind = if let Some("caplin") = agent_split.next() {
+                ClientKind::Caplin
+            } else {
+                ClientKind::Unknown
+            };
+            (client_kind, version, os_version)
+        }
+        _ => {
+            let unknown = String::from("unknown");
+            (ClientKind::Unknown, unknown.clone(), unknown)
+        }
+    }
+}

--- a/anchor/network/src/peer_manager/peerdb/mod.rs
+++ b/anchor/network/src/peer_manager/peerdb/mod.rs
@@ -1,0 +1,2072 @@
+// use crate::discovery::{peer_id_to_node_id, CombinedKey};
+// use crate::{metrics, multiaddr::Multiaddr, types::Subnet, Enr, EnrExt, Gossipsub, PeerId};
+use crate::discovery::SSVSubnet;
+use crate::Enr;
+use itertools::Itertools;
+use libp2p::{Multiaddr, PeerId};
+use lighthouse_network::{metrics, Gossipsub, PeerAction, Subnet};
+use peer_info::{ConnectionDirection, PeerConnectionStatus, PeerInfo};
+use score::{ReportSource, Score, ScoreState};
+use std::net::IpAddr;
+use std::time::Instant;
+use std::{cmp::Ordering, fmt::Display};
+use std::{
+    collections::{HashMap, HashSet},
+    fmt::Formatter,
+};
+use sync_status::SyncStatus;
+use tracing::{debug, error, trace, warn};
+use types::{ChainSpec, DataColumnSubnetId, EthSpec};
+
+pub mod client;
+pub mod peer_info;
+pub mod score;
+pub mod sync_status;
+
+/// Max number of disconnected nodes to remember.
+const MAX_DC_PEERS: usize = 500;
+/// The maximum number of banned nodes to remember.
+pub const MAX_BANNED_PEERS: usize = 1000;
+/// We ban an IP if there are more than `BANNED_PEERS_PER_IP_THRESHOLD` banned peers with this IP.
+const BANNED_PEERS_PER_IP_THRESHOLD: usize = 5;
+/// Relative factor of peers that are allowed to have a negative gossipsub score without penalizing
+/// them in lighthouse.
+const ALLOWED_NEGATIVE_GOSSIPSUB_FACTOR: f32 = 0.1;
+/// The time we allow peers to be in the dialing state in our PeerDb before we revert them to a
+/// disconnected state.
+const DIAL_TIMEOUT: u64 = 15;
+
+/// Storage of known peers, their reputation and information
+pub struct PeerDB {
+    /// The collection of known connected peers, their status and reputation
+    peers: HashMap<PeerId, PeerInfo>,
+    /// The number of disconnected nodes in the database.
+    disconnected_peers: usize,
+    /// Counts banned peers in total and per ip
+    banned_peers_count: BannedPeersCount,
+    /// Specifies if peer scoring is disabled.
+    disable_peer_scoring: bool,
+}
+
+impl PeerDB {
+    pub fn new(trusted_peers: Vec<PeerId>, disable_peer_scoring: bool) -> Self {
+        // Initialize the peers hashmap with trusted peers
+        let peers = trusted_peers
+            .into_iter()
+            .map(|peer_id| (peer_id, PeerInfo::trusted_peer_info()))
+            .collect();
+        Self {
+            disconnected_peers: 0,
+            banned_peers_count: BannedPeersCount::default(),
+            disable_peer_scoring,
+            peers,
+        }
+    }
+
+    /* Getters */
+
+    /// Gives the score of a peer, or default score if it is unknown.
+    pub fn score(&self, peer_id: &PeerId) -> f64 {
+        self.peers
+            .get(peer_id)
+            .map_or(&Score::default(), |info| info.score())
+            .score()
+    }
+
+    /// Returns an iterator over all peers in the db.
+    pub fn peers(&self) -> impl Iterator<Item = (&PeerId, &PeerInfo)> {
+        self.peers.iter()
+    }
+
+    /// Gives the ids of all known peers.
+    pub fn peer_ids(&self) -> impl Iterator<Item = &PeerId> {
+        self.peers.keys()
+    }
+
+    /// Returns a peer's info, if known.
+    pub fn peer_info(&self, peer_id: &PeerId) -> Option<&PeerInfo> {
+        self.peers.get(peer_id)
+    }
+
+    /// Returns a mutable reference to a peer's info if known.
+    // VISIBILITY: The peer manager is able to modify some elements of the peer info, such as sync
+    // status.
+    pub(super) fn peer_info_mut(&mut self, peer_id: &PeerId) -> Option<&mut PeerInfo> {
+        self.peers.get_mut(peer_id)
+    }
+
+    /// Returns if the peer is already connected.
+    pub fn is_connected(&self, peer_id: &PeerId) -> bool {
+        matches!(
+            self.connection_status(peer_id),
+            Some(PeerConnectionStatus::Connected { .. })
+        )
+    }
+
+    /// If we are connected or currently dialing the peer returns true.
+    pub fn is_connected_or_dialing(&self, peer_id: &PeerId) -> bool {
+        matches!(
+            self.connection_status(peer_id),
+            Some(PeerConnectionStatus::Connected { .. })
+                | Some(PeerConnectionStatus::Dialing { .. })
+        )
+    }
+
+    /// If we are connected or in the process of disconnecting
+    pub fn is_connected_or_disconnecting(&self, peer_id: &PeerId) -> bool {
+        matches!(
+            self.connection_status(peer_id),
+            Some(PeerConnectionStatus::Connected { .. })
+                | Some(PeerConnectionStatus::Disconnecting { .. })
+        )
+    }
+
+    /// Returns true if the peer should be dialed. This checks the connection state and the
+    /// score state and determines if the peer manager should dial this peer.
+    pub fn should_dial(&self, peer_id: &PeerId) -> bool {
+        matches!(
+            self.connection_status(peer_id),
+            Some(PeerConnectionStatus::Disconnected { .. })
+                | Some(PeerConnectionStatus::Unknown { .. })
+                | None
+        ) && !self.score_state_banned_or_disconnected(peer_id)
+    }
+
+    /// Returns true if the peer is synced at least to our current head.
+    pub fn is_synced(&self, peer_id: &PeerId) -> bool {
+        match self.peers.get(peer_id).map(|info| info.sync_status()) {
+            Some(SyncStatus::Synced { .. }) => true,
+            Some(_) => false,
+            None => false,
+        }
+    }
+
+    /// Returns the current [`BanResult`] of the peer if banned. This doesn't check the connection state, rather the
+    /// underlying score of the peer. A peer may be banned but still in the connected state
+    /// temporarily.
+    ///
+    /// This is used to determine if we should accept incoming connections or not.
+    pub fn ban_status(&self, peer_id: &PeerId) -> Option<BanResult> {
+        self.peers
+            .get(peer_id)
+            .and_then(|peer| match peer.score_state() {
+                ScoreState::Banned => Some(BanResult::BadScore),
+                _ => self.ip_is_banned(peer).map(BanResult::BannedIp),
+            })
+    }
+
+    /// Checks if the peer's known addresses are currently banned.
+    fn ip_is_banned(&self, peer: &PeerInfo) -> Option<IpAddr> {
+        peer.seen_ip_addresses()
+            .find(|ip| self.banned_peers_count.ip_is_banned(ip))
+    }
+
+    /// Returns true if the IP is banned.
+    pub fn is_ip_banned(&self, ip: &IpAddr) -> bool {
+        self.banned_peers_count.ip_is_banned(ip)
+    }
+
+    /// Returns true if the Peer is either banned or in the disconnected state.
+    fn score_state_banned_or_disconnected(&self, peer_id: &PeerId) -> bool {
+        if let Some(peer) = self.peers.get(peer_id) {
+            match peer.score_state() {
+                ScoreState::Banned | ScoreState::ForcedDisconnect => true,
+                _ => self.ip_is_banned(peer).is_some(),
+            }
+        } else {
+            false
+        }
+    }
+
+    /// Gives the ids and info of all known connected peers.
+    pub fn connected_peers(&self) -> impl Iterator<Item = (&PeerId, &PeerInfo)> {
+        self.peers.iter().filter(|(_, info)| info.is_connected())
+    }
+
+    /// Gives the ids of all known connected peers.
+    pub fn connected_peer_ids(&self) -> impl Iterator<Item = &PeerId> {
+        self.peers
+            .iter()
+            .filter(|(_, info)| info.is_connected())
+            .map(|(peer_id, _)| peer_id)
+    }
+
+    /// Connected or dialing peers
+    pub fn connected_or_dialing_peers(&self) -> impl Iterator<Item = &PeerId> {
+        self.peers
+            .iter()
+            .filter(|(_, info)| info.is_connected() || info.is_dialing())
+            .map(|(peer_id, _)| peer_id)
+    }
+
+    /// Connected outbound-only peers
+    pub fn connected_outbound_only_peers(&self) -> impl Iterator<Item = &PeerId> {
+        self.peers
+            .iter()
+            .filter(|(_, info)| info.is_outbound_only())
+            .map(|(peer_id, _)| peer_id)
+    }
+
+    /// Gives the `peer_id` of all known connected and synced peers.
+    pub fn synced_peers(&self) -> impl Iterator<Item = &PeerId> {
+        self.peers
+            .iter()
+            .filter(|(_, info)| {
+                if info.sync_status().is_synced() || info.sync_status().is_advanced() {
+                    return info.is_connected();
+                }
+                false
+            })
+            .map(|(peer_id, _)| peer_id)
+    }
+
+    /// Gives the `peer_id` of all known connected and advanced peers.
+    pub fn advanced_peers(&self) -> impl Iterator<Item = &PeerId> {
+        self.peers
+            .iter()
+            .filter(|(_, info)| {
+                if info.sync_status().is_advanced() {
+                    return info.is_connected();
+                }
+                false
+            })
+            .map(|(peer_id, _)| peer_id)
+    }
+
+    /// Gives an iterator of all peers on a given subnet.
+    pub fn good_peers_on_subnet(&self, subnet: SSVSubnet) -> impl Iterator<Item = &PeerId> {
+        self.peers
+            .iter()
+            .filter(move |(_, info)| {
+                // We check both the metadata and gossipsub data as we only want to count long-lived subscribed peers
+                info.is_connected()
+                    && info.on_subnet_metadata(&subnet)
+                    && info.on_subnet_gossipsub(&subnet)
+                    && info.is_good_gossipsub_peer()
+            })
+            .map(|(peer_id, _)| peer_id)
+    }
+
+    /// Gives the ids of all known disconnected peers.
+    pub fn disconnected_peers(&self) -> impl Iterator<Item = &PeerId> {
+        self.peers
+            .iter()
+            .filter(|(_, info)| info.is_disconnected())
+            .map(|(peer_id, _)| peer_id)
+    }
+
+    /// Returns the ids of all known banned peers.
+    pub fn banned_peers(&self) -> impl Iterator<Item = &PeerId> {
+        self.peers
+            .iter()
+            .filter(|(_, info)| info.is_banned())
+            .map(|(peer_id, _)| peer_id)
+    }
+
+    /// Gives the ids of all known banned peers.
+    pub fn banned_peers_by_score(&self) -> impl Iterator<Item = &PeerId> {
+        self.peers
+            .iter()
+            .filter(|(_, info)| info.score_is_banned())
+            .map(|(peer_id, _)| peer_id)
+    }
+
+    /// Returns a vector of all connected peers sorted by score beginning with the worst scores.
+    /// Ties get broken randomly.
+    pub fn worst_connected_peers(&self) -> Vec<(&PeerId, &PeerInfo)> {
+        self.peers
+            .iter()
+            .filter(|(_, info)| info.is_connected())
+            .sorted_by(|(_, info_a), (_, info_b)| info_a.score().total_cmp(info_b.score(), false))
+            .collect::<Vec<_>>()
+    }
+
+    /// Returns a vector containing peers (their ids and info), sorted by
+    /// score from highest to lowest, and filtered using `is_status`
+    pub fn best_peers_by_status<F>(&self, is_status: F) -> Vec<(&PeerId, &PeerInfo)>
+    where
+        F: Fn(&PeerInfo) -> bool,
+    {
+        self.peers
+            .iter()
+            .filter(|(_, info)| is_status(info))
+            .sorted_by(|(_, info_a), (_, info_b)| info_a.score().total_cmp(info_b.score(), true))
+            .collect::<Vec<_>>()
+    }
+
+    /// Returns the peer with highest reputation that satisfies `is_status`
+    pub fn best_by_status<F>(&self, is_status: F) -> Option<&PeerId>
+    where
+        F: Fn(&PeerInfo) -> bool,
+    {
+        self.peers
+            .iter()
+            .filter(|(_, info)| is_status(info))
+            .max_by(|(_, info_a), (_, info_b)| info_a.score().total_cmp(info_b.score(), false))
+            .map(|(id, _)| id)
+    }
+
+    /// Returns the peer's connection status. Returns unknown if the peer is not in the DB.
+    pub fn connection_status(&self, peer_id: &PeerId) -> Option<PeerConnectionStatus> {
+        self.peer_info(peer_id)
+            .map(|info| info.connection_status().clone())
+    }
+
+    /* Mutability */
+
+    /// Cleans up the connection state of dialing peers.
+    // Libp2p dial's peerids, but sometimes the response is from another peer-id or libp2p
+    // returns dial errors without a peer-id attached. This function reverts peers that have a
+    // dialing status longer than DIAL_TIMEOUT seconds to a disconnected status. This is important because
+    // we count the number of dialing peers in our inbound connections.
+    pub fn cleanup_dialing_peers(&mut self) {
+        let peers_to_disconnect: Vec<_> = self
+            .peers
+            .iter()
+            .filter_map(|(peer_id, info)| {
+                if let PeerConnectionStatus::Dialing { since } = info.connection_status() {
+                    if (*since) + std::time::Duration::from_secs(DIAL_TIMEOUT)
+                        < std::time::Instant::now()
+                    {
+                        return Some(*peer_id);
+                    }
+                }
+                None
+            })
+            .collect();
+
+        for peer_id in peers_to_disconnect {
+            self.update_connection_state(&peer_id, NewConnectionState::Disconnected);
+        }
+    }
+
+    /// Allows the sync module to update sync status' of peers. Returns None, if the peer doesn't
+    /// exist and returns Some(bool) representing if the sync state was modified.
+    pub fn update_sync_status(
+        &mut self,
+        peer_id: &PeerId,
+        sync_status: SyncStatus,
+    ) -> Option<bool> {
+        let info = self.peers.get_mut(peer_id)?;
+        Some(info.update_sync_status(sync_status))
+    }
+
+    /// Updates the scores of known peers according to their connection status and the time that
+    /// has passed. This function returns a list of peers that have been unbanned.
+    /// NOTE: Peer scores cannot be penalized during the update, they can only increase. Therefore
+    /// it not possible to ban peers when updating scores.
+    #[must_use = "The unbanned peers must be sent to libp2p"]
+    pub(super) fn update_scores(&mut self) -> Vec<(PeerId, ScoreUpdateResult)> {
+        // Peer can be unbanned in this process.
+        // We return the result, such that the peer manager can inform the swarm to lift the libp2p
+        // ban on these peers.
+        let mut peers_to_unban = Vec::new();
+        let mut result = Vec::new();
+
+        for (peer_id, info) in self.peers.iter_mut() {
+            let previous_state = info.score_state();
+            // Update scores
+            info.score_update();
+
+            match Self::handle_score_transition(previous_state, peer_id, info) {
+                // A peer should not be able to be banned from a score update.
+                ScoreTransitionResult::Banned => {
+                    error!(%peer_id, "Peer has been banned in an update")
+                }
+                // A peer should not be able to transition to a disconnected state from a healthy
+                // state in a score update.
+                ScoreTransitionResult::Disconnected => {
+                    error!( %peer_id, "Peer has been disconnected in an update")
+                }
+                ScoreTransitionResult::Unbanned => {
+                    peers_to_unban.push(*peer_id);
+                }
+                ScoreTransitionResult::NoAction => {}
+            }
+        }
+
+        // Update the state in the peerdb
+        for unbanned_peer in peers_to_unban {
+            self.update_connection_state(&unbanned_peer, NewConnectionState::Unbanned);
+            let seen_ip_addresses = self
+                .peers
+                .get(&unbanned_peer)
+                .map(|info| {
+                    info.seen_ip_addresses()
+                        .filter(|ip| !self.is_ip_banned(ip))
+                        .collect::<Vec<_>>()
+                })
+                .unwrap_or_default();
+            result.push((
+                unbanned_peer,
+                ScoreUpdateResult::Unbanned(seen_ip_addresses),
+            ));
+        }
+        // Return the list so that the peer manager can update libp2p
+        result
+    }
+
+    /// Updates gossipsub scores for all peers.
+    #[must_use = "Score updates need to be reported to libp2p"]
+    pub(super) fn update_gossipsub_scores(
+        &mut self,
+        target_peers: usize,
+        gossipsub: &Gossipsub,
+    ) -> Vec<(PeerId, ScoreUpdateResult)> {
+        let mut actions = Vec::new();
+        let mut results = Vec::new();
+
+        let mut peers: Vec<_> = self
+            .peers
+            .iter_mut()
+            .filter(|(_peer_id, info)| info.is_connected())
+            .filter_map(|(peer_id, info)| {
+                gossipsub
+                    .peer_score(peer_id)
+                    .map(|score| (peer_id, info, score))
+            })
+            .collect();
+
+        // sort descending by score
+        peers.sort_unstable_by(|(.., s1), (.., s2)| s2.partial_cmp(s1).unwrap_or(Ordering::Equal));
+
+        let mut to_ignore_negative_peers =
+            (target_peers as f32 * ALLOWED_NEGATIVE_GOSSIPSUB_FACTOR).ceil() as usize;
+
+        for (peer_id, info, score) in peers {
+            let previous_state = info.score_state();
+            info.update_gossipsub_score(
+                score,
+                if score < 0.0 && to_ignore_negative_peers > 0 {
+                    to_ignore_negative_peers -= 1;
+                    // We ignore the negative score for the best negative peers so that their
+                    // gossipsub score can recover without getting disconnected.
+                    true
+                } else {
+                    false
+                },
+            );
+
+            actions.push((
+                *peer_id,
+                Self::handle_score_transition(previous_state, peer_id, info),
+            ));
+        }
+
+        for (peer_id, action) in actions {
+            let result = match action {
+                ScoreTransitionResult::Banned => {
+                    // The peer was banned as a result of this action.
+                    self.update_connection_state(&peer_id, NewConnectionState::Banned)
+                        .into()
+                }
+                ScoreTransitionResult::Disconnected => {
+                    // The peer needs to be disconnected
+
+                    // Update the state
+                    self.update_connection_state(
+                        &peer_id,
+                        NewConnectionState::Disconnecting { to_ban: false },
+                    );
+                    ScoreUpdateResult::Disconnect
+                }
+                ScoreTransitionResult::NoAction => ScoreUpdateResult::NoAction,
+                ScoreTransitionResult::Unbanned => {
+                    self.update_connection_state(&peer_id, NewConnectionState::Unbanned);
+                    let seen_ip_addresses = self
+                        .peers
+                        .get(&peer_id)
+                        .map(|info| {
+                            info.seen_ip_addresses()
+                                .filter(|ip| !self.is_ip_banned(ip))
+                                .collect::<Vec<_>>()
+                        })
+                        .unwrap_or_default();
+
+                    ScoreUpdateResult::Unbanned(seen_ip_addresses)
+                }
+            };
+
+            // Actions to be handled by the peer manager for each peer id
+            if !matches!(result, ScoreUpdateResult::NoAction) {
+                results.push((peer_id, result));
+            }
+        }
+        results
+    }
+
+    /// Reports a peer for some action.
+    ///
+    /// The action can only cause a negative effect. This can lead to disconnecting or banning a
+    /// specific peer. Therefore the result of this function returns if the peer needs to be banned
+    /// or disconnected.
+    ///
+    /// If the peer doesn't exist, log a warning and insert defaults.
+    #[must_use = "Banned and disconnected peers need to be handled in libp2p"]
+    pub(super) fn report_peer(
+        &mut self,
+        peer_id: &PeerId,
+        action: PeerAction,
+        source: ReportSource,
+        msg: &'static str,
+    ) -> ScoreUpdateResult {
+        metrics::inc_counter_vec(&metrics::REPORT_PEER_MSGS, &[msg]);
+
+        match self.peers.get_mut(peer_id) {
+            Some(info) => {
+                let previous_state = info.score_state();
+                info.apply_peer_action_to_score(action);
+                // metrics::inc_counter_vec(
+                //     &metrics::PEER_ACTION_EVENTS_PER_CLIENT,
+                //     &[info.client().kind.as_ref(), action.as_ref(), source.into()],
+                //);
+                let result = Self::handle_score_transition(previous_state, peer_id, info);
+                if previous_state == info.score_state() {
+                    debug!(
+                        %msg,
+                        %peer_id,
+                        score = %info.score(),
+                        "Peer score adjusted"
+                    );
+                }
+                match result {
+                    ScoreTransitionResult::Banned => {
+                        // The peer was banned as a result of this action.
+                        self.update_connection_state(peer_id, NewConnectionState::Banned)
+                            .into()
+                    }
+                    ScoreTransitionResult::Disconnected => {
+                        // The peer needs to be disconnected
+
+                        // Update the state
+                        self.update_connection_state(
+                            peer_id,
+                            NewConnectionState::Disconnecting { to_ban: false },
+                        );
+                        ScoreUpdateResult::Disconnect
+                    }
+                    ScoreTransitionResult::NoAction => ScoreUpdateResult::NoAction,
+                    ScoreTransitionResult::Unbanned => {
+                        error!(
+                            %msg,
+                            %peer_id,
+                            "Report peer action lead to an unbanning"
+                        );
+                        ScoreUpdateResult::NoAction
+                    }
+                }
+            }
+            None => {
+                debug!(
+                    %msg,
+                    %peer_id,
+                    "Reporting a peer that doesn't exist"
+                );
+                ScoreUpdateResult::NoAction
+            }
+        }
+    }
+
+    /// Update min ttl of a peer.
+    // VISIBILITY: Only the peer manager can update the min_ttl
+    pub(super) fn update_min_ttl(&mut self, peer_id: &PeerId, min_ttl: Instant) {
+        let info = self.peers.entry(*peer_id).or_default();
+
+        // only update if the ttl is longer
+        if info.min_ttl().is_none() || Some(&min_ttl) > info.min_ttl() {
+            info.set_min_ttl(min_ttl);
+
+            let min_ttl_secs = min_ttl
+                .checked_duration_since(Instant::now())
+                .map(|duration| duration.as_secs())
+                .unwrap_or_else(|| 0);
+            debug!(
+                %peer_id,
+                future_min_ttl_secs = min_ttl_secs,
+                "Updating the time a peer is required for"
+            )
+        }
+    }
+
+    /// Adds a gossipsub subscription to a peer in the peerdb.
+    // VISIBILITY: The behaviour is able to adjust subscriptions.
+    pub(crate) fn add_subscription(&mut self, peer_id: &PeerId, subnet: SSVSubnet) {
+        if let Some(info) = self.peers.get_mut(peer_id) {
+            info.insert_subnet(subnet);
+        }
+    }
+
+    /// Removes a gossipsub subscription to a peer in the peerdb.
+    // VISIBILITY: The behaviour is able to adjust subscriptions.
+    pub(crate) fn remove_subscription(&mut self, peer_id: &PeerId, subnet: &SSVSubnet) {
+        if let Some(info) = self.peers.get_mut(peer_id) {
+            info.remove_subnet(subnet);
+        }
+    }
+
+    /// Extends the ttl of all peers on the given subnet that have a shorter
+    /// min_ttl than what's given.
+    // VISIBILITY: The behaviour is able to adjust subscriptions.
+    pub(crate) fn extend_peers_on_subnet(&mut self, subnet: &SSVSubnet, min_ttl: Instant) {
+        self.peers
+            .iter_mut()
+            .filter(move |(_, info)| {
+                info.is_connected()
+                    && info.on_subnet_metadata(subnet)
+                    && info.on_subnet_gossipsub(subnet)
+            })
+            .for_each(|(peer_id, info)| {
+                if info.min_ttl().is_none() || Some(&min_ttl) > info.min_ttl() {
+                    info.set_min_ttl(min_ttl);
+                }
+                let min_ttl_secs = min_ttl
+                    .checked_duration_since(Instant::now())
+                    .map(|duration| duration.as_secs())
+                    .unwrap_or_else(|| 0);
+                trace!(
+                    %peer_id,
+                    min_ttl = min_ttl_secs,
+                    "Updating minimum duration a peer is required for"
+                );
+            });
+    }
+
+    /// A peer is being dialed.
+    // VISIBILITY: Only the peer manager can adjust the connection state
+    pub(super) fn dialing_peer(&mut self, peer_id: &PeerId, enr: Option<Enr>) {
+        self.update_connection_state(peer_id, NewConnectionState::Dialing { enr });
+    }
+
+    /// Sets a peer as connected with an ingoing connection.
+    // VISIBILITY: Only the peer manager can adjust the connection state.
+    pub(super) fn connect_ingoing(
+        &mut self,
+        peer_id: &PeerId,
+        seen_address: Multiaddr,
+        enr: Option<Enr>,
+    ) {
+        self.update_connection_state(
+            peer_id,
+            NewConnectionState::Connected {
+                enr,
+                seen_address,
+                direction: ConnectionDirection::Incoming,
+            },
+        );
+    }
+
+    /// Sets a peer as connected with an outgoing connection.
+    // VISIBILITY: Only the peer manager can adjust the connection state.
+    pub(super) fn connect_outgoing(
+        &mut self,
+        peer_id: &PeerId,
+        seen_address: Multiaddr,
+        enr: Option<Enr>,
+    ) {
+        self.update_connection_state(
+            peer_id,
+            NewConnectionState::Connected {
+                enr,
+                seen_address,
+                direction: ConnectionDirection::Outgoing,
+            },
+        );
+    }
+
+    /// The connection state of the peer has been changed. Modify the peer in the db to ensure all
+    /// variables are in sync with libp2p.
+    /// Updating the state can lead to a `BanOperation` which needs to be processed via the peer
+    /// manager and should be handled in the peer manager.
+    // NOTE: This function is vital in keeping the connection state, and thus the peerdb size in
+    // check and up to date with libp2p.
+    fn update_connection_state(
+        &mut self,
+        peer_id: &PeerId,
+        new_state: NewConnectionState,
+    ) -> Option<BanOperation> {
+        let info = self.peers.entry(*peer_id).or_insert_with(|| {
+            // If we are not creating a new connection (or dropping a current inbound connection) log a warning indicating we are updating a
+            // connection state for an unknown peer.
+            if !matches!(
+                new_state,
+                NewConnectionState::Connected { .. }          // We have established a new connection (peer may not have been seen before)
+                    | NewConnectionState::Disconnecting { .. }// We are disconnecting from a peer that may not have been registered before
+                    | NewConnectionState::Dialing { .. }      // We are dialing a potentially new peer
+                    | NewConnectionState::Disconnected { .. } // Dialing a peer that responds by a different ID can be immediately
+                                                              // disconnected without having being stored in the db before
+            ) {
+                warn!(
+                    %peer_id,
+                    ?new_state,
+                    "Updating state of unknown peer");
+            }
+            if self.disable_peer_scoring {
+                PeerInfo::trusted_peer_info()
+            } else {
+                PeerInfo::default()
+            }
+        });
+
+        // Ban the peer if the score is not already low enough.
+        if matches!(new_state, NewConnectionState::Banned) {
+            match info.score_state() {
+                ScoreState::Banned => {}
+                _ => {
+                    // If score isn't low enough to ban, this function has been called incorrectly.
+                    error!(%peer_id, "Banning a peer with a good score");
+                    info.apply_peer_action_to_score(PeerAction::Fatal);
+                }
+            }
+        }
+
+        // Handle all the possible state changes
+        match (info.connection_status().clone(), new_state) {
+            /* CONNECTED
+             *
+             *
+             * Handles the transition to a connected state
+             */
+            (
+                current_state,
+                NewConnectionState::Connected {
+                    enr,
+                    direction,
+                    seen_address,
+                },
+            ) => {
+                // Update the ENR if one exists, and compute the custody subnets
+                if let Some(enr) = enr {
+                    info.set_enr(enr);
+                }
+
+                match current_state {
+                    PeerConnectionStatus::Disconnected { .. } => {
+                        self.disconnected_peers = self.disconnected_peers.saturating_sub(1);
+                    }
+                    PeerConnectionStatus::Banned { .. } => {
+                        error!(%peer_id, "Accepted a connection from a banned peer");
+                        // TODO: check if this happens and report the unban back
+                        self.banned_peers_count
+                            .remove_banned_peer(info.seen_ip_addresses());
+                    }
+                    PeerConnectionStatus::Disconnecting { .. } => {
+                        warn!(%peer_id, "Connected to a disconnecting peer");
+                    }
+                    PeerConnectionStatus::Unknown
+                    | PeerConnectionStatus::Connected { .. }
+                    | PeerConnectionStatus::Dialing { .. } => {}
+                }
+
+                // Update the connection state
+                match direction {
+                    ConnectionDirection::Incoming => info.connect_ingoing(seen_address),
+                    ConnectionDirection::Outgoing => info.connect_outgoing(seen_address),
+                }
+            }
+
+            /* DIALING
+             *
+             *
+             * Handles the transition to a dialing state
+             */
+            (old_state, NewConnectionState::Dialing { enr }) => {
+                match old_state {
+                    PeerConnectionStatus::Banned { .. } => {
+                        warn!(%peer_id, "Dialing a banned peer");
+                        self.banned_peers_count
+                            .remove_banned_peer(info.seen_ip_addresses());
+                    }
+                    PeerConnectionStatus::Disconnected { .. } => {
+                        self.disconnected_peers = self.disconnected_peers.saturating_sub(1);
+                    }
+                    PeerConnectionStatus::Connected { .. } => {
+                        warn!( %peer_id, "Dialing an already connected peer")
+                    }
+                    PeerConnectionStatus::Dialing { .. } => {
+                        warn!(%peer_id, "Dialing an already dialing peer")
+                    }
+                    PeerConnectionStatus::Disconnecting { .. } => {
+                        warn!(%peer_id, "Dialing a disconnecting peer")
+                    }
+                    PeerConnectionStatus::Unknown => {} // default behaviour
+                }
+                // Update the ENR if one is known.
+                if let Some(enr) = enr {
+                    info.set_enr(enr);
+                }
+
+                if let Err(e) = info.set_dialing_peer() {
+                    error!(%peer_id, error = e);
+                }
+            }
+
+            /* DISCONNECTED
+             *
+             *
+             * Handle the transition to the disconnected state
+             */
+            (old_state, NewConnectionState::Disconnected) => {
+                // Remove all subnets for disconnected peers.
+                info.clear_subnets();
+
+                match old_state {
+                    PeerConnectionStatus::Banned { .. } => {}
+                    PeerConnectionStatus::Disconnected { .. } => {}
+                    PeerConnectionStatus::Disconnecting { to_ban } if to_ban => {
+                        // Update the status.
+                        info.set_connection_status(PeerConnectionStatus::Banned {
+                            since: Instant::now(),
+                        });
+                        self.banned_peers_count
+                            .add_banned_peer(info.seen_ip_addresses());
+                        let known_banned_ips = self.banned_peers_count.banned_ips();
+                        let banned_ips = info
+                            .seen_ip_addresses()
+                            .filter(|ip| known_banned_ips.contains(ip))
+                            .collect::<Vec<_>>();
+                        return Some(BanOperation::ReadyToBan(banned_ips));
+                    }
+                    PeerConnectionStatus::Disconnecting { .. } => {
+                        // The peer has been disconnected but not banned. Inform the peer manager
+                        // that this peer could be eligible for a temporary ban.
+                        self.disconnected_peers += 1;
+                        info.set_connection_status(PeerConnectionStatus::Disconnected {
+                            since: Instant::now(),
+                        });
+                        return Some(BanOperation::TemporaryBan);
+                    }
+                    PeerConnectionStatus::Unknown
+                    | PeerConnectionStatus::Connected { .. }
+                    | PeerConnectionStatus::Dialing { .. } => {
+                        self.disconnected_peers += 1;
+                        info.set_connection_status(PeerConnectionStatus::Disconnected {
+                            since: Instant::now(),
+                        });
+                    }
+                }
+            }
+
+            /* DISCONNECTING
+             *
+             *
+             * Handles the transition to a disconnecting state
+             */
+            (PeerConnectionStatus::Banned { .. }, NewConnectionState::Disconnecting { to_ban }) => {
+                error!(
+                     %peer_id,
+                    "Disconnecting from a banned peer"
+                );
+                info.set_connection_status(PeerConnectionStatus::Disconnecting { to_ban });
+            }
+            (
+                PeerConnectionStatus::Disconnected { .. },
+                NewConnectionState::Disconnecting { to_ban },
+            ) => {
+                // If the peer was previously disconnected and is now being disconnected, decrease
+                // the disconnected_peers counter.
+                self.disconnected_peers = self.disconnected_peers.saturating_sub(1);
+                info.set_connection_status(PeerConnectionStatus::Disconnecting { to_ban });
+            }
+            (_, NewConnectionState::Disconnecting { to_ban }) => {
+                // We overwrite all states and set this peer to be disconnecting.
+                // NOTE: A peer can be in the disconnected state and transition straight to a
+                // disconnected state. This occurs when a disconnected peer dials us, we have too
+                // many peers and we transition them straight to the disconnecting state.
+                info.set_connection_status(PeerConnectionStatus::Disconnecting { to_ban });
+            }
+
+            /* BANNED
+             *
+             *
+             * Handles the transition to a banned state
+             */
+            (PeerConnectionStatus::Disconnected { .. }, NewConnectionState::Banned) => {
+                // It is possible to ban a peer that is currently disconnected. This can occur when
+                // there are many events that score it poorly and are processed after it has disconnected.
+                info.set_connection_status(PeerConnectionStatus::Banned {
+                    since: Instant::now(),
+                });
+                self.banned_peers_count
+                    .add_banned_peer(info.seen_ip_addresses());
+                self.disconnected_peers = self.disconnected_peers.saturating_sub(1);
+                let known_banned_ips = self.banned_peers_count.banned_ips();
+                let banned_ips = info
+                    .seen_ip_addresses()
+                    .filter(|ip| known_banned_ips.contains(ip))
+                    .collect::<Vec<_>>();
+                return Some(BanOperation::ReadyToBan(banned_ips));
+            }
+            (PeerConnectionStatus::Disconnecting { .. }, NewConnectionState::Banned) => {
+                // NOTE: This can occur due a rapid downscore of a peer. It goes through the
+                // disconnection phase and straight into banning in a short time-frame.
+                debug!(
+                    %peer_id,
+                    "Banning peer that is currently disconnecting"
+                );
+                // Ban the peer once the disconnection process completes.
+                info.set_connection_status(PeerConnectionStatus::Disconnecting { to_ban: true });
+                return Some(BanOperation::PeerDisconnecting);
+            }
+            (PeerConnectionStatus::Banned { .. }, NewConnectionState::Banned) => {
+                error!(
+                    %peer_id,
+                    "Banning already banned peer"
+                );
+                let known_banned_ips = self.banned_peers_count.banned_ips();
+                let banned_ips = info
+                    .seen_ip_addresses()
+                    .filter(|ip| known_banned_ips.contains(ip))
+                    .collect::<Vec<_>>();
+                return Some(BanOperation::ReadyToBan(banned_ips));
+            }
+            (
+                PeerConnectionStatus::Connected { .. } | PeerConnectionStatus::Dialing { .. },
+                NewConnectionState::Banned,
+            ) => {
+                // update the state
+                info.set_connection_status(PeerConnectionStatus::Disconnecting { to_ban: true });
+                return Some(BanOperation::DisconnectThePeer);
+            }
+            (PeerConnectionStatus::Unknown, NewConnectionState::Banned) => {
+                // shift the peer straight to banned
+                warn!(
+                    %peer_id,
+                    "Banning a peer of unknown connection state"
+                );
+                self.banned_peers_count
+                    .add_banned_peer(info.seen_ip_addresses());
+                info.set_connection_status(PeerConnectionStatus::Banned {
+                    since: Instant::now(),
+                });
+                let known_banned_ips = self.banned_peers_count.banned_ips();
+                let banned_ips = info
+                    .seen_ip_addresses()
+                    .filter(|ip| known_banned_ips.contains(ip))
+                    .collect::<Vec<_>>();
+                return Some(BanOperation::ReadyToBan(banned_ips));
+            }
+
+            /* UNBANNED
+             *
+             *
+             * Handles the transition to an unbanned state
+             */
+            (old_state, NewConnectionState::Unbanned) => {
+                if matches!(info.score_state(), ScoreState::Banned) {
+                    error!(
+                        %peer_id,
+                        "Unbanning a banned peer"
+                    );
+                }
+                match old_state {
+                    PeerConnectionStatus::Unknown | PeerConnectionStatus::Connected { .. } => {
+                        error!(
+                            %peer_id,
+                            "Unbanning a connected peer"
+                        );
+                    }
+                    PeerConnectionStatus::Disconnected { .. }
+                    | PeerConnectionStatus::Disconnecting { .. } => {
+                        debug!(
+                            %peer_id,
+                            "Unbanning disconnected or disconnecting peer"
+                        );
+                    } // These are odd but fine.
+                    PeerConnectionStatus::Dialing { .. } => {} // Also odd but acceptable
+                    PeerConnectionStatus::Banned { since } => {
+                        info.set_connection_status(PeerConnectionStatus::Disconnected { since });
+
+                        // Increment the disconnected count and reduce the banned count
+                        self.banned_peers_count
+                            .remove_banned_peer(info.seen_ip_addresses());
+                        self.disconnected_peers = self.disconnected_peers.saturating_add(1);
+                    }
+                }
+            }
+        }
+        None
+    }
+
+    /// Sets the peer as disconnected. A banned peer remains banned. If the node has become banned,
+    /// this returns true, otherwise this is false.
+    // VISIBILITY: Only the peer manager can adjust the connection state.
+    pub(super) fn inject_disconnect(
+        &mut self,
+        peer_id: &PeerId,
+    ) -> (Option<BanOperation>, Vec<(PeerId, Vec<IpAddr>)>) {
+        // A peer can be banned for disconnecting. Thus another peer could be purged
+        let maybe_ban_op = self.update_connection_state(peer_id, NewConnectionState::Disconnected);
+        let purged_peers = self.shrink_to_fit();
+        (maybe_ban_op, purged_peers)
+    }
+
+    /// The peer manager has notified us that the peer is undergoing a normal disconnect. Optionally tag
+    /// the peer to be banned after the disconnect.
+    // VISIBILITY: Only the peer manager can adjust the connection state.
+    pub(super) fn notify_disconnecting(&mut self, peer_id: &PeerId, to_ban: bool) {
+        self.update_connection_state(peer_id, NewConnectionState::Disconnecting { to_ban });
+    }
+
+    /// Removes banned and disconnected peers from the DB if we have reached any of our limits.
+    /// Drops the peers with the lowest reputation so that the number of disconnected peers is less
+    /// than MAX_DC_PEERS
+    #[must_use = "Unbanned peers need to be reported to libp2p."]
+    fn shrink_to_fit(&mut self) -> Vec<(PeerId, Vec<IpAddr>)> {
+        let excess_peers = self
+            .banned_peers_count
+            .banned_peers()
+            .saturating_sub(MAX_BANNED_PEERS);
+        let mut unbanned_peers = Vec::with_capacity(excess_peers);
+
+        // Remove excess banned peers
+        while self.banned_peers_count.banned_peers() > MAX_BANNED_PEERS {
+            if let Some((to_drop, unbanned_ips)) = if let Some((id, info, _)) = self
+                .peers
+                .iter()
+                .filter_map(|(id, info)| match info.connection_status() {
+                    PeerConnectionStatus::Banned { since } => Some((id, info, since)),
+                    _ => None,
+                })
+                .min_by_key(|(_, _, since)| *since)
+            {
+                self.banned_peers_count
+                    .remove_banned_peer(info.seen_ip_addresses());
+                let unbanned_ips = info
+                    .seen_ip_addresses()
+                    .filter(|ip| !self.is_ip_banned(ip))
+                    .collect::<Vec<_>>();
+
+                Some((*id, unbanned_ips))
+            } else {
+                // If there is no minimum, this is a coding error.
+                // crit!(
+                //     "banned_peers > MAX_BANNED_PEERS despite no banned peers in db!"
+                // );
+                // reset banned_peers this will also exit the loop
+                self.banned_peers_count = BannedPeersCount::default();
+                None
+            } {
+                debug!(
+                    peer_id = %to_drop,
+                    "Removing old banned peer");
+                self.peers.remove(&to_drop);
+                unbanned_peers.push((to_drop, unbanned_ips))
+            }
+        }
+
+        // Remove excess disconnected peers
+        while self.disconnected_peers > MAX_DC_PEERS {
+            if let Some(to_drop) = self
+                .peers
+                .iter()
+                .filter(|(_, info)| info.is_disconnected() && !info.is_trusted())
+                .filter_map(|(id, info)| match info.connection_status() {
+                    PeerConnectionStatus::Disconnected { since } => Some((id, since)),
+                    _ => None,
+                })
+                .min_by_key(|(_, age)| *age)
+                .map(|(id, _)| *id)
+            {
+                debug!(
+                     peer_id = %to_drop,
+                    disconnected_size = self.disconnected_peers.saturating_sub(1),
+                    "Removing old disconnected peer");
+                self.peers.remove(&to_drop);
+            }
+            // If there is no minimum, this is a coding error. For safety we decrease
+            // the count to avoid a potential infinite loop.
+            self.disconnected_peers = self.disconnected_peers.saturating_sub(1);
+        }
+
+        unbanned_peers
+    }
+
+    /// This handles score transitions between states. It transitions peers states from
+    /// disconnected/banned/connected.
+    fn handle_score_transition(
+        previous_state: ScoreState,
+        peer_id: &PeerId,
+        info: &PeerInfo,
+    ) -> ScoreTransitionResult {
+        match (info.score_state(), previous_state) {
+            (ScoreState::Banned, ScoreState::Healthy | ScoreState::ForcedDisconnect) => {
+                debug!(
+                    %peer_id,
+                    score = %info.score(),
+                    "Peer has been banned");
+                ScoreTransitionResult::Banned
+            }
+            (ScoreState::ForcedDisconnect, ScoreState::Banned | ScoreState::Healthy) => {
+                debug!(
+                    %peer_id,
+                    score = %info.score(),
+                    past_score_state = %previous_state,
+                    "Peer transitioned to forced disconnect score state");
+                // disconnect the peer if it's currently connected or dialing
+                if info.is_connected_or_dialing() {
+                    ScoreTransitionResult::Disconnected
+                } else if previous_state == ScoreState::Banned {
+                    ScoreTransitionResult::Unbanned
+                } else {
+                    // The peer was healthy, but is already disconnected, so there is no action to
+                    // take.
+                    ScoreTransitionResult::NoAction
+                }
+            }
+            (ScoreState::Healthy, ScoreState::ForcedDisconnect) => {
+                debug!(
+                    %peer_id,
+                    score = %info.score(),
+                    past_score_state = %previous_state,
+                    "Peer transitioned to healthy score state"
+                );
+                ScoreTransitionResult::NoAction
+            }
+            (ScoreState::Healthy, ScoreState::Banned) => {
+                debug!(
+                    %peer_id,
+                    score = %info.score(),
+                    past_score_state = %previous_state,
+                    "Peer transitioned to healthy score state");
+                // unban the peer if it was previously banned.
+                ScoreTransitionResult::Unbanned
+            }
+            // Explicitly ignore states that haven't transitioned.
+            (ScoreState::Healthy, ScoreState::Healthy) => ScoreTransitionResult::NoAction,
+            (ScoreState::ForcedDisconnect, ScoreState::ForcedDisconnect) => {
+                ScoreTransitionResult::NoAction
+            }
+
+            (ScoreState::Banned, ScoreState::Banned) => ScoreTransitionResult::NoAction,
+        }
+    }
+}
+
+/// Internal enum for managing connection state transitions.
+#[derive(Debug)]
+enum NewConnectionState {
+    /// A peer has connected to us.
+    Connected {
+        /// An optional known ENR if the peer was dialed.
+        enr: Option<Enr>,
+        /// The seen socket address associated with the connection.
+        seen_address: Multiaddr,
+        /// The direction, incoming/outgoing.
+        direction: ConnectionDirection,
+    },
+    /// The peer is in the process of being disconnected.
+    Disconnecting {
+        /// Whether the peer should be banned after the disconnect occurs.
+        to_ban: bool,
+    },
+    /// We are dialing this peer.
+    Dialing {
+        /// An optional known ENR for the peer we are dialing.
+        enr: Option<Enr>,
+    },
+    /// The peer has been disconnected from our local node.
+    Disconnected,
+    /// The peer has been banned and actions to shift the peer to the banned state should be
+    /// undertaken
+    Banned,
+    /// The peer has been unbanned and the connection state should be updated to reflect this.
+    Unbanned,
+}
+
+/// The result of applying a score transition to a peer.
+enum ScoreTransitionResult {
+    /// The peer has become disconnected.
+    Disconnected,
+    /// The peer has been banned.
+    Banned,
+    /// The peer has been unbanned.
+    Unbanned,
+    /// No state change occurred.
+    NoAction,
+}
+
+/// The type of results that can happen from executing the `report_peer` function.
+pub enum ScoreUpdateResult {
+    /// The reported peer must be banned.
+    Ban(BanOperation),
+    ///  The reported peer transitioned to the disconnected state and must be disconnected.
+    Disconnect,
+    /// The peer has been unbanned and this needs to be propagated to libp2p. The list of unbanned
+    /// IP addresses are sent along with it.
+    Unbanned(Vec<IpAddr>),
+    /// The report requires no further action.
+    NoAction,
+}
+
+impl From<Option<BanOperation>> for ScoreUpdateResult {
+    fn from(ban_operation: Option<BanOperation>) -> Self {
+        match ban_operation {
+            None => ScoreUpdateResult::NoAction,
+            Some(bo) => ScoreUpdateResult::Ban(bo),
+        }
+    }
+}
+
+/// When attempting to ban a peer provides the peer manager with the operation that must be taken.
+pub enum BanOperation {
+    /// Optionally temporarily ban this peer to prevent instantaneous reconnection.
+    /// The peer manager will decide if temporary banning is required.
+    TemporaryBan,
+    // The peer is currently connected. Perform a graceful disconnect before banning at the swarm
+    // level.
+    DisconnectThePeer,
+    // The peer is disconnected, it has now been banned and can be banned at the swarm level. It
+    // stores a collection of banned IP addresses to inform the swarm.
+    ReadyToBan(Vec<IpAddr>),
+    // The peer is currently being disconnected, nothing to do.
+    PeerDisconnecting,
+}
+
+/// When checking if a peer is banned, it can be banned for multiple reasons.
+#[derive(Copy, Clone, Debug)]
+pub enum BanResult {
+    /// The peer's score is too low causing it to be banned.
+    BadScore,
+    /// The peer should be banned because it is connecting from a banned IP address.
+    BannedIp(IpAddr),
+}
+
+impl Display for BanResult {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            BanResult::BadScore => write!(f, "Peer has a bad score"),
+            BanResult::BannedIp(addr) => write!(f, "Peer address: {} is banned", addr),
+        }
+    }
+}
+
+impl std::error::Error for BanResult {}
+
+#[derive(Default)]
+pub struct BannedPeersCount {
+    /// The number of banned peers in the database.
+    banned_peers: usize,
+    /// maps ips to number of banned peers with this ip
+    banned_peers_per_ip: HashMap<IpAddr, usize>,
+}
+
+impl BannedPeersCount {
+    /// Removes the peer from the counts if it is banned. Returns true if the peer was banned and
+    /// false otherwise.
+    pub fn remove_banned_peer(&mut self, ip_addresses: impl Iterator<Item = IpAddr>) {
+        self.banned_peers = self.banned_peers.saturating_sub(1);
+        for address in ip_addresses {
+            if let Some(count) = self.banned_peers_per_ip.get_mut(&address) {
+                *count = count.saturating_sub(1);
+            }
+        }
+    }
+
+    pub fn add_banned_peer(&mut self, ip_addresses: impl Iterator<Item = IpAddr>) {
+        self.banned_peers = self.banned_peers.saturating_add(1);
+        for address in ip_addresses {
+            *self.banned_peers_per_ip.entry(address).or_insert(0) += 1;
+        }
+    }
+
+    pub fn banned_peers(&self) -> usize {
+        self.banned_peers
+    }
+
+    pub fn banned_ips(&self) -> HashSet<IpAddr> {
+        self.banned_peers_per_ip
+            .iter()
+            .filter(|(_ip, count)| **count > BANNED_PEERS_PER_IP_THRESHOLD)
+            .map(|(ip, _count)| *ip)
+            .collect()
+    }
+
+    /// An IP is considered banned if more than BANNED_PEERS_PER_IP_THRESHOLD banned peers
+    /// exist with this IP
+    pub fn ip_is_banned(&self, ip: &IpAddr) -> bool {
+        self.banned_peers_per_ip
+            .get(ip)
+            .is_some_and(|count| *count > BANNED_PEERS_PER_IP_THRESHOLD)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use libp2p::core::multiaddr::Protocol;
+    //use slog::{o, Drain};
+    use libp2p::Multiaddr;
+    use lighthouse_network::PeerAction;
+    use std::net::{Ipv4Addr, Ipv6Addr};
+    use types::MinimalEthSpec;
+
+    type M = MinimalEthSpec;
+
+    // pub fn build_log(level: slog::Level, enabled: bool) -> slog::Logger {
+    //     let decorator = slog_term::TermDecorator::new().build();
+    //     let drain = slog_term::FullFormat::new(decorator).build().fuse();
+    //     let drain = slog_async::Async::new(drain).build().fuse();
+    //
+    //     if enabled {
+    //         slog::Logger::root(drain.filter_level(level).fuse(), o!())
+    //     } else {
+    //         slog::Logger::root(drain.filter(|_| false).fuse(), o!())
+    //     }
+    // }
+
+    fn add_score(db: &mut PeerDB, peer_id: &PeerId, score: f64) {
+        if let Some(info) = db.peer_info_mut(peer_id) {
+            info.add_to_score(score);
+        }
+    }
+
+    fn reset_score(db: &mut PeerDB, peer_id: &PeerId) {
+        if let Some(info) = db.peer_info_mut(peer_id) {
+            info.reset_score();
+        }
+    }
+
+    fn get_db() -> PeerDB {
+        PeerDB::new(vec![], false)
+    }
+
+    #[test]
+    #[allow(clippy::float_cmp)]
+    fn test_peer_connected_successfully() {
+        let mut pdb = get_db();
+        let random_peer = PeerId::random();
+
+        let (n_in, n_out) = (10, 20);
+        for _ in 0..n_in {
+            pdb.connect_ingoing(&random_peer, "/ip4/0.0.0.0".parse().unwrap(), None);
+        }
+        for _ in 0..n_out {
+            pdb.connect_outgoing(&random_peer, "/ip4/0.0.0.0".parse().unwrap(), None);
+        }
+
+        // the peer is known
+        let peer_info = pdb.peer_info(&random_peer);
+        assert!(peer_info.is_some());
+        // this is the only peer
+        assert_eq!(pdb.peers().count(), 1);
+        // the peer has the default reputation
+        assert_eq!(pdb.score(&random_peer), Score::default().score());
+        // it should be connected, and therefore not counted as disconnected
+        assert_eq!(pdb.disconnected_peers, 0);
+        assert!(peer_info.unwrap().is_connected());
+        assert_eq!(peer_info.unwrap().connections(), (n_in, n_out));
+    }
+
+    #[test]
+    fn test_outbound_only_peers_counted_correctly() {
+        let mut pdb = get_db();
+        let p0 = PeerId::random();
+        let p1 = PeerId::random();
+        let p2 = PeerId::random();
+        // Create peer with no connections.
+        let _p3 = PeerId::random();
+
+        pdb.connect_ingoing(&p0, "/ip4/0.0.0.0".parse().unwrap(), None);
+        pdb.connect_ingoing(&p1, "/ip4/0.0.0.0".parse().unwrap(), None);
+        pdb.connect_outgoing(&p1, "/ip4/0.0.0.0".parse().unwrap(), None);
+        pdb.connect_outgoing(&p2, "/ip4/0.0.0.0".parse().unwrap(), None);
+
+        // We should only have one outbound-only peer (p2).
+        // Peers that are inbound-only, have both types of connections, or no connections should not be counted.
+        assert_eq!(pdb.connected_outbound_only_peers().count(), 1);
+    }
+
+    #[test]
+    fn test_disconnected_removed_in_correct_order() {
+        let mut pdb = get_db();
+
+        use std::collections::BTreeMap;
+        let mut peer_list = BTreeMap::new();
+        for id in 0..MAX_DC_PEERS + 1 {
+            let new_peer = PeerId::random();
+            pdb.connect_ingoing(&new_peer, "/ip4/0.0.0.0".parse().unwrap(), None);
+            peer_list.insert(id, new_peer);
+        }
+        assert_eq!(pdb.disconnected_peers, 0);
+
+        for (_, p) in peer_list.iter() {
+            pdb.inject_disconnect(p);
+            // Allow the timing to update correctly
+        }
+        assert_eq!(pdb.disconnected_peers, MAX_DC_PEERS);
+        assert_eq!(pdb.disconnected_peers, pdb.disconnected_peers().count());
+
+        // Only the oldest peer should have been removed
+        for (id, peer_id) in peer_list.iter().rev().take(MAX_DC_PEERS) {
+            println!("Testing id {}", id);
+            assert!(
+                pdb.peer_info(peer_id).is_some(),
+                "Latest peer should not be pruned"
+            );
+        }
+
+        assert!(
+            pdb.peer_info(peer_list.iter().next().unwrap().1).is_none(),
+            "First peer should be removed"
+        );
+        assert_eq!(pdb.disconnected_peers, pdb.disconnected_peers().count());
+    }
+
+    #[test]
+    fn new_connection_should_remain() {
+        let mut pdb = get_db();
+
+        use std::collections::BTreeMap;
+        let mut peer_list = BTreeMap::new();
+        for id in 0..MAX_DC_PEERS + 20 {
+            let new_peer = PeerId::random();
+            pdb.connect_ingoing(&new_peer, "/ip4/0.0.0.0".parse().unwrap(), None);
+            peer_list.insert(id, new_peer);
+        }
+        assert_eq!(pdb.disconnected_peers, pdb.disconnected_peers().count());
+        for (_, p) in peer_list.iter() {
+            pdb.inject_disconnect(p);
+        }
+        assert_eq!(pdb.disconnected_peers, pdb.disconnected_peers().count());
+        println!("{}", pdb.disconnected_peers);
+
+        peer_list.clear();
+        for id in 0..MAX_DC_PEERS + 20 {
+            let new_peer = PeerId::random();
+            pdb.connect_ingoing(&new_peer, "/ip4/0.0.0.0".parse().unwrap(), None);
+            peer_list.insert(id, new_peer);
+        }
+
+        let new_peer = PeerId::random();
+        // New peer gets its min_ttl updated because it exists on a subnet
+        let min_ttl = Instant::now() + std::time::Duration::from_secs(12);
+
+        pdb.update_min_ttl(&new_peer, min_ttl);
+        // Peer then gets dialed
+        pdb.dialing_peer(&new_peer, None);
+        assert_eq!(pdb.disconnected_peers, pdb.disconnected_peers().count());
+        // Dialing fails, remove the peer
+        pdb.inject_disconnect(&new_peer);
+        assert_eq!(pdb.disconnected_peers, pdb.disconnected_peers().count());
+
+        assert!(
+            pdb.peer_info(&new_peer).is_some(),
+            "Peer should exist as disconnected"
+        );
+
+        assert_eq!(pdb.disconnected_peers, pdb.disconnected_peers().count());
+        println!("{}", pdb.disconnected_peers);
+    }
+
+    #[test]
+    fn test_disconnected_are_bounded() {
+        let mut pdb = get_db();
+
+        for _ in 0..MAX_DC_PEERS + 1 {
+            let p = PeerId::random();
+            pdb.connect_ingoing(&p, "/ip4/0.0.0.0".parse().unwrap(), None);
+        }
+        assert_eq!(pdb.disconnected_peers, 0);
+
+        for p in pdb.connected_peer_ids().cloned().collect::<Vec<_>>() {
+            pdb.inject_disconnect(&p);
+        }
+        assert_eq!(pdb.disconnected_peers, pdb.disconnected_peers().count());
+
+        assert_eq!(pdb.disconnected_peers, MAX_DC_PEERS);
+    }
+
+    #[test]
+    fn test_banned_are_bounded() {
+        let mut pdb = get_db();
+
+        for _ in 0..MAX_BANNED_PEERS + 1 {
+            let p = PeerId::random();
+            pdb.connect_ingoing(&p, "/ip4/0.0.0.0".parse().unwrap(), None);
+        }
+        assert_eq!(pdb.banned_peers_count.banned_peers(), 0);
+
+        for p in pdb.connected_peer_ids().cloned().collect::<Vec<_>>() {
+            let _ = pdb.report_peer(&p, PeerAction::Fatal, ReportSource::PeerManager, "");
+            pdb.inject_disconnect(&p);
+        }
+
+        assert_eq!(pdb.banned_peers_count.banned_peers(), MAX_BANNED_PEERS);
+    }
+
+    #[test]
+    fn test_best_peers() {
+        let mut pdb = get_db();
+
+        let p0 = PeerId::random();
+        let p1 = PeerId::random();
+        let p2 = PeerId::random();
+        pdb.connect_ingoing(&p0, "/ip4/0.0.0.0".parse().unwrap(), None);
+        pdb.connect_ingoing(&p1, "/ip4/0.0.0.0".parse().unwrap(), None);
+        pdb.connect_ingoing(&p2, "/ip4/0.0.0.0".parse().unwrap(), None);
+        add_score(&mut pdb, &p0, 70.0);
+        add_score(&mut pdb, &p1, 100.0);
+        add_score(&mut pdb, &p2, 50.0);
+
+        let best_peers: Vec<&PeerId> = pdb
+            .best_peers_by_status(PeerInfo::is_connected)
+            .iter()
+            .map(|p| p.0)
+            .collect();
+        assert_eq!(vec![&p1, &p0, &p2], best_peers);
+    }
+
+    #[test]
+    fn test_the_best_peer() {
+        let mut pdb = get_db();
+
+        let p0 = PeerId::random();
+        let p1 = PeerId::random();
+        let p2 = PeerId::random();
+        pdb.connect_ingoing(&p0, "/ip4/0.0.0.0".parse().unwrap(), None);
+        pdb.connect_ingoing(&p1, "/ip4/0.0.0.0".parse().unwrap(), None);
+        pdb.connect_ingoing(&p2, "/ip4/0.0.0.0".parse().unwrap(), None);
+        add_score(&mut pdb, &p0, 70.0);
+        add_score(&mut pdb, &p1, 100.0);
+        add_score(&mut pdb, &p2, 50.0);
+
+        let the_best = pdb.best_by_status(PeerInfo::is_connected);
+        assert!(the_best.is_some());
+        // Consistency check
+        let best_peers = pdb.best_peers_by_status(PeerInfo::is_connected);
+        assert_eq!(the_best.unwrap(), best_peers.first().unwrap().0);
+    }
+
+    #[test]
+    fn test_disconnected_consistency() {
+        let mut pdb = get_db();
+
+        let random_peer = PeerId::random();
+
+        pdb.connect_ingoing(&random_peer, "/ip4/0.0.0.0".parse().unwrap(), None);
+        assert_eq!(pdb.disconnected_peers, pdb.disconnected_peers().count());
+
+        pdb.connect_ingoing(&random_peer, "/ip4/0.0.0.0".parse().unwrap(), None);
+        assert_eq!(pdb.disconnected_peers, pdb.disconnected_peers().count());
+        pdb.inject_disconnect(&random_peer);
+        assert_eq!(pdb.disconnected_peers, pdb.disconnected_peers().count());
+
+        pdb.connect_outgoing(&random_peer, "/ip4/0.0.0.0".parse().unwrap(), None);
+        assert_eq!(pdb.disconnected_peers, pdb.disconnected_peers().count());
+        pdb.inject_disconnect(&random_peer);
+        assert_eq!(pdb.disconnected_peers, pdb.disconnected_peers().count());
+
+        let _ = pdb.report_peer(
+            &random_peer,
+            PeerAction::Fatal,
+            ReportSource::PeerManager,
+            "",
+        );
+        pdb.inject_disconnect(&random_peer);
+        let _ = pdb.report_peer(
+            &random_peer,
+            PeerAction::Fatal,
+            ReportSource::PeerManager,
+            "",
+        );
+        assert_eq!(pdb.disconnected_peers, pdb.disconnected_peers().count());
+        pdb.inject_disconnect(&random_peer);
+        assert_eq!(pdb.disconnected_peers, pdb.disconnected_peers().count());
+
+        pdb.inject_disconnect(&random_peer);
+        assert_eq!(pdb.disconnected_peers, pdb.disconnected_peers().count());
+        pdb.inject_disconnect(&random_peer);
+        assert_eq!(pdb.disconnected_peers, pdb.disconnected_peers().count());
+    }
+
+    #[test]
+    fn test_disconnected_ban_consistency() {
+        let mut pdb = get_db();
+        let mut multiaddr = Multiaddr::empty();
+        multiaddr.push(Protocol::Tcp(9000));
+        multiaddr.push(Protocol::Ip4("0.0.0.0".parse().unwrap()));
+
+        let random_peer = PeerId::random();
+        let random_peer1 = PeerId::random();
+        let random_peer2 = PeerId::random();
+        let random_peer3 = PeerId::random();
+        println!("{}", random_peer);
+        println!("{}", random_peer1);
+        println!("{}", random_peer2);
+        println!("{}", random_peer3);
+
+        // All 4 peers connected on the same IP
+        pdb.connect_ingoing(&random_peer, multiaddr.clone(), None);
+        pdb.connect_ingoing(&random_peer1, multiaddr.clone(), None);
+        pdb.connect_ingoing(&random_peer2, multiaddr.clone(), None);
+        pdb.connect_ingoing(&random_peer3, multiaddr.clone(), None);
+
+        // Should be no disconnected or banned peers
+        assert_eq!(pdb.disconnected_peers, pdb.disconnected_peers().count());
+        assert_eq!(
+            pdb.banned_peers_count.banned_peers(),
+            pdb.banned_peers_by_score().count()
+        );
+
+        // Should be no disconnected peers
+        println!(
+            "1:{},{}",
+            pdb.disconnected_peers, pdb.banned_peers_count.banned_peers
+        );
+        // Disconnect one peer
+        pdb.inject_disconnect(&random_peer1);
+        // Should be 1 disconnected peer
+        println!(
+            "2:{},{}",
+            pdb.disconnected_peers, pdb.banned_peers_count.banned_peers
+        );
+        // Disconnect and ban peer 2
+        let _ = pdb.report_peer(
+            &random_peer2,
+            PeerAction::Fatal,
+            ReportSource::PeerManager,
+            "",
+        );
+        // Should be 1 disconnected peer and one peer in the process of being disconnected
+        println!(
+            "3:{},{}",
+            pdb.disconnected_peers, pdb.banned_peers_count.banned_peers
+        );
+        // The peer is now disconnected and banned
+        pdb.inject_disconnect(&random_peer2);
+        // There should be 2 disconnected peers.
+        println!(
+            "4:{},{}",
+            pdb.disconnected_peers, pdb.banned_peers_count.banned_peers
+        );
+        // Now that the peer is disconnected, register the ban.
+        let _ = pdb.report_peer(
+            &random_peer2,
+            PeerAction::Fatal,
+            ReportSource::PeerManager,
+            "",
+        );
+        // There should be 1 disconnected peer and one banned peer.
+        println!(
+            "5:{},{}",
+            pdb.disconnected_peers, pdb.banned_peers_count.banned_peers
+        );
+        // Re-connect peer3, should have no effect
+        pdb.connect_ingoing(&random_peer3, multiaddr.clone(), None);
+        assert_eq!(pdb.disconnected_peers, pdb.disconnected_peers().count());
+        assert_eq!(
+            pdb.banned_peers_count.banned_peers(),
+            pdb.banned_peers().count()
+        );
+        // Now ban peer 1.
+        let _ = pdb.report_peer(
+            &random_peer1,
+            PeerAction::Fatal,
+            ReportSource::PeerManager,
+            "",
+        );
+        // There should be no disconnected peers and 2 banned peers
+        println!(
+            "6:{},{}",
+            pdb.disconnected_peers, pdb.banned_peers_count.banned_peers
+        );
+        // This should have no effect
+        pdb.inject_disconnect(&random_peer1);
+        // Should still be no disconnected peers and 2 banned peers
+        println!(
+            "7:{},{}",
+            pdb.disconnected_peers, pdb.banned_peers_count.banned_peers
+        );
+        // Same thing here.
+        let _ = pdb.report_peer(
+            &random_peer1,
+            PeerAction::Fatal,
+            ReportSource::PeerManager,
+            "",
+        );
+        println!(
+            "8:{},{}",
+            pdb.disconnected_peers, pdb.banned_peers_count.banned_peers
+        );
+        println!(
+            "{}, {:?}, {}",
+            pdb.disconnected_peers,
+            pdb.disconnected_peers().collect::<Vec<_>>(),
+            pdb.banned_peers_count.banned_peers
+        );
+        assert_eq!(pdb.disconnected_peers, pdb.disconnected_peers().count());
+        assert_eq!(
+            pdb.banned_peers_count.banned_peers(),
+            pdb.banned_peers().count()
+        );
+
+        // Try and reconnect banned peer 2.
+        pdb.connect_outgoing(&random_peer2, multiaddr.clone(), None);
+        pdb.peer_info_mut(&random_peer2)
+            .unwrap()
+            .add_to_score(100.0);
+        // This removes the banned peer and should give us 0 disconnected, 1 banned peer
+        // (peer1)
+        println!(
+            "9:{},{}",
+            pdb.disconnected_peers, pdb.banned_peers_count.banned_peers
+        );
+
+        assert_eq!(pdb.disconnected_peers, pdb.disconnected_peers().count());
+        assert_eq!(
+            pdb.banned_peers_count.banned_peers(),
+            pdb.banned_peers().count()
+        );
+
+        // Ban peer 3
+        let _ = pdb.report_peer(
+            &random_peer3,
+            PeerAction::Fatal,
+            ReportSource::PeerManager,
+            "",
+        );
+        pdb.inject_disconnect(&random_peer3);
+
+        // This should add a new banned peer, there should be 0 disconnected and 2 banned
+        // peers (peer1 and peer3)
+        println!(
+            "10:{},{}",
+            pdb.disconnected_peers, pdb.banned_peers_count.banned_peers
+        );
+
+        assert_eq!(pdb.disconnected_peers, pdb.disconnected_peers().count());
+        assert_eq!(
+            pdb.banned_peers_count.banned_peers(),
+            pdb.banned_peers().count()
+        );
+
+        // Ban peer 3
+        let _ = pdb.report_peer(
+            &random_peer3,
+            PeerAction::Fatal,
+            ReportSource::PeerManager,
+            "",
+        );
+        pdb.inject_disconnect(&random_peer3);
+
+        // Should still have 2 banned peers
+        println!(
+            "11:{},{}",
+            pdb.disconnected_peers, pdb.banned_peers_count.banned_peers
+        );
+
+        // Unban peer 1
+        pdb.connect_ingoing(&random_peer1, multiaddr.clone(), None);
+        pdb.peer_info_mut(&random_peer1)
+            .unwrap()
+            .add_to_score(100.0);
+        // Should have 1 banned peer (peer 3)
+        println!(
+            "12:{},{}",
+            pdb.disconnected_peers, pdb.banned_peers_count.banned_peers
+        );
+
+        // Disconnect peer 2
+        pdb.inject_disconnect(&random_peer2);
+
+        // Should have 1 disconnect (peer 2) and one banned (peer 3)
+        println!(
+            "12:{},{}",
+            pdb.disconnected_peers, pdb.banned_peers_count.banned_peers
+        );
+
+        // Ban peer 3
+        let _ = pdb.report_peer(
+            &random_peer3,
+            PeerAction::Fatal,
+            ReportSource::PeerManager,
+            "",
+        );
+        pdb.inject_disconnect(&random_peer3);
+
+        // Should have 1 disconnect (peer 2) and one banned (peer 3)
+        println!(
+            "13:{},{}",
+            pdb.disconnected_peers, pdb.banned_peers_count.banned_peers
+        );
+
+        // Add peer 0
+        pdb.connect_ingoing(&random_peer, multiaddr, None);
+        pdb.peer_info_mut(&random_peer).unwrap().add_to_score(100.0);
+
+        // Should have 1 disconnect (peer 2) and one banned (peer 3)
+        println!(
+            "14:{},{}",
+            pdb.disconnected_peers, pdb.banned_peers_count.banned_peers
+        );
+        assert_eq!(pdb.disconnected_peers, pdb.disconnected_peers().count());
+        assert_eq!(
+            pdb.banned_peers_count.banned_peers(),
+            pdb.banned_peers().count()
+        );
+
+        // Disconnect peer 0
+        pdb.inject_disconnect(&random_peer);
+        // Should have 2 disconnect (peer 0, peer 2) and one banned (peer 3)
+        println!(
+            "15:{},{}",
+            pdb.disconnected_peers, pdb.banned_peers_count.banned_peers
+        );
+        assert_eq!(pdb.disconnected_peers, pdb.disconnected_peers().count());
+        assert_eq!(
+            pdb.banned_peers_count.banned_peers(),
+            pdb.banned_peers().count()
+        );
+
+        // Disconnect peer 0
+        pdb.inject_disconnect(&random_peer);
+        // Should have 2 disconnect (peer 0, peer 2) and one banned (peer 3)
+        println!(
+            "16:{},{}",
+            pdb.disconnected_peers, pdb.banned_peers_count.banned_peers
+        );
+        assert_eq!(pdb.disconnected_peers, pdb.disconnected_peers().count());
+        assert_eq!(
+            pdb.banned_peers_count.banned_peers(),
+            pdb.banned_peers().count()
+        );
+
+        // Ban peer 0
+        let _ = pdb.report_peer(
+            &random_peer,
+            PeerAction::Fatal,
+            ReportSource::PeerManager,
+            "",
+        );
+        pdb.inject_disconnect(&random_peer);
+
+        // Should have 1 disconnect ( peer 2) and two banned (peer0, peer 3)
+        println!(
+            "17:{},{}",
+            pdb.disconnected_peers, pdb.banned_peers_count.banned_peers
+        );
+        assert_eq!(pdb.disconnected_peers, pdb.disconnected_peers().count());
+    }
+
+    fn connect_peer_with_ips(pdb: &mut PeerDB, ips: Vec<IpAddr>) -> PeerId {
+        let p = PeerId::random();
+
+        for ip in ips {
+            let mut addr = Multiaddr::empty();
+            addr.push(Protocol::from(ip));
+            addr.push(Protocol::Tcp(9000));
+            pdb.connect_ingoing(&p, addr, None);
+        }
+        p
+    }
+
+    #[test]
+    fn test_ban_address() {
+        let mut pdb = get_db();
+
+        let ip1 = Ipv4Addr::new(1, 2, 3, 4).into();
+        let ip2 = Ipv6Addr::new(1, 2, 3, 4, 5, 6, 7, 8).into();
+        let ip3 = Ipv4Addr::new(1, 2, 3, 5).into();
+        let ip4 = Ipv6Addr::new(1, 2, 3, 4, 5, 6, 7, 9).into();
+        let ip5 = Ipv4Addr::new(2, 2, 3, 4).into();
+
+        let mut peers = Vec::new();
+        for i in 0..BANNED_PEERS_PER_IP_THRESHOLD + 2 {
+            peers.push(connect_peer_with_ips(
+                &mut pdb,
+                if i == 0 {
+                    vec![ip1, ip2]
+                } else {
+                    vec![ip1, ip2, ip3, ip4]
+                },
+            ));
+        }
+
+        let p1 = connect_peer_with_ips(&mut pdb, vec![ip1]);
+        let p2 = connect_peer_with_ips(&mut pdb, vec![ip2, ip5]);
+        let p3 = connect_peer_with_ips(&mut pdb, vec![ip3, ip5]);
+        let p4 = connect_peer_with_ips(&mut pdb, vec![ip5, ip4]);
+        let p5 = connect_peer_with_ips(&mut pdb, vec![ip5]);
+
+        for p in &peers[..BANNED_PEERS_PER_IP_THRESHOLD + 1] {
+            let _ = pdb.report_peer(p, PeerAction::Fatal, ReportSource::PeerManager, "");
+            pdb.inject_disconnect(p);
+        }
+
+        //check that ip1 and ip2 are banned but ip3-5 not
+        assert!(pdb.ban_status(&p1).is_some());
+        assert!(pdb.ban_status(&p2).is_some());
+        assert!(pdb.ban_status(&p3).is_none());
+        assert!(pdb.ban_status(&p4).is_none());
+        assert!(pdb.ban_status(&p5).is_none());
+
+        //ban also the last peer in peers
+        let _ = pdb.report_peer(
+            &peers[BANNED_PEERS_PER_IP_THRESHOLD + 1],
+            PeerAction::Fatal,
+            ReportSource::PeerManager,
+            "",
+        );
+        pdb.inject_disconnect(&peers[BANNED_PEERS_PER_IP_THRESHOLD + 1]);
+
+        //check that ip1-ip4 are banned but ip5 not
+        assert!(pdb.ban_status(&p1).is_some());
+        assert!(pdb.ban_status(&p2).is_some());
+        assert!(pdb.ban_status(&p3).is_some());
+        assert!(pdb.ban_status(&p4).is_some());
+        assert!(pdb.ban_status(&p5).is_none());
+
+        //peers[0] gets unbanned
+        reset_score(&mut pdb, &peers[0]);
+        pdb.update_connection_state(&peers[0], NewConnectionState::Unbanned);
+        let _ = pdb.shrink_to_fit();
+
+        //nothing changed
+        assert!(pdb.ban_status(&p1).is_some());
+        assert!(pdb.ban_status(&p2).is_some());
+        assert!(pdb.ban_status(&p3).is_some());
+        assert!(pdb.ban_status(&p4).is_some());
+        assert!(pdb.ban_status(&p5).is_none());
+
+        //peers[1] gets unbanned
+        reset_score(&mut pdb, &peers[1]);
+        pdb.update_connection_state(&peers[1], NewConnectionState::Unbanned);
+        let _ = pdb.shrink_to_fit();
+
+        //all ips are unbanned
+        assert!(pdb.ban_status(&p1).is_none());
+        assert!(pdb.ban_status(&p2).is_none());
+        assert!(pdb.ban_status(&p3).is_none());
+        assert!(pdb.ban_status(&p4).is_none());
+        assert!(pdb.ban_status(&p5).is_none());
+    }
+
+    #[test]
+    fn test_banned_ip_consistent_after_changing_ips() {
+        let mut pdb = get_db();
+
+        let ip1: IpAddr = Ipv4Addr::new(1, 2, 3, 4).into();
+        let ip2: IpAddr = Ipv6Addr::new(1, 2, 3, 4, 5, 6, 7, 8).into();
+
+        let mut peers = Vec::new();
+        for _ in 0..BANNED_PEERS_PER_IP_THRESHOLD + 1 {
+            peers.push(connect_peer_with_ips(&mut pdb, vec![ip1]));
+        }
+
+        let p1 = connect_peer_with_ips(&mut pdb, vec![ip1]);
+        let p2 = connect_peer_with_ips(&mut pdb, vec![ip2]);
+
+        // ban all peers
+        for p in &peers {
+            let _ = pdb.report_peer(p, PeerAction::Fatal, ReportSource::PeerManager, "");
+            pdb.inject_disconnect(p);
+        }
+
+        // check ip is banned
+        assert!(pdb.ban_status(&p1).is_some());
+        assert!(pdb.ban_status(&p2).is_none());
+
+        // unban a peer
+        reset_score(&mut pdb, &peers[0]);
+        pdb.update_connection_state(&peers[0], NewConnectionState::Unbanned);
+        let _ = pdb.shrink_to_fit();
+
+        // check not banned anymore
+        assert!(pdb.ban_status(&p1).is_none());
+        assert!(pdb.ban_status(&p2).is_none());
+
+        // unban all peers
+        for p in &peers {
+            reset_score(&mut pdb, p);
+            pdb.update_connection_state(p, NewConnectionState::Unbanned);
+            let _ = pdb.shrink_to_fit();
+        }
+
+        // add ip2 to all peers and ban them.
+        let mut socker_addr = Multiaddr::from(ip2);
+        socker_addr.push(Protocol::Tcp(8080));
+        for p in &peers {
+            pdb.connect_ingoing(p, socker_addr.clone(), None);
+            let _ = pdb.report_peer(p, PeerAction::Fatal, ReportSource::PeerManager, "");
+            pdb.inject_disconnect(p);
+        }
+
+        // both IP's are now banned
+        assert!(pdb.ban_status(&p1).is_some());
+        assert!(pdb.ban_status(&p2).is_some());
+
+        // unban all peers
+        for p in &peers {
+            reset_score(&mut pdb, p);
+            pdb.update_connection_state(p, NewConnectionState::Unbanned);
+            let _ = pdb.shrink_to_fit();
+        }
+
+        // reban every peer except one
+        for p in &peers[1..] {
+            let _ = pdb.report_peer(p, PeerAction::Fatal, ReportSource::PeerManager, "");
+            pdb.inject_disconnect(p);
+        }
+
+        // nothing is banned
+        assert!(pdb.ban_status(&p1).is_none());
+        assert!(pdb.ban_status(&p2).is_none());
+
+        // reban last peer
+        let _ = pdb.report_peer(&peers[0], PeerAction::Fatal, ReportSource::PeerManager, "");
+        pdb.inject_disconnect(&peers[0]);
+
+        //Ip's are banned again
+        assert!(pdb.ban_status(&p1).is_some());
+        assert!(pdb.ban_status(&p2).is_some());
+    }
+
+    // #[test]
+    // #[allow(clippy::float_cmp)]
+    // fn test_trusted_peers_score() {
+    //     let trusted_peer = PeerId::random();
+    //     let log = build_log(slog::Level::Debug, false);
+    //     let mut pdb: PeerDB<M> = PeerDB::new(vec![trusted_peer], false, &log);
+    //
+    //     pdb.connect_ingoing(&trusted_peer, "/ip4/0.0.0.0".parse().unwrap(), None);
+    //
+    //     // Check trusted status and score
+    //     assert!(pdb.peer_info(&trusted_peer).unwrap().is_trusted());
+    //     assert_eq!(
+    //         pdb.peer_info(&trusted_peer).unwrap().score().score(),
+    //         Score::max_score().score()
+    //     );
+    //
+    //     // Adding/Subtracting score should have no effect on a trusted peer
+    //     add_score(&mut pdb, &trusted_peer, -50.0);
+    //
+    //     assert_eq!(
+    //         pdb.peer_info(&trusted_peer).unwrap().score().score(),
+    //         Score::max_score().score()
+    //     );
+    // }
+    //
+    // #[test]
+    // fn test_disable_peer_scoring() {
+    //     let peer = PeerId::random();
+    //     let log = build_log(slog::Level::Debug, false);
+    //     let mut pdb: PeerDB<M> = PeerDB::new(vec![], true, &log);
+    //
+    //     pdb.connect_ingoing(&peer, "/ip4/0.0.0.0".parse().unwrap(), None);
+    //
+    //     // Check trusted status and score
+    //     assert!(pdb.peer_info(&peer).unwrap().is_trusted());
+    //     assert_eq!(
+    //         pdb.peer_info(&peer).unwrap().score().score(),
+    //         Score::max_score().score()
+    //     );
+    //
+    //     // Adding/Subtracting score should have no effect on a trusted peer
+    //     add_score(&mut pdb, &peer, -50.0);
+    //
+    //     assert_eq!(
+    //         pdb.peer_info(&peer).unwrap().score().score(),
+    //         Score::max_score().score()
+    //     );
+    // }
+}

--- a/anchor/network/src/peer_manager/peerdb/mod.rs
+++ b/anchor/network/src/peer_manager/peerdb/mod.rs
@@ -4,7 +4,7 @@ use crate::discovery::SSVSubnet;
 use crate::Enr;
 use itertools::Itertools;
 use libp2p::{Multiaddr, PeerId};
-use lighthouse_network::{metrics, Gossipsub, PeerAction, Subnet};
+use lighthouse_network::{metrics, Gossipsub, PeerAction};
 use peer_info::{ConnectionDirection, PeerConnectionStatus, PeerInfo};
 use score::{ReportSource, Score, ScoreState};
 use std::net::IpAddr;
@@ -16,7 +16,6 @@ use std::{
 };
 use sync_status::SyncStatus;
 use tracing::{debug, error, trace, warn};
-use types::{ChainSpec, DataColumnSubnetId, EthSpec};
 
 pub mod client;
 pub mod peer_info;
@@ -507,7 +506,7 @@ impl PeerDB {
         &mut self,
         peer_id: &PeerId,
         action: PeerAction,
-        source: ReportSource,
+        _source: ReportSource,
         msg: &'static str,
     ) -> ScoreUpdateResult {
         metrics::inc_counter_vec(&metrics::REPORT_PEER_MSGS, &[msg]);

--- a/anchor/network/src/peer_manager/peerdb/peer_info.rs
+++ b/anchor/network/src/peer_manager/peerdb/peer_info.rs
@@ -172,7 +172,7 @@ impl PeerInfo {
         if let Some(meta_data) = self.meta_data.as_ref() {
             return meta_data.subnets.num_set_bits();
         } else if let Some(enr) = self.enr.as_ref() {
-            if let Ok(attnets) = subnets_bitfield(&enr) {
+            if let Ok(attnets) = subnets_bitfield(enr) {
                 return attnets.num_set_bits();
             }
         }

--- a/anchor/network/src/peer_manager/peerdb/peer_info.rs
+++ b/anchor/network/src/peer_manager/peerdb/peer_info.rs
@@ -1,0 +1,591 @@
+use super::client::Client;
+use super::score::{Score, ScoreState};
+use super::sync_status::SyncStatus;
+use crate::discovery::SSVSubnet;
+use discv5::Enr;
+use libp2p::bytes::Bytes;
+use libp2p::core::multiaddr::{Multiaddr, Protocol};
+use lighthouse_network::PeerAction;
+use serde::{
+    ser::{SerializeStruct, Serializer},
+    Serialize,
+};
+use ssz::{BitVector, Decode};
+use ssz_types::typenum::U128;
+use std::collections::HashSet;
+use std::net::IpAddr;
+use std::time::Instant;
+use strum::AsRefStr;
+use PeerConnectionStatus::*;
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct MetaData {
+    /// A sequential counter indicating when data gets modified.
+    pub seq_number: u64,
+    /// The persistent attestation subnet bitfield.
+    pub subnets: BitVector<U128>,
+}
+
+/// Information about a given connected peer.
+#[derive(Clone, Debug, Serialize)]
+pub struct PeerInfo {
+    /// The peers reputation
+    score: Score,
+    /// Client managing this peer
+    client: Client,
+    /// Connection status of this peer
+    connection_status: PeerConnectionStatus,
+    /// The known listening addresses of this peer. This is given by identify and can be arbitrary
+    /// (including local IPs).
+    listening_addresses: Vec<Multiaddr>,
+    /// These are the multiaddrs we have physically seen and is what we use for banning/un-banning
+    /// peers.
+    seen_multiaddrs: HashSet<Multiaddr>,
+    /// The current syncing state of the peer. The state may be determined after it's initial
+    /// connection.
+    sync_status: SyncStatus,
+    /// The ENR subnet bitfield of the peer. This may be determined after it's initial
+    /// connection.
+    meta_data: Option<MetaData>,
+    /// Subnets the peer is connected to.
+    subnets: HashSet<SSVSubnet>,
+    /// The time we would like to retain this peer. After this time, the peer is no longer
+    /// necessary.
+    #[serde(skip)]
+    min_ttl: Option<Instant>,
+    /// Is the peer a trusted peer.
+    is_trusted: bool,
+    /// Direction of the first connection of the last (or current) connected session with this peer.
+    /// None if this peer was never connected.
+    connection_direction: Option<ConnectionDirection>,
+    /// The enr of the peer, if known.
+    enr: Option<Enr>,
+}
+
+impl Default for PeerInfo {
+    fn default() -> PeerInfo {
+        PeerInfo {
+            score: Score::default(),
+            client: Client::default(),
+            connection_status: Default::default(),
+            listening_addresses: Vec::new(),
+            seen_multiaddrs: HashSet::new(),
+            subnets: HashSet::new(),
+            sync_status: SyncStatus::Unknown,
+            meta_data: None,
+            min_ttl: None,
+            is_trusted: false,
+            connection_direction: None,
+            enr: None,
+        }
+    }
+}
+
+impl PeerInfo {
+    /// Return a PeerInfo struct for a trusted peer.
+    pub fn trusted_peer_info() -> Self {
+        PeerInfo {
+            score: Score::max_score(),
+            is_trusted: true,
+            ..Default::default()
+        }
+    }
+
+    /// Returns if the peer is subscribed to a given `Subnet` from the metadata attnets/syncnets field.
+    /// Also returns true if the peer is assigned to custody a given data column `Subnet` computed from the metadata `custody_group_count` field or ENR `cgc` field.
+    pub fn on_subnet_metadata(&self, subnet: &SSVSubnet) -> bool {
+        if let Some(meta_data) = &self.meta_data {
+            return match subnet {
+                SSVSubnet::Subnet(id) => meta_data.subnets.get(**id as usize).unwrap_or(false),
+            };
+        }
+        false
+    }
+
+    /// Obtains the client of the peer.
+    pub fn client(&self) -> &Client {
+        &self.client
+    }
+
+    /// Returns the listening addresses of the Peer.
+    pub fn listening_addresses(&self) -> &Vec<Multiaddr> {
+        &self.listening_addresses
+    }
+
+    /// Returns the connection direction for the peer.
+    pub fn connection_direction(&self) -> Option<&ConnectionDirection> {
+        self.connection_direction.as_ref()
+    }
+
+    /// Returns true if this is an incoming ipv4 connection.
+    pub fn is_incoming_ipv4_connection(&self) -> bool {
+        self.seen_multiaddrs.iter().any(|multiaddr| {
+            multiaddr
+                .iter()
+                .any(|protocol| matches!(protocol, libp2p::core::multiaddr::Protocol::Ip4(_)))
+        })
+    }
+
+    /// Returns true if this is an incoming ipv6 connection.
+    pub fn is_incoming_ipv6_connection(&self) -> bool {
+        self.seen_multiaddrs.iter().any(|multiaddr| {
+            multiaddr
+                .iter()
+                .any(|protocol| matches!(protocol, libp2p::core::multiaddr::Protocol::Ip6(_)))
+        })
+    }
+
+    /// Returns the sync status of the peer.
+    pub fn sync_status(&self) -> &SyncStatus {
+        &self.sync_status
+    }
+
+    /// Returns the metadata for the peer if currently known.
+    pub fn meta_data(&self) -> Option<&MetaData> {
+        self.meta_data.as_ref()
+    }
+
+    /// Returns whether the peer is a trusted peer or not.
+    pub fn is_trusted(&self) -> bool {
+        self.is_trusted
+    }
+
+    /// The time a peer is expected to be useful until for an attached validator. If this is set to
+    /// None, the peer is not required for any upcoming duty.
+    pub fn min_ttl(&self) -> Option<&Instant> {
+        self.min_ttl.as_ref()
+    }
+
+    /// The ENR of the peer if it is known.
+    pub fn enr(&self) -> Option<&Enr> {
+        self.enr.as_ref()
+    }
+
+    /// An iterator over all the subnets this peer is subscribed to.
+    pub fn subnets(&self) -> impl Iterator<Item = &SSVSubnet> {
+        self.subnets.iter()
+    }
+
+    /// Returns the number of long lived subnets a peer is subscribed to.
+    // NOTE: This currently excludes sync committee subnets
+    pub fn long_lived_subnet_count(&self) -> usize {
+        if let Some(meta_data) = self.meta_data.as_ref() {
+            return meta_data.subnets.num_set_bits();
+        } else if let Some(enr) = self.enr.as_ref() {
+            if let Ok(attnets) = subnets_bitfield(&enr) {
+                return attnets.num_set_bits();
+            }
+        }
+        0
+    }
+
+    /// Returns an iterator over the long-lived subnets if it has any.
+    pub fn long_lived_subnets(&self) -> Vec<SSVSubnet> {
+        let mut long_lived_subnets = Vec::new();
+        // Check the meta_data
+        if let Some(meta_data) = self.meta_data.as_ref() {
+            for subnet in 0..=meta_data.subnets.highest_set_bit().unwrap_or(0) {
+                if meta_data.subnets.get(subnet).unwrap_or(false) {
+                    long_lived_subnets.push(SSVSubnet::Subnet((subnet as u64).into()));
+                }
+            }
+        } else if let Some(enr) = self.enr.as_ref() {
+            if let Ok(attnets) = subnets_bitfield(enr) {
+                for subnet in 0..=attnets.highest_set_bit().unwrap_or(0) {
+                    if attnets.get(subnet).unwrap_or(false) {
+                        long_lived_subnets.push(SSVSubnet::Subnet((subnet as u64).into()));
+                    }
+                }
+            }
+        }
+        long_lived_subnets
+    }
+
+    /// Returns if the peer is subscribed to a given `Subnet` from the gossipsub subscriptions.
+    pub fn on_subnet_gossipsub(&self, subnet: &SSVSubnet) -> bool {
+        self.subnets.contains(subnet)
+    }
+
+    /// Returns true if the peer is connected to a long-lived subnet.
+    pub fn has_long_lived_subnet(&self) -> bool {
+        // Check the meta_data
+        if let Some(meta_data) = self.meta_data.as_ref() {
+            if !meta_data.subnets.is_zero() && !self.subnets.is_empty() {
+                return true;
+            }
+        }
+
+        // We may not have the metadata but may have an ENR. Lets check that
+        if let Some(enr) = self.enr.as_ref() {
+            if let Ok(attnets) = subnets_bitfield(enr) {
+                if !attnets.is_zero() && !self.subnets.is_empty() {
+                    return true;
+                }
+            }
+        }
+        false
+    }
+
+    /// Returns the seen addresses of the peer.
+    pub fn seen_multiaddrs(&self) -> impl Iterator<Item = &Multiaddr> + '_ {
+        self.seen_multiaddrs.iter()
+    }
+
+    /// Returns a list of seen IP addresses for the peer.
+    pub fn seen_ip_addresses(&self) -> impl Iterator<Item = IpAddr> + '_ {
+        self.seen_multiaddrs.iter().filter_map(|multiaddr| {
+            multiaddr.iter().find_map(|protocol| {
+                match protocol {
+                    Protocol::Ip4(ip) => Some(ip.into()),
+                    Protocol::Ip6(ip) => Some(ip.into()),
+                    _ => None, // Only care for IP addresses
+                }
+            })
+        })
+    }
+
+    /// Returns the connection status of the peer.
+    pub fn connection_status(&self) -> &PeerConnectionStatus {
+        &self.connection_status
+    }
+
+    /// Reports if this peer has some future validator duty in which case it is valuable to keep it.
+    pub fn has_future_duty(&self) -> bool {
+        self.min_ttl.is_some_and(|i| i >= Instant::now())
+    }
+
+    /// Returns score of the peer.
+    pub fn score(&self) -> &Score {
+        &self.score
+    }
+
+    /// Returns the state of the peer based on the score.
+    pub(crate) fn score_state(&self) -> ScoreState {
+        self.score.state()
+    }
+
+    /// Returns true if the gossipsub score is sufficient.
+    pub fn is_good_gossipsub_peer(&self) -> bool {
+        self.score.is_good_gossipsub_peer()
+    }
+
+    /* Peer connection status API */
+
+    /// Checks if the status is connected.
+    pub fn is_connected(&self) -> bool {
+        matches!(
+            self.connection_status,
+            PeerConnectionStatus::Connected { .. }
+        )
+    }
+
+    /// Checks if the status is connected.
+    pub fn is_dialing(&self) -> bool {
+        matches!(self.connection_status, PeerConnectionStatus::Dialing { .. })
+    }
+
+    /// The peer is either connected or in the process of being dialed.
+    pub fn is_connected_or_dialing(&self) -> bool {
+        self.is_connected() || self.is_dialing()
+    }
+
+    /// Checks if the connection status is banned. This can lag behind the score state
+    /// temporarily.
+    pub fn is_banned(&self) -> bool {
+        matches!(self.connection_status, PeerConnectionStatus::Banned { .. })
+    }
+
+    /// Checks if the peer's score is banned.
+    pub fn score_is_banned(&self) -> bool {
+        matches!(self.score.state(), ScoreState::Banned)
+    }
+
+    /// Checks if the status is disconnected.
+    pub fn is_disconnected(&self) -> bool {
+        matches!(self.connection_status, Disconnected { .. })
+    }
+
+    /// Checks if the peer is outbound-only
+    pub fn is_outbound_only(&self) -> bool {
+        matches!(self.connection_status, Connected {n_in, n_out, ..} if n_in == 0 && n_out > 0)
+    }
+
+    /// Returns the number of connections with this peer.
+    pub fn connections(&self) -> (u8, u8) {
+        match self.connection_status {
+            Connected { n_in, n_out, .. } => (n_in, n_out),
+            _ => (0, 0),
+        }
+    }
+
+    /* Mutable Functions */
+
+    /// Updates the sync status. Returns true if the status was changed.
+    // VISIBILITY: Both the peer manager the network sync is able to update the sync state of a peer
+    pub fn update_sync_status(&mut self, sync_status: SyncStatus) -> bool {
+        self.sync_status.update(sync_status)
+    }
+
+    /// Sets the client of the peer.
+    // VISIBILITY: The peer manager is able to set the client
+    pub(in crate::peer_manager) fn set_client(&mut self, client: Client) {
+        self.client = client
+    }
+
+    /// Replaces the current listening addresses with those specified, returning the current
+    /// listening addresses.
+    // VISIBILITY: The peer manager is able to set the listening addresses
+    pub(in crate::peer_manager) fn set_listening_addresses(
+        &mut self,
+        listening_addresses: Vec<Multiaddr>,
+    ) -> Vec<Multiaddr> {
+        std::mem::replace(&mut self.listening_addresses, listening_addresses)
+    }
+
+    /// Sets an explicit value for the meta data.
+    // VISIBILITY: The peer manager is able to adjust the meta_data
+    pub(in crate::peer_manager) fn set_meta_data(&mut self, meta_data: MetaData) {
+        self.meta_data = Some(meta_data);
+    }
+
+    /// Sets the connection status of the peer.
+    pub(super) fn set_connection_status(&mut self, connection_status: PeerConnectionStatus) {
+        self.connection_status = connection_status
+    }
+
+    /// Sets the ENR of the peer if one is known.
+    pub(super) fn set_enr(&mut self, enr: Enr) {
+        self.enr = Some(enr)
+    }
+
+    /// Sets the time that the peer is expected to be needed until for an attached validator duty.
+    pub(super) fn set_min_ttl(&mut self, min_ttl: Instant) {
+        self.min_ttl = Some(min_ttl)
+    }
+
+    /// Adds a known subnet for the peer.
+    pub(super) fn insert_subnet(&mut self, subnet: SSVSubnet) {
+        self.subnets.insert(subnet);
+    }
+
+    /// Removes a subnet from the peer.
+    pub(super) fn remove_subnet(&mut self, subnet: &SSVSubnet) {
+        self.subnets.remove(subnet);
+    }
+
+    /// Removes all subnets from the peer.
+    pub(super) fn clear_subnets(&mut self) {
+        self.subnets.clear()
+    }
+
+    /// Applies decay rates to a non-trusted peer's score.
+    pub(super) fn score_update(&mut self) {
+        if !self.is_trusted {
+            self.score.update()
+        }
+    }
+
+    /// Apply peer action to a non-trusted peer's score.
+    // VISIBILITY: The peer manager is able to modify the score of a peer.
+    pub(in crate::peer_manager) fn apply_peer_action_to_score(&mut self, peer_action: PeerAction) {
+        if !self.is_trusted {
+            self.score.apply_peer_action(peer_action)
+        }
+    }
+
+    /// Updates the gossipsub score with a new score. Optionally ignore the gossipsub score.
+    pub(super) fn update_gossipsub_score(&mut self, new_score: f64, ignore: bool) {
+        self.score.update_gossipsub_score(new_score, ignore);
+    }
+
+    #[cfg(test)]
+    /// Resets the peers score.
+    pub fn reset_score(&mut self) {
+        self.score.test_reset();
+    }
+
+    /// Modifies the status to Dialing
+    /// Returns an error if the current state is unexpected.
+    pub(super) fn set_dialing_peer(&mut self) -> Result<(), &'static str> {
+        match &mut self.connection_status {
+            Connected { .. } => return Err("Dialing connected peer"),
+            Dialing { .. } => return Err("Dialing an already dialing peer"),
+            Disconnecting { .. } => return Err("Dialing a disconnecting peer"),
+            Disconnected { .. } | Banned { .. } | Unknown => {}
+        }
+        self.connection_status = Dialing {
+            since: Instant::now(),
+        };
+        Ok(())
+    }
+
+    /// Modifies the status to Connected and increases the number of ingoing
+    /// connections by one
+    pub(super) fn connect_ingoing(&mut self, multiaddr: Multiaddr) {
+        self.seen_multiaddrs.insert(multiaddr.clone());
+
+        match &mut self.connection_status {
+            Connected { n_in, .. } => *n_in += 1,
+            Disconnected { .. }
+            | Banned { .. }
+            | Dialing { .. }
+            | Disconnecting { .. }
+            | Unknown => {
+                self.connection_status = Connected {
+                    n_in: 1,
+                    n_out: 0,
+                    multiaddr,
+                };
+                self.connection_direction = Some(ConnectionDirection::Incoming);
+            }
+        }
+    }
+
+    /// Modifies the status to Connected and increases the number of outgoing
+    /// connections by one
+    pub(super) fn connect_outgoing(&mut self, multiaddr: Multiaddr) {
+        self.seen_multiaddrs.insert(multiaddr.clone());
+        match &mut self.connection_status {
+            Connected { n_out, .. } => *n_out += 1,
+            Disconnected { .. }
+            | Banned { .. }
+            | Dialing { .. }
+            | Disconnecting { .. }
+            | Unknown => {
+                self.connection_status = Connected {
+                    n_in: 0,
+                    n_out: 1,
+                    multiaddr,
+                };
+                self.connection_direction = Some(ConnectionDirection::Outgoing);
+            }
+        }
+    }
+
+    #[cfg(test)]
+    /// Add an f64 to a non-trusted peer's score abiding by the limits.
+    pub fn add_to_score(&mut self, score: f64) {
+        if !self.is_trusted {
+            self.score.test_add(score)
+        }
+    }
+
+    #[cfg(test)]
+    pub fn set_gossipsub_score(&mut self, score: f64) {
+        self.score.set_gossipsub_score(score);
+    }
+}
+
+/// Connection Direction of connection.
+#[derive(Debug, Clone, Serialize, AsRefStr)]
+#[strum(serialize_all = "snake_case")]
+pub enum ConnectionDirection {
+    /// The connection was established by a peer dialing us.
+    Incoming,
+    /// The connection was established by us dialing a peer.
+    Outgoing,
+}
+
+/// Connection Status of the peer.
+#[derive(Debug, Clone, Default)]
+pub enum PeerConnectionStatus {
+    /// The peer is connected.
+    Connected {
+        /// The multiaddr that we are connected via.
+        multiaddr: Multiaddr,
+        /// number of ingoing connections.
+        n_in: u8,
+        /// number of outgoing connections.
+        n_out: u8,
+    },
+    /// The peer is being disconnected.
+    Disconnecting {
+        // After the disconnection the peer will be considered banned.
+        to_ban: bool,
+    },
+    /// The peer has disconnected.
+    Disconnected {
+        /// last time the peer was connected or discovered.
+        since: Instant,
+    },
+    /// The peer has been banned and is disconnected.
+    Banned {
+        /// moment when the peer was banned.
+        since: Instant,
+    },
+    /// We are currently dialing this peer.
+    Dialing {
+        /// time since we last communicated with the peer.
+        since: Instant,
+    },
+    /// The connection status has not been specified.
+    #[default]
+    Unknown,
+}
+
+/// Serialization for http requests.
+impl Serialize for PeerConnectionStatus {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let mut s = serializer.serialize_struct("connection_status", 6)?;
+        match self {
+            Connected {
+                n_in,
+                n_out,
+                multiaddr,
+            } => {
+                s.serialize_field("multiaddr", multiaddr)?;
+                s.serialize_field("status", "connected")?;
+                s.serialize_field("connections_in", n_in)?;
+                s.serialize_field("connections_out", n_out)?;
+                s.serialize_field("last_seen", &0)?;
+                s.end()
+            }
+            Disconnecting { .. } => {
+                s.serialize_field("status", "disconnecting")?;
+                s.serialize_field("connections_in", &0)?;
+                s.serialize_field("connections_out", &0)?;
+                s.serialize_field("last_seen", &0)?;
+                s.end()
+            }
+            Disconnected { since } => {
+                s.serialize_field("status", "disconnected")?;
+                s.serialize_field("connections_in", &0)?;
+                s.serialize_field("connections_out", &0)?;
+                s.serialize_field("last_seen", &since.elapsed().as_secs())?;
+                s.serialize_field("banned_ips", &Vec::<IpAddr>::new())?;
+                s.end()
+            }
+            Banned { since } => {
+                s.serialize_field("status", "banned")?;
+                s.serialize_field("connections_in", &0)?;
+                s.serialize_field("connections_out", &0)?;
+                s.serialize_field("last_seen", &since.elapsed().as_secs())?;
+                s.end()
+            }
+            Dialing { since } => {
+                s.serialize_field("status", "dialing")?;
+                s.serialize_field("connections_in", &0)?;
+                s.serialize_field("connections_out", &0)?;
+                s.serialize_field("last_seen", &since.elapsed().as_secs())?;
+                s.end()
+            }
+            Unknown => {
+                s.serialize_field("status", "unknown")?;
+                s.serialize_field("connections_in", &0)?;
+                s.serialize_field("connections_out", &0)?;
+                s.serialize_field("last_seen", &0)?;
+                s.end()
+            }
+        }
+    }
+}
+
+fn subnets_bitfield(enr: &Enr) -> Result<BitVector<U128>, &'static str> {
+    let bitfield_bytes: Bytes = enr
+        .get_decodable("subnets")
+        .ok_or("ENR subnets bitfield non-existent")?
+        .map_err(|_| "Invalid SSZ Encoding")?;
+
+    BitVector::<U128>::from_ssz_bytes(&bitfield_bytes)
+        .map_err(|_| "Could not decode the ENR attnets bitfield")
+}

--- a/anchor/network/src/peer_manager/peerdb/score.rs
+++ b/anchor/network/src/peer_manager/peerdb/score.rs
@@ -11,7 +11,6 @@ use serde::Serialize;
 use std::cmp::Ordering;
 use std::sync::LazyLock;
 use std::time::Instant;
-use strum::AsRefStr;
 use tokio::time::Duration;
 
 static HALFLIFE_DECAY: LazyLock<f64> = LazyLock::new(|| -(2.0f64.ln()) / SCORE_HALFLIFE);

--- a/anchor/network/src/peer_manager/peerdb/score.rs
+++ b/anchor/network/src/peer_manager/peerdb/score.rs
@@ -46,7 +46,7 @@ const GOSSIPSUB_POSITIVE_SCORE_WEIGHT: f64 = GOSSIPSUB_NEGATIVE_SCORE_WEIGHT;
 #[derive(Debug)]
 pub enum ReportSource {
     Gossipsub,
-    RPC,
+    Rpc,
     Processor,
     SyncService,
     PeerManager,
@@ -56,7 +56,7 @@ impl From<ReportSource> for &'static str {
     fn from(report_source: ReportSource) -> &'static str {
         match report_source {
             ReportSource::Gossipsub => "gossipsub",
-            ReportSource::RPC => "rpc_error",
+            ReportSource::Rpc => "rpc_error",
             ReportSource::Processor => "processor",
             ReportSource::SyncService => "sync",
             ReportSource::PeerManager => "peer_manager",

--- a/anchor/network/src/peer_manager/peerdb/score.rs
+++ b/anchor/network/src/peer_manager/peerdb/score.rs
@@ -1,0 +1,392 @@
+//! This contains the scoring logic for peers.
+//!
+//! A peer's score is a rational number in the range [-100, 100].
+//!
+//! As the logic develops this documentation will advance.
+//!
+//! The scoring algorithms are currently experimental.
+//use crate::service::gossipsub_scoring_parameters::GREYLIST_THRESHOLD as GOSSIPSUB_GREYLIST_THRESHOLD;
+use lighthouse_network::PeerAction;
+use serde::Serialize;
+use std::cmp::Ordering;
+use std::sync::LazyLock;
+use std::time::Instant;
+use strum::AsRefStr;
+use tokio::time::Duration;
+
+static HALFLIFE_DECAY: LazyLock<f64> = LazyLock::new(|| -(2.0f64.ln()) / SCORE_HALFLIFE);
+
+/// The default score for new peers.
+pub(crate) const DEFAULT_SCORE: f64 = 0.0;
+/// The minimum reputation before a peer is disconnected.
+const MIN_SCORE_BEFORE_DISCONNECT: f64 = -20.0;
+/// The minimum reputation before a peer is banned.
+const MIN_SCORE_BEFORE_BAN: f64 = -50.0;
+/// If a peer has a lighthouse score below this constant all other score parts will get ignored and
+/// the peer will get banned regardless of the other parts.
+const MIN_LIGHTHOUSE_SCORE_BEFORE_BAN: f64 = -60.0;
+/// The maximum score a peer can obtain.
+const MAX_SCORE: f64 = 100.0;
+/// The minimum score a peer can obtain.
+const MIN_SCORE: f64 = -100.0;
+/// The halflife of a peer's score. I.e the number of seconds it takes for the score to decay to half its value.
+const SCORE_HALFLIFE: f64 = 600.0;
+/// The number of seconds we ban a peer for before their score begins to decay.
+const BANNED_BEFORE_DECAY: Duration = Duration::from_secs(12 * 3600); // 12 hours
+
+// Const as this is used in the peer manager to prevent gossip from disconnecting peers.
+pub const GOSSIPSUB_GREYLIST_THRESHOLD: f64 = -16000.0;
+
+/// We weight negative gossipsub scores in such a way that they never result in a disconnect by
+/// themselves. This "solves" the problem of non-decaying gossipsub scores for disconnected peers.
+const GOSSIPSUB_NEGATIVE_SCORE_WEIGHT: f64 =
+    (MIN_SCORE_BEFORE_DISCONNECT + 1.0) / GOSSIPSUB_GREYLIST_THRESHOLD;
+const GOSSIPSUB_POSITIVE_SCORE_WEIGHT: f64 = GOSSIPSUB_NEGATIVE_SCORE_WEIGHT;
+
+/// Service reporting a `PeerAction` for a peer.
+#[derive(Debug)]
+pub enum ReportSource {
+    Gossipsub,
+    RPC,
+    Processor,
+    SyncService,
+    PeerManager,
+}
+
+impl From<ReportSource> for &'static str {
+    fn from(report_source: ReportSource) -> &'static str {
+        match report_source {
+            ReportSource::Gossipsub => "gossipsub",
+            ReportSource::RPC => "rpc_error",
+            ReportSource::Processor => "processor",
+            ReportSource::SyncService => "sync",
+            ReportSource::PeerManager => "peer_manager",
+        }
+    }
+}
+
+/// The expected state of the peer given the peer's score.
+#[derive(Debug, PartialEq, Clone, Copy)]
+pub(crate) enum ScoreState {
+    /// We are content with the peers performance. We permit connections and messages.
+    Healthy,
+    /// The peer should be disconnected. We allow re-connections if the peer is persistent.
+    ForcedDisconnect,
+    /// The peer is banned. We disallow new connections until it's score has decayed into a
+    /// tolerable threshold.
+    Banned,
+}
+
+impl std::fmt::Display for ScoreState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ScoreState::Healthy => write!(f, "Healthy"),
+            ScoreState::Banned => write!(f, "Banned"),
+            ScoreState::ForcedDisconnect => write!(f, "Disconnected"),
+        }
+    }
+}
+
+/// A peer's score (perceived potential usefulness).
+///
+/// This simplistic version consists of a global score per peer which decays to 0 over time. The
+/// decay rate applies equally to positive and negative scores.
+#[derive(PartialEq, Clone, Debug, Serialize)]
+pub struct RealScore {
+    /// The global score.
+    // NOTE: In the future we may separate this into sub-scores involving the RPC, Gossipsub and
+    // lighthouse.
+    lighthouse_score: f64,
+    gossipsub_score: f64,
+    /// We ignore the negative gossipsub scores of some peers to allow decaying without
+    /// disconnecting.
+    ignore_negative_gossipsub_score: bool,
+    score: f64,
+    /// The time the score was last updated to perform time-based adjustments such as score-decay.
+    #[serde(skip)]
+    last_updated: Instant,
+}
+
+impl Default for RealScore {
+    fn default() -> Self {
+        RealScore {
+            lighthouse_score: DEFAULT_SCORE,
+            gossipsub_score: DEFAULT_SCORE,
+            score: DEFAULT_SCORE,
+            last_updated: Instant::now(),
+            ignore_negative_gossipsub_score: false,
+        }
+    }
+}
+
+impl RealScore {
+    /// Access to the underlying score.
+    fn recompute_score(&mut self) {
+        self.score = self.lighthouse_score;
+        if self.lighthouse_score <= MIN_LIGHTHOUSE_SCORE_BEFORE_BAN {
+            //ignore all other scores, i.e. do nothing here
+        } else if self.gossipsub_score >= 0.0 {
+            self.score += self.gossipsub_score * GOSSIPSUB_POSITIVE_SCORE_WEIGHT;
+        } else if !self.ignore_negative_gossipsub_score {
+            self.score += self.gossipsub_score * GOSSIPSUB_NEGATIVE_SCORE_WEIGHT;
+        }
+    }
+
+    fn score(&self) -> f64 {
+        self.score
+    }
+
+    /// Modifies the score based on a peer's action.
+    pub fn apply_peer_action(&mut self, peer_action: PeerAction) {
+        match peer_action {
+            PeerAction::Fatal => self.set_lighthouse_score(MIN_SCORE), // The worst possible score
+            PeerAction::LowToleranceError => self.add(-10.0),
+            PeerAction::MidToleranceError => self.add(-5.0),
+            PeerAction::HighToleranceError => self.add(-1.0),
+        }
+    }
+
+    fn set_lighthouse_score(&mut self, new_score: f64) {
+        self.lighthouse_score = new_score;
+        self.update_state();
+    }
+
+    /// Add an f64 to the score abiding by the limits.
+    fn add(&mut self, score: f64) {
+        let new_score = (self.lighthouse_score + score).clamp(MIN_SCORE, MAX_SCORE);
+        self.set_lighthouse_score(new_score);
+    }
+
+    fn update_state(&mut self) {
+        let was_not_banned = self.score > MIN_SCORE_BEFORE_BAN;
+        self.recompute_score();
+        if was_not_banned && self.score <= MIN_SCORE_BEFORE_BAN {
+            //we ban this peer for at least BANNED_BEFORE_DECAY seconds
+            self.last_updated += BANNED_BEFORE_DECAY;
+        }
+    }
+
+    /// Add an f64 to the score abiding by the limits.
+    #[cfg(test)]
+    pub fn test_add(&mut self, score: f64) {
+        self.add(score);
+    }
+
+    #[cfg(test)]
+    // reset the score
+    pub fn test_reset(&mut self) {
+        self.set_lighthouse_score(0f64);
+    }
+
+    // Set the gossipsub_score to a specific f64.
+    // Used in testing to induce score status changes during a heartbeat.
+    #[cfg(test)]
+    pub fn set_gossipsub_score(&mut self, score: f64) {
+        self.gossipsub_score = score;
+        self.update_state();
+    }
+
+    /// Applies time-based logic such as decay rates to the score.
+    /// This function should be called periodically.
+    pub fn update(&mut self) {
+        self.update_at(Instant::now())
+    }
+
+    /// Applies time-based logic such as decay rates to the score with the given now value.
+    /// This private sub function is mainly used for testing.
+    fn update_at(&mut self, now: Instant) {
+        // Decay the current score
+        // Using exponential decay based on a constant half life.
+
+        // It is important that we use here `checked_duration_since` instead of elapsed, since
+        // we set last_updated to the future when banning peers. Therefore `checked_duration_since`
+        // will return None in this case and the score does not get decayed.
+        if let Some(secs_since_update) = now
+            .checked_duration_since(self.last_updated)
+            .map(|d| d.as_secs())
+        {
+            // e^(-ln(2)/HL*t)
+            let decay_factor = (*HALFLIFE_DECAY * secs_since_update as f64).exp();
+            self.lighthouse_score *= decay_factor;
+            self.last_updated = now;
+            self.update_state();
+        }
+    }
+
+    pub fn update_gossipsub_score(&mut self, new_score: f64, ignore: bool) {
+        // we only update gossipsub if last_updated is in the past which means either the peer is
+        // not banned or the BANNED_BEFORE_DECAY time is over.
+        if self.last_updated <= Instant::now() {
+            self.gossipsub_score = new_score;
+            self.ignore_negative_gossipsub_score = ignore;
+            self.update_state();
+        }
+    }
+
+    pub fn is_good_gossipsub_peer(&self) -> bool {
+        self.gossipsub_score >= 0.0
+    }
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub enum Score {
+    Max,
+    Real(RealScore),
+}
+
+impl Default for Score {
+    fn default() -> Self {
+        Self::Real(RealScore::default())
+    }
+}
+
+macro_rules! apply {
+    ( $method:ident $(, $param_name: ident: $param_type: ty)*) => {
+        impl Score {
+            pub fn $method(
+                &mut self, $($param_name: $param_type, )*
+            ) {
+                if let Self::Real(score) = self {
+                    score.$method($($param_name, )*);
+                }
+            }
+        }
+    };
+}
+
+apply!(apply_peer_action, peer_action: PeerAction);
+apply!(update);
+apply!(update_gossipsub_score, new_score: f64, ignore: bool);
+#[cfg(test)]
+apply!(test_add, score: f64);
+#[cfg(test)]
+apply!(test_reset);
+#[cfg(test)]
+apply!(set_gossipsub_score, score: f64);
+
+impl Score {
+    pub fn score(&self) -> f64 {
+        match self {
+            Self::Max => f64::INFINITY,
+            Self::Real(score) => score.score(),
+        }
+    }
+
+    pub fn max_score() -> Self {
+        Self::Max
+    }
+
+    /// Returns the expected state of the peer given it's score.
+    pub(crate) fn state(&self) -> ScoreState {
+        match self.score() {
+            x if x <= MIN_SCORE_BEFORE_BAN => ScoreState::Banned,
+            x if x <= MIN_SCORE_BEFORE_DISCONNECT => ScoreState::ForcedDisconnect,
+            _ => ScoreState::Healthy,
+        }
+    }
+
+    pub fn is_good_gossipsub_peer(&self) -> bool {
+        match self {
+            Self::Max => true,
+            Self::Real(score) => score.is_good_gossipsub_peer(),
+        }
+    }
+
+    /// Instead of implementing `Ord` for `Score`, as we are underneath dealing with f64,
+    /// follow std convention and impl `Score::total_cmp` similar to `f64::total_cmp`.
+    pub fn total_cmp(&self, other: &Score, reverse: bool) -> Ordering {
+        match self.score().partial_cmp(&other.score()) {
+            Some(v) => {
+                // Only reverse when none of the items is NAN,
+                // so that NAN's are never considered.
+                if reverse {
+                    v.reverse()
+                } else {
+                    v
+                }
+            }
+            None if self.score().is_nan() && !other.score().is_nan() => Ordering::Less,
+            None if !self.score().is_nan() && other.score().is_nan() => Ordering::Greater,
+            // Both are NAN.
+            None => Ordering::Equal,
+        }
+    }
+}
+
+impl std::fmt::Display for Score {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:.2}", self.score())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    #[allow(clippy::float_cmp)]
+    fn test_reputation_change() {
+        let mut score = Score::default();
+
+        // 0 change does not change de reputation
+        //
+        let change = 0.0;
+        score.test_add(change);
+        assert_eq!(score.score(), DEFAULT_SCORE);
+
+        // underflowing change is capped
+        let mut score = Score::default();
+        let change = MIN_SCORE - 50.0;
+        score.test_add(change);
+        assert_eq!(score.score(), MIN_SCORE);
+
+        // overflowing change is capped
+        let mut score = Score::default();
+        let change = MAX_SCORE + 50.0;
+        score.test_add(change);
+        assert_eq!(score.score(), MAX_SCORE);
+
+        // Score adjusts
+        let mut score = Score::default();
+        let change = 1.32;
+        score.test_add(change);
+        assert_eq!(score.score(), DEFAULT_SCORE + change);
+    }
+
+    #[test]
+    #[allow(clippy::float_cmp)]
+    fn test_ban_time() {
+        let mut score = RealScore::default();
+        let now = Instant::now();
+
+        let change = MIN_SCORE_BEFORE_BAN;
+        score.test_add(change);
+        assert_eq!(score.score(), MIN_SCORE_BEFORE_BAN);
+
+        score.update_at(now + BANNED_BEFORE_DECAY);
+        assert_eq!(score.score(), MIN_SCORE_BEFORE_BAN);
+
+        score.update_at(now + BANNED_BEFORE_DECAY + Duration::from_secs(1));
+        assert!(score.score() > MIN_SCORE_BEFORE_BAN);
+    }
+
+    // #[test]
+    // fn test_very_negative_gossipsub_score() {
+    //     let mut score = Score::default();
+    //     score.update_gossipsub_score(GOSSIPSUB_GREYLIST_THRESHOLD, false);
+    //     assert!(!score.is_good_gossipsub_peer());
+    //     assert!(score.score() < 0.0);
+    //     assert_eq!(score.state(), ScoreState::Healthy);
+    //     score.test_add(-1.0001);
+    //     assert_eq!(score.state(), ScoreState::ForcedDisconnect);
+    // }
+    //
+    // #[test]
+    // #[allow(clippy::float_cmp)]
+    // fn test_ignored_gossipsub_score() {
+    //     let mut score = Score::default();
+    //     score.update_gossipsub_score(GOSSIPSUB_GREYLIST_THRESHOLD, true);
+    //     assert!(!score.is_good_gossipsub_peer());
+    //     assert_eq!(score.score(), 0.0);
+    // }
+}

--- a/anchor/network/src/peer_manager/peerdb/sync_status.rs
+++ b/anchor/network/src/peer_manager/peerdb/sync_status.rs
@@ -1,0 +1,84 @@
+//! Handles individual sync status for peers.
+
+use serde::Serialize;
+use types::{Epoch, Hash256, Slot};
+
+#[derive(Clone, Debug, Serialize)]
+/// The current sync status of the peer.
+pub enum SyncStatus {
+    /// At the current state as our node or ahead of us.
+    Synced { info: SyncInfo },
+    /// The peer has greater knowledge about the canonical chain than we do.
+    Advanced { info: SyncInfo },
+    /// Is behind our current head and not useful for block downloads.
+    Behind { info: SyncInfo },
+    /// This peer is in an incompatible network.
+    IrrelevantPeer,
+    /// Not currently known as a STATUS handshake has not occurred.
+    Unknown,
+}
+
+/// A relevant peer's sync information.
+#[derive(Clone, Debug, Serialize)]
+pub struct SyncInfo {
+    pub head_slot: Slot,
+    pub head_root: Hash256,
+    pub finalized_epoch: Epoch,
+    pub finalized_root: Hash256,
+}
+
+impl std::cmp::PartialEq for SyncStatus {
+    fn eq(&self, other: &Self) -> bool {
+        matches!(
+            (self, other),
+            (SyncStatus::Synced { .. }, SyncStatus::Synced { .. })
+                | (SyncStatus::Advanced { .. }, SyncStatus::Advanced { .. })
+                | (SyncStatus::Behind { .. }, SyncStatus::Behind { .. })
+                | (SyncStatus::IrrelevantPeer, SyncStatus::IrrelevantPeer)
+                | (SyncStatus::Unknown, SyncStatus::Unknown)
+        )
+    }
+}
+
+impl SyncStatus {
+    /// Returns true if the peer has advanced knowledge of the chain.
+    pub fn is_advanced(&self) -> bool {
+        matches!(self, SyncStatus::Advanced { .. })
+    }
+
+    /// Returns true if the peer is up to date with the current chain.
+    pub fn is_synced(&self) -> bool {
+        matches!(self, SyncStatus::Synced { .. })
+    }
+
+    /// Returns true if the peer is behind the current chain.
+    pub fn is_behind(&self) -> bool {
+        matches!(self, SyncStatus::Behind { .. })
+    }
+
+    /// Updates the peer's sync status, returning whether the status transitioned.
+    ///
+    /// E.g. returns `true` if the state changed from `Synced` to `Advanced`, but not if
+    /// the status remained `Synced` with different `SyncInfo` within.
+    pub fn update(&mut self, new_state: SyncStatus) -> bool {
+        let changed_status = *self != new_state;
+        *self = new_state;
+        changed_status
+    }
+
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            SyncStatus::Advanced { .. } => "Advanced",
+            SyncStatus::Behind { .. } => "Behind",
+            SyncStatus::Synced { .. } => "Synced",
+            SyncStatus::Unknown => "Unknown",
+            SyncStatus::IrrelevantPeer => "Irrelevant",
+        }
+    }
+}
+
+impl std::fmt::Display for SyncStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}


### PR DESCRIPTION
## Issue Addressed

Related to https://github.com/sigp/anchor/issues/18

## Proposed Changes

**Dependencies:**

Updated Cargo.toml and anchor/network/Cargo.toml to include new dependencies such as smallvec, arbitrary, delay_map, and itertools.

**Network Types:**

Added peer_manager module to anchor/network/src/lib.rs.

**Network Implementation:**

Enhanced anchor/network/src/behaviour.rs and anchor/network/src/network.rs to integrate the PeerManager.
The PeerManager is responsible for managing peer connections, including dialing, connecting, and disconnecting peers.
It includes logic to maintain the target peer count, ensuring the network has the desired number of peers connected.

**Peer Manager:**

Added a new peer_manager directory with modules for managing peers.
Implemented functionality in PeerManager to handle peer connections, maintain the target peer count, and manage peer discovery.

## Additional Info

For now, it's mostly a copy from LH with a few modifications. However, there are efforts to make the LH code more modular, generic, and thus easier to reuse. See https://github.com/sigp/lighthouse/pull/6840 and https://github.com/sigp/lighthouse/issues/6757
