### PR TITLE
Ignore warn log when historical syncing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2147,7 +2147,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1145d32e826a7748b69ee8fc62d3e6355ff7f1051df53141e7048162fc90481b"
 dependencies = [
  "data-encoding",
- "syn 2.0.98",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -3393,9 +3393,9 @@ checksum = "b07f60793ff0a4d9cef0f18e63b5357e06209987153a64648c972c1e5aff336f"
 
 [[package]]
 name = "hickory-proto"
-version = "0.24.2"
+version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "447afdcdb8afb9d0a852af6dc65d9b285ce720ed7a59e42a8bf2e931c67bc1b5"
+checksum = "2ad3d6d98c648ed628df039541a5577bee1a7c83e9e16fe3dbedeea4cdfeb971"
 dependencies = [
  "async-trait",
  "cfg-if",

--- a/anchor/eth/src/event_processor.rs
+++ b/anchor/eth/src/event_processor.rs
@@ -82,10 +82,11 @@ impl EventProcessor {
                 .get(topic0)
                 .expect("Handler should always exist");
 
-            // Handle the log and emit a warning for the malformed event if we are in live sync
             if let Err(e) = handler(self, log) {
                 if live {
                     warn!("Malformed event: {e}");
+                } else {
+                    debug!("Malformed event: {e}");
                 }
                 continue;
             }

--- a/anchor/eth/src/event_processor.rs
+++ b/anchor/eth/src/event_processor.rs
@@ -82,9 +82,11 @@ impl EventProcessor {
                 .get(topic0)
                 .expect("Handler should always exist");
 
-            // Handle the log and emit warning for any malformed events
+            // Handle the log and emit a warning for the malformed event if we are in live sync
             if let Err(e) = handler(self, log) {
-                warn!("Malformed event: {e}");
+                if live {
+                    warn!("Malformed event: {e}");
+                }
                 continue;
             }
 


### PR DESCRIPTION
## Issue Addressed

#99 

## Proposed Changes

Only emit malformed event logs during live sync. We know there are a number of malformed events that are encountered during historical sync and these are expected so we dont want to flood the screen with warn logs. 
