### PR TITLE
qbft data: do not do a root hash, but a flat hash

### DIFF
--- a/anchor/common/ssv_types/src/consensus.rs
+++ b/anchor/common/ssv_types/src/consensus.rs
@@ -289,7 +289,12 @@ impl QbftData for BeaconVote {
     type Hash = Hash256;
 
     fn hash(&self) -> Self::Hash {
-        self.tree_hash_root()
+        let bytes = self.as_ssz_bytes();
+
+        let mut hasher = Sha256::new();
+        hasher.update(bytes);
+        let hash: [u8; 32] = hasher.finalize().into();
+        Hash256::from(hash)
     }
 
     fn validate(&self) -> bool {

--- a/anchor/message_validator/src/consensus_message.rs
+++ b/anchor/message_validator/src/consensus_message.rs
@@ -1,4 +1,4 @@
-use crate::{compute_quorum_size, hash_data_root, ValidationFailure};
+use crate::{compute_quorum_size, hash_data, ValidationFailure};
 use ssv_types::consensus::{QbftMessage, QbftMessageType};
 use ssv_types::message::SignedSSVMessage;
 use ssv_types::msgid::Role;
@@ -41,7 +41,7 @@ pub(crate) fn validate_consensus_message_semantics(
             return Err(ValidationFailure::PrepareOrCommitWithFullData);
         }
 
-        let hashed_full_data = hash_data_root(signed_ssv_message.full_data());
+        let hashed_full_data = hash_data(signed_ssv_message.full_data());
         // Rule: Full data hash must match root
         if hashed_full_data != consensus_message.root {
             return Err(ValidationFailure::InvalidHash);
@@ -581,7 +581,7 @@ mod tests {
         let full_data = vec![0xAA, 0xBB, 0xCC, 0xDD];
 
         // Hash the data to create the root
-        let root = hash_data_root(&full_data);
+        let root = hash_data(&full_data);
 
         // Create a message with the correct root hash
         let signers = vec![OperatorId(1), OperatorId(2), OperatorId(3)]; // 3 signers meets quorum for committee of 4

--- a/anchor/message_validator/src/lib.rs
+++ b/anchor/message_validator/src/lib.rs
@@ -246,7 +246,7 @@ pub(crate) fn get_f(committee_size: usize) -> usize {
     (committee_size - 1) / 3
 }
 
-pub(crate) fn hash_data_root(full_data: &[u8]) -> [u8; 32] {
+pub(crate) fn hash_data(full_data: &[u8]) -> [u8; 32] {
     let mut hasher = Sha256::new();
     hasher.update(full_data);
     let hash: [u8; 32] = hasher.finalize().into();
@@ -255,7 +255,7 @@ pub(crate) fn hash_data_root(full_data: &[u8]) -> [u8; 32] {
 
 #[cfg(test)]
 mod tests {
-    use crate::{compute_quorum_size, hash_data_root};
+    use crate::{compute_quorum_size, hash_data};
     use ssv_types::{CommitteeInfo, IndexSet, OperatorId, ValidatorIndex};
 
     // Constants for committee sizes in tests to improve readability
@@ -308,8 +308,8 @@ mod tests {
         let data1 = vec![1, 2, 3, 4];
         let data2 = vec![1, 2, 3, 5]; // One byte different
 
-        let hash1 = hash_data_root(&data1);
-        let hash2 = hash_data_root(&data2);
+        let hash1 = hash_data(&data1);
+        let hash2 = hash_data(&data2);
 
         assert_ne!(
             hash1, hash2,
@@ -317,7 +317,7 @@ mod tests {
         );
         assert_eq!(
             hash1,
-            hash_data_root(&data1),
+            hash_data(&data1),
             "Same data should produce the same hash"
         );
     }


### PR DESCRIPTION
"root hash" implies that we do a tree hash, but we don't.

- fix hashing in qbft
- fix function name in validation