### PR TITLE
Build docker images through CI

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -36,8 +36,7 @@ jobs:
         runs-on: ubuntu-24.04
         strategy:
             matrix:
-#                cpu_arch: [aarch64, x86_64]
-                cpu_arch: [x86_64]
+                cpu_arch: [aarch64, x86_64]
                 include:
                     - profile: maxperf
 
@@ -99,56 +98,58 @@ jobs:
 #            - name: Move built binary into Docker scope
 #              run: mv ./target/${{ matrix.cpu_arch }}-unknown-linux-gnu/${{ matrix.profile }}/anchor ./bin
 
-#            - name: Install QEMU
-#              if: env.SELF_HOSTED_RUNNERS == 'false'
+            - name: Install QEMU
+              if: env.SELF_HOSTED_RUNNERS == 'false'
+              uses: docker/setup-qemu-action@v3
 #              run: sudo apt-get update && sudo apt-get install -y qemu-user-static
 
             - name: Set up Docker Buildx
               if: env.SELF_HOSTED_RUNNERS == 'false'
               uses: docker/setup-buildx-action@v3
 
-            - name: Build Dockerfile and push
-              run: |
-                docker buildx build \
-                    --platform=linux/${SHORT_ARCH} \
-                    --file ./Dockerfile . \
-                    --tag ${IMAGE_NAME}:${VERSION}-${SHORT_ARCH}${VERSION_SUFFIX} \
-                    --push
+#            - name: Build Dockerfile and push
+#              run: |
+#                docker buildx build \
+#                    --platform=linux/${SHORT_ARCH} \
+#                    --file ./Dockerfile . \
+#                    --tag ${IMAGE_NAME}:${VERSION}-${SHORT_ARCH}${VERSION_SUFFIX} \
+#                    --push
 
-#            - name: Build and push
-#              uses: docker/build-push-action@v5
-#              with:
-#                file: ./anchor/Dockerfile.cross
-#                context: .
-#                platforms: linux/${{ env.SHORT_ARCH }}
-#                labels: |
-#                    git.revision=${{ github.sha }}
-#                    git.branch=${{ github.ref }}
-#                    git.tag=${{ github.ref }}
-#                    git.repository=${{ github.repository }}
-#                push: true
-#                tags: |
-#                  ${{ github.repository_owner}}/anchor:${{ env.VERSION }}-${{ env.SHORT_ARCH }}${{ env.VERSION_SUFFIX }}
-#                build-args: |
-#                  RUST_VERSION=${{ env.RUST_VERSION }}
-#                  TARGETPLATFORM=linux/${{ env.SHORT_ARCH }}
-                  
+            - name: Build and push
+              uses: docker/build-push-action@v6
+              with:
+                file: ./anchor/Dockerfile
+                context: .
+                platforms: linux/${{ env.SHORT_ARCH }}
+                labels: |
+                    git.revision=${{ github.sha }}
+                    git.branch=${{ github.ref }}
+                    git.tag=${{ github.ref }}
+                    git.repository=${{ github.repository }}
+                push: true
+                tags: |
+                  ${IMAGE_NAME}:${VERSION}-${SHORT_ARCH}${VERSION_SUFFIX}
+                  ${IMAGE_NAME}:${VERSION}${VERSION_SUFFIX}
+                build-args: |
+                  RUST_VERSION=${{ env.RUST_VERSION }}
+                  TARGETPLATFORM=linux/${{ env.SHORT_ARCH }}
+                 
 
-    build-docker-multiarch:
-      name: build-docker-multiarch
-      runs-on: ubuntu-24.04
-      needs: [build-docker-single-arch, extract-version]
-      env:
-        # We need to enable experimental docker features in order to use `docker manifest`
-        DOCKER_CLI_EXPERIMENTAL: enabled
-        VERSION: ${{ needs.extract-version.outputs.VERSION }}
-        VERSION_SUFFIX: ${{ needs.extract-version.outputs.VERSION_SUFFIX }}
-      steps:
-        - name: Dockerhub login
-          run: |
-            echo "${DOCKER_PASSWORD}" | docker login --username ${DOCKER_USERNAME} --password-stdin
-        - name: Create and push multiarch manifest
-          run: |
-            docker manifest create ${IMAGE_NAME}:${VERSION}${VERSION_SUFFIX} \
-                --amend ${IMAGE_NAME}:${VERSION}-amd64${VERSION_SUFFIX};
-            docker manifest push ${IMAGE_NAME}:${VERSION}${VERSION_SUFFIX}
+#    docker-multiarch-manifest:
+#      name: docker-multiarch-manifest
+#      runs-on: ubuntu-24.04
+#      needs: [build-docker-single-arch, extract-version]
+#      env:
+#        # We need to enable experimental docker features in order to use `docker manifest`
+#        DOCKER_CLI_EXPERIMENTAL: enabled
+#        VERSION: ${{ needs.extract-version.outputs.VERSION }}
+#        VERSION_SUFFIX: ${{ needs.extract-version.outputs.VERSION_SUFFIX }}
+#      steps:
+#        - name: Dockerhub login
+#          run: |
+#            echo "${DOCKER_PASSWORD}" | docker login --username ${DOCKER_USERNAME} --password-stdin
+#        - name: Create and push multiarch manifest
+#          run: |
+#            docker manifest create ${IMAGE_NAME}:${VERSION}${VERSION_SUFFIX} \
+#                --amend ${IMAGE_NAME}:${VERSION}-amd64${VERSION_SUFFIX};
+#            docker manifest push ${IMAGE_NAME}:${VERSION}${VERSION_SUFFIX}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,9 +3,11 @@ name: Docker build and push
 on:
   push:
     branches:
+      - unstable
       - stable
-    tags:
-      - v*
+      - build-docker
+#    tags:
+#      - v*
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -21,14 +23,20 @@ env:
     # Prevent Github API rate limiting
     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+    DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+    DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+    IMAGE_NAME: ${{ secrets.DOCKER_USERNAME }}/anchor
+
+
 jobs:
     extract-version:
         uses: ./.github/workflows/extract-version.yml
 
     
-    build-docker-multi-arch:
+    build-docker-single-arch:
         name: build-docker-anchor-${{ matrix.cpu_arch }}
-        runs-on: ${{ github.repository == 'sigp/anchor' && fromJson('["self-hosted", "linux", "release"]') || 'ubuntu-22.04'  }}
+#        runs-on: ${{ github.repository == 'sigp/anchor' && fromJson('["self-hosted", "linux", "release"]') || 'ubuntu-22.04'  }}
+        runs-on: ubuntu-22.04
         strategy:
             matrix:
                 cpu_arch: [aarch64, x86_64]
@@ -76,19 +84,21 @@ jobs:
             - name: Get latest version of stable Rust
               run: echo "rust version is ${{ env.RUST_VERSION }}"
 
-            - name: Retrieve Docker credentials from Vault
-              uses: hashicorp/vault-action@v2
-              with:
-                url: https://vault.sigp.io
-                method: github
-                githubToken: ${{ secrets.GH_TOKEN }}
-                secrets: |
-                    spesi_kv/data/dev/docker/anchor DOCKER_USERNAME ;
-                    spesi_kv/data/dev/docker/anchor DOCKER_PASSWORD
+#            - name: Retrieve Docker credentials from Vault
+#              uses: hashicorp/vault-action@v2
+#              with:
+#                url: https://vault.sigp.io
+#                method: github
+#                githubToken: ${{ secrets.GH_TOKEN }}
+#                secrets: |
+#                    spesi_kv/data/dev/docker/anchor DOCKER_USERNAME ;
+#                    spesi_kv/data/dev/docker/anchor DOCKER_PASSWORD
 
             - name: Dockerhub login
               run: |
                   echo "${DOCKER_PASSWORD}" | docker login --username ${DOCKER_USERNAME} --password-stdin
+
+
 
             - name: Build binary
               run: |
@@ -132,3 +142,23 @@ jobs:
                   RUST_VERSION=${{ env.RUST_VERSION }}
                   TARGETPLATFORM=linux/${{ env.SHORT_ARCH }}
                   
+
+    build-docker-multiarch:
+      name: build-docker-multiarch
+      runs-on: ubuntu-22.04
+      needs: [build-docker-single-arch, extract-version]
+      env:
+        # We need to enable experimental docker features in order to use `docker manifest`
+        DOCKER_CLI_EXPERIMENTAL: enabled
+        VERSION: ${{ needs.extract-version.outputs.VERSION }}
+        VERSION_SUFFIX: ${{ needs.extract-version.outputs.VERSION_SUFFIX }}
+      steps:
+        - name: Dockerhub login
+          run: |
+            echo "${DOCKER_PASSWORD}" | docker login --username ${DOCKER_USERNAME} --password-stdin
+        - name: Create and push multiarch manifest
+          run: |
+            docker manifest create ${IMAGE_NAME}:${VERSION}${VERSION_SUFFIX} \
+                --amend ${IMAGE_NAME}:${VERSION}-arm64${VERSION_SUFFIX} \
+                --amend ${IMAGE_NAME}:${VERSION}-amd64${VERSION_SUFFIX};
+            docker manifest push ${IMAGE_NAME}:${VERSION}${VERSION_SUFFIX}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - unstable
       - stable
+      - interop1
     tags:
       - v*
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -31,7 +31,7 @@ jobs:
         uses: ./.github/workflows/extract-version.yml
     
     build-docker-single-arch:
-        name: build-docker-anchor-${{ matrix.cpu_arch }}
+        name: build-docker
 #        runs-on: ${{ github.repository == 'sigp/anchor' && fromJson('["self-hosted", "linux", "release"]') || 'ubuntu-22.04'  }}
         runs-on: ubuntu-24.04
 #        strategy:
@@ -128,7 +128,7 @@ jobs:
                     git.repository=${{ github.repository }}
                 push: true
                 tags: |
-                  ${IMAGE_NAME}:${VERSION}${VERSION_SUFFIX}
+                  ${{ env.IMAGE_NAME }}:${{ env.VERSION }}${{ env.VERSION_SUFFIX}}
                 build-args: |
                   RUST_VERSION=${{ env.RUST_VERSION }}
                  

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -6,8 +6,8 @@ on:
       - unstable
       - stable
       - build-docker
-#    tags:
-#      - v*
+    tags:
+      - v*
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -16,8 +16,7 @@ concurrency:
 env:
     # Enable self-hosted runners for the sigp repo only.
     SELF_HOSTED_RUNNERS: ${{ github.repository == 'sigp/anchor' }}
-    RUST_VERSION: '1.80.0'
-    SHORT_ARCH: 'amd64'
+    RUST_VERSION: '1.83.0'
     # Deny warnings in CI
     RUSTFLAGS: "-D warnings -C debuginfo=0"
     # Prevent Github API rate limiting
@@ -27,16 +26,14 @@ env:
     DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
     IMAGE_NAME: ${{ secrets.DOCKER_USERNAME }}/anchor
 
-
 jobs:
     extract-version:
         uses: ./.github/workflows/extract-version.yml
-
     
     build-docker-single-arch:
         name: build-docker-anchor-${{ matrix.cpu_arch }}
 #        runs-on: ${{ github.repository == 'sigp/anchor' && fromJson('["self-hosted", "linux", "release"]') || 'ubuntu-22.04'  }}
-        runs-on: ubuntu-22.04
+        runs-on: ubuntu-24.04
         strategy:
             matrix:
                 cpu_arch: [aarch64, x86_64]
@@ -52,38 +49,31 @@ jobs:
             - name: Map aarch64 to arm64 short arch
               if: startsWith(matrix.cpu_arch, 'aarch64')
               run: echo "SHORT_ARCH=arm64" >> $GITHUB_ENV
-
             - name: Map x86_64 to amd64 short arch
               if: startsWith(matrix.cpu_arch, 'x86_64')
               run: echo "SHORT_ARCH=amd64" >> $GITHUB_ENV
 
+#            - name: Install Rust, Cargo, Cross
+#              run: |
+#                curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+#                source $HOME/.cargo/env
+#                echo "PATH=$HOME/.cargo/bin:$PATH" >> $GITHUB_ENV
+#                cargo install cross
+#                env CROSS_PROFILE=${{ matrix.profile }} make build-${{ matrix.cpu_arch }}
 
-            - name: Install Rust and Cargo
-              run: |
-                curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-                source $HOME/.cargo/env
-                echo "PATH=$HOME/.cargo/bin:$PATH" >> $GITHUB_ENV
-
-                
-            - name: cargo install cross
-              run: |
-                    cargo install cross
-
-            # - uses: actions/checkout@v4
             # - name: Update Rust
             #   if: env.SELF_HOSTED_RUNNERS == 'false'
             #   run: rustup update stable
+
             - name: Checkout sources
               uses: actions/checkout@v4
 
-            - name: Get rust-version 
-              id: get-rust-version 
-              run: |
-                echo "RUST_VERSION=$(./.github/scripts/toml_reader.sh ./anchor/Cargo.toml package rust-version)" >> $GITHUB_ENV
+#            - name: Get rust-version 
+#              id: get-rust-version 
+#              run: |
+#                echo "RUST_VERSION=$(./.github/scripts/toml_reader.sh ./anchor/Cargo.toml package rust-version)" >> $GITHUB_ENV
+#                echo "rust version is ${{ env.RUST_VERSION }}"
           
-            - name: Get latest version of stable Rust
-              run: echo "rust version is ${{ env.RUST_VERSION }}"
-
 #            - name: Retrieve Docker credentials from Vault
 #              uses: hashicorp/vault-action@v2
 #              with:
@@ -98,23 +88,15 @@ jobs:
               run: |
                   echo "${DOCKER_PASSWORD}" | docker login --username ${DOCKER_USERNAME} --password-stdin
 
-
-
-            - name: Build binary
-              run: |
-                cargo install cross
-                env CROSS_PROFILE=${{ matrix.profile }} make build-${{ matrix.cpu_arch }}
-
-
-            - name: Set `make` command for anchor
-              run: |
-                  echo "MAKE_CMD=build-${{ matrix.cpu_arch }}" >> $GITHUB_ENV                
-
-            - name: Make bin dir
-              run: mkdir ./bin
-
-            - name: Move built binary into Docker scope
-              run: mv ./target/${{ matrix.cpu_arch }}-unknown-linux-gnu/${{ matrix.profile }}/anchor ./bin
+#            - name: Set `make` command for anchor
+#              run: |
+#                  echo "MAKE_CMD=build-${{ matrix.cpu_arch }}" >> $GITHUB_ENV                
+#
+#            - name: Make bin dir
+#              run: mkdir ./bin
+#
+#            - name: Move built binary into Docker scope
+#              run: mv ./target/${{ matrix.cpu_arch }}-unknown-linux-gnu/${{ matrix.profile }}/anchor ./bin
 
             - name: Install QEMU
               if: env.SELF_HOSTED_RUNNERS == 'false'
@@ -124,23 +106,31 @@ jobs:
               if: env.SELF_HOSTED_RUNNERS == 'false'
               uses: docker/setup-buildx-action@v3
 
-            - name: Build and push
-              uses: docker/build-push-action@v5
-              with:
-                file: ./anchor/Dockerfile.cross
-                context: .
-                platforms: linux/${{ env.SHORT_ARCH }}
-                labels: |
-                    git.revision=${{ github.sha }}
-                    git.branch=${{ github.ref }}
-                    git.tag=${{ github.ref }}
-                    git.repository=${{ github.repository }}
-                push: true
-                tags: |
-                  ${{ github.repository_owner}}/anchor:${{ env.VERSION }}-${{ env.SHORT_ARCH }}${{ env.VERSION_SUFFIX }}
-                build-args: |
-                  RUST_VERSION=${{ env.RUST_VERSION }}
-                  TARGETPLATFORM=linux/${{ env.SHORT_ARCH }}
+            - name: Build Dockerfile and push
+              run: |
+                docker buildx build \
+                    --platform=linux/${SHORT_ARCH} \
+                    --file ./Dockerfile . \
+                    --tag ${IMAGE_NAME}:${VERSION}-${SHORT_ARCH}${VERSION_SUFFIX} \
+                    --push
+
+#            - name: Build and push
+#              uses: docker/build-push-action@v5
+#              with:
+#                file: ./anchor/Dockerfile.cross
+#                context: .
+#                platforms: linux/${{ env.SHORT_ARCH }}
+#                labels: |
+#                    git.revision=${{ github.sha }}
+#                    git.branch=${{ github.ref }}
+#                    git.tag=${{ github.ref }}
+#                    git.repository=${{ github.repository }}
+#                push: true
+#                tags: |
+#                  ${{ github.repository_owner}}/anchor:${{ env.VERSION }}-${{ env.SHORT_ARCH }}${{ env.VERSION_SUFFIX }}
+#                build-args: |
+#                  RUST_VERSION=${{ env.RUST_VERSION }}
+#                  TARGETPLATFORM=linux/${{ env.SHORT_ARCH }}
                   
 
     build-docker-multiarch:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - unstable
       - stable
-      - build-docker
     tags:
       - v*
 
@@ -32,7 +31,8 @@ jobs:
     
     build-docker:
         name: build-docker
-#        runs-on: ${{ github.repository == 'sigp/anchor' && fromJson('["self-hosted", "linux", "release"]') || 'ubuntu-22.04'  }}
+# TODO: we don't have self-hosted runners available for anchor at the moment
+#        runs-on: ${{ github.repository == 'sigp/anchor' && fromJson('["self-hosted", "linux", "release"]') || 'ubuntu-24.04'  }}
         runs-on: ubuntu-24.04
         strategy:
             matrix:
@@ -53,27 +53,9 @@ jobs:
               if: startsWith(matrix.cpu_arch, 'x86_64')
               run: echo "SHORT_ARCH=amd64" >> $GITHUB_ENV
 
-#            - name: Install Rust, Cargo, Cross
-#              run: |
-#                curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-#                source $HOME/.cargo/env
-#                echo "PATH=$HOME/.cargo/bin:$PATH" >> $GITHUB_ENV
-#                cargo install cross
-#                env CROSS_PROFILE=${{ matrix.profile }} make build-${{ matrix.cpu_arch }}
-
-            # - name: Update Rust
-            #   if: env.SELF_HOSTED_RUNNERS == 'false'
-            #   run: rustup update stable
-
             - name: Checkout sources
               uses: actions/checkout@v4
 
-#            - name: Get rust-version 
-#              id: get-rust-version 
-#              run: |
-#                echo "RUST_VERSION=$(./.github/scripts/toml_reader.sh ./anchor/Cargo.toml package rust-version)" >> $GITHUB_ENV
-#                echo "rust version is ${{ env.RUST_VERSION }}"
-          
 #            - name: Retrieve Docker credentials from Vault
 #              uses: hashicorp/vault-action@v2
 #              with:
@@ -88,30 +70,12 @@ jobs:
               run: |
                   echo "${DOCKER_PASSWORD}" | docker login --username ${DOCKER_USERNAME} --password-stdin
 
-#            - name: Set `make` command for anchor
-#              run: |
-#                  echo "MAKE_CMD=build-${{ matrix.cpu_arch }}" >> $GITHUB_ENV                
-#
-#            - name: Make bin dir
-#              run: mkdir ./bin
-#
-#            - name: Move built binary into Docker scope
-#              run: mv ./target/${{ matrix.cpu_arch }}-unknown-linux-gnu/${{ matrix.profile }}/anchor ./bin
-
-            - name: Install QEMU
+            - name: Setup QEMU
               if: env.SELF_HOSTED_RUNNERS == 'false'
               uses: docker/setup-qemu-action@v3
-            - name: Set up Docker Buildx
+            - name: Setup Docker Buildx
               if: env.SELF_HOSTED_RUNNERS == 'false'
               uses: docker/setup-buildx-action@v3
-
-#            - name: Build Dockerfile and push
-#              run: |
-#                docker buildx build \
-#                    --platform=linux/${SHORT_ARCH} \
-#                    --file ./Dockerfile . \
-#                    --tag ${IMAGE_NAME}:${VERSION}-${SHORT_ARCH}${VERSION_SUFFIX} \
-#                    --push
 
             - name: Build and push
               uses: docker/build-push-action@v6
@@ -127,7 +91,6 @@ jobs:
                   ${{ env.IMAGE_NAME }}:${{ env.VERSION }}${{ env.VERSION_SUFFIX}}-${{ env.SHORT_ARCH }}
                 build-args: |
                   RUST_VERSION=${{ env.RUST_VERSION }}
-#                outputs: type=image,push-by-digest=true,name-canonical=true,push=true
 
     docker-multiarch-manifest:
       name: docker-multiarch-manifest

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -34,11 +34,11 @@ jobs:
         name: build-docker-anchor-${{ matrix.cpu_arch }}
 #        runs-on: ${{ github.repository == 'sigp/anchor' && fromJson('["self-hosted", "linux", "release"]') || 'ubuntu-22.04'  }}
         runs-on: ubuntu-24.04
-        strategy:
-            matrix:
-                cpu_arch: [aarch64, x86_64]
-                include:
-                    - profile: maxperf
+#        strategy:
+#            matrix:
+#                cpu_arch: [aarch64, x86_64]
+#                include:
+#                    - profile: maxperf
 
         needs: [extract-version]
         env:
@@ -46,12 +46,12 @@ jobs:
             VERSION_SUFFIX: ${{ needs.extract-version.outputs.VERSION_SUFFIX }}
         steps:
             
-            - name: Map aarch64 to arm64 short arch
-              if: startsWith(matrix.cpu_arch, 'aarch64')
-              run: echo "SHORT_ARCH=arm64" >> $GITHUB_ENV
-            - name: Map x86_64 to amd64 short arch
-              if: startsWith(matrix.cpu_arch, 'x86_64')
-              run: echo "SHORT_ARCH=amd64" >> $GITHUB_ENV
+#            - name: Map aarch64 to arm64 short arch
+#              if: startsWith(matrix.cpu_arch, 'aarch64')
+#              run: echo "SHORT_ARCH=arm64" >> $GITHUB_ENV
+#            - name: Map x86_64 to amd64 short arch
+#              if: startsWith(matrix.cpu_arch, 'x86_64')
+#              run: echo "SHORT_ARCH=amd64" >> $GITHUB_ENV
 
 #            - name: Install Rust, Cargo, Cross
 #              run: |
@@ -120,7 +120,7 @@ jobs:
               with:
                 file: ./anchor/Dockerfile
                 context: .
-                platforms: linux/${{ env.SHORT_ARCH }}
+                platforms: linux/amd64,linux/arm64
                 labels: |
                     git.revision=${{ github.sha }}
                     git.branch=${{ github.ref }}
@@ -128,11 +128,9 @@ jobs:
                     git.repository=${{ github.repository }}
                 push: true
                 tags: |
-                  ${IMAGE_NAME}:${VERSION}-${SHORT_ARCH}${VERSION_SUFFIX}
                   ${IMAGE_NAME}:${VERSION}${VERSION_SUFFIX}
                 build-args: |
                   RUST_VERSION=${{ env.RUST_VERSION }}
-                  TARGETPLATFORM=linux/${{ env.SHORT_ARCH }}
                  
 
 #    docker-multiarch-manifest:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -150,6 +150,5 @@ jobs:
         - name: Create and push multiarch manifest
           run: |
             docker manifest create ${IMAGE_NAME}:${VERSION}${VERSION_SUFFIX} \
-#                --amend ${IMAGE_NAME}:${VERSION}-arm64${VERSION_SUFFIX} \
                 --amend ${IMAGE_NAME}:${VERSION}-amd64${VERSION_SUFFIX};
             docker manifest push ${IMAGE_NAME}:${VERSION}${VERSION_SUFFIX}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -16,7 +16,7 @@ concurrency:
 env:
     # Enable self-hosted runners for the sigp repo only.
     SELF_HOSTED_RUNNERS: ${{ github.repository == 'sigp/anchor' }}
-    RUST_VERSION: '1.83.0'
+    RUST_VERSION: '1.85.1'
     # Deny warnings in CI
     RUSTFLAGS: "-D warnings -C debuginfo=0"
     # Prevent Github API rate limiting
@@ -36,7 +36,8 @@ jobs:
         runs-on: ubuntu-24.04
         strategy:
             matrix:
-                cpu_arch: [aarch64, x86_64]
+#                cpu_arch: [aarch64, x86_64]
+                cpu_arch: [x86_64]
                 include:
                     - profile: maxperf
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - unstable
       - stable
-      - build-docker
     tags:
       - v*
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -16,7 +16,7 @@ concurrency:
 env:
     # Enable self-hosted runners for the sigp repo only.
     SELF_HOSTED_RUNNERS: ${{ github.repository == 'sigp/anchor' }}
-#    RUST_VERSION: '1.85.1'
+    RUST_VERSION: '1.85.1'
     # Deny warnings in CI
     RUSTFLAGS: "-D warnings -C debuginfo=0"
     # Prevent Github API rate limiting
@@ -30,15 +30,15 @@ jobs:
     extract-version:
         uses: ./.github/workflows/extract-version.yml
     
-    build-docker-single-arch:
+    build-docker:
         name: build-docker
 #        runs-on: ${{ github.repository == 'sigp/anchor' && fromJson('["self-hosted", "linux", "release"]') || 'ubuntu-22.04'  }}
         runs-on: ubuntu-24.04
-#        strategy:
-#            matrix:
-#                cpu_arch: [aarch64, x86_64]
-#                include:
-#                    - profile: maxperf
+        strategy:
+            matrix:
+                cpu_arch: [aarch64, x86_64]
+                include:
+                    - profile: maxperf
 
         needs: [extract-version]
         env:
@@ -46,12 +46,12 @@ jobs:
             VERSION_SUFFIX: ${{ needs.extract-version.outputs.VERSION_SUFFIX }}
         steps:
             
-#            - name: Map aarch64 to arm64 short arch
-#              if: startsWith(matrix.cpu_arch, 'aarch64')
-#              run: echo "SHORT_ARCH=arm64" >> $GITHUB_ENV
-#            - name: Map x86_64 to amd64 short arch
-#              if: startsWith(matrix.cpu_arch, 'x86_64')
-#              run: echo "SHORT_ARCH=amd64" >> $GITHUB_ENV
+            - name: Map aarch64 to arm64 short arch
+              if: startsWith(matrix.cpu_arch, 'aarch64')
+              run: echo "SHORT_ARCH=arm64" >> $GITHUB_ENV
+            - name: Map x86_64 to amd64 short arch
+              if: startsWith(matrix.cpu_arch, 'x86_64')
+              run: echo "SHORT_ARCH=amd64" >> $GITHUB_ENV
 
 #            - name: Install Rust, Cargo, Cross
 #              run: |
@@ -101,8 +101,6 @@ jobs:
             - name: Install QEMU
               if: env.SELF_HOSTED_RUNNERS == 'false'
               uses: docker/setup-qemu-action@v3
-#              run: sudo apt-get update && sudo apt-get install -y qemu-user-static
-
             - name: Set up Docker Buildx
               if: env.SELF_HOSTED_RUNNERS == 'false'
               uses: docker/setup-buildx-action@v3
@@ -118,9 +116,7 @@ jobs:
             - name: Build and push
               uses: docker/build-push-action@v6
               with:
-                file: ./anchor/Dockerfile
-                context: .
-                platforms: linux/amd64,linux/arm64
+                platforms: linux/${{ env.SHORT_ARCH }}
                 labels: |
                     git.revision=${{ github.sha }}
                     git.branch=${{ github.ref }}
@@ -128,26 +124,27 @@ jobs:
                     git.repository=${{ github.repository }}
                 push: true
                 tags: |
-                  ${{ env.IMAGE_NAME }}:${{ env.VERSION }}${{ env.VERSION_SUFFIX}}
+                  ${{ env.IMAGE_NAME }}:${{ env.VERSION }}${{ env.VERSION_SUFFIX}}-${{ env.SHORT_ARCH }}
                 build-args: |
                   RUST_VERSION=${{ env.RUST_VERSION }}
-                 
+#                outputs: type=image,push-by-digest=true,name-canonical=true,push=true
 
-#    docker-multiarch-manifest:
-#      name: docker-multiarch-manifest
-#      runs-on: ubuntu-24.04
-#      needs: [build-docker-single-arch, extract-version]
-#      env:
-#        # We need to enable experimental docker features in order to use `docker manifest`
-#        DOCKER_CLI_EXPERIMENTAL: enabled
-#        VERSION: ${{ needs.extract-version.outputs.VERSION }}
-#        VERSION_SUFFIX: ${{ needs.extract-version.outputs.VERSION_SUFFIX }}
-#      steps:
-#        - name: Dockerhub login
-#          run: |
-#            echo "${DOCKER_PASSWORD}" | docker login --username ${DOCKER_USERNAME} --password-stdin
-#        - name: Create and push multiarch manifest
-#          run: |
-#            docker manifest create ${IMAGE_NAME}:${VERSION}${VERSION_SUFFIX} \
-#                --amend ${IMAGE_NAME}:${VERSION}-amd64${VERSION_SUFFIX};
-#            docker manifest push ${IMAGE_NAME}:${VERSION}${VERSION_SUFFIX}
+    docker-multiarch-manifest:
+      name: docker-multiarch-manifest
+      runs-on: ubuntu-24.04
+      needs: [build-docker, extract-version]
+      env:
+        # We need to enable experimental docker features in order to use `docker manifest`
+        DOCKER_CLI_EXPERIMENTAL: enabled
+        VERSION: ${{ needs.extract-version.outputs.VERSION }}
+        VERSION_SUFFIX: ${{ needs.extract-version.outputs.VERSION_SUFFIX }}
+      steps:
+        - name: Dockerhub login
+          run: |
+            echo "${DOCKER_PASSWORD}" | docker login --username ${DOCKER_USERNAME} --password-stdin
+        - name: Create and push multiarch manifest
+          run: |
+            docker manifest create ${IMAGE_NAME}:${VERSION}${VERSION_SUFFIX} \
+                --amend ${IMAGE_NAME}:${VERSION}${VERSION_SUFFIX}-amd64; \
+                --amend ${IMAGE_NAME}:${VERSION}${VERSION_SUFFIX}-arm64;
+            docker manifest push ${IMAGE_NAME}:${VERSION}${VERSION_SUFFIX}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -16,7 +16,7 @@ concurrency:
 env:
     # Enable self-hosted runners for the sigp repo only.
     SELF_HOSTED_RUNNERS: ${{ github.repository == 'sigp/anchor' }}
-    RUST_VERSION: '1.85.1'
+#    RUST_VERSION: '1.85.1'
     # Deny warnings in CI
     RUSTFLAGS: "-D warnings -C debuginfo=0"
     # Prevent Github API rate limiting
@@ -99,9 +99,9 @@ jobs:
 #            - name: Move built binary into Docker scope
 #              run: mv ./target/${{ matrix.cpu_arch }}-unknown-linux-gnu/${{ matrix.profile }}/anchor ./bin
 
-            - name: Install QEMU
-              if: env.SELF_HOSTED_RUNNERS == 'false'
-              run: sudo apt-get update && sudo apt-get install -y qemu-user-static
+#            - name: Install QEMU
+#              if: env.SELF_HOSTED_RUNNERS == 'false'
+#              run: sudo apt-get update && sudo apt-get install -y qemu-user-static
 
             - name: Set up Docker Buildx
               if: env.SELF_HOSTED_RUNNERS == 'false'
@@ -136,7 +136,7 @@ jobs:
 
     build-docker-multiarch:
       name: build-docker-multiarch
-      runs-on: ubuntu-22.04
+      runs-on: ubuntu-24.04
       needs: [build-docker-single-arch, extract-version]
       env:
         # We need to enable experimental docker features in order to use `docker manifest`
@@ -150,6 +150,6 @@ jobs:
         - name: Create and push multiarch manifest
           run: |
             docker manifest create ${IMAGE_NAME}:${VERSION}${VERSION_SUFFIX} \
-                --amend ${IMAGE_NAME}:${VERSION}-arm64${VERSION_SUFFIX} \
+#                --amend ${IMAGE_NAME}:${VERSION}-arm64${VERSION_SUFFIX} \
                 --amend ${IMAGE_NAME}:${VERSION}-amd64${VERSION_SUFFIX};
             docker manifest push ${IMAGE_NAME}:${VERSION}${VERSION_SUFFIX}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - unstable
       - stable
+      - build-docker
     tags:
       - v*
 
@@ -36,7 +37,8 @@ jobs:
         runs-on: ubuntu-24.04
         strategy:
             matrix:
-                cpu_arch: [aarch64, x86_64]
+#                cpu_arch: [aarch64, x86_64]
+                cpu_arch: [x86_64]
                 include:
                     - profile: maxperf
 
@@ -107,7 +109,6 @@ jobs:
             echo "${DOCKER_PASSWORD}" | docker login --username ${DOCKER_USERNAME} --password-stdin
         - name: Create and push multiarch manifest
           run: |
-            docker manifest create ${IMAGE_NAME}:${VERSION}${VERSION_SUFFIX} \
-                --amend ${IMAGE_NAME}:${VERSION}${VERSION_SUFFIX}-amd64; \
-                --amend ${IMAGE_NAME}:${VERSION}${VERSION_SUFFIX}-arm64;
-            docker manifest push ${IMAGE_NAME}:${VERSION}${VERSION_SUFFIX}
+            docker buildx imagetools create -t ${IMAGE_NAME}:${VERSION}${VERSION_SUFFIX} \
+                ${IMAGE_NAME}:${VERSION}${VERSION_SUFFIX}-amd64; 
+#               ${IMAGE_NAME}:${VERSION}${VERSION_SUFFIX}-arm64;

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG RUST_VERSION=1.83.0
+ARG RUST_VERSION=1.85.1
 FROM rust:${RUST_VERSION}-bullseye AS builder
 RUN apt update && apt dist-upgrade -y && apt install -y cmake libclang-dev
 COPY . anchor

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ ENV CARGO_NET_GIT_FETCH_WITH_CLI=$CARGO_USE_GIT_CLI
 RUN cd anchor && make
 
 FROM ubuntu:24.04
-ENTRYPOINT /usr/local/bin/anchor
+ENTRYPOINT ["/usr/local/bin/anchor"]
 RUN apt-get update && apt-get -y upgrade && apt-get install -y --no-install-recommends \
   libssl-dev \
   ca-certificates \

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ ENV PROFILE=$PROFILE
 ENV CARGO_NET_GIT_FETCH_WITH_CLI=$CARGO_USE_GIT_CLI
 RUN cd anchor && make
 
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 ENTRYPOINT /usr/local/bin/anchor
 RUN apt-get update && apt-get -y upgrade && apt-get install -y --no-install-recommends \
   libssl-dev \

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ ENV CARGO_NET_GIT_FETCH_WITH_CLI=$CARGO_USE_GIT_CLI
 RUN cd anchor && make
 
 FROM ubuntu:22.04
+ENTRYPOINT /usr/local/bin/anchor
 RUN apt-get update && apt-get -y upgrade && apt-get install -y --no-install-recommends \
   libssl-dev \
   ca-certificates \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG RUST_VERSION=1.83.0
 FROM rust:${RUST_VERSION}-bullseye AS builder
-RUN apt-get update && apt-get -y upgrade && apt-get install -y cmake libclang-dev
+RUN apt update && apt dist-upgrade -y && apt install -y cmake libclang-dev
 COPY . anchor
 ARG FEATURES
 ARG PROFILE=release
@@ -12,7 +12,7 @@ RUN cd anchor && make
 
 FROM ubuntu:24.04
 ENTRYPOINT ["/usr/local/bin/anchor"]
-RUN apt-get update && apt-get -y upgrade && apt-get install -y --no-install-recommends \
+RUN apt update && apt dist-upgrade -y && apt install -y --no-install-recommends \
   libssl-dev \
   ca-certificates \
   && apt-get clean \

--- a/Dockerfile.cross
+++ b/Dockerfile.cross
@@ -2,6 +2,7 @@
 # It assumes the lighthouse binary has already been
 # compiled for `$TARGETPLATFORM` and moved to `./bin`.
 FROM --platform=$TARGETPLATFORM ubuntu:22.04
+ENTRYPOINT /usr/local/bin/anchor
 RUN apt-get update && apt-get install -y --no-install-recommends \
   libssl-dev \
   ca-certificates \

--- a/Dockerfile.cross
+++ b/Dockerfile.cross
@@ -2,7 +2,7 @@
 # It assumes the lighthouse binary has already been
 # compiled for `$TARGETPLATFORM` and moved to `./bin`.
 FROM --platform=$TARGETPLATFORM ubuntu:24.04
-ENTRYPOINT /usr/local/bin/anchor
+ENTRYPOINT ["/usr/local/bin/anchor"]
 RUN apt-get update && apt-get install -y --no-install-recommends \
   libssl-dev \
   ca-certificates \

--- a/Dockerfile.cross
+++ b/Dockerfile.cross
@@ -1,7 +1,7 @@
 # This image is meant to enable cross-architecture builds.
 # It assumes the lighthouse binary has already been
 # compiled for `$TARGETPLATFORM` and moved to `./bin`.
-FROM --platform=$TARGETPLATFORM ubuntu:22.04
+FROM --platform=$TARGETPLATFORM ubuntu:24.04
 ENTRYPOINT /usr/local/bin/anchor
 RUN apt-get update && apt-get install -y --no-install-recommends \
   libssl-dev \

--- a/Dockerfile.cross
+++ b/Dockerfile.cross
@@ -3,7 +3,7 @@
 # compiled for `$TARGETPLATFORM` and moved to `./bin`.
 FROM --platform=$TARGETPLATFORM ubuntu:24.04
 ENTRYPOINT ["/usr/local/bin/anchor"]
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN apt update && apt dist-upgrade -y && apt install -y --no-install-recommends \
   libssl-dev \
   ca-certificates \
   && apt-get clean \

--- a/Dockerfile.devnet
+++ b/Dockerfile.devnet
@@ -1,4 +1,4 @@
-ARG RUST_VERSION=1.83.0
+ARG RUST_VERSION=1.85.1
 FROM rust:${RUST_VERSION}-bullseye AS builder
 RUN apt update && apt dist-upgrade -y && apt install -y cmake libclang-dev
 COPY . anchor

--- a/Dockerfile.devnet
+++ b/Dockerfile.devnet
@@ -1,6 +1,6 @@
 ARG RUST_VERSION=1.83.0
 FROM rust:${RUST_VERSION}-bullseye AS builder
-RUN apt-get update && apt-get -y upgrade && apt-get install -y cmake libclang-dev
+RUN apt update && apt dist-upgrade -y && apt install -y cmake libclang-dev
 COPY . anchor
 ARG FEATURES=spec-minimal
 ARG PROFILE=release
@@ -12,7 +12,7 @@ RUN cd anchor && make
 
 FROM ubuntu:24.04
 ENTRYPOINT ["/usr/local/bin/anchor"]
-RUN apt-get update && apt-get -y upgrade && apt-get install -y --no-install-recommends \
+RUN apt update && apt dist-upgrade -y && apt-get install -y --no-install-recommends \
   libssl-dev \
   ca-certificates \
   jq \

--- a/Dockerfile.devnet
+++ b/Dockerfile.devnet
@@ -11,7 +11,7 @@ ENV CARGO_NET_GIT_FETCH_WITH_CLI=$CARGO_USE_GIT_CLI
 RUN cd anchor && make
 
 FROM ubuntu:24.04
-ENTRYPOINT /usr/local/bin/anchor
+ENTRYPOINT ["/usr/local/bin/anchor"]
 RUN apt-get update && apt-get -y upgrade && apt-get install -y --no-install-recommends \
   libssl-dev \
   ca-certificates \

--- a/Dockerfile.devnet
+++ b/Dockerfile.devnet
@@ -10,7 +10,7 @@ ENV PROFILE=$PROFILE
 ENV CARGO_NET_GIT_FETCH_WITH_CLI=$CARGO_USE_GIT_CLI
 RUN cd anchor && make
 
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 ENTRYPOINT /usr/local/bin/anchor
 RUN apt-get update && apt-get -y upgrade && apt-get install -y --no-install-recommends \
   libssl-dev \

--- a/Dockerfile.devnet
+++ b/Dockerfile.devnet
@@ -11,6 +11,7 @@ ENV CARGO_NET_GIT_FETCH_WITH_CLI=$CARGO_USE_GIT_CLI
 RUN cd anchor && make
 
 FROM ubuntu:22.04
+ENTRYPOINT /usr/local/bin/anchor
 RUN apt-get update && apt-get -y upgrade && apt-get install -y --no-install-recommends \
   libssl-dev \
   ca-certificates \


### PR DESCRIPTION
## Issue Addressed

https://github.com/sigp/devops-pm/issues/63

## Additional Info

- The `anchor` binary is now defined in the `ENTRYPOINT`, meaning we don't need to specify it anymore when running the container: `docker run sigp/anchor --help` vs. `docker run sigp/anchor anchor --help`. 

- ARM builds are disabled for now as they take [over three hours to complete]. (https://github.com/antondlr/anchor/actions/runs/14017403755/job/39244825764) . 
  We can revisit this once we have our first ARM user :-) 

- Assumes the secrets `DOCKER_USERNAME` and `DOCKER_PASSWORD` are defined. Pulling this from vault is commented out (and untested). 