### PR TITLE
Allow specifying hardcoded networks in testnet dirs

### DIFF
--- a/anchor/common/ssv_network_config/src/lib.rs
+++ b/anchor/common/ssv_network_config/src/lib.rs
@@ -86,8 +86,24 @@ impl SsvNetworkConfig {
             ssv_contract: read(&base_dir.join("ssv_contract_address.txt"))?,
             ssv_contract_block: read(&base_dir.join("ssv_contract_block.txt"))?,
             ssv_domain_type: read(&base_dir.join("ssv_domain_type.txt"))?,
-            eth2_network: Eth2NetworkConfig::load(base_dir)?,
+            eth2_network: Self::load_eth2_network_config(base_dir)?,
         })
+    }
+
+    /// If a hardcoded eth network is specified in "ssv_eth_network.txt", use it, else try to load
+    /// its definition from files.
+    fn load_eth2_network_config(base_dir: PathBuf) -> Result<Eth2NetworkConfig, String> {
+        let ssv_eth_network_path = base_dir.join("ssv_eth_network.txt");
+        if ssv_eth_network_path.exists() {
+            let network_name: String = read(&ssv_eth_network_path)?;
+            Eth2NetworkConfig::constant(&network_name).and_then(|network_config| {
+                network_config.ok_or_else(|| {
+                    "Hardcoded network specified in ssv_eth_network.txt is unknown".to_string()
+                })
+            })
+        } else {
+            Eth2NetworkConfig::load(base_dir)
+        }
     }
 }
 


### PR DESCRIPTION
In SSV, we can have private SSV testnets on public testnets. It would be annoying to specify all the hoodi details in a testnet dir because the genesis state is quite large and lighthouse provides it.

This pr introduces an optional file in the testnet dir: `ssv_eth_network.txt`. If present, we use the eth testnet of the given name, if not present, we load the eth testnet details from the testnet dir as before.