### PR TITLE
Fix flipped condition for committee relevancy check

### DIFF
--- a/anchor/message_receiver/src/manager.rs
+++ b/anchor/message_receiver/src/manager.rs
@@ -128,7 +128,7 @@ impl<S: SlotClock + 'static> MessageReceiver for Arc<NetworkMessageReceiver<S>> 
                             .map(|c| c.cluster_members.contains(&own_id))
                             .unwrap_or(false);
 
-                        if is_member {
+                        if !is_member {
                             // We are not a member for this committee, return without passing.
                             trace!(?committee_id, ?msg_id, "Not interested");
                             return;


### PR DESCRIPTION
I introduced a bug when fixing a TODO in #265. 

When checking whether a committee message is relevant for us, we correctly check whether we are a member of it, but then discard the message if so, instead of if not. This PR flips the condition to fix this.