### PR TITLE
Fix signer state update

### DIFF
--- a/anchor/message_validator/src/consensus_message.rs
+++ b/anchor/message_validator/src/consensus_message.rs
@@ -626,7 +626,7 @@ mod tests {
     use bls::{Hash256, PublicKeyBytes};
     use openssl::hash::MessageDigest;
     use ssv_types::{
-        CommitteeId, OperatorId,
+        OperatorId,
         consensus::{QbftMessage, QbftMessageType},
         domain_type::DomainType,
         message::{MsgType, RSA_SIGNATURE_SIZE, SSVMessage, SignedSSVMessage},
@@ -643,63 +643,6 @@ mod tests {
         },
         validate_ssv_message,
     };
-
-    // Helper struct for directly creating consensus messages for tests
-    struct QbftMessageBuilder {
-        msg_type: QbftMessageType,
-        round: u64,
-        identifier: MessageId,
-        prepare_justification: Vec<SignedSSVMessage>,
-        round_change_justification: Vec<SignedSSVMessage>,
-    }
-
-    impl QbftMessageBuilder {
-        fn new(role: Role, msg_type: QbftMessageType) -> Self {
-            Self {
-                msg_type,
-                round: 1,
-                identifier: create_message_id_for_test(role),
-                prepare_justification: vec![],
-                round_change_justification: vec![],
-            }
-        }
-
-        fn with_round(mut self, round: u64) -> Self {
-            self.round = round;
-            self
-        }
-
-        fn with_identifier(mut self, identifier: MessageId) -> Self {
-            self.identifier = identifier;
-            self
-        }
-
-        fn with_prepare_justification(mut self, justifications: Vec<SignedSSVMessage>) -> Self {
-            self.prepare_justification = justifications;
-            self
-        }
-
-        fn with_round_change_justification(
-            mut self,
-            justifications: Vec<SignedSSVMessage>,
-        ) -> Self {
-            self.round_change_justification = justifications;
-            self
-        }
-
-        fn build(self) -> QbftMessage {
-            QbftMessage {
-                qbft_message_type: self.msg_type,
-                height: 1,
-                round: self.round,
-                identifier: (&self.identifier).into(),
-                root: Hash256::from([0u8; 32]),
-                data_round: 1,
-                round_change_justification: self.round_change_justification,
-                prepare_justification: self.prepare_justification,
-            }
-        }
-    }
 
     #[derive(Default)]
     struct MockDutiesProvider {
@@ -729,62 +672,6 @@ mod tests {
         fn get_voluntary_exit_duty_count(&self, _slot: Slot, _pubkey: &PublicKeyBytes) -> u64 {
             self.voluntary_exit_duty_count
         }
-    }
-
-    // Helper for creating SignedSSVMessage with a QbftMessage
-    fn create_signed_consensus_message(
-        qbft_message: QbftMessage,
-        signers: Vec<OperatorId>,
-        full_data: Vec<u8>,
-        pks: Vec<Rsa<Private>>,
-    ) -> SignedSSVMessage {
-        // Validate that we don't have any zero signers
-        assert!(!signers.is_empty(), "Must provide at least one signer");
-        assert!(
-            signers.iter().all(|s| s.0 > 0),
-            "OperatorId(0) is not allowed as it causes ZeroSigner error"
-        );
-
-        let qbft_bytes = qbft_message.as_ssz_bytes();
-        let slice: &[u8] = qbft_message.identifier.as_ref();
-        let msg_id: [u8; 56] = slice
-            .try_into()
-            .expect("VariableList does not contain exactly 56 bytes");
-        let ssv_msg = SSVMessage::new(
-            MsgType::SSVConsensusMsgType,
-            msg_id.into(),
-            qbft_bytes.clone(),
-        )
-        .expect("SSVMessage should be created");
-
-        let signatures = if pks.is_empty() {
-            signers
-                .iter()
-                .enumerate()
-                .map(|(i, _)| vec![0xAA + i as u8; RSA_SIGNATURE_SIZE])
-                .collect::<Vec<_>>()
-        } else {
-            pks.iter()
-                .map(|pk| {
-                    let p_key = PKey::from_rsa(pk.clone()).unwrap();
-                    let mut signer = Signer::new(MessageDigest::sha256(), &p_key).unwrap();
-                    signer.update(&ssv_msg.as_ssz_bytes()).unwrap();
-                    signer.sign_to_vec().expect("Failed to sign message")
-                })
-                .collect::<Vec<_>>()
-        };
-
-        SignedSSVMessage::new(signatures, signers, ssv_msg, full_data)
-            .expect("SignedSSVMessage should be created")
-    }
-
-    fn create_message_id_for_test(role: Role) -> MessageId {
-        let domain = DomainType([0, 0, 0, 1]);
-        let duty_executor = match role {
-            Role::Committee => DutyExecutor::Committee(CommitteeId([0u8; 32])),
-            _ => DutyExecutor::Validator(PublicKeyBytes::empty()),
-        };
-        MessageId::new(&domain, role, &duty_executor)
     }
 
     // Assert helpers for common validation patterns
@@ -1457,7 +1344,10 @@ mod tests {
     use slot_clock::ManualSlotClock;
     use types::Epoch;
 
-    use crate::ValidationFailure::LateSlotMessage;
+    use crate::{
+        ValidationFailure::LateSlotMessage,
+        tests::{QbftMessageBuilder, create_message_id_for_test, create_signed_consensus_message},
+    };
 
     #[test]
     fn test_verify_message_signatures_success() {

--- a/anchor/message_validator/src/consensus_state.rs
+++ b/anchor/message_validator/src/consensus_state.rs
@@ -265,8 +265,10 @@ impl SignerState {
                 .insert(signed_ssv_message.operator_ids().as_slice().into());
         }
 
-        self.message_counts
-            .record_consensus_message(consensus_message.qbft_message_type);
+        self.message_counts.record_consensus_message(
+            consensus_message.qbft_message_type,
+            signed_ssv_message.operator_ids().len(),
+        );
     }
 }
 

--- a/anchor/message_validator/src/consensus_state.rs
+++ b/anchor/message_validator/src/consensus_state.rs
@@ -131,8 +131,12 @@ impl OperatorState {
             .filter(|s| s.slot == *slot)
     }
 
-    /// Sets the signer state in the circular buffer at the computed index.
-    fn set_signer_state(&mut self, slot: &Slot, signer_state: SignerState) -> &mut SignerState {
+    /// Sets the signer state for a round change in the circular buffer at the computed index.
+    fn set_signer_state_for_round_change(
+        &mut self,
+        slot: &Slot,
+        signer_state: SignerState,
+    ) -> &mut SignerState {
         let index = slot.as_usize() % self.state.len();
         self.state[index] = Some(signer_state);
         self.state[index].as_mut().unwrap()
@@ -160,24 +164,25 @@ impl OperatorState {
         let signer_state = if let Some(signer_state) = maybe_signer_state {
             if consensus_message.round > signer_state.round {
                 let signer_state = SignerState::new(*msg_slot, consensus_message.round);
-                self.set_signer_state(msg_slot, signer_state)
+                self.set_signer_state_for_round_change(msg_slot, signer_state)
             } else {
                 signer_state
             }
         } else {
             let signer_state = SignerState::new(*msg_slot, consensus_message.round);
-            self.set(msg_slot, estimated_msg_epoch, signer_state)
+            self.set_signer_state_for_first_round(msg_slot, estimated_msg_epoch, signer_state)
         };
 
         signer_state.update(signed_ssv_message, consensus_message);
     }
 
-    /// Sets the SignerState for a slot and updates tracking for the maximum slot and epoch.
+    /// Sets the SignerState for the first round of a slot and updates tracking for the maximum slot
+    /// and epoch.
     ///
     /// - Inserts the signer state into the circular buffer.
     /// - Updates `max_slot` if the new slot is higher.
     /// - Updates `max_epoch` and resets duty counters if the epoch has advanced.
-    fn set(
+    fn set_signer_state_for_first_round(
         &mut self,
         msg_slot: &Slot,
         estimated_msg_epoch: &Epoch,

--- a/anchor/message_validator/src/consensus_state.rs
+++ b/anchor/message_validator/src/consensus_state.rs
@@ -116,7 +116,7 @@ impl OperatorState {
     }
 
     /// Retrieves a mutable SignerState reference for a given slot.
-    pub(crate) fn get_signer_state_as_mut(&mut self, slot: &Slot) -> Option<&mut SignerState> {
+    pub(crate) fn get_signer_state_mut(&mut self, slot: &Slot) -> Option<&mut SignerState> {
         let len = self.state.len();
         self.state[slot.as_usize() % len]
             .as_mut()
@@ -155,7 +155,7 @@ impl OperatorState {
         msg_slot: &Slot,
         estimated_msg_epoch: &Epoch,
     ) {
-        let maybe_signer_state = self.get_signer_state_as_mut(msg_slot);
+        let maybe_signer_state = self.get_signer_state_mut(msg_slot);
 
         let signer_state = if let Some(signer_state) = maybe_signer_state {
             if consensus_message.round > signer_state.round {

--- a/anchor/message_validator/src/consensus_state.rs
+++ b/anchor/message_validator/src/consensus_state.rs
@@ -115,15 +115,20 @@ impl OperatorState {
         }
     }
 
-    /// Retrieves the SignerState for a given slot, if it exists.
-    ///
-    /// The state is stored in a circular buffer and is accessed using modulo arithmetic.
-    pub(crate) fn get_signer_state(&mut self, slot: &Slot) -> Option<&mut SignerState> {
+    /// Retrieves a mutable SignerState reference for a given slot.
+    pub(crate) fn get_signer_state_as_mut(&mut self, slot: &Slot) -> Option<&mut SignerState> {
         let len = self.state.len();
-        match self.state[slot.as_usize() % len].as_mut() {
-            Some(s) if s.slot == *slot => Some(s),
-            _ => None,
-        }
+        self.state[slot.as_usize() % len]
+            .as_mut()
+            .filter(|s| s.slot == *slot)
+    }
+
+    /// Retrieves a SignerState reference for a given slot.
+    pub(crate) fn get_signer_state(&self, slot: &Slot) -> Option<&SignerState> {
+        let len = self.state.len();
+        self.state[slot.as_usize() % len]
+            .as_ref()
+            .filter(|s| s.slot == *slot)
     }
 
     /// Sets the signer state in the circular buffer at the computed index.
@@ -134,7 +139,7 @@ impl OperatorState {
     }
 
     /// Returns true if we have not seen a message for a duty in `slot` yet.
-    pub(crate) fn is_first_message_for_duty(&mut self, slot: Slot) -> bool {
+    pub(crate) fn is_first_message_for_duty(&self, slot: Slot) -> bool {
         self.get_signer_state(&slot).is_none()
     }
 
@@ -150,7 +155,7 @@ impl OperatorState {
         msg_slot: &Slot,
         estimated_msg_epoch: &Epoch,
     ) {
-        let maybe_signer_state = self.get_signer_state(msg_slot);
+        let maybe_signer_state = self.get_signer_state_as_mut(msg_slot);
 
         let signer_state = if let Some(signer_state) = maybe_signer_state {
             if consensus_message.round > signer_state.round {

--- a/anchor/message_validator/src/consensus_state.rs
+++ b/anchor/message_validator/src/consensus_state.rs
@@ -322,4 +322,55 @@ mod tests {
             panic!("SignerState should exist for the slot");
         }
     }
+
+    #[test]
+    fn test_decided_message_not_counted() {
+        // Setup a simple ConsensusState
+        let mut consensus_state = ConsensusState::new(10);
+
+        // Create a commit message with a single signer (should be counted)
+        let single_signer_commit =
+            QbftMessageBuilder::new(Role::Committee, QbftMessageType::Commit).build();
+
+        let operator_id = OperatorId(1);
+
+        let signed_single_signer = create_signed_consensus_message(
+            single_signer_commit.clone(),
+            vec![operator_id],
+            vec![],
+            vec![],
+        );
+
+        // Update consensus state with single-signer commit
+        consensus_state.update(&signed_single_signer, &single_signer_commit, 32);
+
+        // Create a commit message with multiple signers (decided message, should NOT be counted)
+        let multi_signer_commit =
+            QbftMessageBuilder::new(Role::Committee, QbftMessageType::Commit).build();
+
+        let signed_multi_signer = create_signed_consensus_message(
+            multi_signer_commit.clone(),
+            vec![OperatorId(1), OperatorId(2), OperatorId(3)],
+            vec![],
+            vec![],
+        );
+
+        // Update consensus state with multi-signer commit
+        consensus_state.update(&signed_multi_signer, &multi_signer_commit, 32);
+
+        // Retrieve the operator state
+        let operator_state = consensus_state.get_or_create_operator(&operator_id);
+        let slot = Slot::from(single_signer_commit.height);
+
+        // Get the signer state for the slot
+        if let Some(signer_state) = operator_state.get_signer_state(&slot) {
+            // Verify commit count is 1 (only the single-signer message was counted)
+            assert_eq!(
+                signer_state.message_counts.commit, 1,
+                "Commit count should be 1 (only single-signer commit should be counted)"
+            );
+        } else {
+            panic!("SignerState should exist for the slot");
+        }
+    }
 }

--- a/anchor/message_validator/src/consensus_state.rs
+++ b/anchor/message_validator/src/consensus_state.rs
@@ -118,21 +118,23 @@ impl OperatorState {
     /// Retrieves the SignerState for a given slot, if it exists.
     ///
     /// The state is stored in a circular buffer and is accessed using modulo arithmetic.
-    pub(crate) fn get_signer_state(&self, slot: &Slot) -> Option<SignerState> {
-        match &self.state[slot.as_usize() % self.state.len()] {
-            Some(s) if s.slot == *slot => Some(s.clone()),
+    pub(crate) fn get_signer_state(&mut self, slot: &Slot) -> Option<&mut SignerState> {
+        let len = self.state.len();
+        match self.state[slot.as_usize() % len].as_mut() {
+            Some(s) if s.slot == *slot => Some(s),
             _ => None,
         }
     }
 
     /// Sets the signer state in the circular buffer at the computed index.
-    fn set_signer_state(&mut self, slot: &Slot, signer_state: &SignerState) {
+    fn set_signer_state(&mut self, slot: &Slot, signer_state: SignerState) -> &mut SignerState {
         let index = slot.as_usize() % self.state.len();
-        self.state[index] = Some(signer_state.clone());
+        self.state[index] = Some(signer_state);
+        self.state[index].as_mut().unwrap()
     }
 
     /// Returns true if we have not seen a message for a duty in `slot` yet.
-    pub(crate) fn is_first_message_for_duty(&self, slot: Slot) -> bool {
+    pub(crate) fn is_first_message_for_duty(&mut self, slot: Slot) -> bool {
         self.get_signer_state(&slot).is_none()
     }
 
@@ -150,18 +152,16 @@ impl OperatorState {
     ) {
         let maybe_signer_state = self.get_signer_state(msg_slot);
 
-        let mut signer_state = if let Some(signer_state) = maybe_signer_state {
+        let signer_state = if let Some(signer_state) = maybe_signer_state {
             if consensus_message.round > signer_state.round {
                 let signer_state = SignerState::new(*msg_slot, consensus_message.round);
-                self.set_signer_state(msg_slot, &signer_state);
-                signer_state
+                self.set_signer_state(msg_slot, signer_state)
             } else {
                 signer_state
             }
         } else {
             let signer_state = SignerState::new(*msg_slot, consensus_message.round);
-            self.set(msg_slot, estimated_msg_epoch, &signer_state);
-            signer_state
+            self.set(msg_slot, estimated_msg_epoch, signer_state)
         };
 
         signer_state.update(signed_ssv_message, consensus_message);
@@ -172,9 +172,14 @@ impl OperatorState {
     /// - Inserts the signer state into the circular buffer.
     /// - Updates `max_slot` if the new slot is higher.
     /// - Updates `max_epoch` and resets duty counters if the epoch has advanced.
-    fn set(&mut self, msg_slot: &Slot, estimated_msg_epoch: &Epoch, signer_state: &SignerState) {
+    fn set(
+        &mut self,
+        msg_slot: &Slot,
+        estimated_msg_epoch: &Epoch,
+        signer_state: SignerState,
+    ) -> &mut SignerState {
         let index = msg_slot.as_usize() % self.state.len();
-        self.state[index] = Some(signer_state.clone());
+        self.state[index] = Some(signer_state);
 
         if msg_slot > &self.max_slot {
             self.max_slot = *msg_slot;
@@ -196,6 +201,7 @@ impl OperatorState {
                 self.prev_epoch_duties += 1;
             }
         }
+        self.state[index].as_mut().unwrap()
     }
 }
 
@@ -256,5 +262,57 @@ impl SignerState {
 
         self.message_counts
             .record_consensus_message(consensus_message.qbft_message_type);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use ssv_types::{OperatorId, Slot, consensus::QbftMessageType, msgid::Role};
+
+    use super::*;
+    use crate::tests::{QbftMessageBuilder, create_signed_consensus_message};
+
+    #[test]
+    fn test_consensus_state_update() {
+        // Setup a simple ConsensusState
+        let mut consensus_state = ConsensusState::new(10);
+
+        let qbft_message =
+            QbftMessageBuilder::new(Role::Committee, QbftMessageType::Proposal).build();
+
+        let operator_id = OperatorId(1);
+
+        let full_data = vec![1, 2, 3];
+        let signed_ssv_message = create_signed_consensus_message(
+            qbft_message.clone(),
+            vec![operator_id],
+            full_data.clone(),
+            vec![],
+        );
+
+        // Update the consensus state
+        consensus_state.update(&signed_ssv_message, &qbft_message, 32);
+
+        // Retrieve the operator state
+        let operator_state = consensus_state.get_or_create_operator(&operator_id);
+        let slot = Slot::from(qbft_message.height);
+
+        // Get the signer state for the slot
+        if let Some(signer_state) = operator_state.get_signer_state(&slot) {
+            // // Verify that the proposal data was correctly stored
+            assert_eq!(
+                &signer_state.proposal_data,
+                &Some(full_data),
+                "Proposal data should match the signed message data"
+            );
+
+            // Verify message counts were updated
+            assert_eq!(
+                signer_state.message_counts.proposal, 1,
+                "Message count for Proposal should be 1"
+            );
+        } else {
+            panic!("SignerState should exist for the slot");
+        }
     }
 }

--- a/anchor/message_validator/src/lib.rs
+++ b/anchor/message_validator/src/lib.rs
@@ -456,13 +456,21 @@ pub(crate) fn hash_data(full_data: &[u8]) -> [u8; 32] {
 
 #[cfg(test)]
 mod tests {
-    use bls::PublicKeyBytes;
-    use openssl::{pkey::Public, rsa::Rsa};
+    use bls::{Hash256, PublicKeyBytes};
+    use openssl::{
+        hash::MessageDigest,
+        pkey::{PKey, Private, Public},
+        rsa::Rsa,
+        sign::Signer,
+    };
     use ssv_types::{
         CommitteeId, CommitteeInfo, IndexSet, OperatorId, ValidatorIndex,
+        consensus::{QbftMessage, QbftMessageType},
         domain_type::DomainType,
+        message::{MsgType, RSA_SIGNATURE_SIZE, SSVMessage, SignedSSVMessage},
         msgid::{DutyExecutor, MessageId, Role},
     };
+    use ssz::Encode;
 
     use crate::{ValidationFailure, compute_quorum_size, hash_data};
 
@@ -470,6 +478,113 @@ mod tests {
     pub(crate) const SINGLE_NODE_COMMITTEE: usize = 1;
     pub(crate) const FOUR_NODE_COMMITTEE: usize = 4;
     pub(crate) const SEVEN_NODE_COMMITTEE: usize = 7;
+
+    // Helper struct for directly creating consensus messages for tests
+    pub(crate) struct QbftMessageBuilder {
+        msg_type: QbftMessageType,
+        round: u64,
+        identifier: MessageId,
+        prepare_justification: Vec<SignedSSVMessage>,
+        round_change_justification: Vec<SignedSSVMessage>,
+    }
+
+    impl QbftMessageBuilder {
+        pub(crate) fn new(role: Role, msg_type: QbftMessageType) -> Self {
+            Self {
+                msg_type,
+                round: 1,
+                identifier: create_message_id_for_test(role),
+                prepare_justification: vec![],
+                round_change_justification: vec![],
+            }
+        }
+
+        pub(crate) fn with_round(mut self, round: u64) -> Self {
+            self.round = round;
+            self
+        }
+
+        pub(crate) fn with_identifier(mut self, identifier: MessageId) -> Self {
+            self.identifier = identifier;
+            self
+        }
+
+        pub(crate) fn with_prepare_justification(
+            mut self,
+            justifications: Vec<SignedSSVMessage>,
+        ) -> Self {
+            self.prepare_justification = justifications;
+            self
+        }
+
+        pub(crate) fn with_round_change_justification(
+            mut self,
+            justifications: Vec<SignedSSVMessage>,
+        ) -> Self {
+            self.round_change_justification = justifications;
+            self
+        }
+
+        pub(crate) fn build(self) -> QbftMessage {
+            QbftMessage {
+                qbft_message_type: self.msg_type,
+                height: 1,
+                round: self.round,
+                identifier: (&self.identifier).into(),
+                root: Hash256::from([0u8; 32]),
+                data_round: 1,
+                round_change_justification: self.round_change_justification,
+                prepare_justification: self.prepare_justification,
+            }
+        }
+    }
+
+    // Helper for creating SignedSSVMessage with a QbftMessage
+    pub(crate) fn create_signed_consensus_message(
+        qbft_message: QbftMessage,
+        signers: Vec<OperatorId>,
+        full_data: Vec<u8>,
+        pks: Vec<Rsa<Private>>,
+    ) -> SignedSSVMessage {
+        // Validate that we don't have any zero signers
+        assert!(!signers.is_empty(), "Must provide at least one signer");
+        assert!(
+            signers.iter().all(|s| s.0 > 0),
+            "OperatorId(0) is not allowed as it causes ZeroSigner error"
+        );
+
+        let qbft_bytes = qbft_message.as_ssz_bytes();
+        let slice: &[u8] = qbft_message.identifier.as_ref();
+        let msg_id: [u8; 56] = slice
+            .try_into()
+            .expect("VariableList does not contain exactly 56 bytes");
+        let ssv_msg = SSVMessage::new(
+            MsgType::SSVConsensusMsgType,
+            msg_id.into(),
+            qbft_bytes.clone(),
+        )
+        .expect("SSVMessage should be created");
+
+        let signatures = if pks.is_empty() {
+            signers
+                .iter()
+                .enumerate()
+                .map(|(i, _)| vec![0xAA + i as u8; RSA_SIGNATURE_SIZE])
+                .collect::<Vec<_>>()
+        } else {
+            pks.iter()
+                .map(|pk| {
+                    let p_key = PKey::from_rsa(pk.clone()).unwrap();
+                    let mut signer = Signer::new(MessageDigest::sha256(), &p_key).unwrap();
+                    signer.update(&ssv_msg.as_ssz_bytes()).unwrap();
+                    signer.sign_to_vec().expect("Failed to sign message")
+                })
+                .collect::<Vec<_>>()
+        };
+
+        SignedSSVMessage::new(signatures, signers, ssv_msg, full_data)
+            .expect("SignedSSVMessage should be created")
+    }
 
     pub(crate) fn generate_random_rsa_public_keys(count: usize) -> Vec<Rsa<Public>> {
         (0..count)
@@ -502,7 +617,7 @@ mod tests {
     }
 
     // Helper to create a message ID for tests
-    pub fn create_message_id_for_test(role: Role) -> MessageId {
+    pub(crate) fn create_message_id_for_test(role: Role) -> MessageId {
         let domain = DomainType([0, 0, 0, 1]);
         let duty_executor = match role {
             Role::Committee => DutyExecutor::Committee(CommitteeId([0u8; 32])),

--- a/anchor/message_validator/src/message_counts.rs
+++ b/anchor/message_validator/src/message_counts.rs
@@ -60,7 +60,7 @@ impl MessageCounts {
         }
     }
 
-    pub fn record_consensus_message(&mut self, msg_type: QbftMessageType, operators_id_len: usize) {
+    pub fn record_consensus_message(&mut self, msg_type: QbftMessageType, signer_count: usize) {
         // Increment the appropriate message counter
         match msg_type {
             QbftMessageType::Proposal => self.proposal += 1,
@@ -68,7 +68,7 @@ impl MessageCounts {
             QbftMessageType::Commit => {
                 // Commit messages with more than one signer (also known as Decided messages) are
                 // not counted
-                if operators_id_len == 1 {
+                if signer_count == 1 {
                     self.commit += 1;
                 }
             }

--- a/anchor/message_validator/src/message_counts.rs
+++ b/anchor/message_validator/src/message_counts.rs
@@ -60,12 +60,18 @@ impl MessageCounts {
         }
     }
 
-    pub fn record_consensus_message(&mut self, msg_type: QbftMessageType) {
+    pub fn record_consensus_message(&mut self, msg_type: QbftMessageType, operators_id_len: usize) {
         // Increment the appropriate message counter
         match msg_type {
             QbftMessageType::Proposal => self.proposal += 1,
             QbftMessageType::Prepare => self.prepare += 1,
-            QbftMessageType::Commit => self.commit += 1,
+            QbftMessageType::Commit => {
+                // Commit messages with more than one signer (also known as Decided messages) are
+                // not counted
+                if operators_id_len == 1 {
+                    self.commit += 1;
+                }
+            }
             QbftMessageType::RoundChange => self.round_change += 1,
         }
     }


### PR DESCRIPTION
## Issue Addressed

The `update` function incorrectly passed a `SignerState` reference to the `set` function that cloned it (creating a new instance) and stored it in the `OperatorState`, which incorrectly updated its instance, assuming they were the same.

## Proposed Changes

We now pass ownership to the `set` functions, and they return mutable references, allowing for in-place updates. Key changes include:

- Updating the getter/setter functions in OperatorState to use mutable references.
- Refactoring the test helpers to create and verify consensus messages without duplicating code.

