### PR TITLE
Fix new clippy lints in Rust 1.87

### DIFF
--- a/anchor/client/src/config.rs
+++ b/anchor/client/src/config.rs
@@ -158,8 +158,8 @@ pub fn from_cli(cli_args: &Node) -> Result<Config, String> {
         parse_urls(&mut config.execution_nodes, execution_rpc, "execution RPC")?;
     }
     if let Some(ref execution_ws) = cli_args.execution_ws {
-        let ws = SensitiveUrl::parse(execution_ws)
-            .map_err(|e| format!("Unable to parse  URL: {:?}", e))?;
+        let ws =
+            SensitiveUrl::parse(execution_ws).map_err(|e| format!("Unable to parse URL: {e:?}"))?;
         config.execution_nodes_websocket = ws;
     }
 
@@ -180,7 +180,7 @@ pub fn from_cli(cli_args: &Node) -> Result<Config, String> {
                 // parsing as ENR failed, try as Multiaddr
                 let multi: Multiaddr = addr
                     .parse()
-                    .map_err(|_| format!("Not valid as ENR nor Multiaddr: {}", addr))?;
+                    .map_err(|_| format!("Not valid as ENR nor Multiaddr: {addr}"))?;
                 if !multi.iter().any(|proto| matches!(proto, Protocol::Udp(_))) {
                     error!(addr = multi.to_string(), "Missing UDP in Multiaddr");
                 }
@@ -292,7 +292,7 @@ fn parse_urls(dest: &mut Vec<SensitiveUrl>, src: &[String], kind: &str) -> Resul
         .iter()
         .map(|s| SensitiveUrl::parse(s))
         .collect::<Result<_, _>>()
-        .map_err(|e| format!("Unable to parse {kind} URL: {:?}", e))?;
+        .map_err(|e| format!("Unable to parse {kind} URL: {e:?}"))?;
     Ok(())
 }
 

--- a/anchor/client/src/lib.rs
+++ b/anchor/client/src/lib.rs
@@ -90,7 +90,7 @@ impl Client {
         // `linux` - raise soft fd limit to hard
         // `macos` - raise soft fd limit to `min(kernel limit, hard fd limit)`
         // `windows` & rest - noop
-        match fdlimit::raise_fd_limit().map_err(|e| format!("Unable to raise fd limit: {}", e))? {
+        match fdlimit::raise_fd_limit().map_err(|e| format!("Unable to raise fd limit: {e}"))? {
             fdlimit::Outcome::LimitRaised { from, to } => {
                 debug!(
                     old_limit = from,
@@ -144,7 +144,7 @@ impl Client {
             );
             let listener = TcpListener::bind(socket)
                 .await
-                .map_err(|e| format!("Unable to bind to metrics server port: {}", e))?;
+                .map_err(|e| format!("Unable to bind to metrics server port: {e}"))?;
 
             let metrics_future = http_metrics::serve(listener, shared_state.clone(), exit);
 
@@ -194,10 +194,7 @@ impl Client {
         let slashing_db_path = config.data_dir.join(SLASHING_PROTECTION_FILENAME);
         let slashing_protection =
             SlashingDatabase::open_or_create(&slashing_db_path).map_err(|e| {
-                format!(
-                    "Failed to open or create slashing protection database: {:?}",
-                    e
-                )
+                format!("Failed to open or create slashing protection database: {e:?}",)
             })?;
 
         let last_beacon_node_index = config
@@ -225,7 +222,7 @@ impl Client {
                 // Set default timeout to be the full slot duration.
                 .timeout(slot_duration)
                 .build()
-                .map_err(|e| format!("Unable to build HTTP client: {:?}", e))?;
+                .map_err(|e| format!("Unable to build HTTP client: {e:?}"))?;
 
             // Use quicker timeouts if a fallback beacon node exists.
             let timeouts = if i < last_beacon_node_index && !config.use_long_timeouts {
@@ -569,28 +566,28 @@ impl Client {
 
         block_service
             .start_update_service(block_service_rx)
-            .map_err(|e| format!("Unable to start block service: {}", e))?;
+            .map_err(|e| format!("Unable to start block service: {e}"))?;
 
         attestation_service
             .start_update_service(&spec)
-            .map_err(|e| format!("Unable to start attestation service: {}", e))?;
+            .map_err(|e| format!("Unable to start attestation service: {e}"))?;
 
         sync_committee_service
             .start_update_service(&spec)
-            .map_err(|e| format!("Unable to start sync committee service: {}", e))?;
+            .map_err(|e| format!("Unable to start sync committee service: {e}"))?;
 
         metadata_service
             .start_update_service()
-            .map_err(|e| format!("Unable to start metadata service: {}", e))?;
+            .map_err(|e| format!("Unable to start metadata service: {e}"))?;
 
         preparation_service
             .start_update_service(&spec)
-            .map_err(|e| format!("Unable to start preparation service: {}", e))?;
+            .map_err(|e| format!("Unable to start preparation service: {e}"))?;
 
         http_api_shared_state.write().database_state = Some(database.watch());
         // TODO: reuse this from lighthouse
         // https://github.com/sigp/anchor/issues/251
-        // spawn_notifier(self).map_err(|e| format!("Failed to start notifier: {}", e))?;
+        // spawn_notifier(self).map_err(|e| format!("Failed to start notifier: {e}"))?;
 
         // TODO: reuse this from lighthouse
         // https://github.com/sigp/anchor/issues/250
@@ -697,7 +694,7 @@ async fn wait_for_genesis(
 ) -> Result<(), String> {
     let now = SystemTime::now()
         .duration_since(UNIX_EPOCH)
-        .map_err(|e| format!("Unable to read system time: {:?}", e))?;
+        .map_err(|e| format!("Unable to read system time: {e:?}"))?;
     let genesis_time = Duration::from_secs(genesis_time);
 
     // If the time now is less than (prior to) genesis, then delay until the
@@ -746,7 +743,7 @@ async fn poll_whilst_waiting_for_genesis(
             Ok(is_staking) => {
                 let now = SystemTime::now()
                     .duration_since(UNIX_EPOCH)
-                    .map_err(|e| format!("Unable to read system time: {:?}", e))?;
+                    .map_err(|e| format!("Unable to read system time: {e:?}"))?;
 
                 if !is_staking {
                     error!(
@@ -808,10 +805,10 @@ async fn wait_for_operator_id_and_sync(
 pub fn load_pem_certificate<P: AsRef<Path>>(pem_path: P) -> Result<Certificate, String> {
     let mut buf = Vec::new();
     File::open(&pem_path)
-        .map_err(|e| format!("Unable to open certificate path: {}", e))?
+        .map_err(|e| format!("Unable to open certificate path: {e}"))?
         .read_to_end(&mut buf)
-        .map_err(|e| format!("Unable to read certificate file: {}", e))?;
-    Certificate::from_pem(&buf).map_err(|e| format!("Unable to parse certificate: {}", e))
+        .map_err(|e| format!("Unable to read certificate file: {e}"))?;
+    Certificate::from_pem(&buf).map_err(|e| format!("Unable to parse certificate: {e}"))
 }
 
 fn read_or_generate_private_key(

--- a/anchor/common/bls_lagrange/src/blst.rs
+++ b/anchor/common/bls_lagrange/src/blst.rs
@@ -1,9 +1,5 @@
 // from https://github.com/herumi/mcl/blob/3462cf0983bffb703a6e9f4623e47a26ec6e7fe5/include/mcl/lagrange.hpp
-use std::{
-    iter::{once, repeat_with},
-    mem,
-    num::NonZeroU64,
-};
+use std::{iter::{once, repeat_with}, mem, num::NonZeroU64, ptr};
 
 use bls::Signature;
 use blst::{min_pk::SecretKey, *};
@@ -161,7 +157,7 @@ pub fn combine_signatures(signatures: &[Signature], ids: &[KeyId]) -> Result<Sig
             // ids. So we start by putting id_i into the denominator to compensate for that.
             let mut denominator = id_i.scalar.clone();
             for id_j in ids.iter() {
-                if id_i as *const KeyId != id_j as *const KeyId {
+                if !ptr::eq(id_i, id_j) {
                     // If we end up having zero here, the user specified the same key more than once
                     if !blst_sk_sub_n_check(&mut intermediate, &id_j.scalar, &id_i.scalar) {
                         return Err(Error::RepeatedId);

--- a/anchor/common/bls_lagrange/src/blst.rs
+++ b/anchor/common/bls_lagrange/src/blst.rs
@@ -1,5 +1,10 @@
 // from https://github.com/herumi/mcl/blob/3462cf0983bffb703a6e9f4623e47a26ec6e7fe5/include/mcl/lagrange.hpp
-use std::{iter::{once, repeat_with}, mem, num::NonZeroU64, ptr};
+use std::{
+    iter::{once, repeat_with},
+    mem,
+    num::NonZeroU64,
+    ptr,
+};
 
 use bls::Signature;
 use blst::{min_pk::SecretKey, *};

--- a/anchor/common/ssv_network_config/src/lib.rs
+++ b/anchor/common/ssv_network_config/src/lib.rs
@@ -64,7 +64,7 @@ impl SsvNetworkConfig {
                 .map_err(|_| "Unable to parse built-in block!")?,
             ssv_domain_type: domain_type
                 .parse()
-                .map_err(|e| format!("Unable to parse built-in domain type: {}", e))?,
+                .map_err(|e| format!("Unable to parse built-in domain type: {e}"))?,
         }))
     }
 

--- a/anchor/common/ssv_types/src/domain_type.rs
+++ b/anchor/common/ssv_types/src/domain_type.rs
@@ -7,7 +7,7 @@ impl FromStr for DomainType {
     type Err = String;
 
     fn from_str(hex_str: &str) -> Result<Self, Self::Err> {
-        let bytes = hex::decode(hex_str).map_err(|e| format!("Invalid domain type hex: {}", e))?;
+        let bytes = hex::decode(hex_str).map_err(|e| format!("Invalid domain type hex: {e}"))?;
         if bytes.len() != 4 {
             return Err("Domain type must be 4 bytes".into());
         }

--- a/anchor/common/ssv_types/src/message.rs
+++ b/anchor/common/ssv_types/src/message.rs
@@ -662,7 +662,7 @@ mod tests {
 
         match result {
             Err(SSVMessageError::EmptyData) => (), // success
-            other => panic!("Expected EmptyData, got {:?}", other),
+            other => panic!("Expected EmptyData, got {other:?}"),
         }
     }
 
@@ -678,7 +678,7 @@ mod tests {
                 assert_eq!(got, MAX_ENCODED_CONSENSUS_MSG_SIZE + 1);
                 assert_eq!(max, MAX_ENCODED_CONSENSUS_MSG_SIZE);
             }
-            other => panic!("Expected SSVDataTooBig, got {:?}", other),
+            other => panic!("Expected SSVDataTooBig, got {other:?}"),
         }
     }
 
@@ -698,7 +698,7 @@ mod tests {
                 assert_eq!(got, MAX_ENCODED_PARTIAL_SIGNATURE_SIZE + 1);
                 assert_eq!(max, MAX_ENCODED_PARTIAL_SIGNATURE_SIZE);
             }
-            other => panic!("Expected SSVDataTooBig, got {:?}", other),
+            other => panic!("Expected SSVDataTooBig, got {other:?}"),
         }
     }
 
@@ -767,7 +767,7 @@ mod tests {
                 assert_eq!(provided, MAX_SIGNATURES + 1);
                 assert_eq!(max, MAX_SIGNATURES);
             }
-            other => panic!("Expected TooManySignatures, got {:?}", other),
+            other => panic!("Expected TooManySignatures, got {other:?}"),
         }
     }
 
@@ -793,7 +793,7 @@ mod tests {
                 assert_eq!(length, 255);
                 assert_eq!(sig_length, RSA_SIGNATURE_SIZE);
             }
-            other => panic!("Expected WrongRSASignatureSize, got {:?}", other),
+            other => panic!("Expected WrongRSASignatureSize, got {other:?}"),
         }
     }
 
@@ -811,7 +811,7 @@ mod tests {
                 assert_eq!(provided, MAX_SIGNATURES + 1);
                 assert_eq!(max, MAX_SIGNATURES);
             }
-            other => panic!("Expected TooManyOperatorIDs, got {:?}", other),
+            other => panic!("Expected TooManyOperatorIDs, got {other:?}"),
         }
     }
 
@@ -830,7 +830,7 @@ mod tests {
 
         match result {
             Ok(_) => (),
-            other => panic!("Expected Ok(_), got {:?}", other),
+            other => panic!("Expected Ok(_), got {other:?}"),
         }
     }
 
@@ -849,7 +849,7 @@ mod tests {
                 assert_eq!(length, MAX_FULL_DATA_SIZE + 1);
                 assert_eq!(max, MAX_FULL_DATA_SIZE);
             }
-            other => panic!("Expected FullDataTooLong, got {:?}", other),
+            other => panic!("Expected FullDataTooLong, got {other:?}"),
         }
     }
 
@@ -864,7 +864,7 @@ mod tests {
 
         match signed_msg {
             Ok(msg) => assert_eq!(msg.full_data(), &full_data),
-            other => panic!("Expected SignedSSVMessage, got {:?}", other),
+            other => panic!("Expected SignedSSVMessage, got {other:?}"),
         }
     }
 
@@ -879,7 +879,7 @@ mod tests {
 
         match result {
             Err(NoSigners) => (),
-            other => panic!("Expected NoSigners, got {:?}", other),
+            other => panic!("Expected NoSigners, got {other:?}"),
         }
     }
 
@@ -894,7 +894,7 @@ mod tests {
 
         match result {
             Err(NoSignatures) => (),
-            other => panic!("Expected NoSignatures, got {:?}", other),
+            other => panic!("Expected NoSignatures, got {other:?}"),
         }
     }
 
@@ -910,7 +910,7 @@ mod tests {
 
         match result {
             Err(SignersNotSorted) => (),
-            other => panic!("Expected SignersNotSorted, got {:?}", other),
+            other => panic!("Expected SignersNotSorted, got {other:?}"),
         }
     }
 
@@ -925,7 +925,7 @@ mod tests {
 
         match result {
             Err(ZeroSigner) => (),
-            other => panic!("Expected ZeroSigner, got {:?}", other),
+            other => panic!("Expected ZeroSigner, got {other:?}"),
         }
     }
 
@@ -941,7 +941,7 @@ mod tests {
 
         match result {
             Err(DuplicatedSigner) => (),
-            other => panic!("Expected DuplicatedSigner, got {:?}", other),
+            other => panic!("Expected DuplicatedSigner, got {other:?}"),
         }
     }
 
@@ -956,10 +956,7 @@ mod tests {
 
         match result {
             Err(SignersAndSignaturesWithDifferentLength) => (),
-            other => panic!(
-                "Expected SignersAndSignaturesWithDifferentLength, got {:?}",
-                other
-            ),
+            other => panic!("Expected SignersAndSignaturesWithDifferentLength, got {other:?}"),
         }
     }
 
@@ -1011,7 +1008,7 @@ mod tests {
 
         match result {
             Err(SignedSSVMessageError::SSVMessagError(SSVMessageError::EmptyData)) => (),
-            other => panic!("Expected SSVMessagError(EmptyData), got {:?}", other),
+            other => panic!("Expected SSVMessagError(EmptyData), got {other:?}"),
         }
     }
 

--- a/anchor/common/ssv_types/src/util.rs
+++ b/anchor/common/ssv_types/src/util.rs
@@ -6,11 +6,11 @@ pub fn parse_rsa(pem_data: &str) -> Result<Rsa<Public>, String> {
     // First decode the base64 data
     let pem_decoded = BASE64_STANDARD
         .decode(pem_data)
-        .map_err(|e| format!("Unable to decode base64 pem data: {}", e))?;
+        .map_err(|e| format!("Unable to decode base64 pem data: {e}"))?;
 
     // Convert the decoded data to a string
     let mut pem_string = String::from_utf8(pem_decoded)
-        .map_err(|e| format!("Unable to convert decoded pem data into a string: {}", e))?;
+        .map_err(|e| format!("Unable to convert decoded pem data into a string: {e}"))?;
 
     // Fix the header - replace PKCS1 header with PKCS8 header
     pem_string = pem_string
@@ -22,7 +22,7 @@ pub fn parse_rsa(pem_data: &str) -> Result<Rsa<Public>, String> {
 
     // Parse the PEM string into an RSA public key using PKCS8 format
     let rsa_pubkey = Rsa::public_key_from_pem(pem_string.as_bytes())
-        .map_err(|e| format!("Failed to parse RSA public key: {}", e))?;
+        .map_err(|e| format!("Failed to parse RSA public key: {e}"))?;
 
     Ok(rsa_pubkey)
 }

--- a/anchor/common/version/src/lib.rs
+++ b/anchor/common/version/src/lib.rs
@@ -61,8 +61,7 @@ mod test {
             .unwrap();
         assert!(
             re.is_match(VERSION),
-            "version doesn't match regex: {}",
-            VERSION
+            "version doesn't match regex: {VERSION}",
         );
     }
 }

--- a/anchor/database/src/error.rs
+++ b/anchor/database/src/error.rs
@@ -29,12 +29,12 @@ impl From<SQLError> for DatabaseError {
 impl From<r2d2::Error> for DatabaseError {
     fn from(error: r2d2::Error) -> Self {
         // Use `Display` impl to print "timed out waiting for connection"
-        DatabaseError::SQLPoolError(format!("{}", error))
+        DatabaseError::SQLPoolError(format!("{error}"))
     }
 }
 
 impl Display for DatabaseError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{:?}", self)
+        write!(f, "{self:?}")
     }
 }

--- a/anchor/eth/src/error.rs
+++ b/anchor/eth/src/error.rs
@@ -15,6 +15,6 @@ pub enum ExecutionError {
 
 impl Display for ExecutionError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{:?}", self)
+        write!(f, "{self:?}")
     }
 }

--- a/anchor/eth/src/event_processor.rs
+++ b/anchor/eth/src/event_processor.rs
@@ -142,8 +142,7 @@ impl EventProcessor {
         // Confirm that this operator does not already exist
         if self.db.state().operator_exists(&operator_id) {
             return Err(ExecutionError::Duplicate(format!(
-                "Operator with id {:?} already exists in database",
-                operator_id
+                "Operator with id {operator_id:?} already exists in database"
             )));
         }
 

--- a/anchor/eth/src/sync.rs
+++ b/anchor/eth/src/sync.rs
@@ -218,7 +218,7 @@ impl SsvEventSyncer {
             // These cases should be unreachable due to type constraints, but we handle them
             // explicitly
             Ok(None) => panic!("Network configuration unexpectedly empty"),
-            Err(e) => panic!("Invalid network configuration: {}", e),
+            Err(e) => panic!("Invalid network configuration: {e}"),
         };
 
         // This does not perform a live sync, so we just want to mock websocket fields. This helps

--- a/anchor/eth/src/util.rs
+++ b/anchor/eth/src/util.rs
@@ -58,7 +58,7 @@ pub fn parse_shares(
 
             // Create public key
             let share_pubkey = PublicKeyBytes::from_str(&public_key_hex)
-                .map_err(|e| format!("Failed to create public key: {}", e))?;
+                .map_err(|e| format!("Failed to create public key: {e}"))?;
 
             // Convert encrypted key into fixed array
             let encrypted_array: [u8; 256] = encrypted
@@ -114,7 +114,7 @@ pub fn verify_signature(
     public_key: &PublicKeyBytes,
 ) -> bool {
     // Hash the owner and nonce concatinated
-    let data = format!("{}:{}", owner, nonce);
+    let data = format!("{owner}:{nonce}");
     let hash = keccak256(data);
 
     // Deserialize the signature
@@ -143,8 +143,7 @@ pub fn validate_operators(
     // make sure there is a valid number of operators
     if num_operators > MAX_OPERATORS {
         return Err(ExecutionError::InvalidEvent(format!(
-            "Failed to validate operators: validator has too many operators: {}",
-            num_operators
+            "Failed to validate operators: validator has too many operators: {num_operators}"
         )));
     }
     if num_operators == 0 {
@@ -157,8 +156,7 @@ pub fn validate_operators(
     let threshold = (num_operators - 1) / 3;
     if (num_operators - 1) % 3 != 0 || !(1..=4).contains(&threshold) {
         return Err(ExecutionError::InvalidEvent(format!(
-            "Given {} operators. Cannot build a 3f+1 quorum",
-            num_operators
+            "Given {num_operators} operators. Cannot build a 3f+1 quorum"
         )));
     }
 

--- a/anchor/http_api/src/lib.rs
+++ b/anchor/http_api/src/lib.rs
@@ -49,5 +49,5 @@ pub async fn run(config: Config, shared_state: Arc<RwLock<Shared>>) -> Result<()
     // Start the http api server
     axum::serve(listener, router)
         .await
-        .map_err(|e| format!("{}", e))
+        .map_err(|e| format!("{e}"))
 }

--- a/anchor/http_api/src/router.rs
+++ b/anchor/http_api/src/router.rs
@@ -78,7 +78,7 @@ async fn get_committees(
                 state
                     .get_committee_info_by_committee_id(committee_id)
                     .map(|info| CommitteeData {
-                        committee_id: format!("{:?}", committee_id),
+                        committee_id: format!("{committee_id:?}"),
                         committee_members: info
                             .committee_members
                             .iter()

--- a/anchor/http_metrics/src/lib.rs
+++ b/anchor/http_metrics/src/lib.rs
@@ -123,7 +123,7 @@ async fn metrics_handler<E: EthSpec>(
         Ok(v) => v.into_response(),
         Err(e) => (
             StatusCode::INTERNAL_SERVER_ERROR,
-            format!("Failed to encode promethus data: {}", e),
+            format!("Failed to encode promethus data: {e}"),
         )
             .into_response(),
     }

--- a/anchor/keysplit/src/cli.rs
+++ b/anchor/keysplit/src/cli.rs
@@ -124,14 +124,13 @@ impl FromStr for OperatorIds {
             .filter(|s| !s.is_empty())
             .map(|num| num.parse::<u64>())
             .collect::<Result<Vec<u64>, _>>()
-            .map_err(|e| format!("Failed to parse number: {}", e))?;
+            .map_err(|e| format!("Failed to parse number: {e}"))?;
 
         // Now validate the length matches our requirements
         match numbers.len() {
             4 | 7 | 10 | 13 => Ok(OperatorIds(numbers)),
             len => Err(format!(
-                "Invalid number of operators: {}. Must be 4, 7, 10, or 13 numbers",
-                len
+                "Invalid number of operators: {len}. Must be 4, 7, 10, or 13 numbers"
             )),
         }
     }

--- a/anchor/keysplit/src/crypto.rs
+++ b/anchor/keysplit/src/crypto.rs
@@ -83,7 +83,7 @@ pub fn extract_key(keystore: &Keystore, password: &str) -> Result<ValidatorKeys,
     decryptor.apply_keystream(&mut pk);
 
     let deser_pk = SecretKey::deserialize(pk.as_slice())
-        .map_err(|e| KeysplitError::Misc(format!("Failed to deserialize secret key: {:?}", e)))?;
+        .map_err(|e| KeysplitError::Misc(format!("Failed to deserialize secret key: {e:?}")))?;
     Ok(ValidatorKeys {
         public_key: deser_pk.public_key(),
         secret_key: deser_pk,
@@ -106,7 +106,7 @@ pub fn split_keys(
         .map(|id| KeyId::try_from(*id).unwrap());
 
     split(&sk, threshold as u64, key_ids)
-        .map_err(|e| KeysplitError::SplitFailure(format!("Failed to split key: {:?}", e)))
+        .map_err(|e| KeysplitError::SplitFailure(format!("Failed to split key: {e:?}")))
 }
 
 // Encrypt the keyshare with the operators rsa public key

--- a/anchor/keysplit/src/output.rs
+++ b/anchor/keysplit/src/output.rs
@@ -101,13 +101,13 @@ impl Payload {
         Self {
             public_key: keys.public_key.clone(),
             operator_ids,
-            shares_data: format!("0x{}{}{}", signature, public_keys, encrypted_data),
+            shares_data: format!("0x{signature}{public_keys}{encrypted_data}"),
         }
     }
 
     // Creates a signature with the owner address and the nonce
     fn create_signature(keys: &ValidatorKeys, nonce: u64, owner: Address) -> String {
-        let message = format!("{}:{}", owner, nonce);
+        let message = format!("{owner}:{nonce}");
         let mut hasher = Keccak256::new();
         hasher.update(message.as_bytes());
 

--- a/anchor/logging/src/logging.rs
+++ b/anchor/logging/src/logging.rs
@@ -142,7 +142,7 @@ pub fn init_file_logging(default_logs_dir: PathBuf, config: LoggerConfig) -> Opt
     let mut appender = LogRollerBuilder::new(path, filename)
         .rotation(Rotation::SizeBased(RotationSize::MB(config.max_log_size)))
         .max_keep_files(config.max_log_number.try_into().unwrap_or_else(|e| {
-            eprintln!("Failed to convert max_log_number to u64: {}", e);
+            eprintln!("Failed to convert max_log_number to u64: {e}");
             10
         }));
 

--- a/anchor/logging/src/tracing_libp2p_discv5_layer.rs
+++ b/anchor/logging/src/tracing_libp2p_discv5_layer.rs
@@ -41,7 +41,7 @@ where
         let message = format!("{} {} {}\n", timestamp, log_level, visitor.message);
 
         if let Err(e) = writer.write_all(message.as_bytes()) {
-            eprintln!("Failed to write log: {}", e);
+            eprintln!("Failed to write log: {e}");
         }
     }
 }

--- a/anchor/message_validator/src/consensus_message.rs
+++ b/anchor/message_validator/src/consensus_message.rs
@@ -472,7 +472,7 @@ pub(crate) fn validate_slot_time(
     let earliness = message_earliness(msg_slot, validation_context)?;
     if earliness > CLOCK_ERROR_TOLERANCE {
         return Err(EarlySlotMessage {
-            got: format!("early by {:?}", earliness),
+            got: format!("early by {earliness:?}"),
         });
     }
 
@@ -480,7 +480,7 @@ pub(crate) fn validate_slot_time(
     let lateness = message_lateness(msg_slot, validation_context)?;
     if lateness > CLOCK_ERROR_TOLERANCE {
         return Err(ValidationFailure::LateSlotMessage {
-            got: format!("late by {:?}", lateness),
+            got: format!("late by {lateness:?}"),
         });
     }
 
@@ -773,13 +773,11 @@ mod tests {
         F: Fn(&ValidationFailure) -> bool,
     {
         match result {
-            Ok(_) => panic!("Expected validation to fail with {}", error_name),
+            Ok(_) => panic!("Expected validation to fail with {error_name}"),
             Err(failure) => {
                 assert!(
                     expected_error(&failure),
-                    "Expected {} error, got: {:?}",
-                    error_name,
-                    failure
+                    "Expected {error_name} error, got: {failure:?}"
                 );
             }
         }
@@ -844,7 +842,7 @@ mod tests {
 
         match result {
             Ok(ValidatedSSVMessage::QbftMessage(_)) => {} // success
-            Err(e) => panic!("Expected successful validation, got: {:?}", e),
+            Err(e) => panic!("Expected successful validation, got: {e:?}"),
             _ => {}
         }
 

--- a/anchor/message_validator/src/lib.rs
+++ b/anchor/message_validator/src/lib.rs
@@ -353,20 +353,20 @@ fn verify_message_signature(
 ) -> Result<(), ValidationFailure> {
     let p_key = PKey::from_rsa(operator_pk.clone()).map_err(|e| {
         ValidationFailure::SignatureVerificationFailed {
-            reason: format!("Failed to create PKey: {}", e),
+            reason: format!("Failed to create PKey: {e}"),
         }
     })?;
 
     let mut verifier = Verifier::new(MessageDigest::sha256(), &p_key).map_err(|e| {
         ValidationFailure::SignatureVerificationFailed {
-            reason: format!("Failed to create verifier: {}", e),
+            reason: format!("Failed to create verifier: {e}"),
         }
     })?;
 
     verifier
         .update(&signed_message.ssv_message().as_ssz_bytes())
         .map_err(|e| ValidationFailure::SignatureVerificationFailed {
-            reason: format!("Failed to update verifier: {}", e),
+            reason: format!("Failed to update verifier: {e}"),
         })?;
 
     match verifier.verify(signature) {
@@ -375,7 +375,7 @@ fn verify_message_signature(
             reason: "Signature verification failed".to_string(),
         }),
         Err(e) => Err(ValidationFailure::SignatureVerificationFailed {
-            reason: format!("Signature verification error: {}", e),
+            reason: format!("Signature verification error: {e}"),
         }),
     }
 }
@@ -521,13 +521,11 @@ mod tests {
         F: Fn(&ValidationFailure) -> bool,
     {
         match result {
-            Ok(_) => panic!("Expected validation to fail with {}", error_name),
+            Ok(_) => panic!("Expected validation to fail with {error_name}"),
             Err(failure) => {
                 assert!(
                     expected_error(&failure),
-                    "Expected {} error, got: {:?}",
-                    error_name,
-                    failure
+                    "Expected {error_name} error, got: {failure:?}"
                 );
             }
         }

--- a/anchor/message_validator/src/message_counts.rs
+++ b/anchor/message_validator/src/message_counts.rs
@@ -35,12 +35,12 @@ impl MessageCounts {
         match msg_type {
             QbftMessageType::Proposal if self.proposal >= MAX_MESSAGES_PER_ROUND => {
                 Err(ValidationFailure::DuplicatedMessage {
-                    got: format!("proposal, having {}", self),
+                    got: format!("proposal, having {self}"),
                 })
             }
             QbftMessageType::Prepare if self.prepare >= MAX_MESSAGES_PER_ROUND => {
                 Err(ValidationFailure::DuplicatedMessage {
-                    got: format!("prepare, having {}", self),
+                    got: format!("prepare, having {self}"),
                 })
             }
             QbftMessageType::Commit
@@ -48,12 +48,12 @@ impl MessageCounts {
                     && self.commit >= MAX_MESSAGES_PER_ROUND =>
             {
                 Err(ValidationFailure::DuplicatedMessage {
-                    got: format!("commit, having {}", self),
+                    got: format!("commit, having {self}"),
                 })
             }
             QbftMessageType::RoundChange if self.round_change >= MAX_MESSAGES_PER_ROUND => {
                 Err(ValidationFailure::DuplicatedMessage {
-                    got: format!("round change, having {}", self),
+                    got: format!("round change, having {self}"),
                 })
             }
             _ => Ok(()),

--- a/anchor/message_validator/src/partial_signature.rs
+++ b/anchor/message_validator/src/partial_signature.rs
@@ -413,7 +413,7 @@ mod tests {
         assert!(
             result.is_ok(),
             "{}",
-            format!("Expected successful validation but got: {:?}", result)
+            format!("Expected successful validation but got: {result:?}")
         );
 
         if let Ok(ValidatedSSVMessage::PartialSignatureMessages(messages)) = result {
@@ -492,10 +492,7 @@ mod tests {
         assert!(
             result.is_ok(),
             "{}",
-            format!(
-                "Expected successful validation for Committee role, but got: {:?}",
-                result
-            )
+            format!("Expected successful validation for Committee role, but got: {result:?}")
         );
     }
 }

--- a/anchor/network/src/handshake/node_info.rs
+++ b/anchor/network/src/handshake/node_info.rs
@@ -195,8 +195,7 @@ mod tests {
         // The old serialized data from the Go code
         // (note the "Subnets":"ffffffffffffffffffffffffffffffff")
         let old_serialized_data = format!(
-            r#"{{"Entries":["", "{}", "{{\"NodeVersion\":\"v0.1.12\",\"ExecutionNode\":\"geth/x\",\"ConsensusNode\":\"prysm/x\",\"Subnets\":\"ffffffffffffffffffffffffffffffff\"}}"]}}"#,
-            HOLESKY_WITH_PREFIX
+            r#"{{"Entries":["", "{HOLESKY_WITH_PREFIX}", "{{\"NodeVersion\":\"v0.1.12\",\"ExecutionNode\":\"geth/x\",\"ConsensusNode\":\"prysm/x\",\"Subnets\":\"ffffffffffffffffffffffffffffffff\"}}"]}}"#
         ).into_bytes();
 
         // The "current" NodeInfo data

--- a/anchor/network/src/network.rs
+++ b/anchor/network/src/network.rs
@@ -93,7 +93,7 @@ impl<R: MessageReceiver> Network<R> {
         outcome_rx: mpsc::Receiver<Outcome>,
         executor: TaskExecutor,
         spec: &ChainSpec,
-    ) -> Result<Network<R>, NetworkError> {
+    ) -> Result<Network<R>, Box<NetworkError>> {
         let local_keypair: Keypair = load_private_key(&config.network_dir);
 
         let transport = build_transport(local_keypair.clone(), !config.disable_quic_support)?;
@@ -407,7 +407,7 @@ fn build_swarm(
     transport: Boxed<(PeerId, StreamMuxerBox)>,
     behaviour: AnchorBehaviour,
     _config: &Config,
-) -> Result<Swarm<AnchorBehaviour>, NetworkError> {
+) -> Result<Swarm<AnchorBehaviour>, Box<NetworkError>> {
     struct Executor(task_executor::TaskExecutor);
     impl libp2p::swarm::Executor for Executor {
         fn exec(&self, f: Pin<Box<dyn futures::Future<Output = ()> + Send>>) {

--- a/anchor/network/src/transport.rs
+++ b/anchor/network/src/transport.rs
@@ -15,7 +15,7 @@ use crate::network::NetworkError;
 pub(crate) fn build_transport(
     local_private_key: Keypair,
     quic_support: bool,
-) -> Result<Boxed<(PeerId, StreamMuxerBox)>, NetworkError> {
+) -> Result<Boxed<(PeerId, StreamMuxerBox)>, Box<NetworkError>> {
     let yamux_config = yamux::Config::default();
 
     let tcp = tcp::tokio::Transport::new(tcp::Config::default().nodelay(true))
@@ -38,9 +38,9 @@ pub(crate) fn build_transport(
         tcp.boxed()
     };
 
-    libp2p::dns::tokio::Transport::system(transport)
-        .map_err(NetworkError::DnsTransport)
-        .map(|t| t.boxed())
+    let transport =
+        libp2p::dns::tokio::Transport::system(transport).map_err(NetworkError::DnsTransport)?;
+    Ok(transport.boxed())
 }
 
 /// Generate authenticated XX Noise config from identity keys

--- a/anchor/qbft_manager/src/instance.rs
+++ b/anchor/qbft_manager/src/instance.rs
@@ -157,7 +157,7 @@ impl Uninitialized {
 }
 
 enum RecvResult<D: QbftData> {
-    Message(QbftMessage<D>),
+    Message(Box<QbftMessage<D>>),
     RoundEnd,
     Closed,
 }
@@ -166,7 +166,7 @@ impl<D: QbftData> From<Option<QbftMessage<D>>> for RecvResult<D> {
     fn from(value: Option<QbftMessage<D>>) -> Self {
         match value {
             None => RecvResult::Closed,
-            Some(msg) => RecvResult::Message(msg),
+            Some(msg) => RecvResult::Message(Box::new(msg)),
         }
     }
 }

--- a/anchor/qbft_manager/src/lib.rs
+++ b/anchor/qbft_manager/src/lib.rs
@@ -302,7 +302,7 @@ pub trait QbftDecidable: QbftData<Hash = Hash256> + Send + Sync + 'static {
         id: Self::Id,
     ) -> UnboundedSender<QbftMessage<Self>> {
         let map = Self::get_map(manager);
-        let ret = match map.entry(id) {
+        match map.entry(id) {
             dashmap::Entry::Occupied(entry) => entry.get().clone(),
             dashmap::Entry::Vacant(entry) => {
                 // There is not an instance running yet, store the sender and spawn a new instance
@@ -316,8 +316,7 @@ pub trait QbftDecidable: QbftData<Hash = Hash256> + Send + Sync + 'static {
                 );
                 tx.clone()
             }
-        };
-        ret
+        }
     }
 
     fn instance_height(&self, id: &Self::Id) -> InstanceHeight;

--- a/anchor/validator_store/src/metadata_service.rs
+++ b/anchor/validator_store/src/metadata_service.rs
@@ -88,7 +88,7 @@ impl<E: EthSpec, T: SlotClock + 'static> MetadataService<E, T> {
                 beacon_node
                     .get_validator_attestation_data(slot, 0)
                     .await
-                    .map_err(|e| format!("Failed to produce attestation data: {:?}", e))
+                    .map_err(|e| format!("Failed to produce attestation data: {e:?}"))
                     .map(|result| result.data)
             })
             .await


### PR DESCRIPTION
Rust 1.87 was released and introduced a bunch of new and updated lints. 

This was mainly `ptr::eq` in `qbft_lagrange` and some enums with large variants. 

I took the opportunity and try clippy from nightly, which exclusively complained about moving variables into format strings, which seems reasonable, so I did that as well.