### PR TITLE
Rust Dependency Caching

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -147,19 +147,13 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v4
-    - name: Get latest version of stable Rust
-      uses: moonrepo/setup-rust@v1
-      with:
-          cache: true
-          cache-target: debug
-    - name: Install Rust at MSRV
+    - name: Install Rust at Minimum Supported Rust Version (MSRV)
       run: |
         metadata=$(cargo metadata --no-deps --format-version 1)
         msrv=$(echo $metadata | jq -r '.packages | map(select(.name == "anchor")) | .[0].rust_version')
         rustup override set $msrv
     - name: Run cargo check
       run: cargo check --workspace
-
   cargo-udeps:
     name: cargo-udeps
     needs: [check-labels]

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -8,6 +8,7 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
   merge_group:
+  workflow_dispatch: # Add manual trigger capability
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -77,8 +78,8 @@ jobs:
       if: env.SELF_HOSTED_RUNNERS == 'false'
       uses: moonrepo/setup-rust@v1
       with:
-          cache: false
           channel: stable
+          cache: true
           cache-target: release
           bins: cargo-nextest
       env:
@@ -102,8 +103,9 @@ jobs:
       if: env.SELF_HOSTED_RUNNERS == 'false'
       uses: moonrepo/setup-rust@v1
       with:
-          cache: false
           channel: stable
+          cache: true
+          cache-target: debug
           bins: cargo-nextest
     - name: Run tests in debug
       run: make nextest-debug
@@ -121,6 +123,7 @@ jobs:
       uses: moonrepo/setup-rust@v1
       with:
           channel: stable
+          cache: true
           cache-target: release
           components: rustfmt,clippy
           bins: cargo-audit
@@ -144,13 +147,19 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v4
-    - name: Install Rust at Minimum Supported Rust Version (MSRV)
+    - name: Get latest version of stable Rust
+      uses: moonrepo/setup-rust@v1
+      with:
+          cache: true
+          cache-target: debug
+    - name: Install Rust at MSRV
       run: |
         metadata=$(cargo metadata --no-deps --format-version 1)
         msrv=$(echo $metadata | jq -r '.packages | map(select(.name == "anchor")) | .[0].rust_version')
         rustup override set $msrv
     - name: Run cargo check
       run: cargo check --workspace
+
   cargo-udeps:
     name: cargo-udeps
     needs: [check-labels]
@@ -163,7 +172,8 @@ jobs:
       with:
           channel: nightly
           bins: cargo-udeps
-          cache: false
+          cache: true
+          cache-target: debug
       env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Create Cargo config dir
@@ -211,6 +221,7 @@ jobs:
         uses: moonrepo/setup-rust@v1
         with:
           channel: stable
+          cache: true
           cache-target: release
           bins: cargo-sort, taplo-cli
       - name: Run cargo sort to check if Cargo.toml files are sorted

--- a/Makefile
+++ b/Makefile
@@ -123,7 +123,7 @@ test-full: cargo-fmt test-release test-debug
 # Lints the code for bad style and potentially unsafe arithmetic using Clippy.
 # Clippy lints are opt-in per-crate for now. By default, everything is allowed except for performance and correctness lints.
 lint:
-	cargo clippy --workspace --tests $(EXTRA_CLIPPY_OPTS) --features "$(TEST_FEATURES)" -- \
+	cargo clippy --workspace --tests --no-deps $(EXTRA_CLIPPY_OPTS) --features "$(TEST_FEATURES)" -- \
 		-D warnings
 
 # Lints the code using Clippy and automatically fix some simple compiler warnings.


### PR DESCRIPTION
## Issue Addressed

Speeds up CI builds by caching Rust dependencies.

## Proposed Changes

1. Added cache: true to all moonrepo/setup-rust actions that were previously missing it or had it set to false
2. Set appropriate cache-target values:
   - release for jobs that perform release builds
   - debug for jobs that work with debug builds
3. Fixed the check-msrv job structure by combining the action with proper caching configuration

These changes will speed up CI by reusing dependencies between workflow runs, significantly reducing build times after the first run.

