### PR TITLE
Extend notifier with Anchor-specific logic

### DIFF
--- a/anchor/client/src/lib.rs
+++ b/anchor/client/src/lib.rs
@@ -2,6 +2,7 @@
 
 pub mod cli;
 pub mod config;
+mod notifier;
 
 use std::{
     fs,
@@ -58,11 +59,12 @@ use validator_services::{
     duties_service,
     duties_service::{DutiesServiceBuilder, SelectionProofConfig},
     latency_service::start_latency_service,
-    notifier_service::spawn_notifier,
     preparation_service::PreparationServiceBuilder,
     sync_committee_service::SyncCommitteeService,
 };
 use zeroize::Zeroizing;
+
+use crate::notifier::spawn_notifier;
 
 /// The filename within the `validators` directory that contains the slashing protection DB.
 const SLASHING_PROTECTION_FILENAME: &str = "slashing_protection.sqlite";
@@ -608,8 +610,13 @@ impl Client {
 
         http_api_shared_state.write().database_state = Some(database.watch());
 
-        spawn_notifier(duties_service.clone(), executor.clone(), &spec)
-            .map_err(|e| format!("Failed to start notifier: {e}"))?;
+        spawn_notifier(
+            duties_service.clone(),
+            database.watch(),
+            executor.clone(),
+            &spec,
+        )
+        .map_err(|e| format!("Failed to start notifier: {e}"))?;
 
         if !config.disable_latency_measurement_service {
             start_latency_service(executor.clone(), slot_clock.clone(), beacon_nodes.clone());

--- a/anchor/client/src/lib.rs
+++ b/anchor/client/src/lib.rs
@@ -621,8 +621,7 @@ impl Client {
             database.watch(),
             executor.clone(),
             &spec,
-        )
-        .map_err(|e| format!("Failed to start notifier: {e}"))?;
+        );
 
         if !config.disable_latency_measurement_service {
             start_latency_service(executor.clone(), slot_clock.clone(), beacon_nodes.clone());

--- a/anchor/client/src/notifier.rs
+++ b/anchor/client/src/notifier.rs
@@ -1,0 +1,67 @@
+use std::sync::Arc;
+
+use anchor_validator_store::AnchorValidatorStore;
+use database::NetworkState;
+use slot_clock::SlotClock;
+use task_executor::TaskExecutor;
+use tokio::{
+    sync::watch,
+    time::{Duration, sleep},
+};
+use tracing::{error, info};
+use types::{ChainSpec, EthSpec};
+
+use crate::duties_service::DutiesService;
+
+/// Spawns a notifier service which periodically logs information about the node. It reuses LH's
+/// `notifier_service` for most functionality but adds some Anchor-specific information and logic.
+pub fn spawn_notifier<E: EthSpec, T: SlotClock + 'static>(
+    duties_service: Arc<DutiesService<AnchorValidatorStore<T, E>, T>>,
+    network_state: watch::Receiver<NetworkState>,
+    executor: TaskExecutor,
+    spec: &ChainSpec,
+) -> Result<(), String> {
+    let slot_duration = Duration::from_secs(spec.seconds_per_slot);
+
+    let interval_fut = async move {
+        loop {
+            if let Some(duration_to_next_slot) = duties_service.slot_clock.duration_to_next_slot() {
+                sleep(duration_to_next_slot + slot_duration / 2).await;
+                notify(&duties_service, &network_state).await;
+            } else {
+                error!("Failed to read slot clock");
+                // If we can't read the slot clock, just wait another slot.
+                sleep(slot_duration).await;
+                continue;
+            }
+        }
+    };
+
+    executor.spawn(interval_fut, "validator_notifier");
+    Ok(())
+}
+
+/// Performs a single notification routine.
+async fn notify<E: EthSpec, T: SlotClock + 'static>(
+    duties_service: &DutiesService<AnchorValidatorStore<T, E>, T>,
+    network_state: &watch::Receiver<NetworkState>,
+) {
+    // Scope needed as Rust complains about `state` being held across `await` if using `drop`
+    let (operator_id, clusters) = {
+        let state = network_state.borrow();
+        let operator_id = state.get_own_id();
+        let clusters = state.get_own_clusters().len();
+        (operator_id, clusters)
+    };
+
+    if let Some(operator_id) = operator_id {
+        if duties_service.total_validator_count() > 0 {
+            info!(%operator_id, clusters, "Operator active");
+            validator_services::notifier_service::notify(duties_service).await;
+        } else {
+            info!(%operator_id, "Operator ready, no validators assigned");
+        }
+    } else {
+        error!("No operator ID - the operator might have been removed via the contract");
+    }
+}

--- a/anchor/client/src/notifier.rs
+++ b/anchor/client/src/notifier.rs
@@ -13,19 +13,23 @@ use types::{ChainSpec, EthSpec};
 
 use crate::duties_service::DutiesService;
 
-/// Spawns a notifier service which periodically logs information about the node. It reuses LH's
-/// `notifier_service` for most functionality but adds some Anchor-specific information and logic.
+/// Spawns a notifier service which periodically logs information about the node. It reuses
+/// Lighthouse's `notifier_service` for most functionality but adds some Anchor-specific information
+/// and logic.
+///
+/// Executes [`notify`] once per slot, halfway into it.
 pub fn spawn_notifier<E: EthSpec, T: SlotClock + 'static>(
     duties_service: Arc<DutiesService<AnchorValidatorStore<T, E>, T>>,
     network_state: watch::Receiver<NetworkState>,
     executor: TaskExecutor,
     spec: &ChainSpec,
-) -> Result<(), String> {
+) {
     let slot_duration = Duration::from_secs(spec.seconds_per_slot);
 
     let interval_fut = async move {
         loop {
             if let Some(duration_to_next_slot) = duties_service.slot_clock.duration_to_next_slot() {
+                // Sleep until the middle of the next slot
                 sleep(duration_to_next_slot + slot_duration / 2).await;
                 notify(&duties_service, &network_state).await;
             } else {
@@ -38,25 +42,27 @@ pub fn spawn_notifier<E: EthSpec, T: SlotClock + 'static>(
     };
 
     executor.spawn(interval_fut, "validator_notifier");
-    Ok(())
 }
 
 /// Performs a single notification routine.
+///
+/// This serves to notify the user of the current application status via `info` logging.
+/// Additionally, some metrics are recorded by the `validator_services`.
 async fn notify<E: EthSpec, T: SlotClock + 'static>(
     duties_service: &DutiesService<AnchorValidatorStore<T, E>, T>,
     network_state: &watch::Receiver<NetworkState>,
 ) {
     // Scope needed as Rust complains about `state` being held across `await` if using `drop`
-    let (operator_id, clusters) = {
+    let (operator_id, cluster_count) = {
         let state = network_state.borrow();
         let operator_id = state.get_own_id();
-        let clusters = state.get_own_clusters().len();
-        (operator_id, clusters)
+        let cluster_count = state.get_own_clusters().len();
+        (operator_id, cluster_count)
     };
 
     if let Some(operator_id) = operator_id {
         if duties_service.total_validator_count() > 0 {
-            info!(%operator_id, clusters, "Operator active");
+            info!(%operator_id, cluster_count, "Operator active");
             validator_services::notifier_service::notify(duties_service).await;
         } else {
             info!(%operator_id, "Operator ready, no validators assigned");

--- a/anchor/common/ssv_types/src/operator.rs
+++ b/anchor/common/ssv_types/src/operator.rs
@@ -1,6 +1,6 @@
 use std::{cmp::Eq, fmt::Debug, hash::Hash};
 
-use derive_more::{Deref, From};
+use derive_more::{Deref, Display, From};
 use openssl::{pkey::Public, rsa::Rsa};
 use ssz_derive::{Decode, Encode};
 use types::Address;
@@ -9,7 +9,20 @@ use crate::util::parse_rsa;
 
 /// Unique identifier for an Operator.
 #[derive(
-    Clone, Copy, Debug, Default, Eq, PartialEq, Hash, From, Deref, Encode, Decode, Ord, PartialOrd,
+    Clone,
+    Copy,
+    Debug,
+    Default,
+    Eq,
+    PartialEq,
+    Hash,
+    From,
+    Deref,
+    Encode,
+    Decode,
+    Ord,
+    PartialOrd,
+    Display,
 )]
 #[ssz(struct_behaviour = "transparent")]
 #[cfg_attr(feature = "arbitrary-fuzz", derive(arbitrary::Arbitrary))]


### PR DESCRIPTION
## Issue Addressed

- closes #251 

## Proposed Changes

Instead of calling the notifier service directly, we create our own service to add a bit of own logic to it - this avoids a LH specific message and logs some Anchor specific data such as the operator ID and amount of clusters we're in.
