### PR TITLE
Properly handle messages sent by ourselves

### DIFF
--- a/anchor/common/qbft/src/lib.rs
+++ b/anchor/common/qbft/src/lib.rs
@@ -12,11 +12,10 @@ use types::Hash256;
 // Re-Exports for Manager
 pub use config::{Config, ConfigBuilder};
 pub use error::ConfigBuilderError;
-pub use qbft_types::Message;
 pub use qbft_types::WrappedQbftMessage;
 pub use qbft_types::{
     Completed, ConsensusData, DefaultLeaderFunction, InstanceHeight, InstanceState, LeaderFunction,
-    Round,
+    Round, UnsignedWrappedQbftMessage,
 };
 
 mod config;
@@ -71,7 +70,7 @@ pub struct Qbft<F, D, S>
 where
     F: LeaderFunction + Clone,
     D: QbftData<Hash = Hash256>,
-    S: FnMut(Message),
+    S: FnMut(UnsignedWrappedQbftMessage),
 {
     /// The initial configuration used to establish this instance of QBFT.
     config: Config<F>,
@@ -121,7 +120,7 @@ impl<F, D, S> Qbft<F, D, S>
 where
     F: LeaderFunction + Clone,
     D: QbftData<Hash = Hash256>,
-    S: FnMut(Message),
+    S: FnMut(UnsignedWrappedQbftMessage),
 {
     // Construct a new QBFT Instance and start the first round
     pub fn new(config: Config<F>, start_data: D, send_message: S) -> Self {
@@ -908,7 +907,7 @@ where
         data_hash: D::Hash,
         round_change_justification: Vec<SignedSSVMessage>,
         prepare_justification: Vec<SignedSSVMessage>,
-    ) -> UnsignedSSVMessage {
+    ) -> UnsignedWrappedQbftMessage {
         let data = self.get_message_data(&msg_type, data_hash);
 
         // Create the QBFT message
@@ -930,9 +929,12 @@ where
         );
 
         // Wrap in unsigned SSV message
-        UnsignedSSVMessage {
-            ssv_message,
-            full_data: data.full_data,
+        UnsignedWrappedQbftMessage {
+            unsigned_message: UnsignedSSVMessage {
+                ssv_message,
+                full_data: data.full_data,
+            },
+            qbft_message,
         }
     }
 
@@ -1065,8 +1067,7 @@ where
             prepare_justifications,
         );
 
-        let operator_id = self.config.operator_id();
-        (self.send_message)(Message::Propose(operator_id, unsigned_msg.clone()));
+        (self.send_message)(unsigned_msg);
     }
 
     // Send a new qbft prepare message
@@ -1081,8 +1082,7 @@ where
         let unsigned_msg =
             self.new_unsigned_message(QbftMessageType::Prepare, data_hash, vec![], vec![]);
 
-        let operator_id = self.config.operator_id();
-        (self.send_message)(Message::Prepare(operator_id, unsigned_msg.clone()));
+        (self.send_message)(unsigned_msg);
     }
 
     // Send a new qbft commit message
@@ -1091,8 +1091,7 @@ where
         let unsigned_msg =
             self.new_unsigned_message(QbftMessageType::Commit, data_hash, vec![], vec![]);
 
-        let operator_id = self.config.operator_id();
-        (self.send_message)(Message::Commit(operator_id, unsigned_msg.clone()));
+        (self.send_message)(unsigned_msg);
     }
 
     // Send a new qbft round change message
@@ -1113,8 +1112,7 @@ where
         // forget that we accpeted a proposal
         self.proposal_accepted_for_current_round = false;
 
-        let operator_id = self.config.operator_id();
-        (self.send_message)(Message::RoundChange(operator_id, unsigned_msg.clone()));
+        (self.send_message)(unsigned_msg);
     }
 
     /// Extract the data that the instance has come to consensus on

--- a/anchor/common/qbft/src/qbft_types.rs
+++ b/anchor/common/qbft/src/qbft_types.rs
@@ -50,6 +50,14 @@ pub struct WrappedQbftMessage {
     pub qbft_message: QbftMessage,
 }
 
+// Wrapped qbft message is a wrapper around both an unsigned ssv message, and the underlying qbft
+// message.
+#[derive(Debug, Clone)]
+pub struct UnsignedWrappedQbftMessage {
+    pub unsigned_message: UnsignedSSVMessage,
+    pub qbft_message: QbftMessage,
+}
+
 impl WrappedQbftMessage {
     // Validate that the message is well formed
     pub fn validate(&self) -> bool {
@@ -116,31 +124,6 @@ impl From<InstanceState> for u8 {
             InstanceState::SentRoundChange => 4,
             InstanceState::Complete => 5,
             InstanceState::RoundChangeConsensus => 6,
-        }
-    }
-}
-
-/// Generic Data trait to allow for future implementations of the QBFT module
-// Messages that can be received from the message_in channel
-#[derive(Debug, Clone)]
-pub enum Message {
-    /// A PROPOSE message to be sent on the network.
-    Propose(OperatorId, UnsignedSSVMessage),
-    /// A PREPARE message to be sent on the network.
-    Prepare(OperatorId, UnsignedSSVMessage),
-    /// A commit message to be sent on the network.
-    Commit(OperatorId, UnsignedSSVMessage),
-    /// Round change message to be sent on the network
-    RoundChange(OperatorId, UnsignedSSVMessage),
-}
-
-impl Message {
-    pub fn desugar(&self) -> (OperatorId, UnsignedSSVMessage) {
-        match self {
-            Message::Propose(id, msg)
-            | Message::Prepare(id, msg)
-            | Message::Commit(id, msg)
-            | Message::RoundChange(id, msg) => (*id, msg.clone()),
         }
     }
 }

--- a/anchor/common/qbft/src/tests.rs
+++ b/anchor/common/qbft/src/tests.rs
@@ -5,7 +5,6 @@
 use super::*;
 use qbft_types::DefaultLeaderFunction;
 use sha2::{Digest, Sha256};
-use ssv_types::consensus::UnsignedSSVMessage;
 use ssv_types::message::SignedSSVMessage;
 use ssv_types::OperatorId;
 use ssz_derive::{Decode, Encode};
@@ -40,26 +39,22 @@ impl QbftData for TestData {
     }
 }
 
-fn convert_unsigned_to_wrapped(
-    msg: UnsignedSSVMessage,
+fn convert_unsigned_to_signed(
+    msg: UnsignedWrappedQbftMessage,
     operator_id: OperatorId,
 ) -> WrappedQbftMessage {
     // Create a signed message containing just this operator
     let signed_message = SignedSSVMessage::new(
         vec![vec![0; 96]], // Test signature of 96 bytes
         vec![OperatorId(*operator_id)],
-        msg.ssv_message.clone(),
-        msg.full_data,
+        msg.unsigned_message.ssv_message,
+        msg.unsigned_message.full_data,
     )
     .expect("Should create signed message");
 
-    // Parse the QBFT message from the SSV message data
-    let qbft_message =
-        QbftMessage::from_ssz_bytes(msg.ssv_message.data()).expect("Should decode QBFT message");
-
     WrappedQbftMessage {
         signed_message,
-        qbft_message,
+        qbft_message: msg.qbft_message,
     }
 }
 
@@ -85,7 +80,7 @@ impl Default for TestQBFTCommitteeBuilder {
 impl TestQBFTCommitteeBuilder {
     /// Consumes self and runs a test scenario. This returns a [`TestQBFTCommittee`] which
     /// represents a running quorum.
-    pub fn run<D>(self, data: D) -> TestQBFTCommittee<D, impl FnMut(Message)>
+    pub fn run<D>(self, data: D) -> TestQBFTCommittee<D, impl FnMut(UnsignedWrappedQbftMessage)>
     where
         D: Default + QbftData<Hash = Hash256>,
     {
@@ -102,8 +97,8 @@ impl TestQBFTCommitteeBuilder {
 
 /// A testing structure representing a committee of running instances
 #[allow(clippy::type_complexity)]
-struct TestQBFTCommittee<D: QbftData<Hash = Hash256>, S: FnMut(Message)> {
-    msg_queue: Rc<RefCell<VecDeque<(OperatorId, Message)>>>,
+struct TestQBFTCommittee<D: QbftData<Hash = Hash256>, S: FnMut(UnsignedWrappedQbftMessage)> {
+    msg_queue: Rc<RefCell<VecDeque<(OperatorId, UnsignedWrappedQbftMessage)>>>,
     instances: HashMap<OperatorId, Qbft<DefaultLeaderFunction, D, S>>,
     // All of the instances that are currently active, allows us to stop/restart instances by
     // controlling the messages being sent and received
@@ -117,7 +112,7 @@ struct TestQBFTCommittee<D: QbftData<Hash = Hash256>, S: FnMut(Message)> {
 fn construct_and_run_committee<D: QbftData<Hash = Hash256>>(
     mut config: ConfigBuilder,
     validated_data: D,
-) -> TestQBFTCommittee<D, impl FnMut(Message)> {
+) -> TestQBFTCommittee<D, impl FnMut(UnsignedWrappedQbftMessage)> {
     // The ID of a committee is just an integer in [0,committee_size)
 
     let msg_queue = Rc::new(RefCell::new(VecDeque::new()));
@@ -145,7 +140,7 @@ fn construct_and_run_committee<D: QbftData<Hash = Hash256>>(
     }
 }
 
-impl<D: QbftData<Hash = Hash256>, S: FnMut(Message)> TestQBFTCommittee<D, S> {
+impl<D: QbftData<Hash = Hash256>, S: FnMut(UnsignedWrappedQbftMessage)> TestQBFTCommittee<D, S> {
     fn wait_until_end(mut self) -> i32 {
         loop {
             let msg = self.msg_queue.borrow_mut().pop_front();
@@ -167,15 +162,8 @@ impl<D: QbftData<Hash = Hash256>, S: FnMut(Message)> TestQBFTCommittee<D, S> {
                 // We do not make sure that id != sender since we want to loop back and receive our
                 // own messages
                 let instance = self.instances.get_mut(id).expect("Instance exists");
-                // get the unsigned message and the sender
-                let (_, unsigned) = match msg {
-                    Message::Propose(o, ref u)
-                    | Message::Prepare(o, ref u)
-                    | Message::Commit(o, ref u)
-                    | Message::RoundChange(o, ref u) => (o, u),
-                };
 
-                let wrapped = convert_unsigned_to_wrapped(unsigned.clone(), sender);
+                let wrapped = convert_unsigned_to_signed(msg.clone(), sender);
                 instance.receive(wrapped);
             }
         }

--- a/anchor/message_sender/src/lib.rs
+++ b/anchor/message_sender/src/lib.rs
@@ -9,11 +9,14 @@ use ssv_types::message::SignedSSVMessage;
 use ssv_types::CommitteeId;
 use tokio::sync::mpsc::error::TrySendError;
 
+type MessageCallback = dyn FnOnce(&SignedSSVMessage) + Send + 'static;
+
 pub trait MessageSender: Send + Sync {
     fn sign_and_send(
         &self,
         message: UnsignedSSVMessage,
         committee_id: CommitteeId,
+        additional_message_callback: Option<Box<MessageCallback>>,
     ) -> Result<(), Error>;
     fn send(&self, message: SignedSSVMessage, committee_id: CommitteeId) -> Result<(), Error>;
 }

--- a/anchor/message_sender/src/network.rs
+++ b/anchor/message_sender/src/network.rs
@@ -1,4 +1,4 @@
-use crate::{Error, MessageSender};
+use crate::{Error, MessageCallback, MessageSender};
 use openssl::error::ErrorStack;
 use openssl::hash::MessageDigest;
 use openssl::pkey::{PKey, Private};
@@ -30,6 +30,7 @@ impl MessageSender for Arc<NetworkMessageSender> {
         &self,
         message: UnsignedSSVMessage,
         committee_id: CommitteeId,
+        additional_message_callback: Option<Box<MessageCallback>>,
     ) -> Result<(), Error> {
         if self.network_tx.is_closed() {
             return Err(Error::NetworkQueueClosed);
@@ -59,6 +60,9 @@ impl MessageSender for Arc<NetworkMessageSender> {
                             return;
                         }
                     };
+                    if let Some(callback) = additional_message_callback {
+                        callback(&message);
+                    }
                     sender.do_send(message, committee_id);
                 },
                 SIGNER_NAME,

--- a/anchor/message_sender/src/testing.rs
+++ b/anchor/message_sender/src/testing.rs
@@ -1,4 +1,4 @@
-use crate::{Error, MessageSender};
+use crate::{Error, MessageCallback, MessageSender};
 use ssv_types::consensus::UnsignedSSVMessage;
 use ssv_types::message::SignedSSVMessage;
 use ssv_types::{CommitteeId, OperatorId};
@@ -14,6 +14,7 @@ impl MessageSender for MockMessageSender {
         &self,
         message: UnsignedSSVMessage,
         committee_id: CommitteeId,
+        additional_message_callback: Option<Box<MessageCallback>>,
     ) -> Result<(), Error> {
         let message = SignedSSVMessage::new(
             vec![vec![]],
@@ -22,6 +23,9 @@ impl MessageSender for MockMessageSender {
             message.full_data,
         )
         .unwrap();
+        if let Some(callback) = additional_message_callback {
+            callback(&message);
+        }
         self.send(message, committee_id)
     }
 

--- a/anchor/qbft_manager/src/lib.rs
+++ b/anchor/qbft_manager/src/lib.rs
@@ -2,8 +2,8 @@ use dashmap::DashMap;
 use message_sender::MessageSender;
 use processor::{DropOnFinish, Senders, WorkItem};
 use qbft::{
-    Completed, ConfigBuilder, ConfigBuilderError, DefaultLeaderFunction, InstanceHeight, Message,
-    WrappedQbftMessage,
+    Completed, ConfigBuilder, ConfigBuilderError, DefaultLeaderFunction, InstanceHeight,
+    UnsignedWrappedQbftMessage, WrappedQbftMessage,
 };
 use slot_clock::SlotClock;
 use ssv_types::consensus::{BeaconVote, QbftData, ValidatorConsensusData};
@@ -255,7 +255,7 @@ impl QbftDecidable for BeaconVote {
 }
 
 // States that Qbft instance may be in
-enum QbftInstance<D: QbftData<Hash = Hash256>, S: FnMut(Message)> {
+enum QbftInstance<D: QbftData<Hash = Hash256>, S: FnMut(UnsignedWrappedQbftMessage)> {
     // The instance is uninitialized
     Uninitialized {
         // todo: proooobably limit this
@@ -267,6 +267,7 @@ enum QbftInstance<D: QbftData<Hash = Hash256>, S: FnMut(Message)> {
     Initialized {
         qbft: Box<Qbft<D, S>>,
         round_end: Interval,
+        sent_by_us: UnboundedReceiver<WrappedQbftMessage>,
         on_completed: Vec<oneshot::Sender<Completed<D>>>,
     },
     // The instance has been decided
@@ -290,11 +291,21 @@ async fn qbft_instance<D: QbftData<Hash = Hash256>>(
             QbftInstance::Uninitialized { .. } | QbftInstance::Decided { .. } => rx.recv().await,
             QbftInstance::Initialized {
                 qbft: instance,
+                sent_by_us,
                 round_end,
                 ..
             } => {
                 select! {
                     message = rx.recv() => message,
+                    sent_by_us = sent_by_us.recv() => {
+                        if let Some(sent_by_us) = sent_by_us {
+                            instance.receive(sent_by_us);
+                        } else {
+                            // should not ever happen
+                            error!("QBFT instance dropped message callback");
+                        }
+                        continue;
+                    },
                     _ = round_end.tick() => {
                         warn!("Round timer elapsed");
                         instance.end_round();
@@ -318,6 +329,8 @@ async fn qbft_instance<D: QbftData<Hash = Hash256>>(
                     // The instance is uninitialized and we have received a manager message to
                     // initialize it
                     QbftInstance::Uninitialized { message_buffer } => {
+                        let (sent_by_us_tx, sent_by_us_rx) = mpsc::unbounded_channel();
+
                         let message_sender = message_sender.clone();
                         let committee_id = config
                             .committee_members()
@@ -327,10 +340,19 @@ async fn qbft_instance<D: QbftData<Hash = Hash256>>(
                             .into();
                         // Create a new instance and receive any buffered messages
                         let mut instance = Box::new(Qbft::new(config, initial, move |message| {
-                            let (_, unsigned) = message.desugar();
-                            if let Err(err) =
-                                message_sender.clone().sign_and_send(unsigned, committee_id)
-                            {
+                            let sent_by_us_tx = sent_by_us_tx.clone();
+                            if let Err(err) = message_sender.clone().sign_and_send(
+                                message.unsigned_message,
+                                committee_id,
+                                Some(Box::new(move |signed| {
+                                    // this might fail, but that's ok: it simply means that the
+                                    // instance has shut down (e.g. because it's done)
+                                    let _ = sent_by_us_tx.send(WrappedQbftMessage {
+                                        signed_message: signed.clone(),
+                                        qbft_message: message.qbft_message,
+                                    });
+                                })),
+                            ) {
                                 error!(?err, "Unable to send qbft message!");
                             }
                         }));
@@ -345,12 +367,14 @@ async fn qbft_instance<D: QbftData<Hash = Hash256>>(
                         QbftInstance::Initialized {
                             round_end: interval,
                             qbft: instance,
+                            sent_by_us: sent_by_us_rx,
                             on_completed: vec![on_completed],
                         }
                     }
                     QbftInstance::Initialized {
                         qbft,
                         round_end,
+                        sent_by_us,
                         on_completed: mut on_completed_vec,
                     } => {
                         if qbft.start_data_hash() != &initial.hash() {
@@ -360,6 +384,7 @@ async fn qbft_instance<D: QbftData<Hash = Hash256>>(
                         QbftInstance::Initialized {
                             qbft,
                             round_end,
+                            sent_by_us,
                             on_completed: on_completed_vec,
                         }
                     }
@@ -393,6 +418,7 @@ async fn qbft_instance<D: QbftData<Hash = Hash256>>(
         if let QbftInstance::Initialized {
             qbft,
             round_end,
+            sent_by_us,
             on_completed,
         } = instance
         {
@@ -426,6 +452,7 @@ async fn qbft_instance<D: QbftData<Hash = Hash256>>(
                 instance = QbftInstance::Initialized {
                     qbft,
                     round_end,
+                    sent_by_us,
                     on_completed,
                 }
             }

--- a/anchor/signature_collector/src/lib.rs
+++ b/anchor/signature_collector/src/lib.rs
@@ -145,6 +145,7 @@ impl SignatureCollectorManager {
                                 &DutyExecutor::Validator(pubkey),
                             ),
                             metadata.committee_id,
+                            None,
                         ) {
                             error!(?err, "Error sending validator partial signature");
                         }
@@ -190,6 +191,7 @@ impl SignatureCollectorManager {
                                     &DutyExecutor::Committee(metadata.committee_id),
                                 ),
                                 metadata.committee_id,
+                                None,
                             ) {
                                 error!(?err, "Error sending committee partial signatures");
                             }


### PR DESCRIPTION
The QBFT instance needs to handle messages that it has sent. For this, it needs the signed message - for example, so that it can embed signed quorums in the round change messages.

This PR adds an optional callback mechanism to the common message sender. This is used in the QBFT instance to enqueue signed message for handling by the same instance.

While we're at it, we get rid of `qbft::Message`, which is no longer adequate as outgoing message type. The different variants are not treated differently at all in the current design, where we directly use SSV-specific messages.