### PR TITLE
Validate Partial Signature Message by Duty Logic

### DIFF
--- a/anchor/client/src/lib.rs
+++ b/anchor/client/src/lib.rs
@@ -409,6 +409,7 @@ impl Client {
             database.watch(),
             E::slots_per_epoch(),
             spec.epochs_per_sync_committee_period.as_u64(),
+            E::sync_committee_size(),
             duties_tracker.clone(),
             slot_clock.clone(),
         ));

--- a/anchor/fuzz/fuzz_targets/setup.rs
+++ b/anchor/fuzz/fuzz_targets/setup.rs
@@ -120,6 +120,7 @@ pub fn setup_test_message_validator() -> Arc<Validator<ManualSlotClock, MockDuti
         db.watch(),
         32,
         256,
+        512,
         duties_provider.into(),
         slot_clock.clone(),
     ))
@@ -164,6 +165,7 @@ pub fn setup_test_message_receiver(
         db.watch(),
         32,
         256,
+        512,
         duties_provider.into(),
         slot_clock.clone(),
     ));

--- a/anchor/message_validator/src/consensus_message.rs
+++ b/anchor/message_validator/src/consensus_message.rs
@@ -12,13 +12,13 @@ use ssz::Decode;
 
 use crate::{
     FIRST_ROUND, ValidatedSSVMessage, ValidationContext, ValidationFailure, compute_quorum_size,
-    consensus_state::ConsensusState, hash_data, slot_start_time, validate_beacon_duty,
-    validate_duty_count, validate_slot_time, verify_message_signatures,
+    duty_state::DutyState, hash_data, slot_start_time, validate_beacon_duty, validate_duty_count,
+    validate_slot_time, verify_message_signatures,
 };
 
 pub(crate) fn validate_consensus_message(
     validation_context: ValidationContext<impl SlotClock>,
-    consensus_state: &mut ConsensusState,
+    duty_state: &mut DutyState,
     duty_provider: Arc<impl DutiesProvider>,
 ) -> Result<ValidatedSSVMessage, ValidationFailure> {
     // Decode message to QbftMessage
@@ -36,12 +36,12 @@ pub(crate) fn validate_consensus_message(
         validation_context.committee_info,
     )?;
 
-    validate_qbft_logic(&validation_context, &consensus_message, consensus_state)?;
+    validate_qbft_logic(&validation_context, &consensus_message, duty_state)?;
 
     validate_qbft_message_by_duty_logic(
         &validation_context,
         &consensus_message,
-        consensus_state,
+        duty_state,
         duty_provider,
     )?;
 
@@ -50,7 +50,7 @@ pub(crate) fn validate_consensus_message(
         validation_context.operators_pk,
     )?;
 
-    consensus_state.update_for_consensus_message(
+    duty_state.update_for_consensus_message(
         validation_context.signed_ssv_message,
         &consensus_message,
         validation_context.slots_per_epoch,
@@ -171,7 +171,7 @@ pub(crate) fn validate_justifications(
 pub(crate) fn validate_qbft_logic(
     validation_context: &ValidationContext<impl SlotClock>,
     consensus_message: &QbftMessage,
-    consensus_state: &mut ConsensusState,
+    duty_state: &mut DutyState,
 ) -> Result<(), ValidationFailure> {
     let signed_ssv_message = validation_context.signed_ssv_message;
 
@@ -199,7 +199,7 @@ pub(crate) fn validate_qbft_logic(
     // Check validation rules for each signer
     for signer in signers {
         // Get or create the operator state first, then check if there's a signer state
-        let Some(signer_state) = consensus_state
+        let Some(signer_state) = duty_state
             .get_or_create_operator(signer)
             .get_signer_state(&msg_slot)
         else {
@@ -355,7 +355,7 @@ fn current_estimated_round(since_slot_start: Duration) -> Round {
 pub(crate) fn validate_qbft_message_by_duty_logic(
     validation_context: &ValidationContext<impl SlotClock>,
     consensus_message: &QbftMessage,
-    consensus_state: &mut ConsensusState,
+    duty_state: &mut DutyState,
     duty_provider: Arc<impl DutiesProvider>,
 ) -> Result<(), ValidationFailure> {
     let role = validation_context.role;
@@ -364,7 +364,7 @@ pub(crate) fn validate_qbft_message_by_duty_logic(
     // Rule: Height must not be "old". I.e., signer must not have already advanced to a later slot.
     if role != Role::Committee {
         for &signer in signed_ssv_message.operator_ids() {
-            let signer_state = consensus_state.get_or_create_operator(&signer);
+            let signer_state = duty_state.get_or_create_operator(&signer);
             let max_slot = signer_state.max_slot();
             if max_slot > consensus_message.height {
                 return Err(ValidationFailure::SlotAlreadyAdvanced {
@@ -392,7 +392,7 @@ pub(crate) fn validate_qbft_message_by_duty_logic(
 
     // Rule: valid number of duties per epoch
     for &signer in signed_ssv_message.operator_ids() {
-        let signer_state = consensus_state.get_or_create_operator(&signer);
+        let signer_state = duty_state.get_or_create_operator(&signer);
         validate_duty_count(
             validation_context,
             msg_slot,
@@ -503,7 +503,7 @@ mod tests {
         let expected_duty_count = 5;
         let result = validate_ssv_message(
             validation_context,
-            &mut ConsensusState::new(2),
+            &mut DutyState::new(2),
             Arc::new(MockDutiesProvider {
                 voluntary_exit_duty_count: expected_duty_count,
             }),
@@ -561,7 +561,7 @@ mod tests {
 
         let result = validate_ssv_message(
             validation_context,
-            &mut ConsensusState::new(2),
+            &mut DutyState::new(2),
             Arc::new(MockDutiesProvider {
                 voluntary_exit_duty_count: 0,
             }),
@@ -615,7 +615,7 @@ mod tests {
 
         let result = validate_ssv_message(
             validation_context,
-            &mut ConsensusState::new(2),
+            &mut DutyState::new(2),
             Arc::new(MockDutiesProvider {
                 voluntary_exit_duty_count: 0,
             }),
@@ -663,7 +663,7 @@ mod tests {
 
         let result = validate_ssv_message(
             validation_context,
-            &mut ConsensusState::new(2),
+            &mut DutyState::new(2),
             Arc::new(MockDutiesProvider {
                 voluntary_exit_duty_count: 0,
             }),

--- a/anchor/message_validator/src/consensus_message.rs
+++ b/anchor/message_validator/src/consensus_message.rs
@@ -496,6 +496,7 @@ mod tests {
             operators_pk: &[public_key],
             slots_per_epoch: 32,
             epochs_per_sync_committee_period: 256,
+            sync_committee_size: 512,
             slot_clock,
         };
 
@@ -554,6 +555,7 @@ mod tests {
             operators_pk: &[],
             slots_per_epoch: 32,
             epochs_per_sync_committee_period: 256,
+            sync_committee_size: 512,
             slot_clock,
         };
 
@@ -607,6 +609,7 @@ mod tests {
             operators_pk: &[],
             slots_per_epoch: 32,
             epochs_per_sync_committee_period: 256,
+            sync_committee_size: 512,
             slot_clock,
         };
 
@@ -650,6 +653,7 @@ mod tests {
             operators_pk: &generate_random_rsa_public_keys(signed_msg.operator_ids().len()),
             slots_per_epoch: 32,
             epochs_per_sync_committee_period: 256,
+            sync_committee_size: 512,
             slot_clock: ManualSlotClock::new(
                 Slot::new(0),
                 SystemTime::now().duration_since(UNIX_EPOCH).unwrap(),
@@ -1290,6 +1294,7 @@ mod tests {
             operators_pk: &[],
             slots_per_epoch: 32,
             epochs_per_sync_committee_period: 256,
+            sync_committee_size: 512,
             slot_clock: slot_clock.clone(),
         };
 

--- a/anchor/message_validator/src/consensus_message.rs
+++ b/anchor/message_validator/src/consensus_message.rs
@@ -50,7 +50,7 @@ pub(crate) fn validate_consensus_message(
         validation_context.operators_pk,
     )?;
 
-    consensus_state.update(
+    consensus_state.update_for_consensus_message(
         validation_context.signed_ssv_message,
         &consensus_message,
         validation_context.slots_per_epoch,

--- a/anchor/message_validator/src/consensus_message.rs
+++ b/anchor/message_validator/src/consensus_message.rs
@@ -1,20 +1,19 @@
 use std::{convert::Into, sync::Arc, time::Duration};
 
-use ValidationFailure::EarlySlotMessage;
 use duties_tracker::DutiesProvider;
 use slot_clock::SlotClock;
 use ssv_types::{
-    CommitteeInfo, IndexSet, OperatorId, Round, Slot, ValidatorIndex, VariableList,
+    CommitteeInfo, IndexSet, OperatorId, Round, Slot, VariableList,
     consensus::{QbftMessage, QbftMessageType},
     message::SignedSSVMessage,
-    msgid::{DutyExecutor, Role},
+    msgid::Role,
 };
 use ssz::Decode;
 
 use crate::{
-    ValidatedSSVMessage, ValidationContext, ValidationFailure, compute_quorum_size,
-    consensus_state::{ConsensusState, OperatorState},
-    hash_data, slot_start_time, sync_committee_period, verify_message_signatures,
+    FIRST_ROUND, ValidatedSSVMessage, ValidationContext, ValidationFailure, compute_quorum_size,
+    consensus_state::ConsensusState, hash_data, slot_start_time, validate_beacon_duty,
+    validate_duty_count, validate_slot_time, verify_message_signatures,
 };
 
 pub(crate) fn validate_consensus_message(
@@ -234,7 +233,10 @@ pub(crate) fn validate_qbft_logic(
 
                 signer_state
                     .message_counts
-                    .validate_limits(signed_ssv_message, consensus_message.qbft_message_type)?;
+                    .validate_consensus_message_limits(
+                        signed_ssv_message,
+                        consensus_message.qbft_message_type,
+                    )?;
             }
         } else if signers.len() > 1 {
             // Rule: Decided msg can't have the same signers as previously sent before for the same
@@ -254,7 +256,6 @@ pub(crate) fn validate_qbft_logic(
 }
 
 // Define constants to match the Go implementation
-const FIRST_ROUND: u64 = 1;
 const MAX_ALLOWED_ROUNDS_FUTURE: u64 = 3;
 
 /// Determines the leader for a given height and round using round robin
@@ -350,12 +351,6 @@ fn current_estimated_round(since_slot_start: Duration) -> Round {
     (QUICK_TIMEOUT_THRESHOLD + FIRST_ROUND + delta_slow).into()
 }
 
-/// clockErrorTolerance is the maximum amount of clock error we expect to see between nodes.
-const CLOCK_ERROR_TOLERANCE: Duration = Duration::from_millis(50);
-/// lateMessageMargin is the duration past a message's TTL in which it is still considered valid.
-const LATE_MESSAGE_MARGIN: Duration = Duration::from_secs(3);
-const LATE_SLOT_ALLOWANCE: u64 = 2;
-
 /// Validates QBFT messages based on beacon chain duties
 pub(crate) fn validate_qbft_message_by_duty_logic(
     validation_context: &ValidationContext<impl SlotClock>,
@@ -409,216 +404,6 @@ pub(crate) fn validate_qbft_message_by_duty_logic(
     Ok(())
 }
 
-/// Validates if a validator is assigned to a specific duty
-pub(crate) fn validate_beacon_duty(
-    validation_context: &ValidationContext<impl SlotClock>,
-    slot: Slot,
-    randao_msg: bool,
-    duty_provider: Arc<impl DutiesProvider>,
-) -> Result<(), ValidationFailure> {
-    let role = validation_context.role;
-    let epoch = slot.epoch(validation_context.slots_per_epoch);
-    // Rule: For a proposal duty message, check if the validator is assigned to it
-    if role == Role::Proposer {
-        // Tolerate missing duties for RANDAO signatures during the first slot of an epoch,
-        // while duties are still being fetched from the Beacon node.
-
-        let is_first_slot_of_epoch = epoch.start_slot(validation_context.slots_per_epoch) == slot;
-
-        if randao_msg
-            && is_first_slot_of_epoch
-            && validation_context.slot_clock.now().unwrap_or_default() <= slot
-            && !duty_provider.is_epoch_known_for_proposers(epoch)
-        {
-            return Ok(());
-        }
-
-        // Non-committee roles always have one validator index
-        let validator_index = validation_context
-            .committee_info
-            .validator_indices
-            .first()
-            .copied()
-            .unwrap_or_default();
-        if !duty_provider.is_validator_proposer_at_slot(slot, validator_index) {
-            return Err(ValidationFailure::NoDuty);
-        }
-    }
-
-    // Rule: For a sync committee duty message, check if the validator is assigned
-    if role == Role::SyncCommittee {
-        let period =
-            sync_committee_period(epoch, validation_context.epochs_per_sync_committee_period)?;
-        let validator_index = validation_context
-            .committee_info
-            .validator_indices
-            .first()
-            .copied()
-            .unwrap_or_default();
-        if !duty_provider.is_validator_in_sync_committee(period, validator_index) {
-            return Err(ValidationFailure::NoDuty);
-        }
-    }
-
-    Ok(())
-}
-
-/// Validates that the message's slot timing is correct
-pub(crate) fn validate_slot_time(
-    msg_slot: Slot,
-    validation_context: &ValidationContext<impl SlotClock>,
-) -> Result<(), ValidationFailure> {
-    // Check if the message is too early
-    let earliness = message_earliness(msg_slot, validation_context)?;
-    if earliness > CLOCK_ERROR_TOLERANCE {
-        return Err(EarlySlotMessage {
-            got: format!("early by {earliness:?}"),
-        });
-    }
-
-    // Check if the message is too late
-    let lateness = message_lateness(msg_slot, validation_context)?;
-    if lateness > CLOCK_ERROR_TOLERANCE {
-        return Err(ValidationFailure::LateSlotMessage {
-            got: format!("late by {lateness:?}"),
-        });
-    }
-
-    Ok(())
-}
-
-/// Returns how early a message is compared to its slot start time.
-/// Returns a zero duration if the message is on time or late.
-fn message_earliness(
-    slot: Slot,
-    validation_context: &ValidationContext<impl SlotClock>,
-) -> Result<Duration, ValidationFailure> {
-    let slot_start = slot_start_time(slot, validation_context.slot_clock.clone())
-        .map_err(|_| ValidationFailure::SlotStartTimeNotFound { slot })?;
-    Ok(slot_start
-        .duration_since(validation_context.received_at)
-        .unwrap_or_default())
-}
-
-/// Returns how late a message is compared to its deadline based on role.
-/// If the message was received before the deadline, it returns 0.
-/// If the message was received after the deadline, it returns the duration by which it was late.
-fn message_lateness(
-    slot: Slot,
-    validation_context: &ValidationContext<impl SlotClock>,
-) -> Result<Duration, ValidationFailure> {
-    let ttl = match validation_context.role {
-        Role::Proposer | Role::SyncCommittee => 1 + LATE_SLOT_ALLOWANCE,
-        Role::Committee | Role::Aggregator => {
-            validation_context.slots_per_epoch + LATE_SLOT_ALLOWANCE
-        }
-        // No lateness check for these roles
-        Role::ValidatorRegistration | Role::VoluntaryExit => return Ok(Duration::from_secs(0)),
-    };
-
-    let deadline = slot_start_time(slot + ttl, validation_context.slot_clock.clone())
-        .map_err(|_| ValidationFailure::SlotStartTimeNotFound { slot })?
-        .checked_add(LATE_MESSAGE_MARGIN)
-        .ok_or(ValidationFailure::UnexpectedFailure {
-            msg: "Unexpected overflow calculating message deadline".to_string(),
-        })?;
-
-    Ok(validation_context
-        .received_at
-        .duration_since(deadline)
-        .unwrap_or_default())
-}
-
-/// Validates the duty count for a specific message and operator
-pub(crate) fn validate_duty_count(
-    validation_context: &ValidationContext<impl SlotClock>,
-    slot: Slot,
-    signer_state: &mut OperatorState,
-    duty_provider: Arc<impl DutiesProvider>,
-) -> Result<(), ValidationFailure> {
-    if let Some(limit) = duty_limit(
-        validation_context,
-        slot,
-        &validation_context.committee_info.validator_indices,
-        duty_provider,
-    )? {
-        // Get current duty count for this signer
-        let epoch = slot.epoch(validation_context.slots_per_epoch);
-        let duty_count = signer_state.get_duty_count(epoch);
-
-        // Error if this validator has already been assigned at least as many duties
-        // as allowed for the target epoch. We perform this check *before* incrementing
-        // the in-memory count (so the very first duty will see count==0), hence the
-        // inclusive “>=” comparison.
-        // We only want to check the limit if this is the first message of that duty, as otherwise
-        // the check will fail for non-first messages of the last allowed duty. We do this by
-        // checking if there is a signer state already set for that slot. If so, we have already
-        // processed a message for this duty and the counter will not be increased further in
-        // `OperatorState::update`, so we skip the limit check here also.
-        if signer_state.is_first_message_for_duty(slot) && duty_count >= limit {
-            return Err(ValidationFailure::ExcessiveDutyCount {
-                got: duty_count,
-                limit,
-            });
-        }
-    }
-
-    Ok(())
-}
-
-/// Determines duty limit based on role and validator indices
-fn duty_limit(
-    validation_context: &ValidationContext<impl SlotClock>,
-    slot: Slot,
-    validator_indices: &[ValidatorIndex],
-    duty_provider: Arc<impl DutiesProvider>,
-) -> Result<Option<u64>, ValidationFailure> {
-    match validation_context.role {
-        Role::VoluntaryExit => {
-            // Extract the validator public key from the message ID
-            let pubkey = match validation_context
-                .signed_ssv_message
-                .ssv_message()
-                .msg_id()
-                .duty_executor()
-            {
-                Some(DutyExecutor::Validator(pubkey)) => pubkey,
-                _ => return Err(ValidationFailure::UnknownValidator),
-            };
-            // Get the current voluntary exit duty count for this validator
-            Ok(Some(
-                duty_provider.get_voluntary_exit_duty_count(slot, &pubkey),
-            ))
-        }
-        Role::Aggregator | Role::ValidatorRegistration => Ok(Some(2)),
-        Role::Committee => {
-            let validator_index_count = validator_indices.len() as u64;
-            let slots_per_epoch_val = validation_context.slots_per_epoch;
-
-            // Skip duty search if validators * 2 exceeds slots per epoch
-            if validator_index_count < slots_per_epoch_val / 2 {
-                let epoch = slot.epoch(validation_context.slots_per_epoch);
-                let period = sync_committee_period(
-                    epoch,
-                    validation_context.epochs_per_sync_committee_period,
-                )?;
-
-                // Check if at least one validator is in the sync committee
-                for &index in validator_indices {
-                    if duty_provider.is_validator_in_sync_committee(period, index) {
-                        return Ok(Some(slots_per_epoch_val));
-                    }
-                }
-            }
-            Ok(Some(std::cmp::min(
-                slots_per_epoch_val,
-                2 * validator_index_count,
-            )))
-        }
-        _ => Ok(None),
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use std::time::{SystemTime, UNIX_EPOCH};
@@ -636,43 +421,13 @@ mod tests {
 
     use super::*;
     use crate::{
-        ValidatedSSVMessage,
+        LATE_MESSAGE_MARGIN, LATE_SLOT_ALLOWANCE, ValidatedSSVMessage, duty_limit,
         tests::{
             FOUR_NODE_COMMITTEE, SINGLE_NODE_COMMITTEE, create_committee_info,
             generate_random_rsa_public_keys,
         },
         validate_ssv_message,
     };
-
-    #[derive(Default)]
-    struct MockDutiesProvider {
-        voluntary_exit_duty_count: u64,
-    }
-    impl DutiesProvider for MockDutiesProvider {
-        fn is_validator_in_sync_committee(
-            &self,
-            _committee_period: u64,
-            _validator_index: ValidatorIndex,
-        ) -> bool {
-            true
-        }
-
-        fn is_epoch_known_for_proposers(&self, _epoch: Epoch) -> bool {
-            true
-        }
-
-        fn is_validator_proposer_at_slot(
-            &self,
-            _slot: Slot,
-            _validator_index: ValidatorIndex,
-        ) -> bool {
-            true
-        }
-
-        fn get_voluntary_exit_duty_count(&self, _slot: Slot, _pubkey: &PublicKeyBytes) -> u64 {
-            self.voluntary_exit_duty_count
-        }
-    }
 
     // Assert helpers for common validation patterns
     fn assert_validation_error<T, F>(
@@ -1342,11 +1097,13 @@ mod tests {
         sign::Signer,
     };
     use slot_clock::ManualSlotClock;
-    use types::Epoch;
 
     use crate::{
-        ValidationFailure::LateSlotMessage,
-        tests::{QbftMessageBuilder, create_message_id_for_test, create_signed_consensus_message},
+        ValidationFailure::{EarlySlotMessage, LateSlotMessage},
+        tests::{
+            MockDutiesProvider, QbftMessageBuilder, create_message_id_for_test,
+            create_signed_consensus_message,
+        },
     };
 
     #[test]

--- a/anchor/message_validator/src/consensus_state.rs
+++ b/anchor/message_validator/src/consensus_state.rs
@@ -257,7 +257,7 @@ impl OperatorState {
 #[derive(Debug, Clone)]
 pub(crate) struct SignerState {
     /// The specific slot for which this state is maintained.
-    pub slot: Slot,
+    slot: Slot,
     /// The consensus round number associated with this slot.
     pub(crate) round: u64,
     /// Records the count of each type of consensus message encountered.
@@ -265,7 +265,7 @@ pub(crate) struct SignerState {
     /// Optionally holds proposal-related data if a proposal message was received.
     pub(crate) proposal_data: Option<Vec<u8>>,
     /// A set of CommitteeIds indicating which committees have already been seen.
-    pub(crate) seen_signers: HashSet<CommitteeId>,
+    seen_signers: HashSet<CommitteeId>,
 }
 
 impl SignerState {

--- a/anchor/message_validator/src/consensus_state.rs
+++ b/anchor/message_validator/src/consensus_state.rs
@@ -182,7 +182,7 @@ impl OperatorState {
     /// - Inserts the signer state into the circular buffer.
     /// - Updates `max_slot` if the new slot is higher.
     /// - Updates `max_epoch` and resets duty counters if the epoch has advanced.
-    fn set_signer_state_for_first_round(
+    pub(crate) fn set_signer_state_for_first_round(
         &mut self,
         msg_slot: &Slot,
         estimated_msg_epoch: &Epoch,
@@ -223,7 +223,7 @@ impl OperatorState {
 #[derive(Debug, Clone)]
 pub(crate) struct SignerState {
     /// The specific slot for which this state is maintained.
-    slot: Slot,
+    pub slot: Slot,
     /// The consensus round number associated with this slot.
     pub(crate) round: u64,
     /// Records the count of each type of consensus message encountered.
@@ -231,12 +231,12 @@ pub(crate) struct SignerState {
     /// Optionally holds proposal-related data if a proposal message was received.
     pub(crate) proposal_data: Option<Vec<u8>>,
     /// A set of CommitteeIds indicating which committees have already been seen.
-    seen_signers: HashSet<CommitteeId>,
+    pub(crate) seen_signers: HashSet<CommitteeId>,
 }
 
 impl SignerState {
     /// Creates a new SignerState for a given slot and round.
-    fn new(slot: Slot, round: u64) -> Self {
+    pub fn new(slot: Slot, round: u64) -> Self {
         Self {
             slot,
             round,

--- a/anchor/message_validator/src/consensus_state.rs
+++ b/anchor/message_validator/src/consensus_state.rs
@@ -85,7 +85,7 @@ impl ConsensusState {
 
         // Get or create a signer state for this slot
         let signer_state = match operator_state.get_signer_state_mut(&message_slot) {
-            Some(existing_state) if existing_state.slot == message_slot => existing_state,
+            Some(existing_state) => existing_state,
             _ => {
                 // Create a new signer state
                 let new_signer_state = SignerState::new(message_slot, FIRST_ROUND);

--- a/anchor/message_validator/src/consensus_state.rs
+++ b/anchor/message_validator/src/consensus_state.rs
@@ -7,10 +7,10 @@ use ssv_types::{
     CommitteeId, Epoch, OperatorId, Slot,
     consensus::{QbftMessage, QbftMessageType},
     message::SignedSSVMessage,
+    partial_sig::PartialSignatureMessages,
 };
 
-use crate::message_counts::MessageCounts;
-
+use crate::{FIRST_ROUND, ValidationFailure, message_counts::MessageCounts};
 // consensus_state.rs
 //
 // This file defines structures that help track and validate the consensus process.
@@ -51,7 +51,7 @@ impl ConsensusState {
     /// - Determines the corresponding slot and estimated epoch,
     /// - Retrieves or creates the operator's state,
     /// - And delegates the update to the operator's state.
-    pub fn update(
+    pub(crate) fn update_for_consensus_message(
         &mut self,
         signed_ssv_message: &SignedSSVMessage,
         consensus_message: &QbftMessage,
@@ -69,6 +69,40 @@ impl ConsensusState {
                 &estimated_msg_epoch,
             );
         }
+    }
+
+    /// Updates the consensus state with information about a partial signature message.
+    /// This records the message type in the message counts for the signer at the given slot.
+    pub(crate) fn update_for_partial_signature(
+        &mut self,
+        partial_signature_messages: &PartialSignatureMessages,
+        signer: &OperatorId,
+        slots_per_epoch: u64,
+    ) -> Result<(), ValidationFailure> {
+        let operator_state = self.get_or_create_operator(signer);
+        let message_slot = partial_signature_messages.slot;
+        let message_epoch = Epoch::new(message_slot.as_u64() / slots_per_epoch);
+
+        // Get or create a signer state for this slot
+        let signer_state = match operator_state.get_signer_state_mut(&message_slot) {
+            Some(existing_state) if existing_state.slot == message_slot => existing_state,
+            _ => {
+                // Create a new signer state
+                let new_signer_state = SignerState::new(message_slot, FIRST_ROUND);
+                operator_state.set_signer_state_for_first_round(
+                    &message_slot,
+                    &message_epoch,
+                    new_signer_state,
+                )
+            }
+        };
+
+        // Record the partial signature (only once)
+        signer_state
+            .message_counts
+            .record_partial_signature(partial_signature_messages.kind);
+
+        Ok(())
     }
 }
 
@@ -182,7 +216,7 @@ impl OperatorState {
     /// - Inserts the signer state into the circular buffer.
     /// - Updates `max_slot` if the new slot is higher.
     /// - Updates `max_epoch` and resets duty counters if the epoch has advanced.
-    pub(crate) fn set_signer_state_for_first_round(
+    fn set_signer_state_for_first_round(
         &mut self,
         msg_slot: &Slot,
         estimated_msg_epoch: &Epoch,
@@ -303,7 +337,7 @@ mod tests {
         );
 
         // Update the consensus state
-        consensus_state.update(&signed_ssv_message, &qbft_message, 32);
+        consensus_state.update_for_consensus_message(&signed_ssv_message, &qbft_message, 32);
 
         // Retrieve the operator state
         let operator_state = consensus_state.get_or_create_operator(&operator_id);
@@ -347,7 +381,11 @@ mod tests {
         );
 
         // Update consensus state with single-signer commit
-        consensus_state.update(&signed_single_signer, &single_signer_commit, 32);
+        consensus_state.update_for_consensus_message(
+            &signed_single_signer,
+            &single_signer_commit,
+            32,
+        );
 
         // Create a commit message with multiple signers (decided message, should NOT be counted)
         let multi_signer_commit =
@@ -361,7 +399,11 @@ mod tests {
         );
 
         // Update consensus state with multi-signer commit
-        consensus_state.update(&signed_multi_signer, &multi_signer_commit, 32);
+        consensus_state.update_for_consensus_message(
+            &signed_multi_signer,
+            &multi_signer_commit,
+            32,
+        );
 
         // Retrieve the operator state
         let operator_state = consensus_state.get_or_create_operator(&operator_id);

--- a/anchor/message_validator/src/duty_state.rs
+++ b/anchor/message_validator/src/duty_state.rs
@@ -11,25 +11,25 @@ use ssv_types::{
 };
 
 use crate::{FIRST_ROUND, ValidationFailure, message_counts::MessageCounts};
-// consensus_state.rs
+// duty_state.rs
 //
 // This file defines structures that help track and validate the consensus process.
 // The main components are:
-//  - ConsensusState: The top-level state tracker across operators and slots.
+//  - DutyState: The top-level state tracker across operators and slots.
 //  - OperatorState: The state for a specific operator over a range of slots.
 //  - SignerState: The state of a signer at a particular slot, including message counts and proposal
 //    data.
 
-/// ConsensusState manages the state for consensus validation across operators and slots
+/// DutyState manages the state for duty validation across operators and slots
 pub(crate) struct DutyState {
-    /// Tracks the consensus state for an operator
+    /// Tracks the duty state for an operator
     operators: HashMap<OperatorId, OperatorState>,
     /// The number of slots for which state is stored (defines the size of the circular buffer)
     stored_slot_count: usize,
 }
 
 impl DutyState {
-    /// Creates a new ConsensusState with the specified storage capacity
+    /// Creates a new DutyState with the specified storage capacity
     pub(crate) fn new(stored_slot_count: usize) -> Self {
         Self {
             operators: HashMap::new(),
@@ -45,7 +45,7 @@ impl DutyState {
             .or_insert_with(|| OperatorState::new(self.stored_slot_count))
     }
 
-    /// Updates the consensus state with new incoming messages.
+    /// Updates the duty state with new incoming messages.
     ///
     /// For each operator involved in the signed message, this method:
     /// - Determines the corresponding slot and estimated epoch,
@@ -71,7 +71,7 @@ impl DutyState {
         }
     }
 
-    /// Updates the consensus state with information about a partial signature message.
+    /// Updates the duty state with information about a partial signature message.
     /// This records the message type in the message counts for the signer at the given slot.
     pub(crate) fn update_for_partial_signature(
         &mut self,
@@ -319,8 +319,7 @@ mod tests {
     use crate::tests::{QbftMessageBuilder, create_signed_consensus_message};
 
     #[test]
-    fn test_consensus_state_update() {
-        // Setup a simple ConsensusState
+    fn test_duty_state_update() {
         let mut duty_state = DutyState::new(10);
 
         let qbft_message =
@@ -336,7 +335,7 @@ mod tests {
             vec![],
         );
 
-        // Update the consensus state
+        // Update the duty state
         duty_state.update_for_consensus_message(&signed_ssv_message, &qbft_message, 32);
 
         // Retrieve the operator state
@@ -364,7 +363,6 @@ mod tests {
 
     #[test]
     fn test_decided_message_not_counted() {
-        // Setup a simple ConsensusState
         let mut duty_state = DutyState::new(10);
 
         // Create a commit message with a single signer (should be counted)
@@ -380,7 +378,7 @@ mod tests {
             vec![],
         );
 
-        // Update consensus state with single-signer commit
+        // Update duty state with single-signer commit
         duty_state.update_for_consensus_message(&signed_single_signer, &single_signer_commit, 32);
 
         // Create a commit message with multiple signers (decided message, should NOT be counted)
@@ -394,7 +392,7 @@ mod tests {
             vec![],
         );
 
-        // Update consensus state with multi-signer commit
+        // Update duty state with multi-signer commit
         duty_state.update_for_consensus_message(&signed_multi_signer, &multi_signer_commit, 32);
 
         // Retrieve the operator state

--- a/anchor/message_validator/src/duty_state.rs
+++ b/anchor/message_validator/src/duty_state.rs
@@ -21,14 +21,14 @@ use crate::{FIRST_ROUND, ValidationFailure, message_counts::MessageCounts};
 //    data.
 
 /// ConsensusState manages the state for consensus validation across operators and slots
-pub(crate) struct ConsensusState {
+pub(crate) struct DutyState {
     /// Tracks the consensus state for an operator
     operators: HashMap<OperatorId, OperatorState>,
     /// The number of slots for which state is stored (defines the size of the circular buffer)
     stored_slot_count: usize,
 }
 
-impl ConsensusState {
+impl DutyState {
     /// Creates a new ConsensusState with the specified storage capacity
     pub(crate) fn new(stored_slot_count: usize) -> Self {
         Self {
@@ -321,7 +321,7 @@ mod tests {
     #[test]
     fn test_consensus_state_update() {
         // Setup a simple ConsensusState
-        let mut consensus_state = ConsensusState::new(10);
+        let mut duty_state = DutyState::new(10);
 
         let qbft_message =
             QbftMessageBuilder::new(Role::Committee, QbftMessageType::Proposal).build();
@@ -337,10 +337,10 @@ mod tests {
         );
 
         // Update the consensus state
-        consensus_state.update_for_consensus_message(&signed_ssv_message, &qbft_message, 32);
+        duty_state.update_for_consensus_message(&signed_ssv_message, &qbft_message, 32);
 
         // Retrieve the operator state
-        let operator_state = consensus_state.get_or_create_operator(&operator_id);
+        let operator_state = duty_state.get_or_create_operator(&operator_id);
         let slot = Slot::from(qbft_message.height);
 
         // Get the signer state for the slot
@@ -365,7 +365,7 @@ mod tests {
     #[test]
     fn test_decided_message_not_counted() {
         // Setup a simple ConsensusState
-        let mut consensus_state = ConsensusState::new(10);
+        let mut duty_state = DutyState::new(10);
 
         // Create a commit message with a single signer (should be counted)
         let single_signer_commit =
@@ -381,11 +381,7 @@ mod tests {
         );
 
         // Update consensus state with single-signer commit
-        consensus_state.update_for_consensus_message(
-            &signed_single_signer,
-            &single_signer_commit,
-            32,
-        );
+        duty_state.update_for_consensus_message(&signed_single_signer, &single_signer_commit, 32);
 
         // Create a commit message with multiple signers (decided message, should NOT be counted)
         let multi_signer_commit =
@@ -399,14 +395,10 @@ mod tests {
         );
 
         // Update consensus state with multi-signer commit
-        consensus_state.update_for_consensus_message(
-            &signed_multi_signer,
-            &multi_signer_commit,
-            32,
-        );
+        duty_state.update_for_consensus_message(&signed_multi_signer, &multi_signer_commit, 32);
 
         // Retrieve the operator state
-        let operator_state = consensus_state.get_or_create_operator(&operator_id);
+        let operator_state = duty_state.get_or_create_operator(&operator_id);
         let slot = Slot::from(single_signer_commit.height);
 
         // Get the signer state for the slot

--- a/anchor/message_validator/src/lib.rs
+++ b/anchor/message_validator/src/lib.rs
@@ -224,6 +224,7 @@ struct ValidationContext<'a, S> {
     pub operators_pk: &'a [Rsa<Public>],
     pub slots_per_epoch: u64,
     pub epochs_per_sync_committee_period: u64,
+    pub sync_committee_size: usize,
     pub slot_clock: S,
 }
 
@@ -232,6 +233,7 @@ pub struct Validator<S: SlotClock, D: DutiesProvider> {
     consensus_state_map: DashMap<MessageId, ConsensusState>,
     slots_per_epoch: u64,
     epochs_per_sync_committee_period: u64,
+    sync_committee_size: usize,
     duties_provider: Arc<D>,
     slot_clock: S,
 }
@@ -241,6 +243,7 @@ impl<S: SlotClock, D: DutiesProvider> Validator<S, D> {
         network_state_rx: Receiver<NetworkState>,
         slots_per_epoch: u64,
         epochs_per_sync_committee_period: u64,
+        sync_committee_size: usize,
         duties_provider: Arc<D>,
         slot_clock: S,
     ) -> Self {
@@ -249,6 +252,7 @@ impl<S: SlotClock, D: DutiesProvider> Validator<S, D> {
             consensus_state_map: DashMap::new(),
             slots_per_epoch,
             epochs_per_sync_committee_period,
+            sync_committee_size,
             duties_provider,
             slot_clock,
         }
@@ -304,6 +308,7 @@ impl<S: SlotClock, D: DutiesProvider> Validator<S, D> {
                     operators_pk: &operators_pks,
                     slots_per_epoch: self.slots_per_epoch,
                     epochs_per_sync_committee_period: self.epochs_per_sync_committee_period,
+                    sync_committee_size: self.sync_committee_size,
                     slot_clock: self.slot_clock.clone(),
                 };
 

--- a/anchor/message_validator/src/lib.rs
+++ b/anchor/message_validator/src/lib.rs
@@ -297,8 +297,8 @@ impl<S: SlotClock, D: DutiesProvider> Validator<S, D> {
                     get_operator_pks(&network_state, signed_ssv_message.operator_ids())?;
                 drop(network_state);
 
-                let mut consensus_state =
-                    self.get_consensus_state(ssv_message.msg_id(), self.slots_per_epoch);
+                let mut duty_state =
+                    self.get_duty_state(ssv_message.msg_id(), self.slots_per_epoch);
 
                 let validation_context = ValidationContext {
                     signed_ssv_message: &signed_ssv_message,
@@ -314,7 +314,7 @@ impl<S: SlotClock, D: DutiesProvider> Validator<S, D> {
 
                 validate_ssv_message(
                     validation_context,
-                    consensus_state.value_mut(),
+                    duty_state.value_mut(),
                     self.duties_provider.clone(),
                 )
                 .map(|validated| ValidatedMessage::new(signed_ssv_message.clone(), validated))
@@ -326,8 +326,8 @@ impl<S: SlotClock, D: DutiesProvider> Validator<S, D> {
         }
     }
 
-    /// Gets the consensus state for a message ID, creating a new one if it doesn't exist
-    fn get_consensus_state(
+    /// Gets the duty state for a message ID, creating a new one if it doesn't exist
+    fn get_duty_state(
         &self,
         message_id: &MessageId,
         slots_per_epoch: u64,

--- a/anchor/message_validator/src/lib.rs
+++ b/anchor/message_validator/src/lib.rs
@@ -1,5 +1,5 @@
 mod consensus_message;
-mod consensus_state;
+mod duty_state;
 mod message_counts;
 mod partial_signature;
 
@@ -36,7 +36,7 @@ use types::{Epoch, Slot};
 use crate::{
     ValidationFailure::EarlySlotMessage,
     consensus_message::validate_consensus_message,
-    consensus_state::{ConsensusState, OperatorState},
+    duty_state::{DutyState, OperatorState},
     partial_signature::validate_partial_signature_message,
 };
 
@@ -230,7 +230,7 @@ struct ValidationContext<'a, S> {
 
 pub struct Validator<S: SlotClock, D: DutiesProvider> {
     network_state_rx: Receiver<NetworkState>,
-    consensus_state_map: DashMap<MessageId, ConsensusState>,
+    duty_state_map: DashMap<MessageId, DutyState>,
     slots_per_epoch: u64,
     epochs_per_sync_committee_period: u64,
     sync_committee_size: usize,
@@ -249,7 +249,7 @@ impl<S: SlotClock, D: DutiesProvider> Validator<S, D> {
     ) -> Self {
         Self {
             network_state_rx,
-            consensus_state_map: DashMap::new(),
+            duty_state_map: DashMap::new(),
             slots_per_epoch,
             epochs_per_sync_committee_period,
             sync_committee_size,
@@ -331,30 +331,30 @@ impl<S: SlotClock, D: DutiesProvider> Validator<S, D> {
         &self,
         message_id: &MessageId,
         slots_per_epoch: u64,
-    ) -> RefMut<MessageId, ConsensusState> {
-        self.consensus_state_map
+    ) -> RefMut<MessageId, DutyState> {
+        self.duty_state_map
             .entry(message_id.clone())
             .or_insert_with(|| {
                 let stored_slot_count = slots_per_epoch * 2; // Store last two epochs
 
-                ConsensusState::new(stored_slot_count as usize)
+                DutyState::new(stored_slot_count as usize)
             })
     }
 }
 
 fn validate_ssv_message(
     validation_context: ValidationContext<impl SlotClock>,
-    consensus_state: &mut ConsensusState,
+    duty_state: &mut DutyState,
     duty_provider: Arc<impl DutiesProvider>,
 ) -> Result<ValidatedSSVMessage, ValidationFailure> {
     let ssv_message = validation_context.signed_ssv_message.ssv_message();
 
     match ssv_message.msg_type() {
         MsgType::SSVConsensusMsgType => {
-            validate_consensus_message(validation_context, consensus_state, duty_provider)
+            validate_consensus_message(validation_context, duty_state, duty_provider)
         }
         MsgType::SSVPartialSignatureMsgType => {
-            validate_partial_signature_message(validation_context, consensus_state, duty_provider)
+            validate_partial_signature_message(validation_context, duty_state, duty_provider)
         }
     }
 }

--- a/anchor/message_validator/src/lib.rs
+++ b/anchor/message_validator/src/lib.rs
@@ -5,7 +5,7 @@ mod partial_signature;
 
 use std::{
     sync::Arc,
-    time::{SystemTime, UNIX_EPOCH},
+    time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
 use dashmap::{DashMap, mapref::one::RefMut};
@@ -22,7 +22,7 @@ use safe_arith::SafeArith;
 use sha2::{Digest, Sha256};
 use slot_clock::SlotClock;
 use ssv_types::{
-    CommitteeInfo, OperatorId,
+    CommitteeInfo, OperatorId, ValidatorIndex,
     consensus::QbftMessage,
     message::{MsgType, SignedSSVMessage},
     msgid::{DutyExecutor, MessageId, Role},
@@ -34,9 +34,13 @@ use tracing::{error, trace};
 use types::{Epoch, Slot};
 
 use crate::{
-    consensus_message::validate_consensus_message, consensus_state::ConsensusState,
+    ValidationFailure::EarlySlotMessage,
+    consensus_message::validate_consensus_message,
+    consensus_state::{ConsensusState, OperatorState},
     partial_signature::validate_partial_signature_message,
 };
+
+pub(crate) const FIRST_ROUND: u64 = 1;
 
 // TODO taken from go-SSV as rough guidance. feel free to adjust as needed. https://github.com/ssvlabs/ssv/blob/e12abf7dfbbd068b99612fa2ebbe7e3372e57280/message/validation/errors.go#L55
 #[derive(Debug, PartialEq)]
@@ -132,8 +136,13 @@ pub enum ValidationFailure {
     DuplicatedMessage {
         got: String,
     }, // Updated to include context
-    InvalidPartialSignatureTypeCount,
-    TooManyPartialSignatureMessages,
+    InvalidPartialSignatureTypeCount {
+        got: String,
+    },
+    TooManyPartialSignatureMessages {
+        got: usize,
+        limit: usize,
+    },
     EncodeOperators,
     FailedToGetMaxRound,
     SlotStartTimeNotFound {
@@ -340,7 +349,7 @@ fn validate_ssv_message(
             validate_consensus_message(validation_context, consensus_state, duty_provider)
         }
         MsgType::SSVPartialSignatureMsgType => {
-            validate_partial_signature_message(validation_context)
+            validate_partial_signature_message(validation_context, consensus_state, duty_provider)
         }
     }
 }
@@ -400,6 +409,222 @@ fn verify_message_signatures(
     Ok(())
 }
 
+/// Validates if a validator is assigned to a specific duty
+pub(crate) fn validate_beacon_duty(
+    validation_context: &ValidationContext<impl SlotClock>,
+    slot: Slot,
+    randao_msg: bool,
+    duty_provider: Arc<impl DutiesProvider>,
+) -> Result<(), ValidationFailure> {
+    let role = validation_context.role;
+    let epoch = slot.epoch(validation_context.slots_per_epoch);
+    // Rule: For a proposal duty message, check if the validator is assigned to it
+    if role == Role::Proposer {
+        // Tolerate missing duties for RANDAO signatures during the first slot of an epoch,
+        // while duties are still being fetched from the Beacon node.
+
+        let is_first_slot_of_epoch = epoch.start_slot(validation_context.slots_per_epoch) == slot;
+
+        if randao_msg
+            && is_first_slot_of_epoch
+            && validation_context.slot_clock.now().unwrap_or_default() <= slot
+            && !duty_provider.is_epoch_known_for_proposers(epoch)
+        {
+            return Ok(());
+        }
+
+        // Non-committee roles always have one validator index
+        let validator_index = validation_context
+            .committee_info
+            .validator_indices
+            .first()
+            .copied()
+            .unwrap_or_default();
+        if !duty_provider.is_validator_proposer_at_slot(slot, validator_index) {
+            return Err(ValidationFailure::NoDuty);
+        }
+    }
+
+    // Rule: For a sync committee duty message, check if the validator is assigned
+    if role == Role::SyncCommittee {
+        let period =
+            sync_committee_period(epoch, validation_context.epochs_per_sync_committee_period)?;
+        let validator_index = validation_context
+            .committee_info
+            .validator_indices
+            .first()
+            .copied()
+            .unwrap_or_default();
+        if !duty_provider.is_validator_in_sync_committee(period, validator_index) {
+            return Err(ValidationFailure::NoDuty);
+        }
+    }
+
+    Ok(())
+}
+
+/// clockErrorTolerance is the maximum amount of clock error we expect to see between nodes.
+const CLOCK_ERROR_TOLERANCE: Duration = Duration::from_millis(50);
+/// lateMessageMargin is the duration past a message's TTL in which it is still considered valid.
+const LATE_MESSAGE_MARGIN: Duration = Duration::from_secs(3);
+const LATE_SLOT_ALLOWANCE: u64 = 2;
+
+/// Validates that the message's slot timing is correct
+pub(crate) fn validate_slot_time(
+    msg_slot: Slot,
+    validation_context: &ValidationContext<impl SlotClock>,
+) -> Result<(), ValidationFailure> {
+    // Check if the message is too early
+    let earliness = message_earliness(msg_slot, validation_context)?;
+    if earliness > CLOCK_ERROR_TOLERANCE {
+        return Err(EarlySlotMessage {
+            got: format!("early by {earliness:?}"),
+        });
+    }
+
+    // Check if the message is too late
+    let lateness = message_lateness(msg_slot, validation_context)?;
+    if lateness > CLOCK_ERROR_TOLERANCE {
+        return Err(ValidationFailure::LateSlotMessage {
+            got: format!("late by {lateness:?}"),
+        });
+    }
+
+    Ok(())
+}
+
+/// Returns how early a message is compared to its slot start time.
+/// Returns a zero duration if the message is on time or late.
+fn message_earliness(
+    slot: Slot,
+    validation_context: &ValidationContext<impl SlotClock>,
+) -> Result<Duration, ValidationFailure> {
+    let slot_start = slot_start_time(slot, validation_context.slot_clock.clone())
+        .map_err(|_| ValidationFailure::SlotStartTimeNotFound { slot })?;
+    Ok(slot_start
+        .duration_since(validation_context.received_at)
+        .unwrap_or_default())
+}
+
+/// Returns how late a message is compared to its deadline based on role.
+/// If the message was received before the deadline, it returns 0.
+/// If the message was received after the deadline, it returns the duration by which it was late.
+fn message_lateness(
+    slot: Slot,
+    validation_context: &ValidationContext<impl SlotClock>,
+) -> Result<Duration, ValidationFailure> {
+    let ttl = match validation_context.role {
+        Role::Proposer | Role::SyncCommittee => 1 + LATE_SLOT_ALLOWANCE,
+        Role::Committee | Role::Aggregator => {
+            validation_context.slots_per_epoch + LATE_SLOT_ALLOWANCE
+        }
+        // No lateness check for these roles
+        Role::ValidatorRegistration | Role::VoluntaryExit => return Ok(Duration::from_secs(0)),
+    };
+
+    let deadline = slot_start_time(slot + ttl, validation_context.slot_clock.clone())
+        .map_err(|_| ValidationFailure::SlotStartTimeNotFound { slot })?
+        .checked_add(LATE_MESSAGE_MARGIN)
+        .ok_or(ValidationFailure::UnexpectedFailure {
+            msg: "Unexpected overflow calculating message deadline".to_string(),
+        })?;
+
+    Ok(validation_context
+        .received_at
+        .duration_since(deadline)
+        .unwrap_or_default())
+}
+
+/// Validates the duty count for a specific message and operator
+pub(crate) fn validate_duty_count(
+    validation_context: &ValidationContext<impl SlotClock>,
+    slot: Slot,
+    signer_state: &mut OperatorState,
+    duty_provider: Arc<impl DutiesProvider>,
+) -> Result<(), ValidationFailure> {
+    if let Some(limit) = duty_limit(
+        validation_context,
+        slot,
+        &validation_context.committee_info.validator_indices,
+        duty_provider,
+    )? {
+        // Get current duty count for this signer
+        let epoch = slot.epoch(validation_context.slots_per_epoch);
+        let duty_count = signer_state.get_duty_count(epoch);
+
+        // Error if this validator has already been assigned at least as many duties
+        // as allowed for the target epoch. We perform this check *before* incrementing
+        // the in-memory count (so the very first duty will see count==0), hence the
+        // inclusive “>=” comparison.
+        // We only want to check the limit if this is the first message of that duty, as otherwise
+        // the check will fail for non-first messages of the last allowed duty. We do this by
+        // checking if there is a signer state already set for that slot. If so, we have already
+        // processed a message for this duty and the counter will not be increased further in
+        // `OperatorState::update`, so we skip the limit check here also.
+        if signer_state.is_first_message_for_duty(slot) && duty_count >= limit {
+            return Err(ValidationFailure::ExcessiveDutyCount {
+                got: duty_count,
+                limit,
+            });
+        }
+    }
+
+    Ok(())
+}
+
+/// Determines duty limit based on role and validator indices
+fn duty_limit(
+    validation_context: &ValidationContext<impl SlotClock>,
+    slot: Slot,
+    validator_indices: &[ValidatorIndex],
+    duty_provider: Arc<impl DutiesProvider>,
+) -> Result<Option<u64>, ValidationFailure> {
+    match validation_context.role {
+        Role::VoluntaryExit => {
+            // Extract the validator public key from the message ID
+            let pubkey = match validation_context
+                .signed_ssv_message
+                .ssv_message()
+                .msg_id()
+                .duty_executor()
+            {
+                Some(DutyExecutor::Validator(pubkey)) => pubkey,
+                _ => return Err(ValidationFailure::UnknownValidator),
+            };
+            // Get the current voluntary exit duty count for this validator
+            Ok(Some(
+                duty_provider.get_voluntary_exit_duty_count(slot, &pubkey),
+            ))
+        }
+        Role::Aggregator | Role::ValidatorRegistration => Ok(Some(2)),
+        Role::Committee => {
+            let validator_index_count = validator_indices.len() as u64;
+            let slots_per_epoch_val = validation_context.slots_per_epoch;
+
+            // Skip duty search if validators * 2 exceeds slots per epoch
+            if validator_index_count < slots_per_epoch_val / 2 {
+                let epoch = slot.epoch(validation_context.slots_per_epoch);
+                let period = sync_committee_period(
+                    epoch,
+                    validation_context.epochs_per_sync_committee_period,
+                )?;
+
+                // Check if at least one validator is in the sync committee
+                for &index in validator_indices {
+                    if duty_provider.is_validator_in_sync_committee(period, index) {
+                        return Ok(Some(slots_per_epoch_val));
+                    }
+                }
+            }
+            Ok(Some(std::cmp::min(
+                slots_per_epoch_val,
+                2 * validator_index_count,
+            )))
+        }
+        _ => Ok(None),
+    }
+}
+
 #[derive(thiserror::Error, Debug)]
 pub enum TimeError {
     #[error("clock start-of-slot overflow for slot {0}")]
@@ -457,6 +682,7 @@ pub(crate) fn hash_data(full_data: &[u8]) -> [u8; 32] {
 #[cfg(test)]
 mod tests {
     use bls::{Hash256, PublicKeyBytes};
+    use duties_tracker::DutiesProvider;
     use openssl::{
         hash::MessageDigest,
         pkey::{PKey, Private, Public},
@@ -471,6 +697,7 @@ mod tests {
         msgid::{DutyExecutor, MessageId, Role},
     };
     use ssz::Encode;
+    use types::{Epoch, Slot};
 
     use crate::{ValidationFailure, compute_quorum_size, hash_data};
 
@@ -642,6 +869,36 @@ mod tests {
                     "Expected {error_name} error, got: {failure:?}"
                 );
             }
+        }
+    }
+
+    #[derive(Default)]
+    pub struct MockDutiesProvider {
+        pub(crate) voluntary_exit_duty_count: u64,
+    }
+    impl DutiesProvider for MockDutiesProvider {
+        fn is_validator_in_sync_committee(
+            &self,
+            _committee_period: u64,
+            _validator_index: ValidatorIndex,
+        ) -> bool {
+            true
+        }
+
+        fn is_epoch_known_for_proposers(&self, _epoch: Epoch) -> bool {
+            true
+        }
+
+        fn is_validator_proposer_at_slot(
+            &self,
+            _slot: Slot,
+            _validator_index: ValidatorIndex,
+        ) -> bool {
+            true
+        }
+
+        fn get_voluntary_exit_duty_count(&self, _slot: Slot, _pubkey: &PublicKeyBytes) -> u64 {
+            self.voluntary_exit_duty_count
         }
     }
 

--- a/anchor/message_validator/src/lib.rs
+++ b/anchor/message_validator/src/lib.rs
@@ -432,7 +432,13 @@ pub(crate) fn validate_beacon_duty(
 
         if randao_msg
             && is_first_slot_of_epoch
-            && validation_context.slot_clock.now().unwrap_or_default() <= slot
+            && validation_context
+                .slot_clock
+                .now()
+                .ok_or(ValidationFailure::UnexpectedFailure {
+                    msg: "Failed to get current time".to_string(),
+                })?
+                <= slot
             && !duty_provider.is_epoch_known_for_proposers(epoch)
         {
             return Ok(());
@@ -444,7 +450,10 @@ pub(crate) fn validate_beacon_duty(
             .validator_indices
             .first()
             .copied()
-            .unwrap_or_default();
+            .ok_or(ValidationFailure::UnexpectedFailure {
+                msg: "Unexpected error when getting first validator index".to_string(),
+            })?;
+
         if !duty_provider.is_validator_proposer_at_slot(slot, validator_index) {
             return Err(ValidationFailure::NoDuty);
         }
@@ -459,7 +468,10 @@ pub(crate) fn validate_beacon_duty(
             .validator_indices
             .first()
             .copied()
-            .unwrap_or_default();
+            .ok_or(ValidationFailure::UnexpectedFailure {
+                msg: "Unexpected error when getting first validator index".to_string(),
+            })?;
+
         if !duty_provider.is_validator_in_sync_committee(period, validator_index) {
             return Err(ValidationFailure::NoDuty);
         }

--- a/anchor/message_validator/src/message_counts.rs
+++ b/anchor/message_validator/src/message_counts.rs
@@ -1,6 +1,10 @@
 use std::fmt;
 
-use ssv_types::{consensus::QbftMessageType, message::SignedSSVMessage};
+use ssv_types::{
+    consensus::QbftMessageType,
+    message::SignedSSVMessage,
+    partial_sig::{PartialSignatureKind, PartialSignatureMessages},
+};
 
 use crate::ValidationFailure;
 
@@ -9,25 +13,32 @@ const MAX_MESSAGES_PER_ROUND: u64 = 1;
 /// MessageCounts tracks different types of message counts per slot
 #[derive(Debug, Clone, Copy, Default)]
 pub(crate) struct MessageCounts {
+    pub(crate) pre_consensus: u64,
     pub(crate) proposal: u64,
     pub(crate) prepare: u64,
     pub(crate) commit: u64,
     pub(crate) round_change: u64,
+    pub(crate) post_consensus: u64,
 }
 
 impl fmt::Display for MessageCounts {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "MessageCounts {{ proposal: {}, prepare: {}, commit: {}, round_change: {} }}",
-            self.proposal, self.prepare, self.commit, self.round_change
+            "MessageCounts {{ pre_consensus: {}, proposal: {}, prepare: {}, commit: {}, round_change: {}, post_consensus:{} }}",
+            self.pre_consensus,
+            self.proposal,
+            self.prepare,
+            self.commit,
+            self.round_change,
+            self.post_consensus,
         )
     }
 }
 
 impl MessageCounts {
     /// Validates if the message type exceeds the allowed limits
-    pub fn validate_limits(
+    pub fn validate_consensus_message_limits(
         &self,
         signed_message: &SignedSSVMessage,
         msg_type: QbftMessageType,
@@ -60,6 +71,36 @@ impl MessageCounts {
         }
     }
 
+    /// Validates if the provided partial signature message exceeds the set limits.
+    /// Returns an error if the message type exceeds its respective count limit.
+    pub fn validate_partial_signature_message(
+        &self,
+        messages: &PartialSignatureMessages,
+    ) -> Result<(), ValidationFailure> {
+        match messages.kind {
+            PartialSignatureKind::RandaoPartialSig
+            | PartialSignatureKind::SelectionProofPartialSig
+            | PartialSignatureKind::ContributionProofs
+            | PartialSignatureKind::ValidatorRegistration
+            | PartialSignatureKind::VoluntaryExit => {
+                if self.pre_consensus >= MAX_MESSAGES_PER_ROUND {
+                    return Err(ValidationFailure::InvalidPartialSignatureTypeCount {
+                        got: format!("pre-consensus, having {self}"),
+                    });
+                }
+            }
+            PartialSignatureKind::PostConsensus => {
+                if self.post_consensus >= MAX_MESSAGES_PER_ROUND {
+                    return Err(ValidationFailure::InvalidPartialSignatureTypeCount {
+                        got: format!("post-consensus, having {self}"),
+                    });
+                }
+            }
+        }
+
+        Ok(())
+    }
+
     pub fn record_consensus_message(&mut self, msg_type: QbftMessageType, signer_count: usize) {
         // Increment the appropriate message counter
         match msg_type {
@@ -73,6 +114,18 @@ impl MessageCounts {
                 }
             }
             QbftMessageType::RoundChange => self.round_change += 1,
+        }
+    }
+
+    /// Records a partial signature message by incrementing the appropriate counter
+    pub fn record_partial_signature(&mut self, kind: PartialSignatureKind) {
+        match kind {
+            PartialSignatureKind::RandaoPartialSig
+            | PartialSignatureKind::SelectionProofPartialSig
+            | PartialSignatureKind::ContributionProofs
+            | PartialSignatureKind::ValidatorRegistration
+            | PartialSignatureKind::VoluntaryExit => self.pre_consensus += 1,
+            PartialSignatureKind::PostConsensus => self.post_consensus += 1,
         }
     }
 }

--- a/anchor/message_validator/src/message_counts.rs
+++ b/anchor/message_validator/src/message_counts.rs
@@ -1,5 +1,3 @@
-use std::fmt;
-
 use ssv_types::{
     consensus::QbftMessageType,
     message::SignedSSVMessage,
@@ -21,21 +19,6 @@ pub(crate) struct MessageCounts {
     pub(crate) post_consensus: u64,
 }
 
-impl fmt::Display for MessageCounts {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "MessageCounts {{ pre_consensus: {}, proposal: {}, prepare: {}, commit: {}, round_change: {}, post_consensus:{} }}",
-            self.pre_consensus,
-            self.proposal,
-            self.prepare,
-            self.commit,
-            self.round_change,
-            self.post_consensus,
-        )
-    }
-}
-
 impl MessageCounts {
     /// Validates if the message type exceeds the allowed limits
     pub fn validate_consensus_message_limits(
@@ -46,12 +29,12 @@ impl MessageCounts {
         match msg_type {
             QbftMessageType::Proposal if self.proposal >= MAX_MESSAGES_PER_ROUND => {
                 Err(ValidationFailure::DuplicatedMessage {
-                    got: format!("proposal, having {self}"),
+                    got: format!("proposal, having {self:?}"),
                 })
             }
             QbftMessageType::Prepare if self.prepare >= MAX_MESSAGES_PER_ROUND => {
                 Err(ValidationFailure::DuplicatedMessage {
-                    got: format!("prepare, having {self}"),
+                    got: format!("prepare, having {self:?}"),
                 })
             }
             QbftMessageType::Commit
@@ -59,12 +42,12 @@ impl MessageCounts {
                     && self.commit >= MAX_MESSAGES_PER_ROUND =>
             {
                 Err(ValidationFailure::DuplicatedMessage {
-                    got: format!("commit, having {self}"),
+                    got: format!("commit, having {self:?}"),
                 })
             }
             QbftMessageType::RoundChange if self.round_change >= MAX_MESSAGES_PER_ROUND => {
                 Err(ValidationFailure::DuplicatedMessage {
-                    got: format!("round change, having {self}"),
+                    got: format!("round change, having {self:?}"),
                 })
             }
             _ => Ok(()),
@@ -85,14 +68,14 @@ impl MessageCounts {
             | PartialSignatureKind::VoluntaryExit => {
                 if self.pre_consensus >= MAX_MESSAGES_PER_ROUND {
                     return Err(ValidationFailure::InvalidPartialSignatureTypeCount {
-                        got: format!("pre-consensus, having {self}"),
+                        got: format!("pre-consensus, having {self:?}"),
                     });
                 }
             }
             PartialSignatureKind::PostConsensus => {
                 if self.post_consensus >= MAX_MESSAGES_PER_ROUND {
                     return Err(ValidationFailure::InvalidPartialSignatureTypeCount {
-                        got: format!("post-consensus, having {self}"),
+                        got: format!("post-consensus, having {self:?}"),
                     });
                 }
             }

--- a/anchor/message_validator/src/partial_signature.rs
+++ b/anchor/message_validator/src/partial_signature.rs
@@ -57,7 +57,7 @@ pub(crate) fn validate_partial_signature_message(
         signature,
     )?;
 
-    // Update the consensus state with information about this partial signature message
+    // Update the duty state with information about this partial signature message
     let signer = validation_context
         .signed_ssv_message
         .operator_ids()
@@ -166,7 +166,7 @@ fn validate_partial_sig_messages_by_duty_logic(
         .first()
         .ok_or(ValidationFailure::NoSigners)?;
 
-    // Get consensus state for this signer
+    // Get duty state for this signer
     let operator_state = duty_state.get_or_create_operator(signer);
 
     // Rule: Slot must not be "old" - signer must not have already advanced to a later slot

--- a/anchor/message_validator/src/partial_signature.rs
+++ b/anchor/message_validator/src/partial_signature.rs
@@ -1,14 +1,29 @@
+use std::{collections::HashMap, sync::Arc};
+
+use duties_tracker::DutiesProvider;
 use slot_clock::SlotClock;
 use ssv_types::{
+    OperatorId,
     msgid::Role,
     partial_sig::{PartialSignatureKind, PartialSignatureMessages},
 };
 use ssz::Decode;
+use types::Epoch;
 
-use crate::{ValidatedSSVMessage, ValidationContext, ValidationFailure, verify_message_signature};
+use crate::{
+    FIRST_ROUND, ValidatedSSVMessage, ValidationContext, ValidationFailure,
+    consensus_state::{ConsensusState, SignerState},
+    validate_beacon_duty, validate_duty_count, validate_slot_time, verify_message_signature,
+};
+
+// Constants for validation rules
+const SYNC_COMMITTEE_SIZE: usize = 512;
+const MAX_SIGNATURES_IN_SYNC_COMMITTEE: usize = 13;
 
 pub(crate) fn validate_partial_signature_message(
     validation_context: ValidationContext<impl SlotClock>,
+    consensus_state: &mut ConsensusState,
+    duty_provider: Arc<impl DutiesProvider>,
 ) -> Result<ValidatedSSVMessage, ValidationFailure> {
     // Decode message directly to PartialSignatureMessages
     let messages = match PartialSignatureMessages::from_ssz_bytes(
@@ -21,7 +36,13 @@ pub(crate) fn validate_partial_signature_message(
     // Validate basic semantics
     validate_partial_signature_message_semantics(&validation_context, &messages)?;
 
-    // we still need to validate by duty logic
+    // Validate duty-specific logic
+    validate_partial_sig_messages_by_duty_logic(
+        &validation_context,
+        &messages,
+        consensus_state,
+        duty_provider,
+    )?;
 
     let operator_pk = validation_context
         .operators_pk
@@ -40,7 +61,55 @@ pub(crate) fn validate_partial_signature_message(
         signature,
     )?;
 
+    // Update the consensus state with information about this partial signature message
+    let signer = validation_context
+        .signed_ssv_message
+        .operator_ids()
+        .first()
+        .ok_or(ValidationFailure::NoSigners)?;
+
+    update_partial_signature_state(
+        &messages,
+        consensus_state,
+        signer,
+        validation_context.slots_per_epoch,
+    )?;
+
     Ok(ValidatedSSVMessage::PartialSignatureMessages(messages))
+}
+
+/// Updates the consensus state with information about a partial signature message.
+/// This records the message type in the message counts for the signer at the given slot.
+fn update_partial_signature_state(
+    partial_signature_messages: &PartialSignatureMessages,
+    consensus_state: &mut ConsensusState,
+    signer: &OperatorId,
+    slots_per_epoch: u64,
+) -> Result<(), ValidationFailure> {
+    let operator_state = consensus_state.get_or_create_operator(signer);
+    let message_slot = partial_signature_messages.slot;
+    let message_epoch = Epoch::new(message_slot.as_u64() / slots_per_epoch);
+
+    // Get or create a signer state for this slot
+    let signer_state = match operator_state.get_signer_state_mut(&message_slot) {
+        Some(existing_state) if existing_state.slot == message_slot => existing_state,
+        _ => {
+            // Create a new signer state
+            let new_signer_state = SignerState::new(message_slot, FIRST_ROUND);
+            operator_state.set_signer_state_for_first_round(
+                &message_slot,
+                &message_epoch,
+                new_signer_state,
+            )
+        }
+    };
+
+    // Record the partial signature (only once)
+    signer_state
+        .message_counts
+        .record_partial_signature(partial_signature_messages.kind);
+
+    Ok(())
 }
 
 fn validate_partial_signature_message_semantics(
@@ -119,6 +188,123 @@ fn partial_signature_type_matches_role(kind: PartialSignatureKind, role: Role) -
     }
 }
 
+/// Validates partial signature messages based on duty logic.
+fn validate_partial_sig_messages_by_duty_logic(
+    validation_context: &ValidationContext<impl SlotClock>,
+    partial_signature_messages: &PartialSignatureMessages,
+    consensus_state: &mut ConsensusState,
+    duty_provider: Arc<impl DutiesProvider>,
+) -> Result<(), ValidationFailure> {
+    let role = validation_context.role;
+    let message_slot = partial_signature_messages.slot;
+    let signed_message = validation_context.signed_ssv_message;
+
+    // Get the operator ID (signer)
+    let signer = signed_message
+        .operator_ids()
+        .first()
+        .ok_or(ValidationFailure::NoSigners)?;
+
+    // Get consensus state for this signer
+    let operator_state = consensus_state.get_or_create_operator(signer);
+
+    // Rule: Slot must not be "old" - signer must not have already advanced to a later slot
+    // Skip for committee role
+    if role != Role::Committee {
+        let max_slot = operator_state.max_slot();
+        if max_slot.as_u64() != 0 && max_slot > message_slot {
+            return Err(ValidationFailure::SlotAlreadyAdvanced {
+                got: message_slot.as_u64(),
+                want: max_slot.as_u64(),
+            });
+        }
+    }
+
+    let is_randao_msg = partial_signature_messages.kind == PartialSignatureKind::RandaoPartialSig;
+    validate_beacon_duty(
+        validation_context,
+        message_slot,
+        is_randao_msg,
+        duty_provider.clone(),
+    )?;
+
+    // Check if we've seen messages for this slot already
+    if let Some(signer_state) = operator_state.get_signer_state(&message_slot) {
+        if signer_state.slot != message_slot {
+            // Rule: peer must send only:
+            // - 1 PostConsensusPartialSig, for Committee duty
+            // - 1 RandaoPartialSig and 1 PostConsensusPartialSig for Proposer
+            // - 1 SelectionProofPartialSig and 1 PostConsensusPartialSig for Aggregator
+            // - 1 SelectionProofPartialSig and 1 PostConsensusPartialSig for Sync committee
+            //   contribution
+            // - 1 ValidatorRegistrationPartialSig for Validator Registration
+            // - 1 VoluntaryExitPartialSig for Voluntary Exit
+            signer_state
+                .message_counts
+                .validate_partial_signature_message(partial_signature_messages)?;
+        }
+    }
+
+    // Check timing constraints
+    validate_slot_time(message_slot, validation_context)?;
+
+    // Validate duty count
+    validate_duty_count(
+        validation_context,
+        message_slot,
+        operator_state,
+        duty_provider.clone(),
+    )?;
+
+    // Process role-specific message count constraints
+    let validator_count = validation_context.committee_info.validator_indices.len();
+    let message_count = partial_signature_messages.messages.len();
+
+    match role {
+        Role::Committee => {
+            // Rule: Number of signatures must be <= min(2*V, V + SYNC_COMMITTEE_SIZE)
+            let max_allowed =
+                std::cmp::min(2 * validator_count, validator_count + SYNC_COMMITTEE_SIZE);
+
+            if message_count > max_allowed {
+                return Err(ValidationFailure::TooManyPartialSignatureMessages {
+                    got: message_count,
+                    limit: max_allowed,
+                });
+            }
+
+            // Rule: A validator index can't appear more than 2 times
+            let mut validator_index_count = HashMap::new();
+            for message in &partial_signature_messages.messages {
+                let count = validator_index_count
+                    .entry(message.validator_index)
+                    .or_insert(0);
+                *count += 1;
+                if *count > 2 {
+                    return Err(ValidationFailure::TripleValidatorIndexInPartialSignatures);
+                }
+            }
+        }
+        Role::SyncCommittee if message_count > MAX_SIGNATURES_IN_SYNC_COMMITTEE => {
+            // Rule: Number of signatures must be <= MAX_SIGNATURES_IN_SYNC_COMMITTEE
+            return Err(ValidationFailure::TooManyPartialSignatureMessages {
+                got: message_count,
+                limit: MAX_SIGNATURES_IN_SYNC_COMMITTEE,
+            });
+        }
+        _ if message_count > 1 => {
+            // Rule: For other duties, only one signature is allowed
+            return Err(ValidationFailure::TooManyPartialSignatureMessages {
+                got: message_count,
+                limit: 1,
+            });
+        }
+        _ => {}
+    }
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use std::time::{Duration, SystemTime, UNIX_EPOCH};
@@ -141,7 +327,7 @@ mod tests {
 
     use super::*;
     use crate::tests::{
-        FOUR_NODE_COMMITTEE, assert_validation_error, create_committee_info,
+        FOUR_NODE_COMMITTEE, MockDutiesProvider, assert_validation_error, create_committee_info,
         create_message_id_for_test, generate_random_rsa_public_keys,
     };
 
@@ -177,7 +363,7 @@ mod tests {
 
         let partial_sig_messages = PartialSignatureMessages {
             kind,
-            slot: Slot::new(1),
+            slot: Slot::new(0),
             messages,
         };
 
@@ -257,7 +443,13 @@ mod tests {
         let validation_context =
             create_test_validation_context(&signed_msg, &committee_info, Role::Committee, &binding);
 
-        let result = validate_partial_signature_message(validation_context);
+        let result = validate_partial_signature_message(
+            validation_context,
+            &mut ConsensusState::new(2),
+            Arc::new(MockDutiesProvider {
+                voluntary_exit_duty_count: 0,
+            }),
+        );
 
         assert_validation_error(
             result,
@@ -298,7 +490,13 @@ mod tests {
         let validation_context =
             create_test_validation_context(&signed_msg, &committee_info, Role::Proposer, &binding);
 
-        let result = validate_partial_signature_message(validation_context);
+        let result = validate_partial_signature_message(
+            validation_context,
+            &mut ConsensusState::new(2),
+            Arc::new(MockDutiesProvider {
+                voluntary_exit_duty_count: 0,
+            }),
+        );
 
         assert_validation_error(
             result,
@@ -326,7 +524,13 @@ mod tests {
         let validation_context =
             create_test_validation_context(&signed_msg, &committee_info, Role::Proposer, &binding);
 
-        let result = validate_partial_signature_message(validation_context);
+        let result = validate_partial_signature_message(
+            validation_context,
+            &mut ConsensusState::new(2),
+            Arc::new(MockDutiesProvider {
+                voluntary_exit_duty_count: 0,
+            }),
+        );
 
         assert_validation_error(
             result,
@@ -354,7 +558,13 @@ mod tests {
         let validation_context =
             create_test_validation_context(&signed_msg, &committee_info, Role::Proposer, &binding);
 
-        let result = validate_partial_signature_message(validation_context);
+        let result = validate_partial_signature_message(
+            validation_context,
+            &mut ConsensusState::new(2),
+            Arc::new(MockDutiesProvider {
+                voluntary_exit_duty_count: 0,
+            }),
+        );
 
         assert_validation_error(
             result,
@@ -382,7 +592,13 @@ mod tests {
         let validation_context =
             create_test_validation_context(&signed_msg, &committee_info, Role::Proposer, &binding);
 
-        let result = validate_partial_signature_message(validation_context);
+        let result = validate_partial_signature_message(
+            validation_context,
+            &mut ConsensusState::new(2),
+            Arc::new(MockDutiesProvider {
+                voluntary_exit_duty_count: 0,
+            }),
+        );
 
         assert_validation_error(
             result,
@@ -408,7 +624,13 @@ mod tests {
         let validation_context =
             create_test_validation_context(&signed_msg, &committee_info, Role::Proposer, &binding);
 
-        let result = validate_partial_signature_message(validation_context);
+        let result = validate_partial_signature_message(
+            validation_context,
+            &mut ConsensusState::new(2),
+            Arc::new(MockDutiesProvider {
+                voluntary_exit_duty_count: 0,
+            }),
+        );
 
         assert!(
             result.is_ok(),
@@ -450,7 +672,13 @@ mod tests {
             &binding,
         );
 
-        let result = validate_partial_signature_message(validation_context);
+        let result = validate_partial_signature_message(
+            validation_context,
+            &mut ConsensusState::new(2),
+            Arc::new(MockDutiesProvider {
+                voluntary_exit_duty_count: 0,
+            }),
+        );
 
         assert_validation_error(
             result,
@@ -487,12 +715,131 @@ mod tests {
             &binding,
         );
 
-        let result = validate_partial_signature_message(validation_context);
+        let result = validate_partial_signature_message(
+            validation_context,
+            &mut ConsensusState::new(2),
+            Arc::new(MockDutiesProvider {
+                voluntary_exit_duty_count: 0,
+            }),
+        );
 
         assert!(
             result.is_ok(),
             "{}",
             format!("Expected successful validation for Committee role, but got: {result:?}")
+        );
+    }
+
+    fn create_partial_signature_messages() -> Vec<PartialSignatureMessage> {
+        let mut messages = vec![];
+        for _ in 0..3 {
+            messages.push(PartialSignatureMessage {
+                partial_signature: Signature::empty(),
+                signing_root: Hash256::from([0u8; 32]),
+                signer: OperatorId(1),
+                validator_index: ValidatorIndex(0),
+            });
+        }
+        messages
+    }
+
+    #[test]
+    fn test_too_many_partial_signature_messages() {
+        let committee_info = create_committee_info(FOUR_NODE_COMMITTEE);
+
+        // Create messages with more than allowed count
+        let messages = create_partial_signature_messages();
+
+        let partial_sig_messages = PartialSignatureMessages {
+            kind: PartialSignatureKind::PostConsensus,
+            slot: Slot::new(0),
+            messages,
+        };
+
+        let msg_id = create_message_id_for_test(Role::Proposer); // Not committee role
+        let ssv_msg_data = partial_sig_messages.as_ssz_bytes();
+        let ssv_msg = SSVMessage::new(MsgType::SSVPartialSignatureMsgType, msg_id, ssv_msg_data)
+            .expect("SSVMessage should be created");
+
+        let signed_msg = SignedSSVMessage::new(
+            vec![vec![0xAA; RSA_SIGNATURE_SIZE]],
+            vec![OperatorId(1)],
+            ssv_msg,
+            vec![],
+        )
+        .expect("SignedSSVMessage should be created");
+
+        let binding = generate_random_rsa_public_keys(signed_msg.operator_ids().len());
+        let validation_context =
+            create_test_validation_context(&signed_msg, &committee_info, Role::Proposer, &binding);
+
+        let result = validate_partial_signature_message(
+            validation_context,
+            &mut ConsensusState::new(2),
+            Arc::new(MockDutiesProvider {
+                voluntary_exit_duty_count: 0,
+            }),
+        );
+
+        assert_validation_error(
+            result,
+            |failure| {
+                matches!(
+                    failure,
+                    ValidationFailure::TooManyPartialSignatureMessages { .. }
+                )
+            },
+            "TooManyPartialSignatureMessages",
+        );
+    }
+
+    #[test]
+    fn test_triple_validator_index_fails() {
+        let committee_info = create_committee_info(FOUR_NODE_COMMITTEE);
+
+        // Create messages with a validator index that appears 3 times
+        let messages = create_partial_signature_messages();
+
+        let partial_sig_messages = PartialSignatureMessages {
+            kind: PartialSignatureKind::PostConsensus,
+            slot: Slot::new(0),
+            messages,
+        };
+
+        let msg_id = create_message_id_for_test(Role::Committee);
+        let ssv_msg_data = partial_sig_messages.as_ssz_bytes();
+        let ssv_msg = SSVMessage::new(MsgType::SSVPartialSignatureMsgType, msg_id, ssv_msg_data)
+            .expect("SSVMessage should be created");
+
+        let signed_msg = SignedSSVMessage::new(
+            vec![vec![0xAA; RSA_SIGNATURE_SIZE]],
+            vec![OperatorId(1)],
+            ssv_msg,
+            vec![],
+        )
+        .expect("SignedSSVMessage should be created");
+
+        let binding = generate_random_rsa_public_keys(signed_msg.operator_ids().len());
+        let validation_context =
+            create_test_validation_context(&signed_msg, &committee_info, Role::Committee, &binding);
+
+        let result = validate_partial_signature_message(
+            validation_context,
+            &mut ConsensusState::new(2),
+            Arc::new(MockDutiesProvider {
+                voluntary_exit_duty_count: 0,
+            }),
+        );
+
+        assert_validation_error(
+            result,
+            |failure| {
+                matches!(
+                    failure,
+                    ValidationFailure::TripleValidatorIndexInPartialSignatures
+                )
+            },
+            "TripleValidatorIndexInPartialSignatures",
         );
     }
 }

--- a/anchor/message_validator/src/partial_signature.rs
+++ b/anchor/message_validator/src/partial_signature.rs
@@ -14,7 +14,6 @@ use crate::{
 };
 
 // Constants for validation rules
-const SYNC_COMMITTEE_SIZE: usize = 512;
 const MAX_SIGNATURES_IN_SYNC_COMMITTEE: usize = 13;
 
 pub(crate) fn validate_partial_signature_message(
@@ -225,8 +224,10 @@ fn validate_partial_sig_messages_by_duty_logic(
     match role {
         Role::Committee => {
             // Rule: Number of signatures must be <= min(2*V, V + SYNC_COMMITTEE_SIZE)
-            let max_allowed =
-                std::cmp::min(2 * validator_count, validator_count + SYNC_COMMITTEE_SIZE);
+            let max_allowed = std::cmp::min(
+                2 * validator_count,
+                validator_count + validation_context.sync_committee_size,
+            );
 
             if message_count > max_allowed {
                 return Err(ValidationFailure::TooManyPartialSignatureMessages {
@@ -381,6 +382,7 @@ mod tests {
             operators_pk,
             slots_per_epoch: 32,
             epochs_per_sync_committee_period: 256,
+            sync_committee_size: 512,
             slot_clock: ManualSlotClock::new(
                 Slot::new(0),
                 SystemTime::now().duration_since(UNIX_EPOCH).unwrap(),

--- a/anchor/message_validator/src/partial_signature.rs
+++ b/anchor/message_validator/src/partial_signature.rs
@@ -9,7 +9,7 @@ use ssv_types::{
 use ssz::Decode;
 
 use crate::{
-    ValidatedSSVMessage, ValidationContext, ValidationFailure, consensus_state::ConsensusState,
+    ValidatedSSVMessage, ValidationContext, ValidationFailure, duty_state::DutyState,
     validate_beacon_duty, validate_duty_count, validate_slot_time, verify_message_signature,
 };
 
@@ -18,7 +18,7 @@ const MAX_SIGNATURES_IN_SYNC_COMMITTEE: usize = 13;
 
 pub(crate) fn validate_partial_signature_message(
     validation_context: ValidationContext<impl SlotClock>,
-    consensus_state: &mut ConsensusState,
+    duty_state: &mut DutyState,
     duty_provider: Arc<impl DutiesProvider>,
 ) -> Result<ValidatedSSVMessage, ValidationFailure> {
     // Decode message directly to PartialSignatureMessages
@@ -36,7 +36,7 @@ pub(crate) fn validate_partial_signature_message(
     validate_partial_sig_messages_by_duty_logic(
         &validation_context,
         &messages,
-        consensus_state,
+        duty_state,
         duty_provider,
     )?;
 
@@ -64,7 +64,7 @@ pub(crate) fn validate_partial_signature_message(
         .first()
         .ok_or(ValidationFailure::NoSigners)?;
 
-    consensus_state.update_for_partial_signature(
+    duty_state.update_for_partial_signature(
         &messages,
         signer,
         validation_context.slots_per_epoch,
@@ -153,7 +153,7 @@ fn partial_signature_type_matches_role(kind: PartialSignatureKind, role: Role) -
 fn validate_partial_sig_messages_by_duty_logic(
     validation_context: &ValidationContext<impl SlotClock>,
     partial_signature_messages: &PartialSignatureMessages,
-    consensus_state: &mut ConsensusState,
+    duty_state: &mut DutyState,
     duty_provider: Arc<impl DutiesProvider>,
 ) -> Result<(), ValidationFailure> {
     let role = validation_context.role;
@@ -167,7 +167,7 @@ fn validate_partial_sig_messages_by_duty_logic(
         .ok_or(ValidationFailure::NoSigners)?;
 
     // Get consensus state for this signer
-    let operator_state = consensus_state.get_or_create_operator(signer);
+    let operator_state = duty_state.get_or_create_operator(signer);
 
     // Rule: Slot must not be "old" - signer must not have already advanced to a later slot
     // Skip for committee role
@@ -407,7 +407,7 @@ mod tests {
 
         let result = validate_partial_signature_message(
             validation_context,
-            &mut ConsensusState::new(2),
+            &mut DutyState::new(2),
             Arc::new(MockDutiesProvider {
                 voluntary_exit_duty_count: 0,
             }),
@@ -454,7 +454,7 @@ mod tests {
 
         let result = validate_partial_signature_message(
             validation_context,
-            &mut ConsensusState::new(2),
+            &mut DutyState::new(2),
             Arc::new(MockDutiesProvider {
                 voluntary_exit_duty_count: 0,
             }),
@@ -488,7 +488,7 @@ mod tests {
 
         let result = validate_partial_signature_message(
             validation_context,
-            &mut ConsensusState::new(2),
+            &mut DutyState::new(2),
             Arc::new(MockDutiesProvider {
                 voluntary_exit_duty_count: 0,
             }),
@@ -522,7 +522,7 @@ mod tests {
 
         let result = validate_partial_signature_message(
             validation_context,
-            &mut ConsensusState::new(2),
+            &mut DutyState::new(2),
             Arc::new(MockDutiesProvider {
                 voluntary_exit_duty_count: 0,
             }),
@@ -556,7 +556,7 @@ mod tests {
 
         let result = validate_partial_signature_message(
             validation_context,
-            &mut ConsensusState::new(2),
+            &mut DutyState::new(2),
             Arc::new(MockDutiesProvider {
                 voluntary_exit_duty_count: 0,
             }),
@@ -588,7 +588,7 @@ mod tests {
 
         let result = validate_partial_signature_message(
             validation_context,
-            &mut ConsensusState::new(2),
+            &mut DutyState::new(2),
             Arc::new(MockDutiesProvider {
                 voluntary_exit_duty_count: 0,
             }),
@@ -636,7 +636,7 @@ mod tests {
 
         let result = validate_partial_signature_message(
             validation_context,
-            &mut ConsensusState::new(2),
+            &mut DutyState::new(2),
             Arc::new(MockDutiesProvider {
                 voluntary_exit_duty_count: 0,
             }),
@@ -679,7 +679,7 @@ mod tests {
 
         let result = validate_partial_signature_message(
             validation_context,
-            &mut ConsensusState::new(2),
+            &mut DutyState::new(2),
             Arc::new(MockDutiesProvider {
                 voluntary_exit_duty_count: 0,
             }),
@@ -737,7 +737,7 @@ mod tests {
 
         let result = validate_partial_signature_message(
             validation_context,
-            &mut ConsensusState::new(2),
+            &mut DutyState::new(2),
             Arc::new(MockDutiesProvider {
                 voluntary_exit_duty_count: 0,
             }),
@@ -787,7 +787,7 @@ mod tests {
 
         let result = validate_partial_signature_message(
             validation_context,
-            &mut ConsensusState::new(2),
+            &mut DutyState::new(2),
             Arc::new(MockDutiesProvider {
                 voluntary_exit_duty_count: 0,
             }),

--- a/anchor/message_validator/src/partial_signature.rs
+++ b/anchor/message_validator/src/partial_signature.rs
@@ -191,19 +191,17 @@ fn validate_partial_sig_messages_by_duty_logic(
 
     // Check if we've seen messages for this slot already
     if let Some(signer_state) = operator_state.get_signer_state(&message_slot) {
-        if signer_state.slot == message_slot {
-            // Rule: peer must send only:
-            // - 1 PostConsensusPartialSig, for Committee duty
-            // - 1 RandaoPartialSig and 1 PostConsensusPartialSig for Proposer
-            // - 1 SelectionProofPartialSig and 1 PostConsensusPartialSig for Aggregator
-            // - 1 SelectionProofPartialSig and 1 PostConsensusPartialSig for Sync committee
-            //   contribution
-            // - 1 ValidatorRegistrationPartialSig for Validator Registration
-            // - 1 VoluntaryExitPartialSig for Voluntary Exit
-            signer_state
-                .message_counts
-                .validate_partial_signature_message(partial_signature_messages)?;
-        }
+        // Rule: peer must send only:
+        // - 1 PostConsensusPartialSig, for Committee duty
+        // - 1 RandaoPartialSig and 1 PostConsensusPartialSig for Proposer
+        // - 1 SelectionProofPartialSig and 1 PostConsensusPartialSig for Aggregator
+        // - 1 SelectionProofPartialSig and 1 PostConsensusPartialSig for Sync committee
+        //   contribution
+        // - 1 ValidatorRegistrationPartialSig for Validator Registration
+        // - 1 VoluntaryExitPartialSig for Voluntary Exit
+        signer_state
+            .message_counts
+            .validate_partial_signature_message(partial_signature_messages)?;
     }
 
     // Check timing constraints

--- a/anchor/message_validator/src/partial_signature.rs
+++ b/anchor/message_validator/src/partial_signature.rs
@@ -3,16 +3,13 @@ use std::{collections::HashMap, sync::Arc};
 use duties_tracker::DutiesProvider;
 use slot_clock::SlotClock;
 use ssv_types::{
-    OperatorId,
     msgid::Role,
     partial_sig::{PartialSignatureKind, PartialSignatureMessages},
 };
 use ssz::Decode;
-use types::Epoch;
 
 use crate::{
-    FIRST_ROUND, ValidatedSSVMessage, ValidationContext, ValidationFailure,
-    consensus_state::{ConsensusState, SignerState},
+    ValidatedSSVMessage, ValidationContext, ValidationFailure, consensus_state::ConsensusState,
     validate_beacon_duty, validate_duty_count, validate_slot_time, verify_message_signature,
 };
 
@@ -68,48 +65,13 @@ pub(crate) fn validate_partial_signature_message(
         .first()
         .ok_or(ValidationFailure::NoSigners)?;
 
-    update_partial_signature_state(
+    consensus_state.update_for_partial_signature(
         &messages,
-        consensus_state,
         signer,
         validation_context.slots_per_epoch,
     )?;
 
     Ok(ValidatedSSVMessage::PartialSignatureMessages(messages))
-}
-
-/// Updates the consensus state with information about a partial signature message.
-/// This records the message type in the message counts for the signer at the given slot.
-fn update_partial_signature_state(
-    partial_signature_messages: &PartialSignatureMessages,
-    consensus_state: &mut ConsensusState,
-    signer: &OperatorId,
-    slots_per_epoch: u64,
-) -> Result<(), ValidationFailure> {
-    let operator_state = consensus_state.get_or_create_operator(signer);
-    let message_slot = partial_signature_messages.slot;
-    let message_epoch = Epoch::new(message_slot.as_u64() / slots_per_epoch);
-
-    // Get or create a signer state for this slot
-    let signer_state = match operator_state.get_signer_state_mut(&message_slot) {
-        Some(existing_state) if existing_state.slot == message_slot => existing_state,
-        _ => {
-            // Create a new signer state
-            let new_signer_state = SignerState::new(message_slot, FIRST_ROUND);
-            operator_state.set_signer_state_for_first_round(
-                &message_slot,
-                &message_epoch,
-                new_signer_state,
-            )
-        }
-    };
-
-    // Record the partial signature (only once)
-    signer_state
-        .message_counts
-        .record_partial_signature(partial_signature_messages.kind);
-
-    Ok(())
 }
 
 fn validate_partial_signature_message_semantics(

--- a/anchor/message_validator/src/partial_signature.rs
+++ b/anchor/message_validator/src/partial_signature.rs
@@ -191,7 +191,7 @@ fn validate_partial_sig_messages_by_duty_logic(
 
     // Check if we've seen messages for this slot already
     if let Some(signer_state) = operator_state.get_signer_state(&message_slot) {
-        if signer_state.slot != message_slot {
+        if signer_state.slot == message_slot {
             // Rule: peer must send only:
             // - 1 PostConsensusPartialSig, for Committee duty
             // - 1 RandaoPartialSig and 1 PostConsensusPartialSig for Proposer


### PR DESCRIPTION
## Issue Addressed

https://github.com/sigp/anchor/issues/161

This PR enhances the partial signature message validation by incorporating duty‐based logic and extending consensus state and message count management. Key changes include:

- Integration of duty-specific validations in partial signature message handling.
- Updates to consensus state and message count logic to track and update duty-related information.
- Extension of beacon duty, slot timing, and validator duty count validations in the library.

