### PR TITLE
Switch to unbounded queue

### DIFF
--- a/anchor/eth/src/event_processor.rs
+++ b/anchor/eth/src/event_processor.rs
@@ -324,7 +324,7 @@ impl EventProcessor {
             })?;
 
         // Schedule validator for index lookup
-        if let Err(err) = index_lookup_queue.blocking_send(validator_pubkey) {
+        if let Err(err) = index_lookup_queue.send(validator_pubkey) {
             error!(?err, "Failed to send validator to index lookup");
         }
 

--- a/anchor/eth/src/index_sync.rs
+++ b/anchor/eth/src/index_sync.rs
@@ -8,18 +8,17 @@ use ssv_types::{ValidatorIndex, ValidatorMetadata};
 use task_executor::TaskExecutor;
 use tokio::{
     select,
-    sync::mpsc::{channel, Receiver, Sender},
+    sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender},
     time::sleep,
 };
 use tracing::{debug, error, info, warn};
 use types::PublicKeyBytes;
 
-pub type Tx = Sender<PublicKeyBytes>;
+pub type Tx = UnboundedSender<PublicKeyBytes>;
 
 const INDEX_SYNCER_NAME: &str = "validator_index_syncer";
 
 const MAX_BATCH_SIZE: usize = 512;
-const QUEUE_SIZE: usize = 4096;
 const BATCHING_DELAY: Duration = Duration::from_secs(1);
 const MAX_DELAY: Duration = Duration::from_secs(45);
 
@@ -28,7 +27,7 @@ pub fn start_validator_index_syncer(
     db: Arc<NetworkDatabase>,
     executor: TaskExecutor,
 ) -> Tx {
-    let (tx, rx) = channel(QUEUE_SIZE);
+    let (tx, rx) = unbounded_channel();
     executor.spawn(validator_index_syncer(nodes, db, rx), INDEX_SYNCER_NAME);
     tx
 }
@@ -36,7 +35,7 @@ pub fn start_validator_index_syncer(
 async fn validator_index_syncer(
     nodes: Arc<BeaconNodeFallback<impl SlotClock>>,
     db: Arc<NetworkDatabase>,
-    mut validator_queue_rx: Receiver<PublicKeyBytes>,
+    mut validator_queue_rx: UnboundedReceiver<PublicKeyBytes>,
 ) {
     info!("Starting validator index syncer");
 


### PR DESCRIPTION
I realised that a last minute change in #212 is actually broken - the bounded queue's `blocking_send` can only be used outside of the tokio runtime. While the calling function is not async, we are still in the runtime - causing the call to panic. 

We could use `try_send` instead, but I feel like it is preferable to use an unbounded queue instead. 

We are sending `PublicKeyBytes`, which has a size of 48 bytes. Mainnet has ~100000 validators hosted by SSV, so the worst-case is approximately 4.8 MB, which is very tolerable. The real world case will be far smaller, as the queue is handled rather quickly.