### PR TITLE
Change `validation_mode` to `Permissive` and `MessageAuthenticity` to `RandomAuthor`

### DIFF
--- a/anchor/network/src/network.rs
+++ b/anchor/network/src/network.rs
@@ -350,7 +350,7 @@ async fn build_anchor_behaviour(
         .duplicate_cache_time(duplicate_cache_time)
         .message_id_fn(gossip_message_id)
         .flood_publish(false)
-        .validation_mode(ValidationMode::Anonymous)
+        .validation_mode(ValidationMode::Permissive)
         .mesh_n(8) //D
         .mesh_n_low(6) // Dlo
         .mesh_n_high(12) // Dhi
@@ -362,7 +362,7 @@ async fn build_anchor_behaviour(
         .max_ihave_messages(32)
         .build()?;
 
-    let gossipsub = gossipsub::Behaviour::new(MessageAuthenticity::Anonymous, config)
+    let gossipsub = gossipsub::Behaviour::new(MessageAuthenticity::RandomAuthor, config)
         .map_err(|e| Gossipsub(e.to_string()))?;
 
     let discovery = {


### PR DESCRIPTION
A validation mode of `Anonymous` requires signature, sequence and author field to be empty, but this is not the case. Only the signature is unset.

In order to fill these fields, we set our own authenticity to `RandomAuthor`, retaining anonymity.