### PR TITLE
Commit aggregation

### DIFF
--- a/anchor/common/qbft/src/lib.rs
+++ b/anchor/common/qbft/src/lib.rs
@@ -165,6 +165,12 @@ where
         self.start_round();
     }
 
+
+    // Get the aggregated commit message, if it exists
+    pub fn get_aggregated_commit(&self) -> Option<SignedSSVMessage> {
+        self.aggregated_commit.clone()
+    }
+
     // Validation and check functions.
     fn check_leader(&self, operator_id: &OperatorId) -> bool {
         self.config.leader_fn().leader_function(

--- a/anchor/common/qbft/src/lib.rs
+++ b/anchor/common/qbft/src/lib.rs
@@ -165,7 +165,6 @@ where
         self.start_round();
     }
 
-
     // Get the aggregated commit message, if it exists
     pub fn get_aggregated_commit(&self) -> Option<SignedSSVMessage> {
         self.aggregated_commit.clone()

--- a/anchor/common/qbft/src/lib.rs
+++ b/anchor/common/qbft/src/lib.rs
@@ -697,9 +697,7 @@ where
             // Sanity check that all of the messages match
             commit_quorum[1..]
                 .iter()
-                .all(|commit_msg| {
-                    aggregated_ssv == commit_msg.signed_message.ssv_message()
-                })
+                .all(|commit_msg| aggregated_ssv == commit_msg.signed_message.ssv_message())
                 .then_some(())?;
 
             // Aggregate all of the commits together

--- a/anchor/common/qbft/src/lib.rs
+++ b/anchor/common/qbft/src/lib.rs
@@ -692,19 +692,20 @@ where
             let mut aggregated_commit = first_commit.signed_message.clone();
             let aggregated_as_ssz = aggregated_commit.as_ssz_bytes();
 
-
             // Sanity check that all of the messages match
-            for commit_msg in &commit_quorum[1..] {
-                if aggregated_as_ssz != commit_msg.signed_message.ssv_message().as_ssz_bytes() {
-                    return None;
-                }
+            commit_quorum[1..]
+                .iter()
+                .all(|commit_msg| {
+                    aggregated_as_ssz == commit_msg.signed_message.ssv_message().as_ssz_bytes()
+                })
+                .then_some(())?;
 
-                // If it is a match, we can aggregate this message onto the the main one
-                aggregated_commit.aggregate(&commit_msg.signed_message);
-            }
-
-            // The signatures and operator_ids have to be in sorted order
-            aggregated_commit.sort();
+            // Aggregate all of the commits together
+            let signed_commits = commit_quorum[1..]
+                .iter()
+                .map(|msg| msg.signed_message.clone())
+                .collect();
+            aggregated_commit.aggregate(signed_commits);
             return Some(aggregated_commit);
         }
 

--- a/anchor/common/qbft/src/lib.rs
+++ b/anchor/common/qbft/src/lib.rs
@@ -662,15 +662,33 @@ where
 
             // All validation successful, make sure we are in the proper commit state
             if matches!(self.state, InstanceState::Commit) {
-                // Todo!(). Commit aggregation
-
-                // We have come to commit consensus, mark ourself as completed and record the agreed upon
-                // value
-                self.state = InstanceState::Complete;
-                self.completed = Some(Completed::Success(hash));
-                debug!(in = ?self.config.operator_id(), state = ?self.state, "Reached a COMMIT consensus. Success!");
+                // Aggregate all of the commit messages
+                let commit_quorum = self.commit_container.get_quorum_of_messages(round);
+                match self.aggregate_commit_messages(commit_quorum) {
+                    Some(_aggregated) => {
+                        debug!(in = ?self.config.operator_id(), state = ?self.state, "Reached a COMMIT consensus. Success!");
+                        // We have come to commit consensus, mark ourself as completed and record the agreed upon
+                        // value
+                        self.state = InstanceState::Complete;
+                        self.completed = Some(Completed::Success(hash));
+                        todo!()
+                    }
+                    None => warn!("Failed to aggregate commit quorum"),
+                }
             }
         }
+    }
+
+    fn aggregate_commit_messages(
+        &self,
+        commit_quorum: Vec<WrappedQbftMessage>,
+    ) -> Option<WrappedQbftMessage> {
+        // Join all of the ids and signatures into the first commit messages
+        if let Some(aggregated_commit) = commit_quorum.first().as_mut() {
+            return Some(aggregated_commit.clone());
+        }
+
+        None
     }
 
     /// We have received a round change message.

--- a/anchor/common/qbft/src/lib.rs
+++ b/anchor/common/qbft/src/lib.rs
@@ -687,7 +687,7 @@ where
         // This will be the commit message that we aggregate on top of
         if let Some(first_commit) = commit_quorum.first() {
             let mut aggregated_commit = first_commit.signed_message.clone();
-            let aggregated_as_ssz = aggregated_commit.as_ssz_bytes();
+            let aggregated_as_ssz = aggregated_commit.ssv_message().as_ssz_bytes();
 
             // Sanity check that all of the messages match
             commit_quorum[1..]

--- a/anchor/common/qbft/src/lib.rs
+++ b/anchor/common/qbft/src/lib.rs
@@ -97,6 +97,9 @@ where
     /// Past prepare consensus that we have reached
     past_consensus: HashMap<Round, D::Hash>,
 
+    /// Aggregated commit message
+    aggregated_commit: Option<SignedSSVMessage>,
+
     // Network sender
     send_message: S,
 }
@@ -136,6 +139,8 @@ where
             last_prepared_value: None,
 
             past_consensus: HashMap::new(),
+
+            aggregated_commit: None,
 
             send_message,
         };
@@ -664,16 +669,14 @@ where
             if matches!(self.state, InstanceState::Commit) {
                 // Aggregate all of the commit messages
                 let commit_quorum = self.commit_container.get_quorum_of_messages(round);
-                match self.aggregate_commit_messages(commit_quorum) {
-                    Some(_aggregated) => {
-                        debug!(in = ?self.config.operator_id(), state = ?self.state, "Reached a COMMIT consensus. Success!");
-                        // We have come to commit consensus, mark ourself as completed and record the agreed upon
-                        // value
-                        self.state = InstanceState::Complete;
-                        self.completed = Some(Completed::Success(hash));
-                        todo!()
-                    }
-                    None => warn!("Failed to aggregate commit quorum"),
+                let aggregated_commit = self.aggregate_commit_messages(commit_quorum);
+                if aggregated_commit.is_some() {
+                    debug!(in = ?self.config.operator_id(), state = ?self.state, "Reached a COMMIT consensus. Success!");
+                    self.state = InstanceState::Complete;
+                    self.completed = Some(Completed::Success(hash));
+                    self.aggregated_commit = aggregated_commit;
+                } else {
+                    warn!("Failed to aggregate commit quorum")
                 }
             }
         }
@@ -682,10 +685,27 @@ where
     fn aggregate_commit_messages(
         &self,
         commit_quorum: Vec<WrappedQbftMessage>,
-    ) -> Option<WrappedQbftMessage> {
-        // Join all of the ids and signatures into the first commit messages
-        if let Some(aggregated_commit) = commit_quorum.first().as_mut() {
-            return Some(aggregated_commit.clone());
+    ) -> Option<SignedSSVMessage> {
+        // We know this exists, but in favor of avoiding expect match the first element to Some.
+        // This will be the commit message that we aggregate on top of
+        if let Some(first_commit) = commit_quorum.first() {
+            let mut aggregated_commit = first_commit.signed_message.clone();
+            let aggregated_as_ssz = aggregated_commit.as_ssz_bytes();
+
+
+            // Sanity check that all of the messages match
+            for commit_msg in &commit_quorum[1..] {
+                if aggregated_as_ssz != commit_msg.signed_message.ssv_message().as_ssz_bytes() {
+                    return None;
+                }
+
+                // If it is a match, we can aggregate this message onto the the main one
+                aggregated_commit.aggregate(&commit_msg.signed_message);
+            }
+
+            // The signatures and operator_ids have to be in sorted order
+            aggregated_commit.sort();
+            return Some(aggregated_commit);
         }
 
         None

--- a/anchor/common/qbft/src/lib.rs
+++ b/anchor/common/qbft/src/lib.rs
@@ -678,7 +678,7 @@ where
                     self.completed = Some(Completed::Success(hash));
                     self.aggregated_commit = aggregated_commit;
                 } else {
-                    warn!("Failed to aggregate commit quorum")
+                    error!("Failed to aggregate commit quorum")
                 }
             }
         }
@@ -692,21 +692,20 @@ where
         // This will be the commit message that we aggregate on top of
         if let Some(first_commit) = commit_quorum.first() {
             let mut aggregated_commit = first_commit.signed_message.clone();
-            let aggregated_as_ssz = aggregated_commit.ssv_message().as_ssz_bytes();
+            let aggregated_ssv = aggregated_commit.ssv_message();
 
             // Sanity check that all of the messages match
             commit_quorum[1..]
                 .iter()
                 .all(|commit_msg| {
-                    aggregated_as_ssz == commit_msg.signed_message.ssv_message().as_ssz_bytes()
+                    aggregated_ssv == commit_msg.signed_message.ssv_message()
                 })
                 .then_some(())?;
 
             // Aggregate all of the commits together
             let signed_commits = commit_quorum[1..]
                 .iter()
-                .map(|msg| msg.signed_message.clone())
-                .collect();
+                .map(|msg| msg.signed_message.clone());
             aggregated_commit.aggregate(signed_commits);
             return Some(aggregated_commit);
         }

--- a/anchor/common/qbft/src/msg_container.rs
+++ b/anchor/common/qbft/src/msg_container.rs
@@ -81,6 +81,22 @@ impl MessageContainer {
             .unwrap_or(0)
     }
 
+    /// If we have a quorum for the round, get all of the messages that correspond to that quorum
+    pub fn get_quorum_of_messages(&self, round: Round) -> Vec<WrappedQbftMessage> {
+        let mut msgs = vec![];
+        if let Some(hash) = self.has_quorum(round) {
+            // collect all of the messages where root = quorum hash
+            if let Some(round_messages) = self.messages.get(&round) {
+                for msg in round_messages.values() {
+                    if msg.qbft_message.root == hash {
+                        msgs.push(msg.clone());
+                    }
+                }
+            }
+        }
+        msgs
+    }
+
     /// Gets all messages for a specific round
     pub fn get_messages_for_round(&self, round: Round) -> Vec<&WrappedQbftMessage> {
         // If we have messages for this round in our container, return them all

--- a/anchor/common/ssv_types/src/message.rs
+++ b/anchor/common/ssv_types/src/message.rs
@@ -300,14 +300,17 @@ impl SignedSSVMessage {
         &self.full_data
     }
 
-    /// Aggregates one signed messages with another
-    pub fn aggregate(&mut self, other: &SignedSSVMessage) -> bool{
-        todo!()
-    }
+    /// Aggregate a set of signed ssv messages into Self
+    pub fn aggregate(&mut self, others: Vec<SignedSSVMessage>){
+        for signed_msg in others {
+            // These will only all have 1 signature/operator, but we call extend for safety
+            self.signatures.extend(signed_msg.signatures);
+            self.operator_ids.extend(signed_msg.operator_ids);
+        }
 
-    pub fn sort(&mut self) {
         self.signatures.sort();
         self.operator_ids.sort();
+        todo!()
     }
 
     // Validate the signed message to ensure that it is well formed for qbft processing

--- a/anchor/common/ssv_types/src/message.rs
+++ b/anchor/common/ssv_types/src/message.rs
@@ -310,7 +310,6 @@ impl SignedSSVMessage {
 
         self.signatures.sort();
         self.operator_ids.sort();
-        todo!()
     }
 
     // Validate the signed message to ensure that it is well formed for qbft processing

--- a/anchor/common/ssv_types/src/message.rs
+++ b/anchor/common/ssv_types/src/message.rs
@@ -300,6 +300,16 @@ impl SignedSSVMessage {
         &self.full_data
     }
 
+    /// Aggregates one signed messages with another
+    pub fn aggregate(&mut self, other: &SignedSSVMessage) -> bool{
+        todo!()
+    }
+
+    pub fn sort(&mut self) {
+        self.signatures.sort();
+        self.operator_ids.sort();
+    }
+
     // Validate the signed message to ensure that it is well formed for qbft processing
     pub fn validate(&self) -> bool {
         // OperatorID must have at least one element

--- a/anchor/common/ssv_types/src/message.rs
+++ b/anchor/common/ssv_types/src/message.rs
@@ -303,7 +303,7 @@ impl SignedSSVMessage {
     /// Aggregate a set of signed ssv messages into Self
     pub fn aggregate<I>(&mut self, others: I)
     where
-        I: IntoIterator<Item = SignedSSVMessage>
+        I: IntoIterator<Item = SignedSSVMessage>,
     {
         for signed_msg in others {
             // These will only all have 1 signature/operator, but we call extend for safety

--- a/anchor/common/ssv_types/src/message.rs
+++ b/anchor/common/ssv_types/src/message.rs
@@ -301,7 +301,10 @@ impl SignedSSVMessage {
     }
 
     /// Aggregate a set of signed ssv messages into Self
-    pub fn aggregate(&mut self, others: Vec<SignedSSVMessage>) {
+    pub fn aggregate<I>(&mut self, others: I)
+    where
+        I: IntoIterator<Item = SignedSSVMessage>
+    {
         for signed_msg in others {
             // These will only all have 1 signature/operator, but we call extend for safety
             self.signatures.extend(signed_msg.signatures);

--- a/anchor/common/ssv_types/src/message.rs
+++ b/anchor/common/ssv_types/src/message.rs
@@ -301,7 +301,7 @@ impl SignedSSVMessage {
     }
 
     /// Aggregate a set of signed ssv messages into Self
-    pub fn aggregate(&mut self, others: Vec<SignedSSVMessage>){
+    pub fn aggregate(&mut self, others: Vec<SignedSSVMessage>) {
         for signed_msg in others {
             // These will only all have 1 signature/operator, but we call extend for safety
             self.signatures.extend(signed_msg.signatures);

--- a/anchor/qbft_manager/src/lib.rs
+++ b/anchor/qbft_manager/src/lib.rs
@@ -431,6 +431,17 @@ async fn qbft_instance<D: QbftData<Hash = Hash256>>(
                         error!("could not send qbft result");
                     }
                 }
+
+                // Send the decided message (aggregated commit)
+                match qbft.get_aggregated_commit() {
+                    Some(msg) => {
+                        network_tx.send(msg).unwrap_or_else(|e| {
+                            error!("Failed to send signed ssv message to network: {:?}", e)
+                        });
+                    }
+                    None => error!("Aggregated commit does not exist"),
+                }
+
                 instance = QbftInstance::Decided { value: completed };
             } else {
                 instance = QbftInstance::Initialized {


### PR DESCRIPTION
## Issue Addressed

Part of #103 

## Proposed Changes

This PR introduces commit message aggregation, aka decided messages. This is just the aggregation portion of the PR, the next step is to implement handling for this message type.

A aggregated commit message is just a quorum of commit messages where all of the signatures and operators are joined into one message. Instead of creating a whole new message, I just aggregate this all into the first commit message of the quorum.  This also has to be broadcasted into the network so relevant manager functionality is also added.