### PR TITLE
Remove `faulty` field from database and add calculating function instead

### DIFF
--- a/anchor/common/ssv_types/src/cluster.rs
+++ b/anchor/common/ssv_types/src/cluster.rs
@@ -20,12 +20,22 @@ pub struct Cluster {
     pub owner: Address,
     /// The Eth1 fee address for all validators in the cluster
     pub fee_recipient: Address,
-    /// The number of faulty operator in the Cluster
-    pub faulty: u64,
     /// If the Cluster is liquidated or active
     pub liquidated: bool,
     /// Operators in this cluster
     pub cluster_members: HashSet<OperatorId>,
+}
+
+impl Cluster {
+    /// Returns the maximum tolerable number of faulty members.
+    ///
+    /// In other words, return the largest f where 3f+1 is less than or equal the number of
+    /// cluster members.
+    ///
+    /// Exception: Returns 0 if there are no cluster members
+    pub fn get_f(&self) -> u64 {
+        (self.cluster_members.len().saturating_sub(1) / 3) as u64
+    }
 }
 
 /// A member of a Cluster.

--- a/anchor/common/ssv_types/src/sql_conversions.rs
+++ b/anchor/common/ssv_types/src/sql_conversions.rs
@@ -51,29 +51,21 @@ impl TryFrom<(&Row<'_>, Vec<ClusterMember>)> for Cluster {
     fn try_from(
         (row, cluster_members): (&Row<'_>, Vec<ClusterMember>),
     ) -> Result<Self, Self::Error> {
-        // Get ClusterId from column 0
-        let cluster_id = ClusterId(row.get(0)?);
+        let cluster_id = ClusterId(row.get("cluster_id")?);
 
-        // Get the owner from column 1
-        let owner_str = row.get::<_, String>(1)?;
+        let owner_str = row.get::<_, String>("owner")?;
         let owner = Address::from_str(&owner_str).map_err(|e| from_sql_error(1, Type::Text, e))?;
 
-        // Get the fee_recipient from column 2
-        let fee_recipient_str = row.get::<_, String>(2)?;
+        let fee_recipient_str = row.get::<_, String>("fee_recipient")?;
         let fee_recipient =
             Address::from_str(&fee_recipient_str).map_err(|e| from_sql_error(2, Type::Text, e))?;
 
-        // Get faulty count from column 3
-        let faulty: u64 = row.get(3)?;
-
-        // Get liquidated status from column 4
-        let liquidated: bool = row.get(4)?;
+        let liquidated: bool = row.get("liquidated")?;
 
         Ok(Cluster {
             cluster_id,
             owner,
             fee_recipient,
-            faulty,
             liquidated,
             cluster_members: cluster_members
                 .into_iter()

--- a/anchor/database/src/sql_operations.rs
+++ b/anchor/database/src/sql_operations.rs
@@ -12,7 +12,6 @@ pub(crate) enum SqlStatement {
     InsertCluster,       // Insert a new Cluster into the database
     InsertClusterMember, // Insert a new Cluster Member into the database
     UpdateClusterStatus, // Update the active status of the cluster
-    UpdateClusterFaulty, // Update the number of faulty Operators in the cluster
     GetAllClusters,      // Get all Clusters for state reconstruction
     GetClusterMembers,   // Get all Cluster Members for state reconstruction
 
@@ -65,16 +64,11 @@ pub(crate) static SQL: LazyLock<HashMap<SqlStatement, &'static str>> = LazyLock:
         "UPDATE clusters SET liquidated = ?1 WHERE cluster_id = ?2",
     );
     m.insert(
-        SqlStatement::UpdateClusterFaulty,
-        "UPDATE clusters SET faulty = ?1 WHERE cluster_id = ?2",
-    );
-    m.insert(
         SqlStatement::GetAllClusters,
         "SELECT DISTINCT
             c.cluster_id,
             c.owner,
             c.fee_recipient,
-            c.faulty,
             c.liquidated
         FROM clusters c
         JOIN cluster_members cm ON c.cluster_id = cm.cluster_id",

--- a/anchor/database/src/table_schema.sql
+++ b/anchor/database/src/table_schema.sql
@@ -19,7 +19,6 @@ CREATE TABLE clusters (
     cluster_id BLOB PRIMARY KEY,
     owner TEXT NOT NULL,
     fee_recipient TEXT NOT NULL,
-    faulty INTEGER DEFAULT 0,
     liquidated BOOLEAN DEFAULT FALSE
 );
 

--- a/anchor/database/src/tests/utils.rs
+++ b/anchor/database/src/tests/utils.rs
@@ -216,7 +216,7 @@ pub mod queries {
     // Single selection query statements
     const GET_OPERATOR: &str =
         "SELECT operator_id, public_key, owner_address FROM operators WHERE operator_id = ?1";
-    const GET_CLUSTER: &str = "SELECT cluster_id, owner, fee_recipient, faulty, liquidated FROM clusters WHERE cluster_id = ?1";
+    const GET_CLUSTER: &str = "SELECT cluster_id, owner, fee_recipient, liquidated FROM clusters WHERE cluster_id = ?1";
     const GET_SHARES: &str = "SELECT share_pubkey, encrypted_key, cluster_id, operator_id FROM shares WHERE validator_pubkey = ?1";
     const GET_VALIDATOR: &str = "SELECT validator_pubkey, cluster_id, validator_index,  graffiti FROM validators WHERE validator_pubkey = ?1";
     const GET_MEMBERS: &str = "SELECT operator_id FROM cluster_members WHERE cluster_id = ?1";

--- a/anchor/database/src/tests/utils.rs
+++ b/anchor/database/src/tests/utils.rs
@@ -130,7 +130,6 @@ pub mod generators {
                 cluster_id,
                 owner: owner_recipient,
                 fee_recipient: owner_recipient,
-                faulty: 0,
                 liquidated: false,
                 cluster_members: members,
             }
@@ -147,7 +146,6 @@ pub mod generators {
                 cluster_id,
                 owner: owner_recipient,
                 fee_recipient: owner_recipient,
-                faulty: 0,
                 liquidated: false,
                 cluster_members: members,
             }
@@ -425,7 +423,6 @@ pub mod assertions {
             assert_eq!(c1.cluster_id, c2.cluster_id);
             assert_eq!(c1.owner, c2.owner);
             assert_eq!(c1.fee_recipient, c2.fee_recipient);
-            assert_eq!(c1.faulty, c2.faulty);
             assert_eq!(c1.liquidated, c2.liquidated);
             assert_eq!(c1.cluster_members, c2.cluster_members);
         }

--- a/anchor/database/src/tests/utils.rs
+++ b/anchor/database/src/tests/utils.rs
@@ -216,7 +216,8 @@ pub mod queries {
     // Single selection query statements
     const GET_OPERATOR: &str =
         "SELECT operator_id, public_key, owner_address FROM operators WHERE operator_id = ?1";
-    const GET_CLUSTER: &str = "SELECT cluster_id, owner, fee_recipient, liquidated FROM clusters WHERE cluster_id = ?1";
+    const GET_CLUSTER: &str =
+        "SELECT cluster_id, owner, fee_recipient, liquidated FROM clusters WHERE cluster_id = ?1";
     const GET_SHARES: &str = "SELECT share_pubkey, encrypted_key, cluster_id, operator_id FROM shares WHERE validator_pubkey = ?1";
     const GET_VALIDATOR: &str = "SELECT validator_pubkey, cluster_id, validator_index,  graffiti FROM validators WHERE validator_pubkey = ?1";
     const GET_MEMBERS: &str = "SELECT operator_id FROM cluster_members WHERE cluster_id = ?1";

--- a/anchor/eth/src/event_processor.rs
+++ b/anchor/eth/src/event_processor.rs
@@ -289,7 +289,6 @@ impl EventProcessor {
             cluster_id,
             owner,
             fee_recipient: owner,
-            faulty: 0,
             liquidated: false,
             cluster_members: HashSet::from_iter(operator_ids),
         };

--- a/anchor/qbft_manager/src/lib.rs
+++ b/anchor/qbft_manager/src/lib.rs
@@ -134,7 +134,7 @@ impl<T: SlotClock> QbftManager<T> {
             committee.cluster_members.iter().copied().collect(),
         );
         let config = config
-            .with_quorum_size(committee.cluster_members.len() - committee.faulty as usize)
+            .with_quorum_size(committee.cluster_members.len() - committee.get_f() as usize)
             .build()?;
 
         // Get or spawn a new qbft instance. This will return the sender that we can use to send

--- a/anchor/validator_store/src/lib.rs
+++ b/anchor/validator_store/src/lib.rs
@@ -260,7 +260,7 @@ impl<T: SlotClock, E: EthSpec> AnchorValidatorStore<T, E> {
                 signing_root,
                 threshold: cluster
                     .cluster
-                    .faulty
+                    .get_f()
                     .safe_mul(2)
                     .and_then(|x| x.safe_add(1))
                     .map_err(SpecificError::from)?,


### PR DESCRIPTION
We never calculated the `faulty` field of `Cluster` or read it from the DB until now. Remove the field and calculate it instead, it isn't worth caching such a cheap calculation
