### PR TITLE
Fix cargo sort

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -219,7 +219,7 @@ jobs:
         with:
           channel: stable
           cache-target: release
-          bins: cargo-sort, taplo-cli
+          bins: cargo-sort@2.0.1
       - name: Run cargo sort to check if Cargo.toml files are sorted
         run: make sort
 

--- a/Makefile
+++ b/Makefile
@@ -154,8 +154,6 @@ udeps:
 clean:
 	cargo clean
 
-# Check if dependencies are sorted (requires cargo-sort and taplo-cli)
+# Check if dependencies are sorted (requires cargo-sort)
 sort:
-	cargo sort --check --workspace
-	# separate check for root Cargo toml to check workspace dependencies
-	taplo fmt -o reorder_keys=true -o "indent_string=    " Cargo.toml --diff --check
+	cargo sort --check --workspace --grouped

--- a/anchor/Cargo.toml
+++ b/anchor/Cargo.toml
@@ -5,6 +5,14 @@ edition = { workspace = true }
 authors = ["Sigma Prime <contact@sigmaprime.io>"]
 rust-version = "1.85.0"
 
+[features]
+# Compiles the BLS crypto code so that the binary is portable across machines.
+portable = ["bls/supranational-portable"]
+# Compiles BLST so that it always uses ADX instructions.
+modern = ["bls/supranational-force-adx"]
+# Support minimal spec (used for testing only).
+spec-minimal = []
+
 [dependencies]
 async-channel = { workspace = true }
 bls = { workspace = true }
@@ -24,11 +32,3 @@ tracing = { workspace = true }
 tracing-appender = { workspace = true }
 tracing-subscriber = { workspace = true }
 types = { workspace = true }
-
-[features]
-# Compiles the BLS crypto code so that the binary is portable across machines.
-portable = ["bls/supranational-portable"]
-# Compiles BLST so that it always uses ADX instructions.
-modern = ["bls/supranational-force-adx"]
-# Support minimal spec (used for testing only).
-spec-minimal = []

--- a/anchor/common/bls_lagrange/Cargo.toml
+++ b/anchor/common/bls_lagrange/Cargo.toml
@@ -3,6 +3,12 @@ name = "bls_lagrange"
 version = "0.1.0"
 edition = "2021"
 
+[features]
+default = ["blst_single_thread"]
+blsful = ["dep:blstrs_plus", "dep:vsss-rs"]
+blst = ["dep:blst"]
+blst_single_thread = ["blst"]
+
 [dependencies]
 bls = { workspace = true }
 blst = { workspace = true, optional = true }
@@ -13,9 +19,3 @@ zeroize = { workspace = true }
 
 [dev-dependencies]
 blst = { workspace = true }
-
-[features]
-default = ["blst_single_thread"]
-blsful = ["dep:blstrs_plus", "dep:vsss-rs"]
-blst = ["dep:blst"]
-blst_single_thread = ["blst"]

--- a/anchor/fuzz/Cargo.toml
+++ b/anchor/fuzz/Cargo.toml
@@ -7,6 +7,34 @@ edition = "2021"
 [package.metadata]
 cargo-fuzz = true
 
+[[bin]]
+name = "validate_target"
+path = "fuzz_targets/validate_target.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "receive_target"
+path = "fuzz_targets/receive_target.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "qbft_target"
+path = "fuzz_targets/qbft_target.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "custom_ssz"
+path = "fuzz_targets/custom_ssz.rs"
+test = false
+doc = false
+bench = false
+
 [features]
 arbitrary-fuzz = ["ssv_types/arbitrary-fuzz"]
 
@@ -38,35 +66,7 @@ ssv_types = { workspace = true, features = ["arbitrary-fuzz"] }
 subnet_tracker  = { workspace = true }
 task_executor = { workspace = true }
 tempfile = "3.14.0"
-thiserror =  { workspace = true }
+thiserror = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
 types = { workspace = true }
-
-[[bin]]
-name = "validate_target"
-path = "fuzz_targets/validate_target.rs"
-test = false
-doc = false
-bench = false
-
-[[bin]]
-name = "receive_target"
-path = "fuzz_targets/receive_target.rs"
-test = false
-doc = false
-bench = false
-
-[[bin]]
-name = "qbft_target"
-path = "fuzz_targets/qbft_target.rs"
-test = false
-doc = false
-bench = false
-
-[[bin]]
-name = "custom_ssz"
-path = "fuzz_targets/custom_ssz.rs"
-test = false
-doc = false
-bench = false

--- a/anchor/message_sender/Cargo.toml
+++ b/anchor/message_sender/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 edition = { workspace = true }
 authors = ["Sigma Prime <contact@sigmaprime.io>"]
 
+[features]
+testing = []
+
 [dependencies]
 ethereum_ssz = { workspace = true }
 message_validator = { workspace = true }
@@ -14,6 +17,3 @@ ssv_types = { workspace = true }
 subnet_tracker = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
-
-[features]
-testing = []


### PR DESCRIPTION
- Pin version
- Apply new table order
- Remove taplo
- Add `--grouped` arg

## Additional Info

It now properly handles the workspace toml, so we can remove taplo! :partying_face: 

Personally, I am fine with the new order of `[[bin]]`, `features`, and `dependencies`, wdyt?

Make sure to update your local `cargo sort` with `cargo install cargo-sort`!