### PR TITLE
Anchor to respect log-level flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -730,6 +730,7 @@ dependencies = [
  "regex",
  "sensitive_url",
  "serde",
+ "strum 0.27.1",
  "task_executor",
  "tokio",
  "tracing",

--- a/anchor/Cargo.toml
+++ b/anchor/Cargo.toml
@@ -17,6 +17,7 @@ keygen = { workspace = true }
 keysplit = { workspace = true }
 sensitive_url = { workspace = true }
 serde = { workspace = true }
+strum = { workspace = true }
 task_executor = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }

--- a/anchor/client/src/cli.rs
+++ b/anchor/client/src/cli.rs
@@ -1,8 +1,7 @@
 use clap::builder::styling::*;
 use clap::builder::{ArgAction, ArgPredicate};
-use clap::{Parser, ValueEnum};
+use clap::Parser;
 use serde::{Deserialize, Serialize};
-use strum::Display;
 // use clap_utils::{get_color_style, FLAG_HEADER};
 use ethereum_hashing::have_sha_extensions;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};

--- a/anchor/client/src/cli.rs
+++ b/anchor/client/src/cli.rs
@@ -45,20 +45,6 @@ fn build_profile_name() -> &'static str {
         .unwrap_or("unknown")
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Deserialize, Serialize, Display, ValueEnum)]
-pub enum DebugLevel {
-    #[strum(serialize = "info")]
-    Info,
-    #[strum(serialize = "debug")]
-    Debug,
-    #[strum(serialize = "trace")]
-    Trace,
-    #[strum(serialize = "warn")]
-    Warn,
-    #[strum(serialize = "error")]
-    Error,
-}
-
 #[derive(Parser, Clone, Deserialize, Serialize, Debug)]
 #[clap(
     name = "ssv",
@@ -73,15 +59,6 @@ pub enum DebugLevel {
     display_order = 0,
 )]
 pub struct Node {
-    #[clap(
-        long,
-        value_name = "LEVEL",
-        help = "Specifies the verbosity level used when emitting logs to the terminal.",
-        default_value_t = DebugLevel::Info,
-        display_order = 0,
-    )]
-    pub debug_level: DebugLevel,
-
     #[clap(
         long,
         short = 'd',

--- a/anchor/src/environment.rs
+++ b/anchor/src/environment.rs
@@ -7,8 +7,6 @@ use std::sync::Arc;
 use task_executor::{ShutdownReason, TaskExecutor};
 use tokio::runtime::{Builder as RuntimeBuilder, Runtime};
 use tracing::{error, info, warn};
-use tracing_subscriber::filter::LevelFilter;
-use tracing_subscriber::EnvFilter;
 use {
     futures::Future,
     std::{pin::Pin, task::Context, task::Poll},
@@ -39,12 +37,6 @@ impl Default for Environment {
     ///
     /// If a more fine-grained executor is required, a more general function should be built.
     fn default() -> Self {
-        // Default logging to `debug` for the time being
-        let env_filter = EnvFilter::builder()
-            .with_default_directive(LevelFilter::DEBUG.into())
-            .from_env_lossy();
-        tracing_subscriber::fmt().with_env_filter(env_filter).init();
-
         // Create a multi-threaded task executor
         let runtime = match RuntimeBuilder::new_multi_thread().enable_all().build() {
             Err(e) => {

--- a/anchor/src/logging.rs
+++ b/anchor/src/logging.rs
@@ -34,8 +34,6 @@ impl From<DebugLevel> for Level {
 
 /// Sets up the global tracing logging
 pub fn enable_logging(debug_level: DebugLevel) {
-    // Set up logging
-
     let filter_level: Level = debug_level.into();
     let env_filter = EnvFilter::builder()
         .with_default_directive(filter_level.into())

--- a/anchor/src/logging.rs
+++ b/anchor/src/logging.rs
@@ -1,0 +1,44 @@
+//! Collection of logging logic for initialising Anchor.
+
+use clap::ValueEnum;
+use serde::{Deserialize, Serialize};
+use strum::Display;
+use tracing::Level;
+use tracing_subscriber::EnvFilter;
+
+#[derive(Clone, Copy, Debug, PartialEq, Deserialize, Serialize, Display, ValueEnum)]
+pub enum DebugLevel {
+    #[strum(serialize = "info")]
+    Info,
+    #[strum(serialize = "debug")]
+    Debug,
+    #[strum(serialize = "trace")]
+    Trace,
+    #[strum(serialize = "warn")]
+    Warn,
+    #[strum(serialize = "error")]
+    Error,
+}
+
+impl From<DebugLevel> for Level {
+    fn from(debug_level: DebugLevel) -> Self {
+        match debug_level {
+            DebugLevel::Info => Level::INFO,
+            DebugLevel::Debug => Level::DEBUG,
+            DebugLevel::Trace => Level::TRACE,
+            DebugLevel::Warn => Level::WARN,
+            DebugLevel::Error => Level::ERROR,
+        }
+    }
+}
+
+/// Sets up the global tracing logging
+pub fn enable_logging(debug_level: DebugLevel) {
+    // Set up logging
+
+    let filter_level: Level = debug_level.into();
+    let env_filter = EnvFilter::builder()
+        .with_default_directive(filter_level.into())
+        .from_env_lossy();
+    tracing_subscriber::fmt().with_env_filter(env_filter).init();
+}

--- a/anchor/src/main.rs
+++ b/anchor/src/main.rs
@@ -2,10 +2,12 @@ use clap::Parser;
 use tracing::{error, info};
 
 mod environment;
+mod logging;
 use client::{config, Client, Node};
 use environment::Environment;
 use keygen::Keygen;
 use keysplit::Keysplit;
+use logging::DebugLevel;
 use task_executor::ShutdownReason;
 use types::EthSpecId;
 
@@ -13,6 +15,8 @@ use types::EthSpecId;
 struct Cli {
     #[clap(subcommand)]
     pub subcommand: AnchorSubcommands,
+    #[arg(long, default_value_t = DebugLevel::Info, help = "Specifies the verbosity level used when emitting logs to the terminal")]
+    pub debug_level: DebugLevel,
 }
 
 #[derive(Parser, Clone, Debug)]
@@ -30,7 +34,10 @@ fn main() {
 
     let cli = Cli::parse();
 
-    // Construct the logging, task executor and exit signals
+    // Enable logging based on the CLI
+    logging::enable_logging(cli.debug_level);
+
+    // Construct the task executor and exit signals
     let environment = Environment::default();
 
     match cli.subcommand {


### PR DESCRIPTION
## Issue Addressed

Currently the --debug-level CLI flag in the Anchor subcommand doesn't do anything. 

In fact we set up the logging prior to running the subcommand. 

I've shifted the CLI flag to exist globally so we can adjust the loglevel for all subcommands and made the code respect the CLI choice. 

I think this might be useful for interop testing to optionally remove some noise if we want. 
