### PR TITLE
Create default directory if it doesn't exist

### DIFF
--- a/anchor/client/src/lib.rs
+++ b/anchor/client/src/lib.rs
@@ -27,6 +27,7 @@ use signature_collector::SignatureCollectorManager;
 use slashing_protection::SlashingDatabase;
 use slot_clock::{SlotClock, SystemTimeSlotClock};
 use ssv_types::OperatorId;
+use std::fs;
 use std::fs::File;
 use std::io::{ErrorKind, Read};
 use std::net::SocketAddr;
@@ -92,6 +93,10 @@ impl Client {
                 debug!("Raising soft open file descriptor resource limit is not supported");
             }
         };
+
+        // Try and create the data directory if it doesn't exist.
+        fs::create_dir_all(&config.data_dir)
+            .map_err(|e| format!("Failed to create data directory: {e}"))?;
 
         info!(
             beacon_nodes = format!("{:?}", &config.beacon_nodes),
@@ -759,8 +764,13 @@ fn read_or_generate_private_key(path: &Path) -> Result<Rsa<Private>, String> {
 
             info!(path = %path.as_os_str().to_string_lossy(), "Creating private key");
 
+            // Keygen requires a directory and not the file, so we send the parent path here.
+            let Some(parent_dir) = path.parent() else {
+                return Err(format!("Invalid RSA key path: {path:?}"));
+            };
+
             let key = run_keygen(Keygen {
-                output_path: Some(path.to_string_lossy().to_string()),
+                output_path: Some(parent_dir.to_string_lossy().to_string()),
                 force: false,
             })
             .map_err(|e| format!("Unable to write private key: {e:?}"))?;

--- a/anchor/keygen/src/lib.rs
+++ b/anchor/keygen/src/lib.rs
@@ -82,6 +82,9 @@ pub fn run_keygen(keygen: Keygen) -> Result<Rsa<Private>, KeygenError> {
         PathBuf::from(".") // Current working directory
     };
 
+    // Create the output directory if it doesn't exist
+    fs::create_dir_all(&output_dir)?;
+
     // Create output paths for both files
     let pem_file = output_dir.join("key.pem");
     let json_file = output_dir.join("keys.json");

--- a/anchor/keygen/src/lib.rs
+++ b/anchor/keygen/src/lib.rs
@@ -82,9 +82,6 @@ pub fn run_keygen(keygen: Keygen) -> Result<Rsa<Private>, KeygenError> {
         PathBuf::from(".") // Current working directory
     };
 
-    // Create the output directory if it doesn't exist
-    fs::create_dir_all(&output_dir)?;
-
     // Create output paths for both files
     let pem_file = output_dir.join("key.pem");
     let json_file = output_dir.join("keys.json");

--- a/anchor/src/main.rs
+++ b/anchor/src/main.rs
@@ -59,6 +59,7 @@ fn start_anchor(anchor_config: Node, mut environment: Environment) {
             return;
         }
     };
+
     config.network.domain_type = config.ssv_network.ssv_domain_type.clone();
 
     // Build the core task executor


### PR DESCRIPTION
## Issue Addressed

I'm trying to run Anchor on unstable via `anchor node` on a fresh build. 

It fails because:
```
2025-03-20T02:24:41.373883Z  INFO client: Starting the Anchor client beacon_nodes="[\"http://localhost:5052/\"]" execution_nodes="[\"http://localhost:8545/\", \"ws://localhost:8546/\"]" data_dir="\"/home/age/.anchor/holesky\""
2025-03-20T02:24:41.374907Z  INFO client: Creating private key path=/home/age/.anchor/holesky/key.pem
2025-03-20T02:24:41.414674Z ERROR anchor: Failed to start Anchor reason="Unable to write private key: Output(Os { code: 2, kind: NotFound, message: \"No such file or directory\" })"
```
The default path doesn't exist. 

This PR will create the directory if it doesn't exist allowing the node to start part this point. 
