### PR TITLE
Keygen bugfix

### DIFF
--- a/anchor/keygen/src/lib.rs
+++ b/anchor/keygen/src/lib.rs
@@ -52,7 +52,6 @@ pub struct Keygen {
         long,
         help = "Password for file encryption",
         value_name = "PASSWORD",
-        default_value = ""
     )]
     pub password: Option<String>,
 }

--- a/anchor/keygen/src/lib.rs
+++ b/anchor/keygen/src/lib.rs
@@ -48,11 +48,7 @@ pub struct Keygen {
     )]
     pub force: bool,
 
-    #[clap(
-        long,
-        help = "Password for file encryption",
-        value_name = "PASSWORD",
-    )]
+    #[clap(long, help = "Password for file encryption", value_name = "PASSWORD")]
     pub password: Option<String>,
 }
 
@@ -109,6 +105,8 @@ pub fn run_keygen(keygen: Keygen) -> Result<Rsa<Private>, KeygenError> {
             // Log the public key
             info!("Generated public key: {}", public_pem_encoded);
         } else {
+            info!("Password not supplied. Private key will NOT be encrypted");
+
             // Otherwise, write out plainkey keys to respective files
             let data = PrettyOutput {
                 public: public_pem_encoded,


### PR DESCRIPTION
## Issue Addressed

N/A

## Proposed Changes

Passwords were being defaulted to "" if it was not supplied. This would probably confuse a lot of users as to what their password was unless they read the code. 
