### PR TITLE
Time outs for selection proofs

### DIFF
--- a/anchor/qbft_manager/src/lib.rs
+++ b/anchor/qbft_manager/src/lib.rs
@@ -486,7 +486,7 @@ async fn qbft_instance<D: QbftData<Hash = Hash256>>(
                     // instance state as decided
                     QbftInstance::Decided { value } => {
                         if on_completed.send(value.clone()).is_err() {
-                            error!("could not send qbft result");
+                            warn!("Callback dropped - qbft result is no longer relevant");
                         }
                         QbftInstance::Decided { value }
                     }

--- a/anchor/signature_collector/src/lib.rs
+++ b/anchor/signature_collector/src/lib.rs
@@ -531,8 +531,8 @@ async fn signature_collector(mut rx: mpsc::UnboundedReceiver<CollectorMessage>) 
                 debug!(?signature, "Successfully recovered signature");
 
                 for notifier in mem::take(&mut notifiers) {
-                    if let Err(err) = notifier.send(Arc::clone(&signature)) {
-                        warn!(?err, "Failed to send recovered signature");
+                    if notifier.send(Arc::clone(&signature)).is_err() {
+                        warn!("Callback dropped - signature is no longer relevant");
                     }
                 }
                 full_signature = Some(signature);

--- a/anchor/validator_store/src/lib.rs
+++ b/anchor/validator_store/src/lib.rs
@@ -4,6 +4,7 @@ mod metrics;
 use std::{
     collections::{HashMap, HashSet},
     fmt::Debug,
+    future::Future,
     str::from_utf8,
     sync::{Arc, LazyLock},
     time::Duration,
@@ -494,6 +495,36 @@ impl<T: SlotClock, E: EthSpec> AnchorValidatorStore<T, E> {
     fn update_slot_metadata(&self, metadata: SlotMetadata<E>) {
         self.slot_metadata.send_replace(Some(Arc::new(metadata)));
     }
+
+    /// Return [`SpecificError::Timeout`] if the given future does not complete at `delay` into the
+    /// given slot.
+    ///
+    /// In the unlikely case the `slot_clock` errors, we time out after `delay`;
+    async fn timeout_within_slot<O>(
+        &self,
+        slot: Slot,
+        delay: Duration,
+        future: impl Future<Output = Result<O, impl Into<Error>>>,
+    ) -> Result<O, Error> {
+        let timeout_time = self
+            .slot_clock
+            .start_of(slot)
+            .and_then(|start| {
+                self.slot_clock
+                    .now_duration()
+                    .map(|now| (start + delay).saturating_sub(now))
+            })
+            .unwrap_or(delay);
+
+        select! {
+            result = future => {
+                result.map_err(Into::into)
+            },
+            _ = sleep(timeout_time) => {
+                Err(SpecificError::Timeout.into())
+            }
+        }
+    }
 }
 
 fn handle_slashing_check_result(
@@ -968,14 +999,22 @@ impl<T: SlotClock, E: EthSpec> ValidatorStore for AnchorValidatorStore<T, E> {
         let domain_hash = self.get_domain(epoch, Domain::SelectionProof);
         let signing_root = slot.signing_root(domain_hash);
 
+        // We do not want to spend too long on the selection proof. We will not produce an
+        // aggregation anyway if the proof is not known at 2/3rds into the slot - so we abort then.
+        let delay = Duration::from_secs(self.spec.seconds_per_slot) * 2 / 3;
+
         let signature = self
-            .collect_signature(
-                PartialSignatureKind::SelectionProofPartialSig,
-                Role::Aggregator,
-                None,
-                self.validator(validator_pubkey)?,
-                signing_root,
+            .timeout_within_slot(
                 slot,
+                delay,
+                self.collect_signature(
+                    PartialSignatureKind::SelectionProofPartialSig,
+                    Role::Aggregator,
+                    None,
+                    self.validator(validator_pubkey)?,
+                    signing_root,
+                    slot,
+                ),
             )
             .await?;
 
@@ -1001,14 +1040,22 @@ impl<T: SlotClock, E: EthSpec> ValidatorStore for AnchorValidatorStore<T, E> {
         }
         .signing_root(domain_hash);
 
+        // We do not want to spend too long on the selection proof. We will not produce an
+        // aggregation anyway if the proof is not known at 2/3rds into the slot - so we abort then.
+        let delay = Duration::from_secs(self.spec.seconds_per_slot) * 2 / 3;
+
         let signature = self
-            .collect_signature(
-                PartialSignatureKind::ContributionProofs,
-                Role::SyncCommittee,
-                None,
-                self.validator(*validator_pubkey)?,
-                signing_root,
+            .timeout_within_slot(
                 slot,
+                delay,
+                self.collect_signature(
+                    PartialSignatureKind::ContributionProofs,
+                    Role::SyncCommittee,
+                    None,
+                    self.validator(*validator_pubkey)?,
+                    signing_root,
+                    slot,
+                ),
             )
             .await?;
 


### PR DESCRIPTION
It makes sense for certain signatures to have a long time out. For example, attestations may be included during the whole next epoch. But for other signatures, we rely on them to arrive within the same slot in order to be able to perform the duty: for example selection proofs. 

Waiting for these after a certain point has no benefit at all. This PR adds infrastructure to the Validator Store for easy timeouts and uses it for attestation aggregation selection proofs and sync selection proofs. As it is now expected for callbacks passed to qbft and signature collector managers to close in these cases, we adjust logging there to accurately reflect what's happening.