### PR TITLE
Correctly set fee recipient

### DIFF
--- a/anchor/common/ssv_types/src/sql_conversions.rs
+++ b/anchor/common/ssv_types/src/sql_conversions.rs
@@ -57,7 +57,6 @@ impl TryFrom<(&Row<'_>, Vec<ClusterMember>)> for Cluster {
         (row, cluster_members): (&Row<'_>, Vec<ClusterMember>),
     ) -> Result<Self, Self::Error> {
         let cluster_id = ClusterId(row.get("cluster_id")?);
-        println!("{:?}", cluster_id);
 
         let owner_str = row.get::<_, String>("owner")?;
         let owner = Address::from_str(&owner_str).map_err(|e| from_sql_error(1, Type::Text, e))?;

--- a/anchor/common/ssv_types/src/sql_conversions.rs
+++ b/anchor/common/ssv_types/src/sql_conversions.rs
@@ -61,10 +61,7 @@ impl TryFrom<(&Row<'_>, Vec<ClusterMember>)> for Cluster {
         let owner_str = row.get::<_, String>("owner")?;
         let owner = Address::from_str(&owner_str).map_err(|e| from_sql_error(1, Type::Text, e))?;
 
-        let fee_recipient_str = match row.get::<_, Option<String>>("fee_recipient")? {
-            Some(s) => s,
-            None => owner_str.clone(), // Default to using owner as fee recipient if not set
-        };
+        let fee_recipient_str = row.get::<_, String>("fee_recipient")?;
         let fee_recipient =
             Address::from_str(&fee_recipient_str).map_err(|e| from_sql_error(2, Type::Text, e))?;
 

--- a/anchor/common/ssv_types/src/sql_conversions.rs
+++ b/anchor/common/ssv_types/src/sql_conversions.rs
@@ -61,7 +61,10 @@ impl TryFrom<(&Row<'_>, Vec<ClusterMember>)> for Cluster {
         let owner_str = row.get::<_, String>("owner")?;
         let owner = Address::from_str(&owner_str).map_err(|e| from_sql_error(1, Type::Text, e))?;
 
-        let fee_recipient_str = row.get::<_, String>("fee_recipient")?;
+        let fee_recipient_str = match row.get::<_, Option<String>>("fee_recipient")? {
+            Some(s) => s,
+            None => owner_str.clone(), // Default to using owner as fee recipient if not set
+        };
         let fee_recipient =
             Address::from_str(&fee_recipient_str).map_err(|e| from_sql_error(2, Type::Text, e))?;
 

--- a/anchor/common/ssv_types/src/sql_conversions.rs
+++ b/anchor/common/ssv_types/src/sql_conversions.rs
@@ -57,6 +57,7 @@ impl TryFrom<(&Row<'_>, Vec<ClusterMember>)> for Cluster {
         (row, cluster_members): (&Row<'_>, Vec<ClusterMember>),
     ) -> Result<Self, Self::Error> {
         let cluster_id = ClusterId(row.get("cluster_id")?);
+        println!("{:?}", cluster_id);
 
         let owner_str = row.get::<_, String>("owner")?;
         let owner = Address::from_str(&owner_str).map_err(|e| from_sql_error(1, Type::Text, e))?;

--- a/anchor/database/src/cluster_operations.rs
+++ b/anchor/database/src/cluster_operations.rs
@@ -32,6 +32,12 @@ impl NetworkDatabase {
                 validator.graffiti.0.as_slice(),  // graffiti
             ])?;
 
+        // Insert a fee recipient address if one does not already exist
+        tx.execute(
+            "INSERT OR IGNORE INTO owners (owner, fee_recipient) VALUES (?, ?)",
+            params![cluster.owner.to_string(), cluster.owner.to_string()],
+        )?;
+
         // Record shares if one belongs to the current operator
         let mut our_share = None;
         let own_id = self.state.borrow().single_state.id;

--- a/anchor/database/src/cluster_operations.rs
+++ b/anchor/database/src/cluster_operations.rs
@@ -21,9 +21,8 @@ impl NetworkDatabase {
         // metadata
         tx.prepare_cached(SQL[&SqlStatement::InsertCluster])?
             .execute(params![
-                *cluster.cluster_id,               // cluster id
-                cluster.owner.to_string(),         // owner
-                cluster.fee_recipient.to_string(), // fee recipient
+                *cluster.cluster_id,       // cluster id
+                cluster.owner.to_string(), // owner
             ])?;
         tx.prepare_cached(SQL[&SqlStatement::InsertValidator])?
             .execute(params![
@@ -31,6 +30,11 @@ impl NetworkDatabase {
                 *cluster.cluster_id,              // cluster id
                 validator.index.as_deref(),       // validator index
                 validator.graffiti.0.as_slice(),  // graffiti
+            ])?;
+        tx.prepare_cached(SQL[&SqlStatement::InsertOrUpdateOwnerFeeRecipient])?
+            .execute(params![
+                cluster.owner.to_string(),         // owner
+                cluster.fee_recipient.to_string(), // fee recipient
             ])?;
 
         // Record shares if one belongs to the current operator

--- a/anchor/database/src/cluster_operations.rs
+++ b/anchor/database/src/cluster_operations.rs
@@ -31,11 +31,6 @@ impl NetworkDatabase {
                 validator.index.as_deref(),       // validator index
                 validator.graffiti.0.as_slice(),  // graffiti
             ])?;
-        tx.prepare_cached(SQL[&SqlStatement::InsertOrUpdateOwnerFeeRecipient])?
-            .execute(params![
-                cluster.owner.to_string(),         // owner
-                cluster.fee_recipient.to_string(), // fee recipient
-            ])?;
 
         // Record shares if one belongs to the current operator
         let mut our_share = None;

--- a/anchor/database/src/sql_operations.rs
+++ b/anchor/database/src/sql_operations.rs
@@ -61,7 +61,7 @@ pub(crate) static SQL: LazyLock<HashMap<SqlStatement, &'static str>> = LazyLock:
     // Cluster
     m.insert(
         SqlStatement::InsertCluster,
-        "INSERT OR IGNORE INTO clusters (cluster_id, owner, fee_recipient) VALUES (?1, ?2, ?3)",
+        "INSERT OR IGNORE INTO clusters (cluster_id, owner) VALUES (?1, ?2)",
     );
     m.insert(
         SqlStatement::InsertClusterMember,
@@ -76,9 +76,10 @@ pub(crate) static SQL: LazyLock<HashMap<SqlStatement, &'static str>> = LazyLock:
         "SELECT DISTINCT
             c.cluster_id,
             c.owner,
-            c.fee_recipient,
+            o.fee_recipient,
             c.liquidated
         FROM clusters c
+        LEFT JOIN owners o ON c.owner = o.owner
         JOIN cluster_members cm ON c.cluster_id = cm.cluster_id",
     );
     m.insert(
@@ -123,7 +124,7 @@ pub(crate) static SQL: LazyLock<HashMap<SqlStatement, &'static str>> = LazyLock:
 
     m.insert(
         SqlStatement::UpdateFeeRecipient,
-        "UPDATE clusters SET fee_recipient = ?1 WHERE owner = ?2",
+        "UPDATE owners SET fee_recipient = ?1 WHERE owner = ?2",
     );
     m.insert(
         SqlStatement::SetGraffiti,

--- a/anchor/database/src/sql_operations.rs
+++ b/anchor/database/src/sql_operations.rs
@@ -22,9 +22,11 @@ pub(crate) enum SqlStatement {
     InsertShare, // Insert a KeyShare into the database
     GetShares,   // Get the releveant keyshare for a validator
 
-    UpdateFeeRecipient, // Update the fee recipient address for a cluster
-    SetGraffiti,        // Update the Graffiti for a validator
-    SetIndex,           // Set the Index for a validator
+    InsertOrUpdateOwnerFeeRecipient, // Insert fee recipient or update it
+    GetOwnerFeeRecipient,            // Get the fee recipient for an owner
+    UpdateFeeRecipient,              // Update the fee recipient address for a cluster
+    SetGraffiti,                     // Update the Graffiti for a validator
+    SetIndex,                        // Set the Index for a validator
 
     UpdateBlockNumber, // Update the last block that the database has processed
     GetBlockNumber,    // Get the last block that the database has processed
@@ -109,6 +111,16 @@ pub(crate) static SQL: LazyLock<HashMap<SqlStatement, &'static str>> = LazyLock:
     );
 
     // Misc Datta
+    m.insert(
+        SqlStatement::InsertOrUpdateOwnerFeeRecipient,
+        "INSERT INTO owners (owner, fee_recipient) VALUES (?1, ?2)
+     ON CONFLICT (owner) DO UPDATE SET fee_recipient = ?2",
+    );
+    m.insert(
+        SqlStatement::GetOwnerFeeRecipient,
+        "SELECT fee_recipient FROM owners WHERE owner = ?1",
+    );
+
     m.insert(
         SqlStatement::UpdateFeeRecipient,
         "UPDATE clusters SET fee_recipient = ?1 WHERE owner = ?2",

--- a/anchor/database/src/sql_operations.rs
+++ b/anchor/database/src/sql_operations.rs
@@ -24,7 +24,6 @@ pub(crate) enum SqlStatement {
 
     InsertOrUpdateOwnerFeeRecipient, // Insert fee recipient or update it
     GetOwnerFeeRecipient,            // Get the fee recipient for an owner
-    UpdateFeeRecipient,              // Update the fee recipient address for a cluster
     SetGraffiti,                     // Update the Graffiti for a validator
     SetIndex,                        // Set the Index for a validator
 
@@ -122,10 +121,6 @@ pub(crate) static SQL: LazyLock<HashMap<SqlStatement, &'static str>> = LazyLock:
         "SELECT fee_recipient FROM owners WHERE owner = ?1",
     );
 
-    m.insert(
-        SqlStatement::UpdateFeeRecipient,
-        "UPDATE owners SET fee_recipient = ?1 WHERE owner = ?2",
-    );
     m.insert(
         SqlStatement::SetGraffiti,
         "UPDATE validators SET graffiti = ?1 WHERE validator_pubkey = ?2",

--- a/anchor/database/src/table_schema.sql
+++ b/anchor/database/src/table_schema.sql
@@ -3,6 +3,11 @@ CREATE TABLE block (
 );
 INSERT INTO block (block_number) VALUES (0);
 
+CREATE TABLE owners (
+    owner TEXT PRIMARY KEY,
+    fee_recipient TEXT NOT NULL
+);
+
 CREATE TABLE nonce (
     owner TEXT NOT NULL PRIMARY KEY,
     nonce INTEGER DEFAULT 0

--- a/anchor/database/src/table_schema.sql
+++ b/anchor/database/src/table_schema.sql
@@ -23,7 +23,6 @@ CREATE TABLE operators (
 CREATE TABLE clusters (
     cluster_id BLOB PRIMARY KEY,
     owner TEXT NOT NULL,
-    fee_recipient TEXT NOT NULL,
     liquidated BOOLEAN DEFAULT FALSE
 );
 

--- a/anchor/database/src/tests/cluster_tests.rs
+++ b/anchor/database/src/tests/cluster_tests.rs
@@ -108,7 +108,7 @@ mod cluster_database_tests {
 
         // Confirm that the fee recipient was inserted when the cluster was made
         let fee_recipient = fixture.db.fee_recipient_for_owner(&cluster.owner).unwrap();
-        assert_eq!(fee_recipient, cluster.fee_recipient);
+        assert_eq!(fee_recipient, Some(cluster.fee_recipient));
 
         // Update fee recipient
         let new_fee_recipient = Address::random();
@@ -124,6 +124,6 @@ mod cluster_database_tests {
 
         // Confirm that we have set the correct fee recipient for the owner
         let stored_fee_recipient = fixture.db.fee_recipient_for_owner(&cluster.owner).unwrap();
-        assert_eq!(new_fee_recipient, stored_fee_recipient);
+        assert_eq!(stored_fee_recipient, Some(new_fee_recipient));
     }
 }

--- a/anchor/database/src/tests/cluster_tests.rs
+++ b/anchor/database/src/tests/cluster_tests.rs
@@ -99,4 +99,36 @@ mod cluster_database_tests {
             .insert_validator(fixture.cluster, fixture.validator, fixture.shares)
             .expect_err("Expected failure when inserting cluster that already exists");
     }
+
+    #[test]
+    // Test that we can properly track the fee recipient for an owner
+    fn test_fetch_fee_recipient() {
+        let fixture = TestFixture::new();
+        let mut cluster = fixture.cluster;
+        let new_fee_recipient = Address::random();
+
+        // Update fee recipient
+        assert!(fixture
+            .db
+            .update_fee_recipient(cluster.owner, new_fee_recipient)
+            .is_ok());
+
+        // Confirm that fee recipient was updated
+        cluster.fee_recipient = new_fee_recipient;
+        assertions::cluster::exists_in_db(&fixture.db, &cluster);
+        assertions::cluster::exists_in_memory(&fixture.db, &cluster);
+
+        // Confirm that we have set the correct fee recipient for the owner
+        let stored_fee_recipient = fixture.db.fee_recipient_for_owner(&cluster.owner).unwrap();
+        assert_eq!(Some(new_fee_recipient), stored_fee_recipient);
+
+        // Set it again to confirm that we can update and fetch it
+        let new_fee_recipient = Address::random();
+        assert!(fixture
+            .db
+            .update_fee_recipient(cluster.owner, new_fee_recipient)
+            .is_ok());
+        let stored_fee_recipient = fixture.db.fee_recipient_for_owner(&cluster.owner).unwrap();
+        assert_eq!(Some(new_fee_recipient), stored_fee_recipient);
+    }
 }

--- a/anchor/database/src/tests/cluster_tests.rs
+++ b/anchor/database/src/tests/cluster_tests.rs
@@ -107,6 +107,10 @@ mod cluster_database_tests {
         let mut cluster = fixture.cluster;
         let new_fee_recipient = Address::random();
 
+        // Make sure the fee recipient is not initially set
+        let stored_fee_recipient = fixture.db.fee_recipient_for_owner(&cluster.owner).unwrap();
+        assert_eq!(None, stored_fee_recipient);
+
         // Update fee recipient
         assert!(fixture
             .db

--- a/anchor/database/src/tests/cluster_tests.rs
+++ b/anchor/database/src/tests/cluster_tests.rs
@@ -105,13 +105,13 @@ mod cluster_database_tests {
     fn test_fetch_fee_recipient() {
         let fixture = TestFixture::new();
         let mut cluster = fixture.cluster;
-        let new_fee_recipient = Address::random();
 
-        // Make sure the fee recipient is not initially set
-        let stored_fee_recipient = fixture.db.fee_recipient_for_owner(&cluster.owner).unwrap();
-        assert_eq!(None, stored_fee_recipient);
+        // Confirm that the fee recipient was inserted when the cluster was made
+        let fee_recipient = fixture.db.fee_recipient_for_owner(&cluster.owner).unwrap();
+        assert_eq!(fee_recipient, cluster.fee_recipient);
 
         // Update fee recipient
+        let new_fee_recipient = Address::random();
         assert!(fixture
             .db
             .update_fee_recipient(cluster.owner, new_fee_recipient)
@@ -124,15 +124,6 @@ mod cluster_database_tests {
 
         // Confirm that we have set the correct fee recipient for the owner
         let stored_fee_recipient = fixture.db.fee_recipient_for_owner(&cluster.owner).unwrap();
-        assert_eq!(Some(new_fee_recipient), stored_fee_recipient);
-
-        // Set it again to confirm that we can update and fetch it
-        let new_fee_recipient = Address::random();
-        assert!(fixture
-            .db
-            .update_fee_recipient(cluster.owner, new_fee_recipient)
-            .is_ok());
-        let stored_fee_recipient = fixture.db.fee_recipient_for_owner(&cluster.owner).unwrap();
-        assert_eq!(Some(new_fee_recipient), stored_fee_recipient);
+        assert_eq!(new_fee_recipient, stored_fee_recipient);
     }
 }

--- a/anchor/database/src/tests/utils.rs
+++ b/anchor/database/src/tests/utils.rs
@@ -220,8 +220,10 @@ pub mod queries {
     // Single selection query statements
     const GET_OPERATOR: &str =
         "SELECT operator_id, public_key, owner_address FROM operators WHERE operator_id = ?1";
-    const GET_CLUSTER: &str =
-        "SELECT cluster_id, owner, fee_recipient, liquidated FROM clusters WHERE cluster_id = ?1";
+    const GET_CLUSTER: &str = "SELECT c.cluster_id, c.owner, o.fee_recipient, c.liquidated
+                 FROM clusters c
+                 LEFT JOIN owners o ON c.owner = o.owner
+                 WHERE c.cluster_id = ?1";
     const GET_SHARES: &str = "SELECT share_pubkey, encrypted_key, cluster_id, operator_id FROM shares WHERE validator_pubkey = ?1";
     const GET_VALIDATOR: &str = "SELECT validator_pubkey, cluster_id, validator_index,  graffiti FROM validators WHERE validator_pubkey = ?1";
     const GET_MEMBERS: &str = "SELECT operator_id FROM cluster_members WHERE cluster_id = ?1";

--- a/anchor/database/src/validator_operations.rs
+++ b/anchor/database/src/validator_operations.rs
@@ -25,10 +25,6 @@ impl NetworkDatabase {
                 owner.to_string()          // Owner of the cluster
             ])?;
 
-        // Also update the owner's default fee recipient for future clusters
-        conn.prepare_cached(SQL[&SqlStatement::InsertOrUpdateOwnerFeeRecipient])?
-            .execute(params![owner.to_string(), fee_recipient.to_string()])?;
-
         self.modify_state(|state| {
             if let Some(clusters) = state.multi_state.clusters.get_all_by(&owner) {
                 for mut cluster in clusters {

--- a/anchor/database/src/validator_operations.rs
+++ b/anchor/database/src/validator_operations.rs
@@ -41,13 +41,14 @@ impl NetworkDatabase {
     }
 
     /// Get the fee recipient for an owner
-    /// If the owner doesn't have an entry yet, create one with the owner address as the fee
-    /// recipient
-    pub fn fee_recipient_for_owner(&self, owner: &Address) -> Result<Address, DatabaseError> {
+    /// Returns Some(address) if found, None otherwise
+    pub fn fee_recipient_for_owner(
+        &self,
+        owner: &Address,
+    ) -> Result<Option<Address>, DatabaseError> {
         let conn = self.connection()?;
-
-        // Check if we have already saved a fee recipient for this owner
         let mut stmt = conn.prepare_cached(SQL[&SqlStatement::GetOwnerFeeRecipient])?;
+
         let result = stmt.query_row(params![owner.to_string()], |row| {
             let address_str: String = row.get(0)?;
             let address = Address::from_str(&address_str).map_err(|e| {
@@ -61,15 +62,8 @@ impl NetworkDatabase {
         });
 
         match result {
-            Ok(address) => Ok(address),
-            Err(rusqlite::Error::QueryReturnedNoRows) => {
-                // We do not have a fee recipient for this owner yet, insert it in
-                conn.prepare_cached(SQL[&SqlStatement::InsertOrUpdateOwnerFeeRecipient])?
-                    .execute(params![owner.to_string(), owner.to_string()])?;
-
-                // Return the owner address as the fee recipient
-                Ok(*owner)
-            }
+            Ok(address) => Ok(Some(address)),
+            Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
             Err(e) => Err(DatabaseError::from(e)),
         }
     }

--- a/anchor/database/src/validator_operations.rs
+++ b/anchor/database/src/validator_operations.rs
@@ -19,10 +19,10 @@ impl NetworkDatabase {
     ) -> Result<(), DatabaseError> {
         // Update the database
         let conn = self.connection()?;
-        conn.prepare_cached(SQL[&SqlStatement::UpdateFeeRecipient])?
+        conn.prepare_cached(SQL[&SqlStatement::InsertOrUpdateOwnerFeeRecipient])?
             .execute(params![
-                fee_recipient.to_string(), // New fee recipient address for entire cluster
-                owner.to_string()          // Owner of the cluster
+                owner.to_string(),         // Owner of the cluster
+                fee_recipient.to_string()  // New fee recipient address for entire cluster
             ])?;
 
         self.modify_state(|state| {
@@ -40,15 +40,14 @@ impl NetworkDatabase {
         Ok(())
     }
 
-    // Get the fee recipient for an owner. This is only set if we have previously recieved a
-    // recipient update event for this owner
-    pub fn fee_recipient_for_owner(
-        &self,
-        owner: &Address,
-    ) -> Result<Option<Address>, DatabaseError> {
+    /// Get the fee recipient for an owner
+    /// If the owner doesn't have an entry yet, create one with the owner address as the fee
+    /// recipient
+    pub fn fee_recipient_for_owner(&self, owner: &Address) -> Result<Address, DatabaseError> {
         let conn = self.connection()?;
-        let mut stmt = conn.prepare_cached(SQL[&SqlStatement::GetOwnerFeeRecipient])?;
 
+        // Check if we have already saved a fee recipient for this owner
+        let mut stmt = conn.prepare_cached(SQL[&SqlStatement::GetOwnerFeeRecipient])?;
         let result = stmt.query_row(params![owner.to_string()], |row| {
             let address_str: String = row.get(0)?;
             let address = Address::from_str(&address_str).map_err(|e| {
@@ -62,8 +61,15 @@ impl NetworkDatabase {
         });
 
         match result {
-            Ok(address) => Ok(Some(address)),
-            Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+            Ok(address) => Ok(address),
+            Err(rusqlite::Error::QueryReturnedNoRows) => {
+                // We do not have a fee recipient for this owner yet, insert it in
+                conn.prepare_cached(SQL[&SqlStatement::InsertOrUpdateOwnerFeeRecipient])?
+                    .execute(params![owner.to_string(), owner.to_string()])?;
+
+                // Return the owner address as the fee recipient
+                Ok(*owner)
+            }
             Err(e) => Err(DatabaseError::from(e)),
         }
     }

--- a/anchor/database/src/validator_operations.rs
+++ b/anchor/database/src/validator_operations.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::{collections::HashMap, str::FromStr};
 
 use rusqlite::params;
 use ssv_types::ValidatorIndex;
@@ -25,6 +25,10 @@ impl NetworkDatabase {
                 owner.to_string()          // Owner of the cluster
             ])?;
 
+        // Also update the owner's default fee recipient for future clusters
+        conn.prepare_cached(SQL[&SqlStatement::InsertOrUpdateOwnerFeeRecipient])?
+            .execute(params![owner.to_string(), fee_recipient.to_string()])?;
+
         self.modify_state(|state| {
             if let Some(clusters) = state.multi_state.clusters.get_all_by(&owner) {
                 for mut cluster in clusters {
@@ -38,6 +42,34 @@ impl NetworkDatabase {
             }
         });
         Ok(())
+    }
+
+    // Get the fee recipient for an owner. This is only set if we have previously recieved a
+    // recipient update event for this owner
+    pub fn fee_recipient_for_owner(
+        &self,
+        owner: &Address,
+    ) -> Result<Option<Address>, DatabaseError> {
+        let conn = self.connection()?;
+        let mut stmt = conn.prepare_cached(SQL[&SqlStatement::GetOwnerFeeRecipient])?;
+
+        let result = stmt.query_row(params![owner.to_string()], |row| {
+            let address_str: String = row.get(0)?;
+            let address = Address::from_str(&address_str).map_err(|e| {
+                rusqlite::Error::FromSqlConversionFailure(
+                    0,
+                    rusqlite::types::Type::Text,
+                    Box::new(e),
+                )
+            })?;
+            Ok(address)
+        });
+
+        match result {
+            Ok(address) => Ok(Some(address)),
+            Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+            Err(e) => Err(DatabaseError::from(e)),
+        }
     }
 
     /// Update the Graffiti for a Validator

--- a/anchor/eth/src/event_processor.rs
+++ b/anchor/eth/src/event_processor.rs
@@ -309,12 +309,11 @@ impl EventProcessor {
                 ExecutionError::Database(format!("Failed to fetch validator metadata: {e}"))
             })?;
 
-        // Get the fee recpient for the owner. Will either return the current value if it exists, or
-        // insert itself as the fee recipient
-        let fee_recipient = self.db.fee_recipient_for_owner(&owner).map_err(|e| {
-            debug!(owner = ?owner, "Failed to get fee recipient for owner");
-            ExecutionError::Database(format!("Failed to get fee recipient for owner: {e}"))
-        })?;
+        // Get the fee recipient if one has been stored, otherwise default to the owner address
+        let fee_recipient = match self.db.fee_recipient_for_owner(&owner) {
+            Ok(Some(address)) => address,
+            _ => owner,
+        };
 
         // Finally, construct and insert the full cluster and insert into the database
         let cluster = Cluster {

--- a/anchor/eth/src/event_processor.rs
+++ b/anchor/eth/src/event_processor.rs
@@ -309,12 +309,12 @@ impl EventProcessor {
                 ExecutionError::Database(format!("Failed to fetch validator metadata: {e}"))
             })?;
 
-        // Check if this owner has previously updated their fee recipient address. If so, use that
-        // instead
-        let fee_recipient = match self.db.fee_recipient_for_owner(&owner) {
-            Ok(Some(address)) => address,
-            _ => owner,
-        };
+        // Get the fee recpient for the owner. Will either return the current value if it exists, or
+        // insert itself as the fee recipient
+        let fee_recipient = self.db.fee_recipient_for_owner(&owner).map_err(|e| {
+            debug!(owner = ?owner, "Failed to get fee recipient for owner");
+            ExecutionError::Database(format!("Failed to get fee recipient for owner: {e}"))
+        })?;
 
         // Finally, construct and insert the full cluster and insert into the database
         let cluster = Cluster {

--- a/anchor/eth/src/event_processor.rs
+++ b/anchor/eth/src/event_processor.rs
@@ -309,11 +309,18 @@ impl EventProcessor {
                 ExecutionError::Database(format!("Failed to fetch validator metadata: {e}"))
             })?;
 
+        // Check if this owner has previously updated their fee recipient address. If so, use that
+        // instead
+        let fee_recipient = match self.db.fee_recipient_for_owner(&owner) {
+            Ok(Some(address)) => address,
+            _ => owner,
+        };
+
         // Finally, construct and insert the full cluster and insert into the database
         let cluster = Cluster {
             cluster_id,
             owner,
-            fee_recipient: owner,
+            fee_recipient,
             liquidated: false,
             cluster_members: IndexSet::from_iter(operator_ids),
         };


### PR DESCRIPTION
## Issue Addressed

#289

## Proposed Changes

Makes it so that when a fee recipient address is updated, we store that mapping and reflect it in all current and future clusters.
