### PR TITLE
Reenable `cargo vendor`

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -141,10 +141,8 @@ jobs:
       run: git diff --exit-code Cargo.lock
     - name: Run cargo audit
       run: make audit-CI
-      # Dependency conflicts are causing pain here. Once SLOG is removed from lighthouse this should
-      # be re-enabled
-      # - name: Run cargo vendor to make sure dependencies can be vendored for packaging, reproducibility and archival purpose
-      #run:  CARGO_HOME=$(readlink -f $HOME) make vendor
+    - name: Run cargo vendor to make sure dependencies can be vendored for packaging, reproducibility and archival purpose
+      run:  CARGO_HOME=$(readlink -f $HOME) make vendor
     - name: Markdown-linter
       run: make mdlint
       


### PR DESCRIPTION
## Issue Addressed

- #49

That issue mentions re-enabling `cargo vendor` when tracing is merged, which is. Lets see if it works :)