### PR TITLE
No error on sending duplicates

### DIFF
--- a/anchor/network/src/network.rs
+++ b/anchor/network/src/network.rs
@@ -5,7 +5,9 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use futures::StreamExt;
-use gossipsub::{ConfigBuilderError, IdentTopic, MessageAuthenticity, ValidationMode};
+use gossipsub::{
+    ConfigBuilderError, IdentTopic, MessageAuthenticity, PublishError, ValidationMode,
+};
 use libp2p::core::muxing::StreamMuxerBox;
 use libp2p::core::transport::Boxed;
 use libp2p::core::ConnectedPoint;
@@ -211,7 +213,9 @@ impl<R: MessageReceiver> Network<R> {
                     match event {
                         Some((subnet_id, message)) => {
                             if let Err(err) = self.gossipsub().publish(subnet_to_topic(subnet_id), message) {
-                                error!(?err, "Failed to publish message");
+                                if !matches!(err, PublishError::Duplicate) {
+                                    error!(?err, "Failed to publish message");
+                                }
                             }
                         }
                         None => {


### PR DESCRIPTION
Decided messages are sent on successful completion of a QBFT instance, by all participants of that instance. 

This causes exact copies of these messages to be sent by multiple parties. These messages have the same message ID, as they have the same content. When calling Gossipsub's `publish`, a "Duplicate" error is returned if the message has been seen before.

We do not really want to check if we have seen the message before, as the infrastructure and overhead is not worth it. Instead, ignore "Duplicate" errors. There is still a warning logged by libp2p, which is IMO sufficient.