### PR TITLE
use PublicKeyBytes instead of PublicKey

### DIFF
--- a/anchor/common/ssv_types/src/cluster.rs
+++ b/anchor/common/ssv_types/src/cluster.rs
@@ -1,7 +1,7 @@
 use crate::OperatorId;
 use derive_more::{Deref, From};
 use std::collections::HashSet;
-use types::{Address, Graffiti, PublicKey};
+use types::{Address, Graffiti, PublicKeyBytes};
 
 /// Unique identifier for a cluster
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Hash, From, Deref)]
@@ -45,7 +45,7 @@ pub struct ValidatorIndex(pub usize);
 #[derive(Debug, Clone)]
 pub struct ValidatorMetadata {
     /// Public key of the validator
-    pub public_key: PublicKey,
+    pub public_key: PublicKeyBytes,
     /// The cluster that is responsible for this validator
     pub cluster_id: ClusterId,
     /// Index of the validator

--- a/anchor/common/ssv_types/src/share.rs
+++ b/anchor/common/ssv_types/src/share.rs
@@ -1,17 +1,17 @@
 use crate::{ClusterId, OperatorId};
-use types::PublicKey;
+use types::PublicKeyBytes;
 
 /// One of N shares of a split validator key.
 #[derive(Debug, Clone)]
 pub struct Share {
     /// Public Key of the validator
-    pub validator_pubkey: PublicKey,
+    pub validator_pubkey: PublicKeyBytes,
     /// Operator this share belongs to
     pub operator_id: OperatorId,
     /// Cluster the operator who owns this share belongs to
     pub cluster_id: ClusterId,
     /// The public key of this Share
-    pub share_pubkey: PublicKey,
+    pub share_pubkey: PublicKeyBytes,
     /// The encrypted private key of the share
     pub encrypted_private_key: [u8; 256],
 }

--- a/anchor/common/ssv_types/src/sql_conversions.rs
+++ b/anchor/common/ssv_types/src/sql_conversions.rs
@@ -6,7 +6,7 @@ use openssl::rsa::Rsa;
 use rusqlite::{types::Type, Error as SqlError, Row};
 use std::io::{Error, ErrorKind};
 use std::str::FromStr;
-use types::{Address, Graffiti, PublicKey, GRAFFITI_BYTES_LEN};
+use types::{Address, Graffiti, PublicKeyBytes, GRAFFITI_BYTES_LEN};
 
 // Helper for converting to Rustqlite Error
 fn from_sql_error<E: std::error::Error + Send + Sync + 'static>(
@@ -107,7 +107,7 @@ impl TryFrom<&Row<'_>> for ValidatorMetadata {
     fn try_from(row: &Row) -> Result<Self, Self::Error> {
         // Get public key from column 0
         let validator_pubkey_str = row.get::<_, String>(0)?;
-        let public_key = PublicKey::from_str(&validator_pubkey_str)
+        let public_key = PublicKeyBytes::from_str(&validator_pubkey_str)
             .map_err(|e| from_sql_error(1, Type::Text, Error::new(ErrorKind::InvalidInput, e)))?;
 
         // Get ClusterId from column 1
@@ -134,7 +134,7 @@ impl TryFrom<&Row<'_>> for Share {
     fn try_from(row: &Row) -> Result<Self, Self::Error> {
         // Get Share PublicKey from column 0
         let share_pubkey_str = row.get::<_, String>(0)?;
-        let share_pubkey = PublicKey::from_str(&share_pubkey_str)
+        let share_pubkey = PublicKeyBytes::from_str(&share_pubkey_str)
             .map_err(|e| from_sql_error(0, Type::Text, Error::new(ErrorKind::InvalidInput, e)))?;
 
         // Get the encrypted private key from column 1
@@ -146,7 +146,7 @@ impl TryFrom<&Row<'_>> for Share {
 
         // Get the Validator PublicKey from column 4
         let validator_pubkey_str = row.get::<_, String>(4)?;
-        let validator_pubkey = PublicKey::from_str(&validator_pubkey_str)
+        let validator_pubkey = PublicKeyBytes::from_str(&validator_pubkey_str)
             .map_err(|e| from_sql_error(4, Type::Text, Error::new(ErrorKind::InvalidInput, e)))?;
 
         Ok(Share {

--- a/anchor/database/src/cluster_operations.rs
+++ b/anchor/database/src/cluster_operations.rs
@@ -2,7 +2,7 @@ use super::{DatabaseError, NetworkDatabase, NonUniqueIndex, SqlStatement, Unique
 use rusqlite::params;
 use ssv_types::{Cluster, ClusterId, Share, ValidatorMetadata};
 use std::sync::atomic::Ordering;
-use types::{Address, PublicKey};
+use types::{Address, PublicKeyBytes};
 
 /// Implements all cluster related functionality on the database
 impl NetworkDatabase {
@@ -105,7 +105,7 @@ impl NetworkDatabase {
     /// Delete a validator from a cluster. This will cascade and remove all corresponding share
     /// data for this validator. If this validator is the last one in the cluster, the cluster
     /// and all corresponding cluster members will also be removed
-    pub fn delete_validator(&self, validator_pubkey: &PublicKey) -> Result<(), DatabaseError> {
+    pub fn delete_validator(&self, validator_pubkey: &PublicKeyBytes) -> Result<(), DatabaseError> {
         // Remove from database
         let conn = self.connection()?;
         conn.prepare_cached(SQL[&SqlStatement::DeleteValidator])?

--- a/anchor/database/src/lib.rs
+++ b/anchor/database/src/lib.rs
@@ -8,7 +8,7 @@ use std::path::Path;
 use std::sync::atomic::AtomicU64;
 use std::sync::atomic::Ordering;
 use std::time::Duration;
-use types::{Address, PublicKey};
+use types::{Address, PublicKeyBytes};
 
 pub use crate::error::DatabaseError;
 pub use crate::multi_index::{MultiIndexMap, *};
@@ -38,19 +38,25 @@ type PoolConn = r2d2::PooledConnection<SqliteConnectionManager>;
 /// Secondary: cluster id. corresponds to a list of shares
 /// Tertiary: owner of the cluster. corresponds to a list of shares
 pub(crate) type ShareMultiIndexMap =
-    MultiIndexMap<PublicKey, ClusterId, Address, Share, NonUniqueTag, NonUniqueTag>;
+    MultiIndexMap<PublicKeyBytes, ClusterId, Address, Share, NonUniqueTag, NonUniqueTag>;
 /// Metadata for all validators in the network
 /// Primary: public key of the validator. uniquely identifies the metadata
 /// Secondary: cluster id. corresponds to list of metadata for all validators
 /// Tertiary: owner of the cluster: corresponds to list of metadata for all validators
-pub(crate) type MetadataMultiIndexMap =
-    MultiIndexMap<PublicKey, ClusterId, Address, ValidatorMetadata, NonUniqueTag, NonUniqueTag>;
+pub(crate) type MetadataMultiIndexMap = MultiIndexMap<
+    PublicKeyBytes,
+    ClusterId,
+    Address,
+    ValidatorMetadata,
+    NonUniqueTag,
+    NonUniqueTag,
+>;
 /// All of the clusters in the network
 /// Primary: cluster id. uniquely identifies a cluster
 /// Secondary: public key of the validator. uniquely identifies a cluster
 /// Tertiary: owner of the cluster. uniquely identifies a cluster
 pub(crate) type ClusterMultiIndexMap =
-    MultiIndexMap<ClusterId, PublicKey, Address, Cluster, UniqueTag, UniqueTag>;
+    MultiIndexMap<ClusterId, PublicKeyBytes, Address, Cluster, UniqueTag, UniqueTag>;
 
 // Information that needs to be accessed via multiple different indicies
 #[derive(Debug)]

--- a/anchor/database/src/share_operations.rs
+++ b/anchor/database/src/share_operations.rs
@@ -1,7 +1,7 @@
 use super::{DatabaseError, NetworkDatabase, SqlStatement, SQL};
 use rusqlite::{params, Transaction};
 use ssv_types::Share;
-use types::PublicKey;
+use types::PublicKeyBytes;
 
 /// Implements all Share related functionality on the database
 impl NetworkDatabase {
@@ -9,7 +9,7 @@ impl NetworkDatabase {
         &self,
         tx: &Transaction<'_>,
         share: &Share,
-        validator_pubkey: &PublicKey,
+        validator_pubkey: &PublicKeyBytes,
     ) -> Result<(), DatabaseError> {
         tx.prepare_cached(SQL[&SqlStatement::InsertShare])?
             .execute(params![

--- a/anchor/database/src/tests/cluster_tests.rs
+++ b/anchor/database/src/tests/cluster_tests.rs
@@ -24,7 +24,7 @@ mod cluster_database_tests {
     // cluster, cluster members, and shares are all cleaned up
     fn test_delete_last_validator() {
         let fixture = TestFixture::new();
-        let pubkey = fixture.validator.public_key.clone();
+        let pubkey = fixture.validator.public_key;
         assert!(fixture.db.delete_validator(&pubkey).is_ok());
 
         // Since there was only one validator in the cluster, everything should be removed

--- a/anchor/database/src/tests/mod.rs
+++ b/anchor/database/src/tests/mod.rs
@@ -10,7 +10,7 @@ pub mod test_prelude {
     pub use crate::NetworkDatabase;
     pub use ssv_types::*;
     pub use tempfile::tempdir;
-    pub use types::{Address, Graffiti, PublicKey};
+    pub use types::{Address, Graffiti, PublicKeyBytes};
 }
 
 #[cfg(test)]

--- a/anchor/database/src/validator_operations.rs
+++ b/anchor/database/src/validator_operations.rs
@@ -1,6 +1,6 @@
 use crate::{multi_index::UniqueIndex, DatabaseError, NetworkDatabase, SqlStatement, SQL};
 use rusqlite::params;
-use types::{Address, Graffiti, PublicKey};
+use types::{Address, Graffiti, PublicKeyBytes};
 
 /// Implements all validator specific database functionality
 impl NetworkDatabase {
@@ -31,7 +31,7 @@ impl NetworkDatabase {
     /// Update the Graffiti for a Validator
     pub fn update_graffiti(
         &self,
-        validator_pubkey: &PublicKey,
+        validator_pubkey: &PublicKeyBytes,
         graffiti: Graffiti,
     ) -> Result<(), DatabaseError> {
         // Make sure this validator exists by getting the in memory entry

--- a/anchor/eth/src/event_processor.rs
+++ b/anchor/eth/src/event_processor.rs
@@ -13,7 +13,7 @@ use std::collections::{HashMap, HashSet};
 use std::str::FromStr;
 use std::sync::Arc;
 use tracing::{debug, error, info, instrument, trace, warn};
-use types::PublicKey;
+use types::PublicKeyBytes;
 
 // Specific Handler for a log type
 type EventHandler = fn(&EventProcessor, &Log) -> Result<(), ExecutionError>;
@@ -231,7 +231,7 @@ impl EventProcessor {
         })?;
 
         // Process data into a usable form
-        let validator_pubkey = PublicKey::from_str(&publicKey.to_string()).map_err(|e| {
+        let validator_pubkey = PublicKeyBytes::from_str(&publicKey.to_string()).map_err(|e| {
             debug!(
                 validator_pubkey = %publicKey,
                 error = %e,
@@ -319,7 +319,7 @@ impl EventProcessor {
         debug!(owner = ?owner, public_key = ?publicKey, "Processing Validator Removed");
 
         // Parse the public key
-        let validator_pubkey = PublicKey::from_str(&publicKey.to_string()).map_err(|e| {
+        let validator_pubkey = PublicKeyBytes::from_str(&publicKey.to_string()).map_err(|e| {
             debug!(
                 validator_pubkey = %publicKey,
                 error = %e,

--- a/anchor/eth/src/network_actions.rs
+++ b/anchor/eth/src/network_actions.rs
@@ -6,13 +6,13 @@ use alloy::primitives::Address;
 use alloy::{rpc::types::Log, sol_types::SolEvent};
 use ssv_types::OperatorId;
 use std::str::FromStr;
-use types::PublicKey;
+use types::PublicKeyBytes;
 
 /// Actions that the network has to take in response to a event during the live sync
 #[derive(Debug, PartialEq)]
 pub enum NetworkAction {
     StopValidator {
-        validator_pubkey: PublicKey,
+        validator_pubkey: PublicKeyBytes,
     },
     LiquidateCluster {
         owner: Address,
@@ -27,7 +27,7 @@ pub enum NetworkAction {
         recipient: Address,
     },
     ExitValidator {
-        validator_pubkey: PublicKey,
+        validator_pubkey: PublicKeyBytes,
     },
     NoOp,
 }
@@ -42,7 +42,7 @@ impl TryFrom<&Log> for NetworkAction {
                 let SSVContract::ValidatorRemoved { publicKey, .. } =
                     SSVContract::ValidatorRemoved::decode_from_log(source)?;
                 let validator_pubkey =
-                    PublicKey::from_str(&publicKey.to_string()).map_err(|e| {
+                    PublicKeyBytes::from_str(&publicKey.to_string()).map_err(|e| {
                         ExecutionError::InvalidEvent(format!("Failed to create PublicKey: {e}"))
                     })?;
                 Ok(NetworkAction::StopValidator { validator_pubkey })
@@ -77,7 +77,7 @@ impl TryFrom<&Log> for NetworkAction {
                 let SSVContract::ValidatorExited { publicKey, .. } =
                     SSVContract::ValidatorExited::decode_from_log(source)?;
                 let validator_pubkey =
-                    PublicKey::from_str(&publicKey.to_string()).map_err(|e| {
+                    PublicKeyBytes::from_str(&publicKey.to_string()).map_err(|e| {
                         ExecutionError::InvalidEvent(format!("Failed to create PublicKey: {e}"))
                     })?;
                 Ok(NetworkAction::ExitValidator { validator_pubkey })

--- a/anchor/validator_store/src/lib.rs
+++ b/anchor/validator_store/src/lib.rs
@@ -142,11 +142,11 @@ impl<T: SlotClock, E: EthSpec> AnchorValidatorStore<T, E> {
                     .map(move |metadata| (cluster.clone(), metadata))
             })
         {
-            let pubkey_bytes = validator.public_key.compress();
             // value was not present: add to store
-            if !unseen_validators.remove(&pubkey_bytes) {
-                if let Ok(secret_key) = self.get_share_from_db(&validator, pubkey_bytes) {
-                    let result = self.add_validator(pubkey_bytes, cluster, validator, secret_key);
+            if !unseen_validators.remove(&validator.public_key) {
+                if let Ok(secret_key) = self.get_share_from_db(&validator, validator.public_key) {
+                    let result =
+                        self.add_validator(validator.public_key, cluster, validator, secret_key);
                     if let Err(err) = result {
                         error!(?err, "Unable to initialize validator");
                     }


### PR DESCRIPTION
`PublicKey` is the decompressed version of `PublicKeyBytes`, which is larger in memory and kind of costly to convert. We only need the decompressed version while verifying the signature during sync, so this PR switches to `PublicKeyBytes` everywhere else.