### PR TITLE
Switch back to official `blst` release and revisit zeroing keys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1555,8 +1555,9 @@ dependencies = [
 
 [[package]]
 name = "blst"
-version = "0.3.13"
-source = "git+https://github.com/dknopik/blst?branch=sk-conversion#f9dbf4a269c0c479deb257f20a9031aa2f7a3023"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47c79a94619fade3c0b887670333513a67ac28a6a7e653eb260bf0d4103db38d"
 dependencies = [
  "cc",
  "glob",
@@ -1583,7 +1584,7 @@ dependencies = [
 [[package]]
 name = "blstrs_plus"
 version = "0.8.18"
-source = "git+https://github.com/dknopik/blstrs?branch=pls#76852cb871b39ffea9ae45e68cf6d773b67acf12"
+source = "git+https://github.com/dknopik/blstrs?branch=pls#e281dca0c6c5c70d5c3b748c915612809e367a0d"
 dependencies = [
  "arrayref",
  "blst",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,7 +79,7 @@ alloy = { version = "0.11.0", features = [
 async-channel = "1.9"
 axum = "0.8.1"
 base64 = "0.22.1"
-blst = { git = "https://github.com/dknopik/blst", branch = "sk-conversion" }
+blst = "0.3.14"
 # the custom repo is needed because they fix to a specific version of blst, which conflicts with the line above
 blstrs_plus = { git = "https://github.com/dknopik/blstrs", branch = "pls" }
 clap = { version = "4.5.15", features = ["derive", "wrap_help"] }
@@ -122,8 +122,6 @@ vsss-rs = "5.1.0"
 zeroize = "1.8.1"
 
 [patch.crates-io]
-# todo: remove when https://github.com/supranational/blst/pull/248 is merged
-blst = { git = "https://github.com/dknopik/blst", branch = "sk-conversion" }
 # todo: remove when libp2p versions are aligned again. this is only needed because cargo audit crashes otherwise
 libp2p = { git = "https://github.com/libp2p/rust-libp2p.git", rev = "082eb16" }
 libp2p-mplex = { git = "https://github.com/libp2p/rust-libp2p.git", rev = "082eb16" }

--- a/anchor/common/bls_lagrange/src/blsful.rs
+++ b/anchor/common/bls_lagrange/src/blsful.rs
@@ -43,7 +43,7 @@ impl From<KeyId> for u64 {
 }
 
 pub fn split_with_rng(
-    key: bls::SecretKey,
+    key: &bls::SecretKey,
     threshold: u64,
     ids: impl IntoIterator<Item = KeyId>,
     rng: &mut (impl CryptoRng + Rng),
@@ -55,7 +55,7 @@ pub fn split_with_rng(
             .map_err(|_| Error::InternalError)?,
     );
     let key = if result.is_some().into() {
-        IdentifierPrimeField(result.unwrap())
+        Zeroizing::new(IdentifierPrimeField(result.unwrap()))
     } else {
         return Err(Error::InternalError);
     };
@@ -66,7 +66,7 @@ pub fn split_with_rng(
         shamir::split_secret_with_participant_generator(
             threshold as usize,
             ids.len(),
-            &key,
+            &*key,
             rng,
             &[ParticipantIdGeneratorType::List { list: &ids }],
         )

--- a/anchor/common/bls_lagrange/src/blst.rs
+++ b/anchor/common/bls_lagrange/src/blst.rs
@@ -5,10 +5,9 @@ use blst::min_pk::SecretKey;
 use blst::*;
 use rand::prelude::*;
 use std::iter::{once, repeat_with};
-use std::mem::MaybeUninit;
+use std::mem;
 use std::num::NonZeroU64;
 use std::sync::LazyLock;
-use zeroize::Zeroizing;
 
 static WARNING: LazyLock<()> = LazyLock::new(|| {
     eprintln!(
@@ -25,7 +24,8 @@ static WARNING: LazyLock<()> = LazyLock::new(|| {
 #[derive(Debug, Clone)]
 pub struct KeyId {
     num: u64,
-    fr: blst_fr,
+    // note: while blst_scalar is also used for bls keys, the scalars used in key ids are NOT secret
+    scalar: blst_scalar,
 }
 
 impl TryFrom<u64> for KeyId {
@@ -34,11 +34,11 @@ impl TryFrom<u64> for KeyId {
     fn try_from(value: u64) -> Result<Self, Error> {
         if value != 0 {
             unsafe {
-                let mut id = MaybeUninit::<blst_fr>::uninit();
-                blst_fr_from_uint64(id.as_mut_ptr(), &value);
+                let mut id = blst_scalar::default();
+                blst_scalar_from_uint64(&mut id, &value);
                 Ok(KeyId {
                     num: value,
-                    fr: id.assume_init(),
+                    scalar: id,
                 })
             }
         } else {
@@ -49,11 +49,11 @@ impl TryFrom<u64> for KeyId {
 impl From<NonZeroU64> for KeyId {
     fn from(value: NonZeroU64) -> Self {
         unsafe {
-            let mut id = MaybeUninit::<blst_fr>::uninit();
-            blst_fr_from_uint64(id.as_mut_ptr(), &value.get());
+            let mut id = blst_scalar::default();
+            blst_scalar_from_uint64(&mut id, &value.get());
             KeyId {
                 num: value.get(),
-                fr: id.assume_init(),
+                scalar: id,
             }
         }
     }
@@ -65,57 +65,40 @@ impl From<KeyId> for u64 {
     }
 }
 
-#[inline]
-fn key_to_fr(key: &SecretKey) -> blst_fr {
-    let mut key_fr = MaybeUninit::<blst_fr>::uninit();
-    unsafe {
-        blst_fr_from_scalar(key_fr.as_mut_ptr(), <&blst_scalar>::from(key));
-        key_fr.assume_init()
-    }
-}
-
 pub fn split_with_rng(
-    key: bls::SecretKey,
+    key: &bls::SecretKey,
     threshold: u64,
     ids: impl IntoIterator<Item = KeyId>,
     rng: &mut (impl CryptoRng + Rng),
 ) -> Result<Vec<(KeyId, bls::SecretKey)>, Error> {
     LazyLock::force(&WARNING);
-    let key = key.point();
-
     if threshold <= 1 {
         return Err(Error::InvalidThreshold);
     }
 
-    // MaybeUninit needed to make `Zeroizing` work
-    let msk = Zeroizing::new(
-        once(Ok(MaybeUninit::new(key_to_fr(key))))
-            .chain(
-                repeat_with(|| random_key(rng).map(|sk| MaybeUninit::new(key_to_fr(sk.point()))))
-                    .take((threshold - 1) as usize),
-            )
-            .collect::<Result<Vec<_>, _>>()?,
-    );
+    // `bls::SecretKey` contains a blst `SecretKey`, which zeroizes on drop.
+    let keys = repeat_with(|| random_key(rng))
+        .take((threshold - 1) as usize)
+        .collect::<Result<Vec<_>, _>>()?;
+
+    let msk = once(key)
+        .chain(keys.iter())
+        .map(|key| <&blst_scalar>::from(key.point()))
+        .collect::<Vec<_>>();
+
     ids.into_iter()
-        .map(|id| {
-            let mut intermediate = MaybeUninit::<blst_fr>::uninit();
-            unsafe {
-                let mut y = (*msk).last().copied().unwrap();
-                for i in (0..=(threshold - 2)).rev() {
-                    blst_fr_mul(intermediate.as_mut_ptr(), y.as_ptr(), &id.fr);
-                    blst_fr_add(
-                        y.as_mut_ptr(),
-                        intermediate.as_ptr(),
-                        msk[i as usize].as_ptr(),
-                    );
+        .map(|id| unsafe {
+            let mut y = (*msk.last().expect("at least one element is present (key)")).clone();
+            for i in (0..=(threshold - 2)).rev() {
+                if !blst_sk_mul_n_check(&mut y, &y, &id.scalar) {
+                    return Err(Error::ZeroId);
                 }
-                let mut scalar = blst_scalar::default();
-                blst_scalar_from_fr(&mut scalar, y.as_ptr());
-                Ok((
-                    id,
-                    bls::SecretKey::from_point(SecretKey::from_scalar_unchecked(scalar)),
-                ))
+                assert!(blst_sk_add_n_check(&mut y, &y, msk[i as usize]));
             }
+            Ok((
+                id,
+                bls::SecretKey::from_point(mem::transmute::<blst_scalar, SecretKey>(y)),
+            ))
         })
         .collect()
 }
@@ -134,42 +117,40 @@ pub fn combine_signatures(signatures: &[Signature], ids: &[KeyId]) -> Result<Sig
         .map(|sig| sig.point().cloned().ok_or(Error::InvalidSignature))
         .collect::<Result<Vec<_>, _>>()?;
 
-    // intermediates.
-    let mut ifr = blst_fr::default();
-    let mut is = blst_scalar::default();
+    let mut intermediate = blst_scalar::default();
 
-    let zero = unsafe {
-        blst_fr_from_uint64(&mut ifr, &0);
-        ifr
-    };
-
-    let mut numerator = ids[0].clone().fr;
+    let mut numerator = ids[0].clone().scalar;
     unsafe {
         for id in &ids[1..] {
-            blst_fr_mul(&mut numerator, &numerator, &id.fr);
+            if !blst_sk_mul_n_check(&mut numerator, &numerator, &id.scalar) {
+                return Err(Error::ZeroId);
+            }
         }
-    }
-    if numerator == zero {
-        return Err(Error::ZeroId);
     }
 
     let mut d = Vec::with_capacity(ids.len() * 32);
     unsafe {
         for id_i in ids {
-            let mut denominator = id_i.fr;
+            let mut denominator = id_i.scalar.clone();
             for id_j in ids.iter() {
                 if id_i as *const KeyId != id_j as *const KeyId {
-                    blst_fr_sub(&mut ifr, &id_j.fr, &id_i.fr);
-                    if ifr == zero {
+                    if !blst_sk_sub_n_check(&mut intermediate, &id_j.scalar, &id_i.scalar) {
                         return Err(Error::RepeatedId);
                     }
-                    blst_fr_mul(&mut denominator, &denominator, &ifr);
+                    assert!(blst_sk_mul_n_check(
+                        &mut denominator,
+                        &denominator,
+                        &intermediate
+                    ));
                 }
             }
-            blst_fr_inverse(&mut denominator, &denominator);
-            blst_fr_mul(&mut ifr, &denominator, &numerator);
-            blst_scalar_from_fr(&mut is, &ifr);
-            d.extend(is.b);
+            blst_sk_inverse(&mut denominator, &denominator);
+            assert!(blst_sk_mul_n_check(
+                &mut intermediate,
+                &denominator,
+                &numerator
+            ));
+            d.extend(&intermediate.b);
         }
     }
 

--- a/anchor/common/bls_lagrange/src/lib.rs
+++ b/anchor/common/bls_lagrange/src/lib.rs
@@ -24,7 +24,7 @@ pub enum Error {
 }
 
 pub fn split(
-    key: SecretKey,
+    key: &SecretKey,
     threshold: u64,
     ids: impl IntoIterator<Item = KeyId>,
 ) -> Result<Vec<(KeyId, SecretKey)>, Error> {
@@ -33,8 +33,9 @@ pub fn split(
 
 #[cfg(any(feature = "blst", test))]
 pub(crate) fn random_key(rng: &mut (impl CryptoRng + Rng)) -> Result<SecretKey, Error> {
-    let ikm: [u8; 32] = rng.gen();
-    let sk = ::blst::min_pk::SecretKey::key_gen(&ikm, &[]).map_err(|_| Error::InternalError)?;
+    let ikm = zeroize::Zeroizing::new(rng.gen::<[u8; 32]>());
+    let sk =
+        ::blst::min_pk::SecretKey::key_gen(ikm.as_ref(), &[]).map_err(|_| Error::InternalError)?;
     Ok(SecretKey::from_point(sk))
 }
 
@@ -61,7 +62,7 @@ mod tests {
         let pk = master.public_key();
 
         let mut keys = split_with_rng(
-            master,
+            &master,
             threshold as u64,
             (1..=total).map(|x| KeyId::try_from(x as u64).unwrap()),
             rng,
@@ -110,7 +111,7 @@ mod tests {
         let master = random_key(rng).unwrap();
 
         let mut keys = split_with_rng(
-            master,
+            &master,
             threshold as u64,
             (1..=total).map(|x| KeyId::try_from(x as u64).unwrap()),
             rng,


### PR DESCRIPTION
Now that https://github.com/supranational/blst/pull/248 is merged, we can move back to the new `blst` release. Additionally, this PR cleans up the implementation a bit:

- Use `blst_scalar` instead of `blst_fr` as advised by the `blst` maintainer
- Be more careful with key material. We should be almost good to go for `blst`, only the latest changes from https://github.com/sigp/lighthouse/pull/6829 are missing and will be introduced with the next update of the `anchor` branch in lighthouse. For `blsful`, we should be good as well, but only under the assumption that `blsful` itself is fine in that regard.