### PR TITLE
create common component for message serialization and signing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1822,6 +1822,7 @@ dependencies = [
  "http_api",
  "http_metrics",
  "hyper 1.6.0",
+ "message_sender",
  "network",
  "openssl",
  "parking_lot",
@@ -5074,6 +5075,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "message_sender"
+version = "0.1.0"
+dependencies = [
+ "database",
+ "ethereum_ssz",
+ "openssl",
+ "processor",
+ "ssv_types",
+ "subnet_tracker",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "metastruct"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6192,10 +6207,9 @@ dependencies = [
  "ethereum_ssz",
  "ethereum_ssz_derive",
  "futures",
- "openssl",
+ "message_sender",
  "processor",
  "qbft",
- "rand 0.8.5",
  "slot_clock",
  "ssv_types",
  "task_executor",
@@ -7262,6 +7276,7 @@ version = "0.1.0"
 dependencies = [
  "bls_lagrange",
  "dashmap",
+ "message_sender",
  "processor",
  "slot_clock",
  "ssv_types",
@@ -7626,7 +7641,6 @@ dependencies = [
  "alloy",
  "database",
  "ethereum_serde_utils",
- "log",
  "serde",
  "ssv_types",
  "task_executor",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ members = [
     "anchor/eth",
     "anchor/http_api",
     "anchor/http_metrics",
+    "anchor/message_sender",
     "anchor/network",
     "anchor/processor",
     "anchor/qbft_manager",
@@ -33,6 +34,7 @@ database = { path = "anchor/database" }
 eth = { path = "anchor/eth" }
 http_api = { path = "anchor/http_api" }
 http_metrics = { path = "anchor/http_metrics" }
+message_sender = { path = "anchor/message_sender" }
 network = { path = "anchor/network" }
 processor = { path = "anchor/processor" }
 qbft = { path = "anchor/common/qbft" }

--- a/anchor/client/Cargo.toml
+++ b/anchor/client/Cargo.toml
@@ -22,6 +22,7 @@ fdlimit = "0.3"
 http_api = { workspace = true }
 http_metrics = { workspace = true }
 hyper = { workspace = true }
+message_sender = { workspace = true }
 network = { workspace = true }
 openssl = { workspace = true }
 parking_lot = { workspace = true }

--- a/anchor/client/src/lib.rs
+++ b/anchor/client/src/lib.rs
@@ -350,7 +350,6 @@ impl Client {
             processor_senders.clone(),
             network_tx.clone(),
             key.clone(),
-            database.watch(),
             operator_id,
             network::SUBNET_COUNT,
         )?;

--- a/anchor/client/src/lib.rs
+++ b/anchor/client/src/lib.rs
@@ -13,6 +13,7 @@ use config::Config;
 use database::NetworkDatabase;
 use eth2::reqwest::{Certificate, ClientBuilder};
 use eth2::{BeaconNodeHttpClient, Timeouts};
+use message_sender::NetworkMessageSender;
 use network::Network;
 use openssl::pkey::Private;
 use openssl::rsa::Rsa;
@@ -22,7 +23,6 @@ use sensitive_url::SensitiveUrl;
 use signature_collector::SignatureCollectorManager;
 use slashing_protection::SlashingDatabase;
 use slot_clock::{SlotClock, SystemTimeSlotClock};
-use ssv_types::message::SignedSSVMessage;
 use ssv_types::OperatorId;
 use std::fs::File;
 use std::io::{ErrorKind, Read, Write};
@@ -30,7 +30,7 @@ use std::net::SocketAddr;
 use std::path::Path;
 use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
-use subnet_tracker::start_subnet_tracker;
+use subnet_tracker::{start_subnet_tracker, SubnetId};
 use task_executor::TaskExecutor;
 use tokio::net::TcpListener;
 use tokio::select;
@@ -350,21 +350,32 @@ impl Client {
             .await
             .ok_or("Failed waiting for operator id")?;
 
-        // Create the signature collector
-        let signature_collector =
-            SignatureCollectorManager::new(processor_senders.clone(), slot_clock.clone())
-                .map_err(|e| format!("Unable to initialize signature collector manager: {e:?}"))?;
-
         // Network sender/receiver
-        let (network_tx, _network_rx) = mpsc::unbounded_channel::<SignedSSVMessage>();
+        let (network_tx, _network_rx) = mpsc::channel::<(SubnetId, Vec<u8>)>(9001);
+
+        let network_message_sender = NetworkMessageSender::new(
+            processor_senders.clone(),
+            network_tx.clone(),
+            key.clone(),
+            database.watch(),
+            operator_id,
+            network::SUBNET_COUNT,
+        )?;
+
+        // Create the signature collector
+        let signature_collector = SignatureCollectorManager::new(
+            processor_senders.clone(),
+            network_message_sender.clone(),
+            slot_clock.clone(),
+        )
+        .map_err(|e| format!("Unable to initialize signature collector manager: {e:?}"))?;
 
         // Create the qbft manager
         let qbft_manager = QbftManager::new(
             processor_senders.clone(),
             operator_id,
             slot_clock.clone(),
-            key.clone(),
-            network_tx.clone(),
+            network_message_sender,
         )
         .map_err(|e| format!("Unable to initialize qbft manager: {e:?}"))?;
 

--- a/anchor/client/src/lib.rs
+++ b/anchor/client/src/lib.rs
@@ -145,13 +145,6 @@ impl Client {
         let subnet_tracker =
             start_subnet_tracker(database.watch(), network::SUBNET_COUNT, &executor);
 
-        // Start the p2p network
-        let network = Network::try_new(&config.network, subnet_tracker, executor.clone())
-            .await
-            .map_err(|e| format!("Unable to start network: {e}"))?;
-        // Spawn the network listening task
-        executor.spawn(network.run(), "network");
-
         // Initialize slashing protection.
         let slashing_db_path = config.data_dir.join(SLASHING_PROTECTION_FILENAME);
         let slashing_protection =
@@ -351,7 +344,7 @@ impl Client {
             .ok_or("Failed waiting for operator id")?;
 
         // Network sender/receiver
-        let (network_tx, _network_rx) = mpsc::channel::<(SubnetId, Vec<u8>)>(9001);
+        let (network_tx, network_rx) = mpsc::channel::<(SubnetId, Vec<u8>)>(9001);
 
         let network_message_sender = NetworkMessageSender::new(
             processor_senders.clone(),
@@ -361,6 +354,18 @@ impl Client {
             operator_id,
             network::SUBNET_COUNT,
         )?;
+
+        // Start the p2p network
+        let network = Network::try_new(
+            &config.network,
+            subnet_tracker,
+            network_rx,
+            executor.clone(),
+        )
+        .await
+        .map_err(|e| format!("Unable to start network: {e}"))?;
+        // Spawn the network listening task
+        executor.spawn(network.run(), "network");
 
         // Create the signature collector
         let signature_collector = SignatureCollectorManager::new(

--- a/anchor/message_sender/Cargo.toml
+++ b/anchor/message_sender/Cargo.toml
@@ -1,15 +1,18 @@
 [package]
-name = "subnet_tracker"
+name = "message_sender"
 version = "0.1.0"
 edition = { workspace = true }
 authors = ["Sigma Prime <contact@sigmaprime.io>"]
 
 [dependencies]
-alloy = { workspace = true }
 database = { workspace = true }
-ethereum_serde_utils = "0.7.0"
-serde = { workspace = true }
+ethereum_ssz = { workspace = true }
+openssl = { workspace = true }
+processor = { workspace = true }
 ssv_types = { workspace = true }
-task_executor = { workspace = true }
+subnet_tracker = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
+
+[features]
+testing = []

--- a/anchor/message_sender/src/lib.rs
+++ b/anchor/message_sender/src/lib.rs
@@ -6,8 +6,15 @@ pub mod testing;
 pub use crate::network::*;
 use ssv_types::consensus::UnsignedSSVMessage;
 use ssv_types::message::SignedSSVMessage;
+use tokio::sync::mpsc::error::TrySendError;
 
 pub trait MessageSender: Send + Sync {
-    fn sign_and_send(&self, message: UnsignedSSVMessage);
-    fn send(&self, message: SignedSSVMessage);
+    fn sign_and_send(&self, message: UnsignedSSVMessage) -> Result<(), Error>;
+    fn send(&self, message: SignedSSVMessage) -> Result<(), Error>;
+}
+
+#[derive(Debug)]
+pub enum Error {
+    Processor(TrySendError<processor::WorkItem>),
+    NetworkQueueClosed,
 }

--- a/anchor/message_sender/src/lib.rs
+++ b/anchor/message_sender/src/lib.rs
@@ -1,0 +1,13 @@
+mod network;
+
+#[cfg(feature = "testing")]
+pub mod testing;
+
+pub use crate::network::*;
+use ssv_types::consensus::UnsignedSSVMessage;
+use ssv_types::message::SignedSSVMessage;
+
+pub trait MessageSender: Send + Sync {
+    fn sign_and_send(&self, message: UnsignedSSVMessage);
+    fn send(&self, message: SignedSSVMessage);
+}

--- a/anchor/message_sender/src/lib.rs
+++ b/anchor/message_sender/src/lib.rs
@@ -6,11 +6,16 @@ pub mod testing;
 pub use crate::network::*;
 use ssv_types::consensus::UnsignedSSVMessage;
 use ssv_types::message::SignedSSVMessage;
+use ssv_types::CommitteeId;
 use tokio::sync::mpsc::error::TrySendError;
 
 pub trait MessageSender: Send + Sync {
-    fn sign_and_send(&self, message: UnsignedSSVMessage) -> Result<(), Error>;
-    fn send(&self, message: SignedSSVMessage) -> Result<(), Error>;
+    fn sign_and_send(
+        &self,
+        message: UnsignedSSVMessage,
+        committee_id: CommitteeId,
+    ) -> Result<(), Error>;
+    fn send(&self, message: SignedSSVMessage, committee_id: CommitteeId) -> Result<(), Error>;
 }
 
 #[derive(Debug)]

--- a/anchor/message_sender/src/network.rs
+++ b/anchor/message_sender/src/network.rs
@@ -1,5 +1,4 @@
 use crate::{Error, MessageSender};
-use database::{NetworkState, UniqueIndex};
 use openssl::error::ErrorStack;
 use openssl::hash::MessageDigest;
 use openssl::pkey::{PKey, Private};
@@ -7,13 +6,12 @@ use openssl::rsa::Rsa;
 use openssl::sign::Signer;
 use ssv_types::consensus::UnsignedSSVMessage;
 use ssv_types::message::SignedSSVMessage;
-use ssv_types::msgid::DutyExecutor;
-use ssv_types::OperatorId;
+use ssv_types::{CommitteeId, OperatorId};
 use ssz::Encode;
 use std::sync::Arc;
 use subnet_tracker::SubnetId;
+use tokio::sync::mpsc;
 use tokio::sync::mpsc::error::TrySendError;
-use tokio::sync::{mpsc, watch};
 use tracing::{debug, error, warn};
 
 const SIGNER_NAME: &str = "message_sign_and_send";
@@ -23,13 +21,16 @@ pub struct NetworkMessageSender {
     processor: processor::Senders,
     network_tx: mpsc::Sender<(SubnetId, Vec<u8>)>,
     private_key: PKey<Private>,
-    network_state_rx: watch::Receiver<NetworkState>,
     operator_id: OperatorId,
     subnet_count: usize,
 }
 
 impl MessageSender for Arc<NetworkMessageSender> {
-    fn sign_and_send(&self, message: UnsignedSSVMessage) -> Result<(), Error> {
+    fn sign_and_send(
+        &self,
+        message: UnsignedSSVMessage,
+        committee_id: CommitteeId,
+    ) -> Result<(), Error> {
         if self.network_tx.is_closed() {
             return Err(Error::NetworkQueueClosed);
         }
@@ -58,14 +59,14 @@ impl MessageSender for Arc<NetworkMessageSender> {
                             return;
                         }
                     };
-                    sender.do_send(message);
+                    sender.do_send(message, committee_id);
                 },
                 SIGNER_NAME,
             )
             .map_err(Error::Processor)
     }
 
-    fn send(&self, message: SignedSSVMessage) -> Result<(), Error> {
+    fn send(&self, message: SignedSSVMessage, committee_id: CommitteeId) -> Result<(), Error> {
         if self.network_tx.is_closed() {
             return Err(Error::NetworkQueueClosed);
         }
@@ -75,7 +76,7 @@ impl MessageSender for Arc<NetworkMessageSender> {
             .urgent_consensus
             .send_blocking(
                 move || {
-                    sender.do_send(message);
+                    sender.do_send(message, committee_id);
                 },
                 SENDER_NAME,
             )
@@ -88,7 +89,6 @@ impl NetworkMessageSender {
         processor: processor::Senders,
         network_tx: mpsc::Sender<(SubnetId, Vec<u8>)>,
         private_key: Rsa<Private>,
-        network_state_rx: watch::Receiver<NetworkState>,
         operator_id: OperatorId,
         subnet_count: usize,
     ) -> Result<Arc<Self>, String> {
@@ -98,20 +98,13 @@ impl NetworkMessageSender {
             processor,
             network_tx,
             private_key,
-            network_state_rx,
             operator_id,
             subnet_count,
         }))
     }
 
-    fn do_send(&self, message: SignedSSVMessage) {
-        let subnet = match self.determine_subnet(&message) {
-            Ok(subnet) => subnet,
-            Err(err) => {
-                error!(?err, "Unable to determine subnet for outgoing message");
-                return;
-            }
-        };
+    fn do_send(&self, message: SignedSSVMessage, committee_id: CommitteeId) {
+        let subnet = SubnetId::from_committee(committee_id, self.subnet_count);
         match self.network_tx.try_send((subnet, message.as_ssz_bytes())) {
             Ok(_) => debug!(?subnet, "Successfully sent message to network"),
             Err(TrySendError::Closed(_)) => warn!("Network queue closed (shutting down?)"),
@@ -124,23 +117,5 @@ impl NetworkMessageSender {
         let mut signer = Signer::new(MessageDigest::sha256(), &self.private_key)?;
         signer.update(&serialized)?;
         signer.sign_to_vec()
-    }
-
-    fn determine_subnet(&self, message: &SignedSSVMessage) -> Result<SubnetId, String> {
-        let msg_id = message.ssv_message().msg_id();
-        let committee_id = match msg_id.duty_executor() {
-            Some(DutyExecutor::Committee(committee_id)) => committee_id,
-            Some(DutyExecutor::Validator(pubkey)) => {
-                let database = self.network_state_rx.borrow();
-                let Some(cluster) = database.clusters().get_by(&pubkey) else {
-                    return Err(format!(
-                        "No cluster for validator: {pubkey}"
-                    ));
-                };
-                cluster.committee_id()
-            }
-            None => return Err(format!("Invalid message id: {msg_id:?}",)),
-        };
-        Ok(SubnetId::from_committee(committee_id, self.subnet_count))
     }
 }

--- a/anchor/message_sender/src/network.rs
+++ b/anchor/message_sender/src/network.rs
@@ -1,0 +1,141 @@
+use crate::MessageSender;
+use database::{NetworkState, UniqueIndex};
+use openssl::error::ErrorStack;
+use openssl::hash::MessageDigest;
+use openssl::pkey::{PKey, Private};
+use openssl::rsa::Rsa;
+use openssl::sign::Signer;
+use ssv_types::consensus::UnsignedSSVMessage;
+use ssv_types::message::SignedSSVMessage;
+use ssv_types::msgid::DutyExecutor;
+use ssv_types::OperatorId;
+use ssz::Encode;
+use std::sync::Arc;
+use subnet_tracker::SubnetId;
+use tokio::sync::mpsc::error::TrySendError;
+use tokio::sync::{mpsc, watch};
+use tracing::{debug, error, warn};
+
+const SIGNER_NAME: &str = "message_sign_and_send";
+const SENDER_NAME: &str = "message_send";
+
+pub struct NetworkMessageSender {
+    processor: processor::Senders,
+    network_tx: mpsc::Sender<(SubnetId, Vec<u8>)>,
+    private_key: PKey<Private>,
+    database: watch::Receiver<NetworkState>,
+    operator_id: OperatorId,
+    subnet_count: usize,
+}
+
+impl MessageSender for Arc<NetworkMessageSender> {
+    fn sign_and_send(&self, message: UnsignedSSVMessage) {
+        let sender = self.clone();
+        self.processor
+            .urgent_consensus
+            .send_blocking(
+                move || {
+                    let signature = match sender.sign(&message) {
+                        Ok(signature) => signature,
+                        Err(err) => {
+                            error!(?err, "Signing message failed!");
+                            return;
+                        }
+                    };
+                    let message = match SignedSSVMessage::new(
+                        vec![signature],
+                        vec![sender.operator_id],
+                        message.ssv_message,
+                        message.full_data,
+                    ) {
+                        Ok(signature) => signature,
+                        Err(err) => {
+                            error!(?err, "Creating signed message failed!");
+                            return;
+                        }
+                    };
+                    sender.do_send(message);
+                },
+                SIGNER_NAME,
+            )
+            .unwrap_or_else(|e| warn!("Failed to send to processor: {}", e));
+    }
+
+    fn send(&self, message: SignedSSVMessage) {
+        let sender = self.clone();
+        self.processor
+            .urgent_consensus
+            .send_blocking(
+                move || {
+                    sender.do_send(message);
+                },
+                SENDER_NAME,
+            )
+            .unwrap_or_else(|e| warn!("Failed to send to processor: {}", e));
+    }
+}
+
+impl NetworkMessageSender {
+    pub fn new(
+        processor: processor::Senders,
+        network_tx: mpsc::Sender<(SubnetId, Vec<u8>)>,
+        private_key: Rsa<Private>,
+        database: watch::Receiver<NetworkState>,
+        operator_id: OperatorId,
+        subnet_count: usize,
+    ) -> Result<Arc<Self>, String> {
+        let private_key = PKey::from_rsa(private_key)
+            .map_err(|err| format!("Failed to create PKey from RSA: {err}"))?;
+        Ok(Arc::new(Self {
+            processor,
+            network_tx,
+            private_key,
+            database,
+            operator_id,
+            subnet_count,
+        }))
+    }
+
+    fn do_send(&self, message: SignedSSVMessage) {
+        let subnet = match self.determine_subnet(&message) {
+            Ok(subnet) => subnet,
+            Err(err) => {
+                error!(?err, "Unable to determine subnet for outgoing message");
+                return;
+            }
+        };
+        match self.network_tx.try_send((subnet, message.as_ssz_bytes())) {
+            Ok(_) => debug!(?subnet, "Successfully sent message to network"),
+            Err(TrySendError::Closed(_)) => warn!("Network queue closed (shutting down?)"),
+            Err(TrySendError::Full(_)) => warn!("Network queue full, unable to send message!"),
+        }
+    }
+
+    fn sign(&self, message: &UnsignedSSVMessage) -> Result<Vec<u8>, ErrorStack> {
+        let serialized = message.ssv_message.as_ssz_bytes();
+        let mut signer = Signer::new(MessageDigest::sha256(), &self.private_key)?;
+        signer.update(&serialized)?;
+        signer.sign_to_vec()
+    }
+
+    fn determine_subnet(&self, message: &SignedSSVMessage) -> Result<SubnetId, String> {
+        let msg_id = message.ssv_message().msg_id();
+        let committee_id = match msg_id.duty_executor() {
+            Some(DutyExecutor::Committee(committee_id)) => committee_id,
+            Some(DutyExecutor::Validator(pubkey)) => {
+                let database = self.database.borrow();
+                let Some(metadata) = database.metadata().get_by(&pubkey) else {
+                    return Err(format!("Unknown validator: {pubkey}"));
+                };
+                let Some(cluster) = database.clusters().get_by(&metadata.cluster_id) else {
+                    return Err(format!(
+                        "Inconsistent database, no cluster for validator: {pubkey}"
+                    ));
+                };
+                cluster.committee_id()
+            }
+            None => return Err(format!("Invalid message id: {msg_id:?}",)),
+        };
+        Ok(SubnetId::from_committee(committee_id, self.subnet_count))
+    }
+}

--- a/anchor/message_sender/src/network.rs
+++ b/anchor/message_sender/src/network.rs
@@ -1,4 +1,4 @@
-use crate::MessageSender;
+use crate::{Error, MessageSender};
 use database::{NetworkState, UniqueIndex};
 use openssl::error::ErrorStack;
 use openssl::hash::MessageDigest;
@@ -23,13 +23,17 @@ pub struct NetworkMessageSender {
     processor: processor::Senders,
     network_tx: mpsc::Sender<(SubnetId, Vec<u8>)>,
     private_key: PKey<Private>,
-    database: watch::Receiver<NetworkState>,
+    network_state_rx: watch::Receiver<NetworkState>,
     operator_id: OperatorId,
     subnet_count: usize,
 }
 
 impl MessageSender for Arc<NetworkMessageSender> {
-    fn sign_and_send(&self, message: UnsignedSSVMessage) {
+    fn sign_and_send(&self, message: UnsignedSSVMessage) -> Result<(), Error> {
+        if self.network_tx.is_closed() {
+            return Err(Error::NetworkQueueClosed);
+        }
+
         let sender = self.clone();
         self.processor
             .urgent_consensus
@@ -48,7 +52,7 @@ impl MessageSender for Arc<NetworkMessageSender> {
                         message.ssv_message,
                         message.full_data,
                     ) {
-                        Ok(signature) => signature,
+                        Ok(signed_message) => signed_message,
                         Err(err) => {
                             error!(?err, "Creating signed message failed!");
                             return;
@@ -58,10 +62,14 @@ impl MessageSender for Arc<NetworkMessageSender> {
                 },
                 SIGNER_NAME,
             )
-            .unwrap_or_else(|e| warn!("Failed to send to processor: {}", e));
+            .map_err(Error::Processor)
     }
 
-    fn send(&self, message: SignedSSVMessage) {
+    fn send(&self, message: SignedSSVMessage) -> Result<(), Error> {
+        if self.network_tx.is_closed() {
+            return Err(Error::NetworkQueueClosed);
+        }
+
         let sender = self.clone();
         self.processor
             .urgent_consensus
@@ -71,7 +79,7 @@ impl MessageSender for Arc<NetworkMessageSender> {
                 },
                 SENDER_NAME,
             )
-            .unwrap_or_else(|e| warn!("Failed to send to processor: {}", e));
+            .map_err(Error::Processor)
     }
 }
 
@@ -80,7 +88,7 @@ impl NetworkMessageSender {
         processor: processor::Senders,
         network_tx: mpsc::Sender<(SubnetId, Vec<u8>)>,
         private_key: Rsa<Private>,
-        database: watch::Receiver<NetworkState>,
+        network_state_rx: watch::Receiver<NetworkState>,
         operator_id: OperatorId,
         subnet_count: usize,
     ) -> Result<Arc<Self>, String> {
@@ -90,7 +98,7 @@ impl NetworkMessageSender {
             processor,
             network_tx,
             private_key,
-            database,
+            network_state_rx,
             operator_id,
             subnet_count,
         }))
@@ -123,13 +131,10 @@ impl NetworkMessageSender {
         let committee_id = match msg_id.duty_executor() {
             Some(DutyExecutor::Committee(committee_id)) => committee_id,
             Some(DutyExecutor::Validator(pubkey)) => {
-                let database = self.database.borrow();
-                let Some(metadata) = database.metadata().get_by(&pubkey) else {
-                    return Err(format!("Unknown validator: {pubkey}"));
-                };
-                let Some(cluster) = database.clusters().get_by(&metadata.cluster_id) else {
+                let database = self.network_state_rx.borrow();
+                let Some(cluster) = database.clusters().get_by(&pubkey) else {
                     return Err(format!(
-                        "Inconsistent database, no cluster for validator: {pubkey}"
+                        "No cluster for validator: {pubkey}"
                     ));
                 };
                 cluster.committee_id()

--- a/anchor/message_sender/src/testing.rs
+++ b/anchor/message_sender/src/testing.rs
@@ -1,16 +1,16 @@
-use crate::MessageSender;
+use crate::{Error, MessageSender};
 use ssv_types::consensus::UnsignedSSVMessage;
 use ssv_types::message::SignedSSVMessage;
 use ssv_types::OperatorId;
 use tokio::sync::mpsc;
 
-pub struct TestingMessageSender {
+pub struct MockMessageSender {
     message_tx: mpsc::UnboundedSender<SignedSSVMessage>,
     operator_id: OperatorId,
 }
 
-impl MessageSender for TestingMessageSender {
-    fn sign_and_send(&self, message: UnsignedSSVMessage) {
+impl MessageSender for MockMessageSender {
+    fn sign_and_send(&self, message: UnsignedSSVMessage) -> Result<(), Error> {
         let message = SignedSSVMessage::new(
             vec![vec![]],
             vec![self.operator_id],
@@ -18,15 +18,15 @@ impl MessageSender for TestingMessageSender {
             message.full_data,
         )
         .unwrap();
-        self.send(message);
+        self.send(message)
     }
 
-    fn send(&self, message: SignedSSVMessage) {
-        self.message_tx.send(message).unwrap();
+    fn send(&self, message: SignedSSVMessage) -> Result<(), Error> {
+        self.message_tx.send(message).map_err(|_| Error::NetworkQueueClosed)
     }
 }
 
-impl TestingMessageSender {
+impl MockMessageSender {
     pub fn new(
         message_tx: mpsc::UnboundedSender<SignedSSVMessage>,
         operator_id: OperatorId,

--- a/anchor/message_sender/src/testing.rs
+++ b/anchor/message_sender/src/testing.rs
@@ -1,0 +1,39 @@
+use crate::MessageSender;
+use ssv_types::consensus::UnsignedSSVMessage;
+use ssv_types::message::SignedSSVMessage;
+use ssv_types::OperatorId;
+use tokio::sync::mpsc;
+
+pub struct TestingMessageSender {
+    message_tx: mpsc::UnboundedSender<SignedSSVMessage>,
+    operator_id: OperatorId,
+}
+
+impl MessageSender for TestingMessageSender {
+    fn sign_and_send(&self, message: UnsignedSSVMessage) {
+        let message = SignedSSVMessage::new(
+            vec![vec![]],
+            vec![self.operator_id],
+            message.ssv_message,
+            message.full_data,
+        )
+        .unwrap();
+        self.send(message);
+    }
+
+    fn send(&self, message: SignedSSVMessage) {
+        self.message_tx.send(message).unwrap();
+    }
+}
+
+impl TestingMessageSender {
+    pub fn new(
+        message_tx: mpsc::UnboundedSender<SignedSSVMessage>,
+        operator_id: OperatorId,
+    ) -> Self {
+        Self {
+            message_tx,
+            operator_id,
+        }
+    }
+}

--- a/anchor/message_sender/src/testing.rs
+++ b/anchor/message_sender/src/testing.rs
@@ -1,7 +1,7 @@
 use crate::{Error, MessageSender};
 use ssv_types::consensus::UnsignedSSVMessage;
 use ssv_types::message::SignedSSVMessage;
-use ssv_types::OperatorId;
+use ssv_types::{CommitteeId, OperatorId};
 use tokio::sync::mpsc;
 
 pub struct MockMessageSender {
@@ -10,7 +10,11 @@ pub struct MockMessageSender {
 }
 
 impl MessageSender for MockMessageSender {
-    fn sign_and_send(&self, message: UnsignedSSVMessage) -> Result<(), Error> {
+    fn sign_and_send(
+        &self,
+        message: UnsignedSSVMessage,
+        committee_id: CommitteeId,
+    ) -> Result<(), Error> {
         let message = SignedSSVMessage::new(
             vec![vec![]],
             vec![self.operator_id],
@@ -18,11 +22,13 @@ impl MessageSender for MockMessageSender {
             message.full_data,
         )
         .unwrap();
-        self.send(message)
+        self.send(message, committee_id)
     }
 
-    fn send(&self, message: SignedSSVMessage) -> Result<(), Error> {
-        self.message_tx.send(message).map_err(|_| Error::NetworkQueueClosed)
+    fn send(&self, message: SignedSSVMessage, _committee_id: CommitteeId) -> Result<(), Error> {
+        self.message_tx
+            .send(message)
+            .map_err(|_| Error::NetworkQueueClosed)
     }
 }
 

--- a/anchor/network/src/network.rs
+++ b/anchor/network/src/network.rs
@@ -60,6 +60,7 @@ pub enum NetworkError {
 pub struct Network {
     swarm: Swarm<AnchorBehaviour>,
     subnet_event_receiver: mpsc::Receiver<SubnetEvent>,
+    message_rx: mpsc::Receiver<(SubnetId, Vec<u8>)>,
     peer_id: PeerId,
     node_info: NodeInfo,
 }
@@ -70,6 +71,7 @@ impl Network {
     pub async fn try_new(
         config: &Config,
         subnet_event_receiver: mpsc::Receiver<SubnetEvent>,
+        message_rx: mpsc::Receiver<(SubnetId, Vec<u8>)>,
         executor: TaskExecutor,
     ) -> Result<Network, NetworkError> {
         let local_keypair: Keypair = load_private_key(&config.network_dir);
@@ -99,6 +101,7 @@ impl Network {
                 config,
             )?,
             subnet_event_receiver,
+            message_rx,
             peer_id,
             node_info,
         };
@@ -212,7 +215,19 @@ impl Network {
                         }
                     }
                 }
-                // TODO match input channels
+                event = self.message_rx.recv() => {
+                    match event {
+                        Some((subnet_id, message)) => {
+                            if let Err(err) = self.gossipsub().publish(subnet_to_topic(subnet_id), message) {
+                                error!(?err, "Failed to publish message");
+                            }
+                        }
+                        None => {
+                            error!("message queue was closed");
+                            return;
+                        }
+                    }
+                }
             }
         }
     }
@@ -233,12 +248,7 @@ impl Network {
     fn on_subnet_tracker_event(&mut self, event: SubnetEvent) {
         match event {
             SubnetEvent::Join(subnet) => {
-                if let Err(err) = self
-                    .swarm
-                    .behaviour_mut()
-                    .gossipsub
-                    .subscribe(&subnet_to_topic(subnet))
-                {
+                if let Err(err) = self.gossipsub().subscribe(&subnet_to_topic(subnet)) {
                     error!(?err, subnet = *subnet, "can't subscribe");
                 }
                 let SubnetConnectActions { dial, discover } =
@@ -264,6 +274,10 @@ impl Network {
 
     fn peer_manager(&mut self) -> &mut PeerManager {
         &mut self.swarm.behaviour_mut().peer_manager
+    }
+
+    fn gossipsub(&mut self) -> &mut gossipsub::Behaviour {
+        &mut self.swarm.behaviour_mut().gossipsub
     }
 
     fn handle_handshake_result(&mut self, result: Result<handshake::Completed, handshake::Failed>) {
@@ -395,6 +409,7 @@ mod test {
     use std::time::Duration;
     use subnet_tracker::test_tracker;
     use task_executor::TaskExecutor;
+    use tokio::sync::mpsc;
 
     #[tokio::test]
     async fn create_network() {
@@ -403,10 +418,14 @@ mod test {
         let (shutdown_tx, _) = futures::channel::mpsc::channel(1);
         let task_executor = TaskExecutor::new(handle, exit, shutdown_tx);
         let subnet_tracker = test_tracker(task_executor.clone(), vec![], Duration::ZERO);
-        assert!(
-            Network::try_new(&Config::default(), subnet_tracker, task_executor)
-                .await
-                .is_ok()
-        );
+        let (_, message_rx) = mpsc::channel(1);
+        assert!(Network::try_new(
+            &Config::default(),
+            subnet_tracker,
+            message_rx,
+            task_executor
+        )
+        .await
+        .is_ok());
     }
 }

--- a/anchor/qbft_manager/Cargo.toml
+++ b/anchor/qbft_manager/Cargo.toml
@@ -8,7 +8,7 @@ edition = { workspace = true }
 dashmap = { workspace = true }
 ethereum_ssz = { workspace = true }
 ethereum_ssz_derive = { workspace = true }
-openssl = { workspace = true }
+message_sender = { workspace = true }
 processor = { workspace = true }
 qbft = { workspace = true }
 slot_clock = { workspace = true }
@@ -20,8 +20,7 @@ types = { workspace = true }
 [dev-dependencies]
 async-channel = { workspace = true }
 futures = { workspace = true }
-openssl = { workspace = true }
-rand = { workspace = true }
+message_sender = { workspace = true, features = ["testing"] }
 task_executor = { workspace = true }
 tokio = { workspace = true, features = ["test-util"] }
 tracing-subscriber = { workspace = true }

--- a/anchor/qbft_manager/src/lib.rs
+++ b/anchor/qbft_manager/src/lib.rs
@@ -1,22 +1,14 @@
 use dashmap::DashMap;
-use openssl::hash::MessageDigest;
-use openssl::pkey::{PKey, Private};
-use openssl::rsa::Rsa;
-use openssl::sign::Signer;
-
+use message_sender::MessageSender;
 use processor::{DropOnFinish, Senders, WorkItem};
 use qbft::{
     Completed, ConfigBuilder, ConfigBuilderError, DefaultLeaderFunction, InstanceHeight, Message,
     WrappedQbftMessage,
 };
 use slot_clock::SlotClock;
-use ssv_types::consensus::{BeaconVote, QbftData, UnsignedSSVMessage, ValidatorConsensusData};
-use std::error::Error;
-
-use ssv_types::message::SignedSSVMessage;
+use ssv_types::consensus::{BeaconVote, QbftData, ValidatorConsensusData};
 use ssv_types::OperatorId as QbftOperatorId;
 use ssv_types::{Cluster, CommitteeId, OperatorId};
-use ssz::Encode;
 use std::fmt::Debug;
 use std::hash::Hash;
 use std::sync::Arc;
@@ -35,7 +27,6 @@ mod tests;
 const QBFT_INSTANCE_NAME: &str = "qbft_instance";
 const QBFT_MESSAGE_NAME: &str = "qbft_message";
 const QBFT_CLEANER_NAME: &str = "qbft_cleaner";
-const QBFT_SIGNER_NAME: &str = "qbft_signer";
 
 /// Number of slots to keep before the current slot
 const QBFT_RETAIN_SLOTS: u64 = 1;
@@ -101,10 +92,8 @@ pub struct QbftManager {
     validator_consensus_data_instances: Map<ValidatorInstanceId, ValidatorConsensusData>,
     // All of the QBFT instances that are voting on beacon data
     beacon_vote_instances: Map<CommitteeInstanceId, BeaconVote>,
-    // Private key used for signing messages
-    pkey: Arc<PKey<Private>>,
-    // Channel to pass signed messages along to the network
-    network_tx: mpsc::UnboundedSender<SignedSSVMessage>,
+    // Utility to sign and serialize network messages
+    message_sender: Arc<dyn MessageSender>,
 }
 
 impl QbftManager {
@@ -113,18 +102,14 @@ impl QbftManager {
         processor: Senders,
         operator_id: OperatorId,
         slot_clock: impl SlotClock + 'static,
-        key: Rsa<Private>,
-        network_tx: mpsc::UnboundedSender<SignedSSVMessage>,
+        message_sender: impl MessageSender + 'static,
     ) -> Result<Arc<Self>, QbftError> {
-        let pkey = Arc::new(PKey::from_rsa(key).expect("Failed to create PKey from RSA"));
-
         let manager = Arc::new(QbftManager {
             processor,
             operator_id,
             validator_consensus_data_instances: DashMap::new(),
             beacon_vote_instances: DashMap::new(),
-            pkey,
-            network_tx,
+            message_sender: Arc::new(message_sender),
         });
 
         // Start a long running task that will clean up old instances
@@ -235,12 +220,7 @@ pub trait QbftDecidable: QbftData<Hash = Hash256> + Send + Sync + 'static {
                 let (tx, rx) = mpsc::unbounded_channel();
                 let tx = entry.insert(tx);
                 let _ = manager.processor.permitless.send_async(
-                    Box::pin(qbft_instance(
-                        rx,
-                        manager.network_tx.clone(),
-                        manager.pkey.clone(),
-                        manager.processor.clone(),
-                    )),
+                    Box::pin(qbft_instance(rx, manager.message_sender.clone())),
                     QBFT_INSTANCE_NAME,
                 );
                 tx.clone()
@@ -297,9 +277,7 @@ enum QbftInstance<D: QbftData<Hash = Hash256>, S: FnMut(Message)> {
 
 async fn qbft_instance<D: QbftData<Hash = Hash256>>(
     mut rx: UnboundedReceiver<QbftMessage<D>>,
-    network_tx: mpsc::UnboundedSender<SignedSSVMessage>,
-    pkey: Arc<PKey<Private>>,
-    processor: Senders,
+    message_sender: Arc<dyn MessageSender>,
 ) {
     // Signal a new instance that is uninitialized
     let mut instance = QbftInstance::Uninitialized {
@@ -342,24 +320,8 @@ async fn qbft_instance<D: QbftData<Hash = Hash256>>(
                     QbftInstance::Uninitialized { message_buffer } => {
                         // Create a new instance and receive any buffered messages
                         let mut instance = Box::new(Qbft::new(config, initial, |message| {
-                            let (id, unsigned) = message.desugar();
-                            let serialized = unsigned.as_ssz_bytes();
-                            let pkey = pkey.clone();
-                            let network_tx = network_tx.clone();
-
-                            processor
-                                .urgent_consensus
-                                .send_blocking(
-                                    move || {
-                                        if let Err(e) = sign_and_send_message(
-                                            pkey, id, unsigned, serialized, network_tx,
-                                        ) {
-                                            error!("Signing failed: {}", e);
-                                        }
-                                    },
-                                    QBFT_SIGNER_NAME,
-                                )
-                                .unwrap_or_else(|e| warn!("Failed to send to processor: {}", e));
+                            let (_, unsigned) = message.desugar();
+                            message_sender.clone().sign_and_send(unsigned);
                         }));
                         for message in message_buffer {
                             instance.receive(message);
@@ -432,11 +394,7 @@ async fn qbft_instance<D: QbftData<Hash = Hash256>>(
 
                 // Send the decided message (aggregated commit)
                 match qbft.get_aggregated_commit() {
-                    Some(msg) => {
-                        network_tx.send(msg).unwrap_or_else(|e| {
-                            error!("Failed to send signed ssv message to network: {:?}", e)
-                        });
-                    }
+                    Some(msg) => message_sender.clone().send(msg),
                     None => error!("Aggregated commit does not exist"),
                 }
 
@@ -450,33 +408,6 @@ async fn qbft_instance<D: QbftData<Hash = Hash256>>(
             }
         }
     }
-}
-
-// Sign a message and send it to the network via the network_tx
-fn sign_and_send_message(
-    pkey: Arc<PKey<Private>>,
-    id: OperatorId,
-    unsigned: UnsignedSSVMessage,
-    serialized: Vec<u8>,
-    network_tx: UnboundedSender<SignedSSVMessage>,
-) -> Result<(), Box<dyn Error>> {
-    // Create the signature
-    let mut signer = Signer::new(MessageDigest::sha256(), &pkey)?;
-    signer.update(&serialized)?;
-    let sig = signer.sign_to_vec()?;
-
-    // Build the signed ssv message, then serialize it and send to the network
-    let signed = SignedSSVMessage::new(
-        vec![sig],
-        vec![id],
-        unsigned.ssv_message,
-        unsigned.full_data,
-    )?;
-    network_tx
-        .send(signed)
-        .map_err(|e| format!("Failed to send signed ssv message to network: {}", e))?;
-
-    Ok(())
 }
 
 #[derive(Debug, Clone)]

--- a/anchor/qbft_manager/src/lib.rs
+++ b/anchor/qbft_manager/src/lib.rs
@@ -318,10 +318,19 @@ async fn qbft_instance<D: QbftData<Hash = Hash256>>(
                     // The instance is uninitialized and we have received a manager message to
                     // initialize it
                     QbftInstance::Uninitialized { message_buffer } => {
+                        let message_sender = message_sender.clone();
+                        let committee_id = config
+                            .committee_members()
+                            .iter()
+                            .cloned()
+                            .collect::<Vec<_>>()
+                            .into();
                         // Create a new instance and receive any buffered messages
-                        let mut instance = Box::new(Qbft::new(config, initial, |message| {
+                        let mut instance = Box::new(Qbft::new(config, initial, move |message| {
                             let (_, unsigned) = message.desugar();
-                            if let Err(err) = message_sender.clone().sign_and_send(unsigned) {
+                            if let Err(err) =
+                                message_sender.clone().sign_and_send(unsigned, committee_id)
+                            {
                                 error!(?err, "Unable to send qbft message!");
                             }
                         }));
@@ -397,10 +406,18 @@ async fn qbft_instance<D: QbftData<Hash = Hash256>>(
                 // Send the decided message (aggregated commit)
                 match qbft.get_aggregated_commit() {
                     Some(msg) => {
-                        if let Err(err) = message_sender.clone().send(msg) {
+                        let committee_id = qbft
+                            .config()
+                            .committee_members()
+                            .iter()
+                            .cloned()
+                            .collect::<Vec<_>>()
+                            .into();
+
+                        if let Err(err) = message_sender.clone().send(msg, committee_id) {
                             error!(?err, "Unable to send aggregated commit message");
                         }
-                    },
+                    }
                     None => error!("Aggregated commit does not exist"),
                 }
 

--- a/anchor/qbft_manager/src/lib.rs
+++ b/anchor/qbft_manager/src/lib.rs
@@ -321,7 +321,9 @@ async fn qbft_instance<D: QbftData<Hash = Hash256>>(
                         // Create a new instance and receive any buffered messages
                         let mut instance = Box::new(Qbft::new(config, initial, |message| {
                             let (_, unsigned) = message.desugar();
-                            message_sender.clone().sign_and_send(unsigned);
+                            if let Err(err) = message_sender.clone().sign_and_send(unsigned) {
+                                error!(?err, "Unable to send qbft message!");
+                            }
                         }));
                         for message in message_buffer {
                             instance.receive(message);
@@ -394,7 +396,11 @@ async fn qbft_instance<D: QbftData<Hash = Hash256>>(
 
                 // Send the decided message (aggregated commit)
                 match qbft.get_aggregated_commit() {
-                    Some(msg) => message_sender.clone().send(msg),
+                    Some(msg) => {
+                        if let Err(err) = message_sender.clone().send(msg) {
+                            error!(?err, "Unable to send aggregated commit message");
+                        }
+                    },
                     None => error!("Aggregated commit does not exist"),
                 }
 

--- a/anchor/qbft_manager/src/tests.rs
+++ b/anchor/qbft_manager/src/tests.rs
@@ -1,7 +1,7 @@
 use super::{
     CommitteeInstanceId, Completed, QbftDecidable, QbftError, QbftManager, WrappedQbftMessage,
 };
-use message_sender::testing::TestingMessageSender;
+use message_sender::testing::MockMessageSender;
 use processor::Senders;
 use slot_clock::{ManualSlotClock, SlotClock};
 use ssv_types::consensus::{BeaconVote, QbftMessage, QbftMessageType};
@@ -240,7 +240,7 @@ where
                 sender_queues.clone(),
                 operator_id,
                 slot_clock.clone(),
-                TestingMessageSender::new(network_tx.clone(), operator_id),
+                MockMessageSender::new(network_tx.clone(), operator_id),
             )
             .expect("Creation should not fail");
 

--- a/anchor/qbft_manager/src/tests.rs
+++ b/anchor/qbft_manager/src/tests.rs
@@ -1,7 +1,7 @@
 use super::{
     CommitteeInstanceId, Completed, QbftDecidable, QbftError, QbftManager, WrappedQbftMessage,
 };
-use openssl::rsa::Rsa;
+use message_sender::testing::TestingMessageSender;
 use processor::Senders;
 use slot_clock::{ManualSlotClock, SlotClock};
 use ssv_types::consensus::{BeaconVote, QbftMessage, QbftMessageType};
@@ -229,9 +229,6 @@ where
         // broadcasted back into the instances
         let (network_tx, network_rx) = mpsc::unbounded_channel();
 
-        // generate a random private key
-        let pkey = Rsa::generate(2048).expect("Should not fail");
-
         // Construct and save a manager for each operator in the committee. By having access to all
         // the managers in the committee, we can direct messages to the proper place and
         // spawn multiple concurrent instances
@@ -243,8 +240,7 @@ where
                 sender_queues.clone(),
                 operator_id,
                 slot_clock.clone(),
-                pkey.clone(),
-                network_tx.clone(),
+                TestingMessageSender::new(network_tx.clone(), operator_id),
             )
             .expect("Creation should not fail");
 

--- a/anchor/signature_collector/Cargo.toml
+++ b/anchor/signature_collector/Cargo.toml
@@ -7,6 +7,7 @@ authors = ["Sigma Prime <contact@sigmaprime.io>"]
 [dependencies]
 bls_lagrange = { workspace = true }
 dashmap = { workspace = true }
+message_sender = { workspace = true }
 processor = { workspace = true }
 slot_clock = { workspace = true }
 ssv_types = { workspace = true }

--- a/anchor/signature_collector/src/lib.rs
+++ b/anchor/signature_collector/src/lib.rs
@@ -1,5 +1,6 @@
 use bls_lagrange::KeyId;
 use dashmap::DashMap;
+use message_sender::MessageSender;
 use processor::{DropOnFinish, Senders, WorkItem};
 use slot_clock::SlotClock;
 use ssv_types::{ClusterId, OperatorId};
@@ -29,16 +30,19 @@ struct SignatureCollector {
 
 pub struct SignatureCollectorManager {
     processor: Senders,
+    _message_sender: Arc<dyn MessageSender>,
     signature_collectors: DashMap<Hash256, SignatureCollector>,
 }
 
 impl SignatureCollectorManager {
-    pub fn new<T>(processor: Senders, slot_clock: T) -> Result<Arc<Self>, CollectionError>
-    where
-        T: SlotClock + 'static,
-    {
+    pub fn new(
+        processor: Senders,
+        message_sender: impl MessageSender + 'static,
+        slot_clock: impl SlotClock + 'static,
+    ) -> Result<Arc<Self>, CollectionError> {
         let manager = Arc::new(Self {
             processor,
+            _message_sender: Arc::new(message_sender),
             signature_collectors: DashMap::new(),
         });
 
@@ -77,8 +81,8 @@ impl SignatureCollectorManager {
         self.processor.urgent_consensus.send_blocking(
             move || {
                 let signature = Box::new(our_key.sign(request.signing_root));
+                // todo use: manager.message_sender.sign_and_send();
                 let _ = manager.receive_partial_signature(request, our_operator_id, signature);
-                // TODO send signature over network
             },
             SIGNER_NAME,
         )?;

--- a/anchor/subnet_tracker/src/lib.rs
+++ b/anchor/subnet_tracker/src/lib.rs
@@ -1,14 +1,14 @@
 use alloy::primitives::ruint::aliases::U256;
 use database::{NetworkState, UniqueIndex};
-use log::warn;
 use serde::{Deserialize, Serialize};
+use ssv_types::CommitteeId;
 use std::collections::HashSet;
 use std::ops::Deref;
 use std::time::Duration;
 use task_executor::TaskExecutor;
 use tokio::sync::{mpsc, watch};
 use tokio::time::sleep;
-use tracing::debug;
+use tracing::{debug, warn};
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(transparent)]
@@ -17,6 +17,16 @@ pub struct SubnetId(#[serde(with = "serde_utils::quoted_u64")] u64);
 impl SubnetId {
     pub fn new(id: u64) -> Self {
         id.into()
+    }
+
+    pub fn from_committee(committee_id: CommitteeId, subnet_count: usize) -> Self {
+        // Derive a numeric "committee ID" and convert to an index in [0..subnet_count].
+        let id = U256::from_be_bytes(*committee_id);
+        SubnetId(
+            (id % U256::from(subnet_count))
+                .try_into()
+                .expect("modulo must be < subnet_count"),
+        )
     }
 }
 
@@ -73,12 +83,8 @@ async fn subnet_tracker(
             let state = db.borrow();
             for cluster_id in state.get_own_clusters() {
                 if let Some(cluster) = state.clusters().get_by(cluster_id) {
-                    // Derive a numeric "committee ID" and convert to an index in [0..subnet_count].
-                    let id = U256::from_be_bytes(*cluster.committee_id());
-                    let index = (id % U256::from(subnet_count))
-                        .try_into()
-                        .expect("modulo must be < subnet_count");
-                    current_subnets.insert(index);
+                    let subnet_id = SubnetId::from_committee(cluster.committee_id(), subnet_count);
+                    current_subnets.insert(subnet_id);
                 }
             }
         }
@@ -87,11 +93,7 @@ async fn subnet_tracker(
         // send a `Leave` event.
         for subnet in previous_subnets.difference(&current_subnets) {
             debug!(?subnet, "send leave");
-            if tx
-                .send(SubnetEvent::Leave(SubnetId(*subnet)))
-                .await
-                .is_err()
-            {
+            if tx.send(SubnetEvent::Leave(*subnet)).await.is_err() {
                 warn!("Network no longer listening for subnets");
                 return;
             }
@@ -101,7 +103,7 @@ async fn subnet_tracker(
         // send a `Join` event.
         for subnet in current_subnets.difference(&previous_subnets) {
             debug!(?subnet, "send join");
-            if tx.send(SubnetEvent::Join(SubnetId(*subnet))).await.is_err() {
+            if tx.send(SubnetEvent::Join(*subnet)).await.is_err() {
                 warn!("Network no longer listening for subnets");
                 return;
             }


### PR DESCRIPTION
Both the partial signature manager and the QBFT manager need to send messages. This PR introduces a component that schedules such tasks via the processor.

It also provides a mock message sender for use in tests.