### PR TITLE
Trim whitespace from testnet directory files

### DIFF
--- a/anchor/common/ssv_network_config/src/lib.rs
+++ b/anchor/common/ssv_network_config/src/lib.rs
@@ -111,6 +111,7 @@ impl SsvNetworkConfig {
 fn read<T: FromStr>(file: &Path) -> Result<T, String> {
     std::fs::read_to_string(file)
         .map_err(|e| format!("Unable to read {file:?}: {e}"))?
+        .trim()
         .parse()
         .map_err(|_| format!("Unable to parse {file:?}"))
 }


### PR DESCRIPTION
It is easy to accidentally put white space (e.g. a trailing newline) into testnet directory files. This may cause errors when parsing the contained values, so let's trim all trailing or leading white space.
