### PR TITLE
Message sending for Signature Collector

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -752,6 +752,7 @@ dependencies = [
  "task_executor",
  "tokio",
  "tracing",
+ "tree_hash",
  "types",
  "validator_metrics",
  "validator_services",
@@ -7276,6 +7277,7 @@ version = "0.1.0"
 dependencies = [
  "bls_lagrange",
  "dashmap",
+ "ethereum_ssz",
  "message_sender",
  "processor",
  "slot_clock",

--- a/anchor/client/src/lib.rs
+++ b/anchor/client/src/lib.rs
@@ -318,7 +318,7 @@ impl Client {
                     .full
                     .to_string(),
                 beacon_url: "".to_string(), // this one is not actually needed :)
-                network: config.ssv_network,
+                network: config.ssv_network.clone(),
                 historic_finished_notify: Some(historic_finished_tx),
             },
         )
@@ -369,6 +369,8 @@ impl Client {
         // Create the signature collector
         let signature_collector = SignatureCollectorManager::new(
             processor_senders.clone(),
+            operator_id,
+            config.ssv_network.ssv_domain_type.clone(),
             network_message_sender.clone(),
             slot_clock.clone(),
         )
@@ -391,7 +393,6 @@ impl Client {
             slot_clock.clone(),
             spec.clone(),
             genesis_validators_root,
-            operator_id,
             key,
             executor.clone(),
         );

--- a/anchor/network/src/network.rs
+++ b/anchor/network/src/network.rs
@@ -127,13 +127,7 @@ impl Network {
             log_address.push(Protocol::P2p(peer_id));
             info!(address = %log_address, "Listening established");
         }
-        /*
-        TODO
-        - Dial peers
-        - Subscribe gossip topics
-         */
 
-        // TODO: Return channels for input/output
         Ok(network)
     }
 

--- a/anchor/signature_collector/Cargo.toml
+++ b/anchor/signature_collector/Cargo.toml
@@ -7,6 +7,7 @@ authors = ["Sigma Prime <contact@sigmaprime.io>"]
 [dependencies]
 bls_lagrange = { workspace = true }
 dashmap = { workspace = true }
+ethereum_ssz = { workspace = true }
 message_sender = { workspace = true }
 processor = { workspace = true }
 slot_clock = { workspace = true }

--- a/anchor/signature_collector/src/lib.rs
+++ b/anchor/signature_collector/src/lib.rs
@@ -1,9 +1,17 @@
 use bls_lagrange::KeyId;
-use dashmap::DashMap;
+use dashmap::{DashMap, Entry};
 use message_sender::MessageSender;
 use processor::{DropOnFinish, Senders, WorkItem};
 use slot_clock::SlotClock;
-use ssv_types::{ClusterId, OperatorId};
+use ssv_types::consensus::UnsignedSSVMessage;
+use ssv_types::domain_type::DomainType;
+use ssv_types::message::{MsgType, SSVMessage};
+use ssv_types::msgid::{DutyExecutor, MessageId, Role};
+use ssv_types::partial_sig::{
+    PartialSignatureKind, PartialSignatureMessage, PartialSignatureMessages,
+};
+use ssv_types::{CommitteeId, OperatorId, ValidatorIndex};
+use ssz::Encode;
 use std::collections::{hash_map, HashMap};
 use std::mem;
 use std::sync::Arc;
@@ -13,37 +21,61 @@ use tokio::sync::oneshot::error::RecvError;
 use tokio::sync::{mpsc, oneshot};
 use tokio::time::sleep;
 use tracing::error;
-use types::{Hash256, SecretKey, Signature, Slot};
+use types::{Hash256, PublicKeyBytes, SecretKey, Signature, Slot};
 
 const COLLECTOR_NAME: &str = "signature_collector";
 const COLLECTOR_MESSAGE_NAME: &str = "signature_collector_message";
 const COLLECTOR_CLEANER_NAME: &str = "signature_collector_cleaner";
-const SIGNER_NAME: &str = "signer";
+const SIGNER_NAME: &str = "partial_signer";
 
 /// number of slots to keep before the current slot
 const SIGNATURE_COLLECTOR_RETAIN_SLOTS: u64 = 1;
 
+/// A handle to message the instance collecting a single specific signature
 struct SignatureCollector {
     sender: UnboundedSender<CollectorMessage>,
     for_slot: Slot,
 }
 
+/// Outgoing partial signature messages that collected for a committee
+/// As soon as the partial signature for every validator in the committee is ready, it is sent.
+struct CommitteeSignatures {
+    signatures: Vec<PartialSignatureMessage>,
+    for_slot: Slot,
+}
+
 pub struct SignatureCollectorManager {
+    /// The handle to the processor, for queueing messages to the instances.
     processor: Senders,
-    _message_sender: Arc<dyn MessageSender>,
-    signature_collectors: DashMap<Hash256, SignatureCollector>,
+    /// The local operator we act for.
+    operator_id: OperatorId,
+    /// The network domain to be embedded in the message id of outgoing messages.
+    domain: DomainType,
+    /// A message sender used for outgoing messages.
+    message_sender: Arc<dyn MessageSender>,
+    /// A map from the signing root and signing validator to the corresponding signature collector.
+    signature_collectors: DashMap<(Hash256, ValidatorIndex), SignatureCollector>,
+    /// A map from a hash of an underlying decided committee value and committee id to a container
+    /// for all partial signatures based on that value for the committee.
+    /// Note that this hash may differ from the actual signing root.
+    committee_signatures: DashMap<(Hash256, CommitteeId), CommitteeSignatures>,
 }
 
 impl SignatureCollectorManager {
     pub fn new(
         processor: Senders,
+        operator_id: OperatorId,
+        domain: DomainType,
         message_sender: impl MessageSender + 'static,
         slot_clock: impl SlotClock + 'static,
     ) -> Result<Arc<Self>, CollectionError> {
         let manager = Arc::new(Self {
             processor,
-            _message_sender: Arc::new(message_sender),
+            operator_id,
+            domain,
+            message_sender: Arc::new(message_sender),
             signature_collectors: DashMap::new(),
+            committee_signatures: DashMap::new(),
         });
 
         manager.processor.permitless.send_async(
@@ -54,60 +86,176 @@ impl SignatureCollectorManager {
         Ok(manager)
     }
 
+    /// Sign a message and wait until the signature has been reconstructed.
+    /// Will timeout if the instance is cleaned up, see [`SIGNATURE_COLLECTOR_RETAIN_SLOTS`].
+    /// Check the fields of the parameter structs for more info.
+    /// The rough idea behind the separation is that `metadata` will be the same across all calls if
+    /// we sign for all validators in a committee, while `validator_signing_data` varies for each.
     pub async fn sign_and_collect(
         self: &Arc<Self>,
-        request: SignatureRequest,
-        our_operator_id: OperatorId,
-        our_key: SecretKey,
+        metadata: SignatureMetadata,
+        requester: SignatureRequester,
+        validator_signing_data: ValidatorSigningData,
     ) -> Result<Arc<Signature>, CollectionError> {
         let (result_tx, result_rx) = oneshot::channel();
 
-        // first, register notifier
-        let cloned_request = request.clone();
+        // first, register notifier with preexisting or newly spawned instance
+        let cloned_metadata = metadata.clone();
         let manager = self.clone();
         self.processor.permitless.send_immediate(
             move |drop_on_finish| {
-                let sender = manager.get_or_spawn(cloned_request);
+                let sender = manager.get_or_spawn(
+                    validator_signing_data.root,
+                    validator_signing_data.index,
+                    cloned_metadata.slot,
+                );
                 let _ = sender.send(CollectorMessage {
-                    kind: CollectorMessageKind::Notify { notify: result_tx },
-                    drop_on_finish,
+                    kind: CollectorMessageKind::RegisterNotifier {
+                        notify: result_tx,
+                        threshold: cloned_metadata.threshold,
+                    },
+                    _drop_on_finish: drop_on_finish,
                 });
             },
             COLLECTOR_MESSAGE_NAME,
         )?;
 
-        // then, trigger signing via blocking code
+        // then, create the partial signature - and maybe send the message.
         let manager = self.clone();
         self.processor.urgent_consensus.send_blocking(
             move || {
-                let signature = Box::new(our_key.sign(request.signing_root));
-                // todo use: manager.message_sender.sign_and_send();
-                let _ = manager.receive_partial_signature(request, our_operator_id, signature);
+                let partial_signature = validator_signing_data
+                    .share
+                    .sign(validator_signing_data.root);
+
+                let message = PartialSignatureMessage {
+                    partial_signature,
+                    signing_root: validator_signing_data.root,
+                    signer: manager.operator_id,
+                    validator_index: validator_signing_data.index,
+                };
+                match requester {
+                    SignatureRequester::SingleValidator { pubkey } => {
+                        // we do not have to wait for other partial signatures - send the message
+                        // immediately.
+                        if let Err(err) = manager.message_sender.sign_and_send(
+                            manager.create_message(
+                                &metadata,
+                                vec![message.clone()],
+                                &DutyExecutor::Validator(pubkey),
+                            ),
+                            metadata.committee_id,
+                        ) {
+                            error!(?err, "Error sending validator partial signature");
+                        }
+                    }
+                    SignatureRequester::Committee {
+                        mut validators,
+                        base_hash,
+                    } => {
+                        // We have to collect all signatures from the given validators.
+                        // To check this create or get an entry from the `committee_signatures` map.
+                        let mut entry = match manager
+                            .committee_signatures
+                            .entry((base_hash, metadata.committee_id))
+                        {
+                            Entry::Occupied(occupied) => occupied,
+                            Entry::Vacant(vacant) => vacant.insert_entry(CommitteeSignatures {
+                                signatures: Vec::with_capacity(validators.len()),
+                                for_slot: metadata.slot,
+                            }),
+                        };
+                        let signatures = &mut entry.get_mut().signatures;
+
+                        // Enter the signature we just signed for this validator.
+                        signatures.push(message.clone());
+
+                        // If we collected the correct amount of signatures...
+                        if signatures.len() == validators.len() {
+                            let signatures = entry.remove().signatures;
+
+                            // ... do a sanity check if we have the expected validators ...
+                            validators.retain(|idx| {
+                                signatures.iter().all(|sig| sig.validator_index != *idx)
+                            });
+                            if !validators.is_empty() {
+                                error!("Double signature for a validator in committee!");
+                            }
+
+                            // ... and then create and sign the final message!
+                            if let Err(err) = manager.message_sender.sign_and_send(
+                                manager.create_message(
+                                    &metadata,
+                                    signatures,
+                                    &DutyExecutor::Committee(metadata.committee_id),
+                                ),
+                                metadata.committee_id,
+                            ) {
+                                error!(?err, "Error sending committee partial signatures");
+                            }
+                        }
+                    }
+                }
+
+                // Finally, make the local instance aware of the partial signature.
+                let _ = manager.receive_partial_signature(message, metadata.slot);
             },
             SIGNER_NAME,
         )?;
 
-        // finally, we resolve the collector future - if we are lucky, the signature is even already
-        // done (as we received enough shares before this fn is even called)
+        // We resolve the collector future - if we are lucky, the signature is even already done
+        // because we received enough shares before this fn was even called.
         Ok(result_rx.await?)
     }
 
-    pub fn receive_partial_signature(
+    fn create_message(
+        &self,
+        metadata: &SignatureMetadata,
+        signatures: Vec<PartialSignatureMessage>,
+        duty_executor: &DutyExecutor,
+    ) -> UnsignedSSVMessage {
+        let partial_sig_messages = PartialSignatureMessages {
+            kind: metadata.kind,
+            slot: metadata.slot,
+            messages: signatures,
+        };
+
+        UnsignedSSVMessage {
+            ssv_message: SSVMessage::new(
+                MsgType::SSVPartialSignatureMsgType,
+                MessageId::new(&self.domain, metadata.role, duty_executor),
+                partial_sig_messages.as_ssz_bytes(),
+            ),
+            full_data: vec![],
+        }
+    }
+
+    pub fn receive_partial_signatures(
         self: &Arc<Self>,
-        request: SignatureRequest,
-        operator_id: OperatorId,
-        signature: Box<Signature>,
+        messages: PartialSignatureMessages,
+    ) -> Result<(), CollectionError> {
+        for message in messages.messages {
+            self.receive_partial_signature(message, messages.slot)?;
+        }
+        Ok(())
+    }
+
+    fn receive_partial_signature(
+        self: &Arc<Self>,
+        message: PartialSignatureMessage,
+        slot: Slot,
     ) -> Result<(), CollectionError> {
         let manager = self.clone();
         self.processor.permitless.send_immediate(
             move |drop_on_finish| {
-                let sender = manager.get_or_spawn(request);
+                let sender =
+                    manager.get_or_spawn(message.signing_root, message.validator_index, slot);
                 let _ = sender.send(CollectorMessage {
                     kind: CollectorMessageKind::PartialSignature {
-                        operator_id,
-                        signature,
+                        operator_id: message.signer,
+                        signature: Box::new(message.partial_signature),
                     },
-                    drop_on_finish,
+                    _drop_on_finish: drop_on_finish,
                 });
             },
             COLLECTOR_MESSAGE_NAME,
@@ -115,23 +263,28 @@ impl SignatureCollectorManager {
         Ok(())
     }
 
-    pub fn remove(&self, signing_hash: Hash256) {
-        self.signature_collectors.remove(&signing_hash);
-    }
-
-    fn get_or_spawn(&self, request: SignatureRequest) -> UnboundedSender<CollectorMessage> {
-        match self.signature_collectors.entry(request.signing_root) {
-            dashmap::Entry::Occupied(entry) => entry.get().sender.clone(),
-            dashmap::Entry::Vacant(entry) => {
+    fn get_or_spawn(
+        &self,
+        signing_root: Hash256,
+        validator_index: ValidatorIndex,
+        slot: Slot,
+    ) -> UnboundedSender<CollectorMessage> {
+        match self
+            .signature_collectors
+            .entry((signing_root, validator_index))
+        {
+            Entry::Occupied(entry) => entry.get().sender.clone(),
+            Entry::Vacant(entry) => {
+                // this channel is effectively limited by the processor permit amount
                 let (tx, rx) = mpsc::unbounded_channel();
                 entry.insert(SignatureCollector {
                     sender: tx.clone(),
-                    for_slot: request.slot,
+                    for_slot: slot,
                 });
                 let _ = self
                     .processor
                     .permitless
-                    .send_async(Box::pin(signature_collector(rx, request)), COLLECTOR_NAME);
+                    .send_async(Box::pin(signature_collector(rx)), COLLECTOR_NAME);
                 tx
             }
         }
@@ -150,30 +303,73 @@ impl SignatureCollectorManager {
             };
             let cutoff = slot.saturating_sub(SIGNATURE_COLLECTOR_RETAIN_SLOTS);
             self.signature_collectors
-                .retain(|_, collector| collector.for_slot >= cutoff)
+                .retain(|_, collector| collector.for_slot >= cutoff);
+            self.committee_signatures
+                .retain(|_, signatures| signatures.for_slot >= cutoff);
         }
     }
 }
 
+/// Metadata around the signature(s) to create.
 #[derive(Debug, Clone)]
-pub struct SignatureRequest {
-    pub cluster_id: ClusterId,
-    pub signing_root: Hash256,
+pub struct SignatureMetadata {
+    /// The signature kind to transmit. Only needed for the network message we send.
+    pub kind: PartialSignatureKind,
+    /// The role to transmit. Only needed for the network message we send.
+    pub role: Role,
+    /// The signature threshold amount after which we can reconstruct the full signature.
     pub threshold: u64,
+    /// The slot relevant for this signature. The collector instance is cleaned up one slot after
+    /// this. Also used in the network message.
     pub slot: Slot,
+    /// The committee of the signer(s). Used in the created network message.
+    pub committee_id: CommitteeId,
 }
 
-pub struct CollectorMessage {
-    pub kind: CollectorMessageKind,
-    pub drop_on_finish: DropOnFinish,
-}
-
-pub enum CollectorMessageKind {
-    Notify {
-        notify: oneshot::Sender<Arc<Signature>>,
+/// Who is signing this - only a single validator, or potentially multiple validators in a
+/// committee? This is relevant because we send only one message in the latter case.
+#[derive(Debug, Clone)]
+pub enum SignatureRequester {
+    /// The only validator signing this is the one passed when `sign_and_collect` is called.
+    SingleValidator {
+        /// The public key of the validator. Used in the created network message.
+        pubkey: PublicKeyBytes,
     },
+    /// We need to wait for all these validators to submit their signature until we can send.
+    Committee {
+        /// The validator indices we have to wait for.
+        validators: Vec<ValidatorIndex>,
+        /// A hash that identifies what we are signing. Note that the actual signing root might be
+        /// different - for example, because we are in different beacon chain attestation
+        /// committees, and the attestation data differs therefore.
+        base_hash: Hash256,
+    },
+}
+
+#[derive(Clone)]
+pub struct ValidatorSigningData {
+    pub root: Hash256,
+    pub index: ValidatorIndex,
+    pub share: SecretKey,
+}
+
+struct CollectorMessage {
+    kind: CollectorMessageKind,
+    _drop_on_finish: DropOnFinish,
+}
+
+enum CollectorMessageKind {
+    /// A new task is waiting for the result of this collector instance.
+    RegisterNotifier {
+        notify: oneshot::Sender<Arc<Signature>>,
+        threshold: u64,
+    },
+    /// A new partial signature is available - either because it arrived from the network, or
+    /// because we created it
     PartialSignature {
+        /// The signer.
         operator_id: OperatorId,
+        /// The signature, boxed because else Clippy complains.
         signature: Box<Signature>,
     },
 }
@@ -208,21 +404,37 @@ impl From<bls_lagrange::Error> for CollectionError {
     }
 }
 
-async fn signature_collector(
-    mut rx: mpsc::UnboundedReceiver<CollectorMessage>,
-    request: SignatureRequest,
-) {
+/// The actual signature collector task, waiting for messages
+async fn signature_collector(mut rx: mpsc::UnboundedReceiver<CollectorMessage>) {
     let mut notifiers = vec![];
     let mut signature_share = HashMap::new();
     let mut full_signature: Option<Arc<Signature>> = None;
+    let mut threshold = None;
 
     while let Some(message) = rx.recv().await {
         match message.kind {
-            CollectorMessageKind::Notify { notify } => {
+            CollectorMessageKind::RegisterNotifier {
+                notify,
+                threshold: new_threshold,
+            } => {
                 if let Some(full_signature) = &full_signature {
+                    // We already got a reconstructed signature, send it immediately.
                     let _ = notify.send(full_signature.clone());
                 } else {
+                    // Register the notifier and threshold.
                     notifiers.push(notify);
+                    if let Some(old_threshold) = threshold {
+                        if new_threshold != old_threshold {
+                            // Different tasks expect different thresholds. We can not know which
+                            // is correct, so we exit this instance.
+                            error!(
+                                new_threshold,
+                                old_threshold, "Conflicting thresholds passed!"
+                            );
+                            return;
+                        }
+                    }
+                    threshold = Some(new_threshold);
                 }
             }
             CollectorMessageKind::PartialSignature {
@@ -230,41 +442,43 @@ async fn signature_collector(
                 signature,
             } => {
                 if full_signature.is_some() {
-                    // already got the full signature :)
+                    // Already got the full signature.
                     continue;
                 }
 
-                // always insert to make sure we're not duplicated
+                // Insert the signature into our map.
                 match signature_share.entry(operator_id) {
                     hash_map::Entry::Vacant(entry) => {
                         entry.insert(*signature);
                     }
                     hash_map::Entry::Occupied(entry) => {
                         if entry.get() != &*signature {
+                            // We can not know which signature is correct. This is serious
+                            // misbehaviour from the operator!
                             error!(
                                 ?operator_id,
-                                "received conflicting signatures from operator"
+                                "Received conflicting signatures from operator"
                             );
                         }
                     }
                 }
+            }
+        }
 
-                if signature_share.len() as u64 >= request.threshold {
-                    // TODO move to blocking threadpool?
-
-                    let signature = match combine_signatures(mem::take(&mut signature_share)) {
-                        Ok(signature) => Arc::new(signature),
-                        Err(err) => {
-                            error!(?err, "Failed to recover signature");
-                            return;
-                        }
-                    };
-
-                    for notifier in mem::take(&mut notifiers) {
-                        let _ = notifier.send(Arc::clone(&signature));
+        if let Some(threshold) = threshold {
+            if signature_share.len() as u64 >= threshold {
+                let signature = match combine_signatures(mem::take(&mut signature_share)) {
+                    Ok(signature) => Arc::new(signature),
+                    Err(err) => {
+                        error!(?err, "Failed to recover signature");
+                        return;
                     }
-                    full_signature = Some(signature);
+                };
+
+                for notifier in mem::take(&mut notifiers) {
+                    let _ = notifier.send(Arc::clone(&signature));
                 }
+                full_signature = Some(signature);
             }
         }
     }
@@ -276,9 +490,7 @@ fn combine_signatures(
     let (ids, signatures): (Vec<_>, Vec<_>) = shares
         .into_iter()
         .map(|(k, s)| KeyId::try_from(*k).map(|k| (k, s)))
-        .collect::<Result<Vec<_>, _>>()?
-        .into_iter()
-        .unzip();
+        .collect::<Result<_, _>>()?;
 
     Ok(bls_lagrange::combine_signatures(&signatures, &ids)?)
 }

--- a/anchor/validator_store/Cargo.toml
+++ b/anchor/validator_store/Cargo.toml
@@ -24,6 +24,7 @@ ssv_types = { workspace = true }
 task_executor = { workspace = true }
 tokio = { workspace = true, features = ["sync", "time"] }
 tracing = { workspace = true }
+tree_hash = { workspace = true }
 types = { workspace = true }
 validator_metrics = { workspace = true }
 validator_services = { workspace = true }

--- a/anchor/validator_store/src/lib.rs
+++ b/anchor/validator_store/src/lib.rs
@@ -11,7 +11,10 @@ use qbft_manager::{
     CommitteeInstanceId, QbftError, QbftManager, ValidatorDutyKind, ValidatorInstanceId,
 };
 use safe_arith::{ArithError, SafeArith};
-use signature_collector::{CollectionError, SignatureCollectorManager, SignatureRequest};
+use signature_collector::{
+    CollectionError, SignatureCollectorManager, SignatureMetadata, SignatureRequester,
+    ValidatorSigningData,
+};
 use slashing_protection::{NotSafe, Safe, SlashingDatabase};
 use slot_clock::SlotClock;
 use ssv_types::consensus::{
@@ -20,7 +23,9 @@ use ssv_types::consensus::{
     DATA_VERSION_ALTAIR, DATA_VERSION_BELLATRIX, DATA_VERSION_CAPELLA, DATA_VERSION_DENEB,
     DATA_VERSION_PHASE0, DATA_VERSION_UNKNOWN,
 };
-use ssv_types::{Cluster, OperatorId, ValidatorIndex, ValidatorMetadata};
+use ssv_types::msgid::Role;
+use ssv_types::partial_sig::PartialSignatureKind;
+use ssv_types::{Cluster, CommitteeId, ValidatorIndex, ValidatorMetadata};
 use ssz::Encode;
 use std::collections::HashSet;
 use std::fmt::Debug;
@@ -31,6 +36,7 @@ use std::time::Duration;
 use task_executor::TaskExecutor;
 use tokio::sync::watch::Receiver;
 use tracing::{error, info, warn};
+use tree_hash::TreeHash;
 use types::attestation::Attestation;
 use types::beacon_block::BeaconBlock;
 use types::graffiti::Graffiti;
@@ -73,6 +79,7 @@ struct InitializedValidator {
 
 pub struct AnchorValidatorStore<T: SlotClock + 'static, E: EthSpec> {
     validators: DashMap<PublicKeyBytes, InitializedValidator>,
+    validators_per_committee: DashMap<CommitteeId, HashSet<ValidatorIndex>>,
     signature_collector: Arc<SignatureCollectorManager>,
     qbft_manager: Arc<QbftManager>,
     slashing_protection: SlashingDatabase,
@@ -80,7 +87,6 @@ pub struct AnchorValidatorStore<T: SlotClock + 'static, E: EthSpec> {
     slot_clock: T,
     spec: Arc<ChainSpec>,
     genesis_validators_root: Hash256,
-    operator_id: OperatorId,
     private_key: Rsa<Private>,
     _ethspec: PhantomData<E>,
 }
@@ -95,12 +101,12 @@ impl<T: SlotClock, E: EthSpec> AnchorValidatorStore<T, E> {
         slot_clock: T,
         spec: Arc<ChainSpec>,
         genesis_validators_root: Hash256,
-        operator_id: OperatorId,
         private_key: Rsa<Private>,
         task_executor: TaskExecutor,
     ) -> Arc<AnchorValidatorStore<T, E>> {
         let ret = Arc::new(Self {
             validators: DashMap::new(),
+            validators_per_committee: DashMap::new(),
             signature_collector,
             qbft_manager,
             slashing_protection,
@@ -108,7 +114,6 @@ impl<T: SlotClock, E: EthSpec> AnchorValidatorStore<T, E> {
             slot_clock,
             spec,
             genesis_validators_root,
-            operator_id,
             private_key,
             _ethspec: PhantomData,
         });
@@ -162,7 +167,7 @@ impl<T: SlotClock, E: EthSpec> AnchorValidatorStore<T, E> {
         }
 
         for validator in unseen_validators {
-            self.validators.remove(&validator);
+            self.remove_validator(&validator);
             info!(%validator, "Validator disabled");
         }
     }
@@ -225,11 +230,25 @@ impl<T: SlotClock, E: EthSpec> AnchorValidatorStore<T, E> {
                 decrypted_key_share,
             },
         );
+
+        // we do NOT enter into validators_per_committee here, because the index is still inaccurate
+
         self.slashing_protection
             .register_validator(pubkey_bytes)
             .map_err(Error::Slashable)?;
         info!(validator = %pubkey_bytes, "Validator enabled");
         Ok(())
+    }
+
+    fn remove_validator(&self, pubkey_bytes: &PublicKeyBytes) {
+        let Some((_, validator)) = self.validators.remove(pubkey_bytes) else {
+            return;
+        };
+        if validator.metadata.index != ValidatorIndex(0) {
+            for mut committee in self.validators_per_committee.iter_mut() {
+                committee.remove(&validator.metadata.index);
+            }
+        }
     }
 
     fn validator(&self, validator_pubkey: PublicKeyBytes) -> Result<InitializedValidator, Error> {
@@ -250,25 +269,51 @@ impl<T: SlotClock, E: EthSpec> AnchorValidatorStore<T, E> {
 
     async fn collect_signature(
         &self,
-        cluster: InitializedValidator,
+        signature_kind: PartialSignatureKind,
+        role: Role,
+        base_hash: Option<Hash256>,
+        validator: InitializedValidator,
         signing_root: Hash256,
-        for_slot: Slot,
+        slot: Slot,
     ) -> Result<Signature, Error> {
-        let collector = self.signature_collector.sign_and_collect(
-            SignatureRequest {
-                cluster_id: cluster.cluster.cluster_id,
-                signing_root,
-                threshold: cluster
-                    .cluster
-                    .get_f()
-                    .safe_mul(2)
-                    .and_then(|x| x.safe_add(1))
-                    .map_err(SpecificError::from)?,
-                slot: for_slot,
-            },
-            self.operator_id,
-            cluster.decrypted_key_share,
-        );
+        let committee_id = validator.cluster.committee_id();
+        let metadata = SignatureMetadata {
+            kind: signature_kind,
+            role,
+            threshold: validator
+                .cluster
+                .get_f()
+                .safe_mul(2)
+                .and_then(|x| x.safe_add(1))
+                .map_err(SpecificError::from)?,
+            slot,
+            committee_id,
+        };
+
+        let requester = if let Some(base_hash) = base_hash {
+            SignatureRequester::Committee {
+                validators: self
+                    .validators_per_committee
+                    .get(&committee_id)
+                    .map(|indices| indices.iter().copied().collect())
+                    .unwrap_or(vec![validator.metadata.index]),
+                base_hash,
+            }
+        } else {
+            SignatureRequester::SingleValidator {
+                pubkey: validator.metadata.public_key,
+            }
+        };
+
+        let signing_data = ValidatorSigningData {
+            root: signing_root,
+            index: validator.metadata.index,
+            share: validator.decrypted_key_share.clone(),
+        };
+
+        let collector =
+            self.signature_collector
+                .sign_and_collect(metadata, requester, signing_data);
         Ok((*collector.await.map_err(SpecificError::from)?).clone())
     }
 
@@ -365,6 +410,9 @@ impl<T: SlotClock, E: EthSpec> AnchorValidatorStore<T, E> {
         let signing_root = block.signing_root(domain_hash);
         let signature = self
             .collect_signature(
+                PartialSignatureKind::PostConsensus,
+                Role::Proposer,
+                None,
                 self.validator(validator_pubkey)?,
                 signing_root,
                 block.slot(),
@@ -404,7 +452,14 @@ impl<T: SlotClock, E: EthSpec> AnchorValidatorStore<T, E> {
         let domain = self.get_domain(epoch, Domain::SyncCommittee);
         let signing_root = data.block_root.signing_root(domain);
         let signature = self
-            .collect_signature(validator, signing_root, slot)
+            .collect_signature(
+                PartialSignatureKind::PostConsensus,
+                Role::Committee,
+                Some(signing_root),
+                validator,
+                signing_root,
+                slot,
+            )
             .await?;
 
         Ok(SyncCommitteeMessage {
@@ -497,9 +552,16 @@ impl<T: SlotClock, E: EthSpec> AnchorValidatorStore<T, E> {
                         selection_proof: contribution.selection_proof_sig,
                     };
                     let signing_root = message.signing_root(domain_hash);
-                    self.collect_signature(cluster, signing_root, slot)
-                        .await
-                        .map(|signature| SignedContributionAndProof { message, signature })
+                    self.collect_signature(
+                        PartialSignatureKind::PostConsensus,
+                        Role::Aggregator,
+                        None,
+                        cluster,
+                        signing_root,
+                        slot,
+                    )
+                    .await
+                    .map(|signature| SignedContributionAndProof { message, signature })
                 }
             })
             .collect::<Vec<_>>();
@@ -642,6 +704,9 @@ impl<T: SlotClock, E: EthSpec> ValidatorStore for AnchorValidatorStore<T, E> {
         let domain_hash = self.get_domain(signing_epoch, Domain::Randao);
         let signing_root = signing_epoch.signing_root(domain_hash);
         self.collect_signature(
+            PartialSignatureKind::RandaoPartialSig,
+            Role::Proposer,
+            None,
             self.validator(validator_pubkey)?,
             signing_root,
             signing_epoch.end_slot(E::slots_per_epoch()),
@@ -656,7 +721,12 @@ impl<T: SlotClock, E: EthSpec> ValidatorStore for AnchorValidatorStore<T, E> {
                 "Trying to set index for unknown validator"
             ),
             Some(mut v) => {
-                v.metadata.index = ValidatorIndex(index as usize);
+                let index = ValidatorIndex(index as usize);
+                v.metadata.index = index;
+                self.validators_per_committee
+                    .entry(v.cluster.committee_id())
+                    .or_default()
+                    .insert(index);
             }
         }
     }
@@ -739,6 +809,7 @@ impl<T: SlotClock, E: EthSpec> ValidatorStore for AnchorValidatorStore<T, E> {
             Completed::TimedOut => return Err(Error::SpecificError(SpecificError::Timeout)),
             Completed::Success(data) => data,
         };
+        let data_hash = data.tree_hash_root();
         attestation.data_mut().beacon_block_root = data.block_root;
         attestation.data_mut().source = data.source;
         attestation.data_mut().target = data.target;
@@ -758,7 +829,14 @@ impl<T: SlotClock, E: EthSpec> ValidatorStore for AnchorValidatorStore<T, E> {
 
         let signing_root = attestation.data().signing_root(domain_hash);
         let signature = self
-            .collect_signature(validator, signing_root, attestation.data().slot)
+            .collect_signature(
+                PartialSignatureKind::PostConsensus,
+                Role::Committee,
+                Some(data_hash),
+                validator,
+                signing_root,
+                attestation.data().slot,
+            )
             .await?;
         attestation
             .add_signature(&signature, validator_committee_position)
@@ -797,6 +875,9 @@ impl<T: SlotClock, E: EthSpec> ValidatorStore for AnchorValidatorStore<T, E> {
 
         let signature = self
             .collect_signature(
+                PartialSignatureKind::ValidatorRegistration,
+                Role::Proposer,
+                None,
                 self.validator(validator_registration_data.pubkey)?,
                 signing_root,
                 validity_slot,
@@ -866,7 +947,14 @@ impl<T: SlotClock, E: EthSpec> ValidatorStore for AnchorValidatorStore<T, E> {
         let domain_hash = self.get_domain(signing_epoch, Domain::AggregateAndProof);
         let signing_root = message.signing_root(domain_hash);
         let signature = self
-            .collect_signature(validator, signing_root, message.aggregate().get_slot())
+            .collect_signature(
+                PartialSignatureKind::PostConsensus,
+                Role::Aggregator,
+                None,
+                validator,
+                signing_root,
+                message.aggregate().get_slot(),
+            )
             .await?;
 
         Ok(SignedAggregateAndProof::from_aggregate_and_proof(
@@ -883,9 +971,16 @@ impl<T: SlotClock, E: EthSpec> ValidatorStore for AnchorValidatorStore<T, E> {
         let domain_hash = self.get_domain(epoch, Domain::SelectionProof);
         let signing_root = slot.signing_root(domain_hash);
 
-        self.collect_signature(self.validator(validator_pubkey)?, signing_root, slot)
-            .await
-            .map(SelectionProof::from)
+        self.collect_signature(
+            PartialSignatureKind::SelectionProofPartialSig,
+            Role::Aggregator,
+            None,
+            self.validator(validator_pubkey)?,
+            signing_root,
+            slot,
+        )
+        .await
+        .map(SelectionProof::from)
     }
 
     async fn produce_sync_selection_proof(
@@ -902,9 +997,16 @@ impl<T: SlotClock, E: EthSpec> ValidatorStore for AnchorValidatorStore<T, E> {
         }
         .signing_root(domain_hash);
 
-        self.collect_signature(self.validator(*validator_pubkey)?, signing_root, slot)
-            .await
-            .map(SyncSelectionProof::from)
+        self.collect_signature(
+            PartialSignatureKind::SelectionProofPartialSig,
+            Role::SyncCommittee,
+            None,
+            self.validator(*validator_pubkey)?,
+            signing_root,
+            slot,
+        )
+        .await
+        .map(SyncSelectionProof::from)
     }
 
     async fn produce_sync_committee_signature(


### PR DESCRIPTION
Updates signature collector to send messages via the common message sender component. 

There are some bigger changes because I was unaware how the signatures are bundled for the `Committee` role. Let me know if something is unclear.
