### PR TITLE
Fix index uniqueness for cluster owners

### DIFF
--- a/anchor/database/src/lib.rs
+++ b/anchor/database/src/lib.rs
@@ -72,7 +72,7 @@ pub type MetadataMultiIndexMap = MultiIndexMap<
 /// All of the clusters in the network
 /// Primary: cluster id. uniquely identifies a cluster
 /// Secondary: public key of the validator. uniquely identifies a cluster
-/// Tertiary: owner of the cluster. uniquely identifies a cluster
+/// Tertiary: owner of the cluster. does not uniquely identify a cluster
 pub type ClusterMultiIndexMap = MultiIndexMap<
     ClusterId,
     PublicKeyBytes,
@@ -80,7 +80,7 @@ pub type ClusterMultiIndexMap = MultiIndexMap<
     CommitteeId,
     Cluster,
     UniqueTag,
-    UniqueTag,
+    NonUniqueTag,
     NonUniqueTag,
 >;
 

--- a/anchor/database/src/validator_operations.rs
+++ b/anchor/database/src/validator_operations.rs
@@ -5,7 +5,9 @@ use ssv_types::ValidatorIndex;
 use tracing::warn;
 use types::{Address, Graffiti, PublicKeyBytes};
 
-use crate::{multi_index::UniqueIndex, DatabaseError, NetworkDatabase, NonUniqueIndex, SqlStatement, SQL};
+use crate::{
+    multi_index::UniqueIndex, DatabaseError, NetworkDatabase, NonUniqueIndex, SqlStatement, SQL,
+};
 
 /// Implements all validator specific database functionality
 impl NetworkDatabase {

--- a/anchor/database/src/validator_operations.rs
+++ b/anchor/database/src/validator_operations.rs
@@ -5,7 +5,7 @@ use ssv_types::ValidatorIndex;
 use tracing::warn;
 use types::{Address, Graffiti, PublicKeyBytes};
 
-use crate::{multi_index::UniqueIndex, DatabaseError, NetworkDatabase, SqlStatement, SQL};
+use crate::{multi_index::UniqueIndex, DatabaseError, NetworkDatabase, NonUniqueIndex, SqlStatement, SQL};
 
 /// Implements all validator specific database functionality
 impl NetworkDatabase {
@@ -24,13 +24,15 @@ impl NetworkDatabase {
             ])?;
 
         self.modify_state(|state| {
-            if let Some(mut cluster) = state.multi_state.clusters.get_by(&owner) {
-                // Update in memory
-                cluster.fee_recipient = fee_recipient;
-                state
-                    .multi_state
-                    .clusters
-                    .update(&cluster.cluster_id.clone(), cluster);
+            if let Some(clusters) = state.multi_state.clusters.get_all_by(&owner) {
+                for mut cluster in clusters {
+                    // Update in memory
+                    cluster.fee_recipient = fee_recipient;
+                    state
+                        .multi_state
+                        .clusters
+                        .update(&cluster.cluster_id.clone(), cluster);
+                }
             }
         });
         Ok(())


### PR DESCRIPTION
Owners can own multiple clusters. Accurately reflect this by in our `MultiIndexMap` by setting the `NonUniqueTag`.