### PR TITLE
Only complain about missing aggregated commit if the instance completed successfully

### DIFF
--- a/anchor/qbft_manager/src/lib.rs
+++ b/anchor/qbft_manager/src/lib.rs
@@ -536,7 +536,11 @@ async fn qbft_instance<D: QbftData<Hash = Hash256>>(
                             error!(?err, "Unable to send aggregated commit message");
                         }
                     }
-                    None => error!("Aggregated commit does not exist"),
+                    None => {
+                        if let Completed::Success(_) = completed {
+                            error!("Aggregated commit does not exist");
+                        }
+                    }
                 }
 
                 instance = QbftInstance::Decided { value: completed };


### PR DESCRIPTION
If a QBFT instance completes successfully, we send a message with all commit signatures. There should always be an aggregated commit message available if the instance completes successfully.

We log an error if there is no aggregated commit message - but until now also in cases where the instance timed out. As we do not expect there to be a message in that case, this PR checks if the instance was successful before logging the failure.