### PR TITLE
Add `Role::{ValidatorRegistration, VoluntaryExit}`

### DIFF
--- a/anchor/common/ssv_types/src/msgid.rs
+++ b/anchor/common/ssv_types/src/msgid.rs
@@ -12,6 +12,8 @@ pub enum Role {
     Aggregator,
     Proposer,
     SyncCommittee,
+    ValidatorRegistration,
+    VoluntaryExit,
 }
 
 impl From<Role> for [u8; 4] {
@@ -21,6 +23,8 @@ impl From<Role> for [u8; 4] {
             Role::Aggregator => [1, 0, 0, 0],
             Role::Proposer => [2, 0, 0, 0],
             Role::SyncCommittee => [3, 0, 0, 0],
+            Role::ValidatorRegistration => [4, 0, 0, 0],
+            Role::VoluntaryExit => [5, 0, 0, 0],
         }
     }
 }
@@ -34,6 +38,8 @@ impl TryFrom<&[u8]> for Role {
             [1, 0, 0, 0] => Ok(Role::Aggregator),
             [2, 0, 0, 0] => Ok(Role::Proposer),
             [3, 0, 0, 0] => Ok(Role::SyncCommittee),
+            [4, 0, 0, 0] => Ok(Role::ValidatorRegistration),
+            [5, 0, 0, 0] => Ok(Role::VoluntaryExit),
             _ => Err(DecodeError::NoMatchingVariant),
         }
     }
@@ -81,11 +87,9 @@ impl MessageId {
         // which kind of executor we need to get depends on the role
         match self.role()? {
             Role::Committee => self.0[24..].try_into().ok().map(DutyExecutor::Committee),
-            Role::Aggregator | Role::Proposer | Role::SyncCommittee => {
-                PublicKeyBytes::deserialize(&self.0[8..])
-                    .ok()
-                    .map(DutyExecutor::Validator)
-            }
+            _ => PublicKeyBytes::deserialize(&self.0[8..])
+                .ok()
+                .map(DutyExecutor::Validator),
         }
     }
 }

--- a/anchor/eth/src/sync.rs
+++ b/anchor/eth/src/sync.rs
@@ -88,7 +88,7 @@ pub struct SsvEventSyncer {
 }
 
 impl SsvEventSyncer {
-    #[instrument(skip(db))]
+    #[instrument(skip(db, config))]
     /// Create a new SsvEventSyncer to sync all of the events from the chain
     pub async fn new(db: Arc<NetworkDatabase>, config: Config) -> Result<Self, ExecutionError> {
         info!(?config, "Creating new SSV Event Syncer");

--- a/anchor/validator_store/src/lib.rs
+++ b/anchor/validator_store/src/lib.rs
@@ -876,7 +876,7 @@ impl<T: SlotClock, E: EthSpec> ValidatorStore for AnchorValidatorStore<T, E> {
         let signature = self
             .collect_signature(
                 PartialSignatureKind::ValidatorRegistration,
-                Role::Proposer,
+                Role::ValidatorRegistration,
                 None,
                 self.validator(validator_registration_data.pubkey)?,
                 signing_root,


### PR DESCRIPTION
Add two Roles that have not been added yet and have been causing validation failures on my end.

`ValidatorRegistration` is for registering the validator at MEV relays and has been previously erroneously treated as `Proposer`.
`VoluntaryExit` is for chain triggered exits, which is currently unsupported by Anchor.