### PR TITLE
Fix last duty per epoch validation

### DIFF
--- a/anchor/message_validator/src/consensus_message.rs
+++ b/anchor/message_validator/src/consensus_message.rs
@@ -555,7 +555,7 @@ pub(crate) fn validate_duty_count(
         // checking if there is a signer state already set for that slot. If so, we have already
         // processed a message for this duty and the counter will not be increased further in
         // `OperatorState::update`, so we skip the limit check here also.
-        if signer_state.get_signer_state(&slot).is_none() && duty_count >= limit {
+        if signer_state.is_first_message_for_duty(slot) && duty_count >= limit {
             return Err(ValidationFailure::ExcessiveDutyCount {
                 got: duty_count,
                 limit,

--- a/anchor/message_validator/src/consensus_message.rs
+++ b/anchor/message_validator/src/consensus_message.rs
@@ -550,10 +550,10 @@ pub(crate) fn validate_duty_count(
         // as allowed for the target epoch. We perform this check *before* incrementing
         // the in-memory count (so the very first duty will see count==0), hence the
         // inclusive “>=” comparison.
-        // We only want to check the limit if this is the first message of that duty, as otherwise 
+        // We only want to check the limit if this is the first message of that duty, as otherwise
         // the check will fail for non-first messages of the last allowed duty. We do this by
         // checking if there is a signer state already set for that slot. If so, we have already
-        // processed a message for this duty and the counter will not be increased further in 
+        // processed a message for this duty and the counter will not be increased further in
         // `OperatorState::update`, so we skip the limit check here also.
         if signer_state.get_signer_state(&slot).is_none() && duty_count >= limit {
             return Err(ValidationFailure::ExcessiveDutyCount {

--- a/anchor/message_validator/src/consensus_message.rs
+++ b/anchor/message_validator/src/consensus_message.rs
@@ -550,7 +550,12 @@ pub(crate) fn validate_duty_count(
         // as allowed for the target epoch. We perform this check *before* incrementing
         // the in-memory count (so the very first duty will see count==0), hence the
         // inclusive “>=” comparison.
-        if duty_count >= limit {
+        // We only want to check the limit if this is the first message of that duty, as otherwise 
+        // the check will fail for non-first messages of the last allowed duty. We do this by
+        // checking if there is a signer state already set for that slot. If so, we have already
+        // processed a message for this duty and the counter will not be increased further in 
+        // `OperatorState::update`, so we skip the limit check here also.
+        if signer_state.get_signer_state(&slot).is_none() && duty_count >= limit {
             return Err(ValidationFailure::ExcessiveDutyCount {
                 got: duty_count,
                 limit,

--- a/anchor/message_validator/src/consensus_state.rs
+++ b/anchor/message_validator/src/consensus_state.rs
@@ -131,6 +131,11 @@ impl OperatorState {
         self.state[index] = Some(signer_state.clone());
     }
 
+    /// Returns true if we have not seen a message for a duty in `slot` yet.
+    pub(crate) fn is_first_message_for_duty(&self, slot: Slot) -> bool {
+        self.get_signer_state(&slot).is_none()
+    }
+
     /// Updates the SignerState for the given slot.
     ///
     /// If a state already exists and the incoming consensus round is higher,


### PR DESCRIPTION
## Issue Addressed

- #324

## Proposed Changes

Current behaviour: We count the number of duties per epoch per operator. If the operator sends another message while we are at the limit, the message is rejected. However, this behaviour is not quite correct, as we need to allow messages belonging to the duty that pushed the operator to the limit. This PR changes the check to only occur on the first message of a new duty. All further messages of that duty will not increase the duty count, so it does not make sense to check the count then.

## Additional Info

While the issue started occurring after #311, it was not the root cause. The bug fixed by #311 merely masked this issue.
