### PR TITLE
Avoid async in event processor

### DIFF
--- a/anchor/eth/src/event_processor.rs
+++ b/anchor/eth/src/event_processor.rs
@@ -1,12 +1,6 @@
 use std::sync::Arc;
 
-use alloy::{
-    eips::BlockNumberOrTag,
-    primitives::Address,
-    providers::{Provider, RootProvider},
-    rpc::types::Log,
-    sol_types::SolEvent,
-};
+use alloy::{primitives::Address, rpc::types::Log, sol_types::SolEvent};
 use database::{NetworkDatabase, UniqueIndex};
 use eth2::types::PublicKeyBytes;
 use indexmap::IndexSet;
@@ -47,18 +41,12 @@ pub struct EventProcessor {
     pub db: Arc<NetworkDatabase>,
     /// Signal if we should only do relevant keysplitting processing
     mode: Mode,
-    /// RPC client for fetching data from the network
-    rpc_client: Arc<RootProvider>,
 }
 
 impl EventProcessor {
     /// Construct a new EventProcessor
-    pub fn new(db: Arc<NetworkDatabase>, mode: Mode, rpc_client: Arc<RootProvider>) -> Self {
-        Self {
-            db,
-            mode,
-            rpc_client,
-        }
+    pub fn new(db: Arc<NetworkDatabase>, mode: Mode) -> Self {
+        Self { db, mode }
     }
 
     /// Process a new set of logs
@@ -95,37 +83,34 @@ impl EventProcessor {
 
             // Process log based on signature hash
             let result = match *topic0 {
-                hash if hash == SSVContract::OperatorAdded::SIGNATURE_HASH => {
-                    self.process_operator_added(log, &tx)
-                }
+                SSVContract::OperatorAdded::SIGNATURE_HASH => self.process_operator_added(log, &tx),
 
-                hash if hash == SSVContract::OperatorRemoved::SIGNATURE_HASH => {
+                SSVContract::OperatorRemoved::SIGNATURE_HASH => {
                     self.process_operator_removed(log, &tx)
                 }
 
-                hash if hash == SSVContract::ValidatorAdded::SIGNATURE_HASH => {
+                SSVContract::ValidatorAdded::SIGNATURE_HASH => {
                     self.process_validator_added(log, &tx)
                 }
 
-                hash if hash == SSVContract::ValidatorRemoved::SIGNATURE_HASH => {
+                SSVContract::ValidatorRemoved::SIGNATURE_HASH => {
                     self.process_validator_removed(log, &tx)
                 }
 
-                hash if hash == SSVContract::ClusterLiquidated::SIGNATURE_HASH => {
+                SSVContract::ClusterLiquidated::SIGNATURE_HASH => {
                     self.process_cluster_liquidated(log, &tx)
                 }
 
-                hash if hash == SSVContract::ClusterReactivated::SIGNATURE_HASH => {
+                SSVContract::ClusterReactivated::SIGNATURE_HASH => {
                     self.process_cluster_reactivated(log, &tx)
                 }
 
-                hash if hash == SSVContract::FeeRecipientAddressUpdated::SIGNATURE_HASH => {
+                SSVContract::FeeRecipientAddressUpdated::SIGNATURE_HASH => {
                     self.process_fee_recipient_updated(log, &tx)
                 }
 
-                hash if hash == SSVContract::ValidatorExited::SIGNATURE_HASH => {
-                    // Block so we can keep this fn sync
-                    tokio::runtime::Handle::current().block_on(self.process_validator_exited(log))
+                SSVContract::ValidatorExited::SIGNATURE_HASH if live => {
+                    self.process_validator_exited(log)
                 }
                 _ => {
                     debug!(?topic0, "Unknown event signature, skipping");
@@ -586,7 +571,7 @@ impl EventProcessor {
 
     // A validator has exited the beacon chain
     #[instrument(skip(self, log), fields(validator_pubkey, owner))]
-    async fn process_validator_exited(&self, log: &Log) -> Result<(), ExecutionError> {
+    fn process_validator_exited(&self, log: &Log) -> Result<(), ExecutionError> {
         // In KeySplit mode, we don't need to process validator exits
         let Mode::Node { exit_tx, .. } = &self.mode else {
             return Ok(());
@@ -609,41 +594,9 @@ impl EventProcessor {
         // network
         validate_operators(&operator_ids, &computed_cluster_id, &self.db.state())?;
 
-        let block_timestamp = match log.block_timestamp {
-            Some(ts) => ts,
-            None => {
-                debug!("Block timestamp not available");
-
-                // Get the block_number for epoch calculation
-                let block_number = log.block_number.ok_or_else(|| {
-                    ExecutionError::InvalidEvent("Block number not available".to_string())
-                })?;
-
-                let block = match self
-                    .rpc_client
-                    .get_block_by_number(BlockNumberOrTag::from(block_number))
-                    .await
-                {
-                    Ok(Some(block)) => {
-                        debug!(?block, "Fetched block");
-                        block
-                    }
-                    Ok(None) => {
-                        debug!("Block not found");
-                        return Err(ExecutionError::InvalidEvent("Block not found".to_string()));
-                    }
-                    Err(e) => {
-                        error!(?e, "Failed to fetch block");
-                        return Err(ExecutionError::InvalidEvent(
-                            "Failed to fetch block".to_string(),
-                        ));
-                    }
-                };
-
-                // Calculate the slot at which to process this exit
-                block.header.timestamp
-            }
-        };
+        let block_timestamp = log
+            .block_timestamp
+            .ok_or_else(|| ExecutionError::InvalidEvent("Block timestamp not set".to_string()))?;
 
         let validator_index = match self.get_validator_index(&validator_pubkey) {
             Ok(Some(value)) => value,

--- a/anchor/eth/src/sync.rs
+++ b/anchor/eth/src/sync.rs
@@ -1,6 +1,6 @@
 use std::{
     cmp::{max, min},
-    collections::BTreeMap,
+    collections::{BTreeMap, HashMap},
     sync::{
         Arc, LazyLock,
         atomic::{AtomicBool, Ordering},
@@ -8,6 +8,7 @@ use std::{
 };
 
 use alloy::{
+    eips::BlockNumberOrTag,
     primitives::Address,
     providers::{Provider, ProviderBuilder, RootProvider, WsConnect},
     rpc::types::{Filter, Log},
@@ -104,7 +105,7 @@ pub struct Config {
 /// and operators. Provides both historical synchronization and live event monitoring
 pub struct SsvEventSyncer {
     /// Http client connected to the L1 to fetch historical SSV event information
-    rpc_client: Arc<RootProvider>,
+    rpc_client: RootProvider,
     /// Websocket client connected to L1 to stream live SSV event information
     ws_client: RootProvider,
     /// Websocket connection url
@@ -132,7 +133,7 @@ impl SsvEventSyncer {
         info!("Creating new SSV Event Syncer");
 
         // Construct the rpc provider
-        let rpc_client = Arc::new(http_with_timeout_and_fallback(&config.http_urls));
+        let rpc_client = http_with_timeout_and_fallback(&config.http_urls);
         debug!("Created rpc client");
 
         // Construct Websocket Provider
@@ -155,7 +156,6 @@ impl SsvEventSyncer {
                 index_sync_tx,
                 exit_tx,
             },
-            rpc_client.clone(),
         );
         debug!("Created event processor - done");
 
@@ -175,9 +175,9 @@ impl SsvEventSyncer {
     /// Create a new event syncer for a keysplit sync
     pub fn new_keysplit(db: Arc<NetworkDatabase>, rpc_endpoint: String, network: String) -> Self {
         let http_url: Url = rpc_endpoint.parse().expect("Failed to parse HTTP URL");
-        let rpc_client = Arc::new(ProviderBuilder::default().on_http(http_url.clone()));
+        let rpc_client = ProviderBuilder::default().on_http(http_url.clone());
 
-        let event_processor = EventProcessor::new(db, Mode::KeySplit, rpc_client.clone());
+        let event_processor = EventProcessor::new(db, Mode::KeySplit);
 
         // The network is enforced to be a supported network so this will never fail.
         let network = match SsvNetworkConfig::constant(&network) {
@@ -562,6 +562,53 @@ impl SsvEventSyncer {
         Ok(result)
     }
 
+    /// Exit logs need the block timestamps set. Ensure every exit in a batch of logs has a block
+    /// timestamp set, fetching it from the EL if needed.
+    async fn preprocess_exits(&mut self, logs: &mut [Log]) -> Result<(), ExecutionError> {
+        let mut timestamps = HashMap::new();
+        for log in logs.iter_mut() {
+            if log.topic0() != Some(&SSVContract::ValidatorExited::SIGNATURE_HASH)
+                || log.block_timestamp.is_some()
+            {
+                continue;
+            }
+
+            let block_number = log.block_number.ok_or_else(|| {
+                ExecutionError::InvalidEvent("Block number not available".to_string())
+            })?;
+
+            if let Some(timestamp) = timestamps.get(&block_number) {
+                log.block_timestamp = Some(*timestamp);
+            } else {
+                debug!("Block timestamp not available");
+
+                let block = match self
+                    .rpc_client
+                    .get_block_by_number(BlockNumberOrTag::from(block_number))
+                    .await
+                {
+                    Ok(Some(block)) => {
+                        debug!(?block, "Fetched block");
+                        block
+                    }
+                    Ok(None) => {
+                        return Err(ExecutionError::InvalidEvent("Block not found".to_string()));
+                    }
+                    Err(e) => {
+                        return Err(ExecutionError::RpcError(format!(
+                            "Failed to fetch block {e}"
+                        )));
+                    }
+                };
+
+                // Store timestamp in log and cache in map
+                log.block_timestamp = Some(block.header.timestamp);
+                timestamps.insert(block_number, block.header.timestamp);
+            }
+        }
+        Ok(())
+    }
+
     // Once caught up with the chain, start live sync which will stream in live blocks from the
     // network. The events will be processed and duties will be created in response to network
     // actions
@@ -611,7 +658,7 @@ impl SsvEventSyncer {
                     block_header.number as i64,
                 );
 
-                let logs = self
+                let mut logs = self
                     .fetch_logs(
                         relevant_block,
                         relevant_block,
@@ -620,13 +667,17 @@ impl SsvEventSyncer {
                     )
                     .await?;
 
-                info!(
-                    log_count = logs.len(),
-                    "Processing events from block {}", relevant_block
-                );
+                self.preprocess_exits(&mut logs).await?;
+
+                let log_count = logs.len();
 
                 self.event_processor
                     .process_logs(logs, true, relevant_block)?;
+
+                info!(
+                    log_count,
+                    "Processed contract events from block {}", relevant_block
+                );
             }
 
             // If we get here, the stream ended (likely due to disconnect)

--- a/anchor/eth/src/sync.rs
+++ b/anchor/eth/src/sync.rs
@@ -564,8 +564,8 @@ impl SsvEventSyncer {
 
     /// Exit logs need the block timestamps set. Ensure every exit in a batch of logs has a block
     /// timestamp set, fetching it from the EL if needed.
-    async fn preprocess_exits(&mut self, logs: &mut [Log]) -> Result<(), ExecutionError> {
-        let mut timestamps = HashMap::new();
+    async fn set_block_timestamps(&mut self, logs: &mut [Log]) -> Result<(), ExecutionError> {
+        let mut block_timestamp_cache = HashMap::new();
         for log in logs.iter_mut() {
             if log.topic0() != Some(&SSVContract::ValidatorExited::SIGNATURE_HASH)
                 || log.block_timestamp.is_some()
@@ -577,7 +577,7 @@ impl SsvEventSyncer {
                 ExecutionError::InvalidEvent("Block number not available".to_string())
             })?;
 
-            if let Some(timestamp) = timestamps.get(&block_number) {
+            if let Some(timestamp) = block_timestamp_cache.get(&block_number) {
                 log.block_timestamp = Some(*timestamp);
             } else {
                 trace!(block_number, "Block timestamp not available");
@@ -603,7 +603,7 @@ impl SsvEventSyncer {
 
                 // Store timestamp in log and cache in map
                 log.block_timestamp = Some(block.header.timestamp);
-                timestamps.insert(block_number, block.header.timestamp);
+                block_timestamp_cache.insert(block_number, block.header.timestamp);
             }
         }
         Ok(())
@@ -667,7 +667,7 @@ impl SsvEventSyncer {
                     )
                     .await?;
 
-                self.preprocess_exits(&mut logs).await?;
+                self.set_block_timestamps(&mut logs).await?;
 
                 let log_count = logs.len();
 

--- a/anchor/eth/src/sync.rs
+++ b/anchor/eth/src/sync.rs
@@ -24,7 +24,7 @@ use reqwest::Url;
 use sensitive_url::SensitiveUrl;
 use ssv_network_config::SsvNetworkConfig;
 use tokio::{sync::oneshot::Sender, time::Duration};
-use tracing::{debug, error, info, instrument, warn};
+use tracing::{debug, error, info, instrument, trace, warn};
 
 use crate::{
     error::ExecutionError,
@@ -580,7 +580,7 @@ impl SsvEventSyncer {
             if let Some(timestamp) = timestamps.get(&block_number) {
                 log.block_timestamp = Some(*timestamp);
             } else {
-                debug!("Block timestamp not available");
+                trace!(block_number, "Block timestamp not available");
 
                 let block = match self
                     .rpc_client
@@ -588,7 +588,7 @@ impl SsvEventSyncer {
                     .await
                 {
                     Ok(Some(block)) => {
-                        debug!(?block, "Fetched block");
+                        trace!(?block, "Fetched block");
                         block
                     }
                     Ok(None) => {


### PR DESCRIPTION
## Issue Addressed

The approach of calling the `process_validator_exited` function with `block_on` does not work, as that panics:

```
thread 'tokio-runtime-worker' panicked at anchor/eth/src/event_processor.rs:126:55:
Cannot start a runtime from within a runtime. This happens because a function (like `block_on`) attempted to block the current thread while the thread is being used to drive asynchronous tasks.
```

## Proposed Changes

Instead, during live sync, check whether the logs need any block timestamp from the EL **before** calling `process_logs`.

Also, process exits only during live sync, as they are already expired when history syncing.
