### PR TITLE
add `--enable-high-validator-count-metrics`

### DIFF
--- a/anchor/client/src/cli.rs
+++ b/anchor/client/src/cli.rs
@@ -318,6 +318,16 @@ pub struct Node {
     )]
     pub metrics_port: Option<u16>,
 
+    #[clap(
+        long,
+        help = "Enable per validator metrics for > 64 validators. \
+                Note: This flag is automatically enabled for <= 64 validators. \
+                Enabling this metric for higher validator counts will lead to higher volume \
+                of prometheus metrics being collected.",
+        display_order = 0,
+        help_heading = FLAG_HEADER
+    )]
+    pub enable_high_validator_count_metrics: bool,
     // TODO: Metrics CORS Origin
     // https://github.com/sigp/anchor/issues/249
     #[clap(

--- a/anchor/client/src/config.rs
+++ b/anchor/client/src/config.rs
@@ -49,6 +49,8 @@ pub struct Config {
     pub network: network::Config,
     /// Configuration for the HTTP REST API.
     pub http_metrics: http_metrics::Config,
+    /// Should we gather per validator metrics for > 64 validators.
+    pub enable_high_validator_count_metrics: bool,
     /// A list of custom certificates that the validator client will additionally use when
     /// connecting to a beacon node over SSL/TLS.
     pub beacon_nodes_tls_certs: Option<Vec<PathBuf>>,
@@ -112,6 +114,7 @@ impl Config {
             use_long_timeouts: false,
             http_api: <_>::default(),
             http_metrics: <_>::default(),
+            enable_high_validator_count_metrics: false,
             network: <_>::default(),
             beacon_nodes_tls_certs: None,
             execution_nodes_tls_certs: None,
@@ -256,6 +259,8 @@ pub fn from_cli(cli_args: &Node) -> Result<Config, String> {
     if let Some(port) = cli_args.metrics_port {
         config.http_metrics.listen_port = port;
     }
+
+    config.enable_high_validator_count_metrics = cli_args.enable_high_validator_count_metrics;
 
     // debugging stuff
     config.impostor = cli_args.impostor.map(OperatorId);

--- a/anchor/client/src/lib.rs
+++ b/anchor/client/src/lib.rs
@@ -485,7 +485,7 @@ impl Client {
                 .validator_store(validator_store.clone())
                 .spec(spec.clone())
                 .executor(executor.clone())
-                //.enable_high_validator_count_metrics(config.enable_high_validator_count_metrics)
+                .enable_high_validator_count_metrics(config.enable_high_validator_count_metrics)
                 .distributed(true)
                 .build()?,
         );
@@ -502,8 +502,6 @@ impl Client {
             .beacon_nodes(beacon_nodes.clone())
             .executor(executor.clone())
             .chain_spec(spec.clone());
-        //.graffiti(config.graffiti)
-        //.graffiti_file(config.graffiti_file.clone());
 
         // If we have proposer nodes, add them to the block service builder.
         if proposer_nodes.num_total().await > 0 {
@@ -703,7 +701,7 @@ async fn wait_for_genesis(
         tokio::select! {
             result = poll_whilst_waiting_for_genesis(beacon_nodes, genesis_time) => result?,
             () = sleep(genesis_time - now) => ()
-        };
+        }
 
         info!(
             ms_since_genesis = (genesis_time - now).as_millis(),


### PR DESCRIPTION
add CLI flag to specify if we should enable per validator metrics if we have a high validator count
