### PR TITLE
Start curr_epoch_duties at 0 for a new epoch

### DIFF
--- a/anchor/message_validator/src/consensus_state.rs
+++ b/anchor/message_validator/src/consensus_state.rs
@@ -179,7 +179,7 @@ impl OperatorState {
             Ordering::Greater => {
                 self.max_epoch = *estimated_msg_epoch;
                 self.prev_epoch_duties = self.curr_epoch_duties;
-                self.curr_epoch_duties = 1;
+                self.curr_epoch_duties = 0;
             }
             Ordering::Equal => {
                 self.curr_epoch_duties += 1;


### PR DESCRIPTION
## Issue Addressed

https://github.com/sigp/anchor/pull/301/files starts `curr_epoch_duties`at 1 for a new epoch, but it should be zero as the state is updated only after checking. In the current code, the check will fail if our limit is 1.

## Proposed Changes

Start curr_epoch_duties at 0 for a new epoch

