### PR TITLE
network: disable libp2p message signing

### DIFF
--- a/anchor/network/src/network.rs
+++ b/anchor/network/src/network.rs
@@ -350,7 +350,7 @@ async fn build_anchor_behaviour(
         .duplicate_cache_time(duplicate_cache_time)
         .message_id_fn(gossip_message_id)
         .flood_publish(false)
-        .validation_mode(ValidationMode::Permissive)
+        .validation_mode(ValidationMode::Anonymous)
         .mesh_n(8) //D
         .mesh_n_low(6) // Dlo
         .mesh_n_high(12) // Dhi

--- a/anchor/network/src/network.rs
+++ b/anchor/network/src/network.rs
@@ -362,9 +362,8 @@ async fn build_anchor_behaviour(
         .max_ihave_messages(32)
         .build()?;
 
-    let gossipsub =
-        gossipsub::Behaviour::new(MessageAuthenticity::Signed(local_keypair.clone()), config)
-            .map_err(|e| Gossipsub(e.to_string()))?;
+    let gossipsub = gossipsub::Behaviour::new(MessageAuthenticity::Anonymous, config)
+        .map_err(|e| Gossipsub(e.to_string()))?;
 
     let discovery = {
         // Build and start the discovery sub-behaviour


### PR DESCRIPTION
## Issue Addressed

SSV node rejects messages from Anchor on libp2p level with the `unexpected signature` error:
```
{"level":"\u001b[35mDEBUG\u001b[0m","time":"2025-03-20T17:49:22.143585Z","name":"P2PNetwork.PubsubTrace","msg":"pubsub event","selfPeer":"16Uiu2HAkvNzRHEEwS8He6iF7esFCBN4nPWsswjVJRPByPjH4sDdh","type":"REJECT_MESSAGE","receivedFrom":"16Uiu2HAmPamdZidzgF47ZqCTCYQ6Lp6nxHtRs64ccFuu2VAChdiZ","msgID":"baea56cec621b52300000000","topic":"ssv.v2.84","reason":"unexpected signature"}
```

## Proposed Changes

Disable message signing on the libp2p level by setting `MessageAuthenticity` to `Anonymous`

## Additional Info

SSV node disables signing on the libp2p level because its messages have a payload with signature: https://github.com/ssvlabs/ssv/blob/v2.2.0/network/topics/pubsub.go#L138

This allows choosing a signing scheme that's appropriate in terms of resource consumption.
