### PR TITLE
temporary disable cargo audit warnings for upstream vulns in promethe…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -137,7 +137,7 @@ install-audit:
 	cargo install --force cargo-audit
 
 audit-CI:
-	cargo audit
+	cargo audit --ignore RUSTSEC-2025-0009 --ignore RUSTSEC-2024-0437
 
 # Runs `cargo vendor` to make sure dependencies can be vendored for packaging, reproducibility and archival purpose.
 vendor:


### PR DESCRIPTION
There is an upstream audit failure in prometheus and lighthouse. 

Temporarily disabling cargo audit warning until this is resolved. 

See 
https://github.com/sigp/lighthouse/issues/7090
https://github.com/sigp/lighthouse/issues/7091
