### PR TITLE
Disable mainnet support

### DIFF
--- a/anchor/client/src/cli.rs
+++ b/anchor/client/src/cli.rs
@@ -88,9 +88,9 @@ pub struct Node {
         long,
         global = true,
         value_name = "NETWORK",
-        value_parser = vec!["mainnet", "holesky", "hoodi"],
+        value_parser = vec!["holesky", "hoodi"],
         conflicts_with = "testnet_dir",
-        help = "Name of the chain Anchor will validate.",
+        help = "Name of the chain Anchor will validate. Mainnet is not supported.",
         display_order = 0,
         default_value = crate::config::DEFAULT_HARDCODED_NETWORK,
     )]

--- a/anchor/client/src/config.rs
+++ b/anchor/client/src/config.rs
@@ -140,14 +140,6 @@ pub fn from_cli(cli_args: &Node) -> Result<Config, String> {
             .and_then(|net| net.ok_or_else(|| format!("Unknown network {}", cli_args.network)))
     }?;
 
-    if let Some(network) = eth2_network.clone().eth2_network.config.config_name {
-        if network == "mainnet" {
-            return Err(
-                "Mainnet is not supported. Please use a testnet configuration.".to_string(),
-            );
-        }
-    }
-
     let mut config = Config::new(eth2_network);
 
     if let Some(datadir) = cli_args.datadir.clone() {

--- a/anchor/client/src/config.rs
+++ b/anchor/client/src/config.rs
@@ -140,6 +140,14 @@ pub fn from_cli(cli_args: &Node) -> Result<Config, String> {
             .and_then(|net| net.ok_or_else(|| format!("Unknown network {}", cli_args.network)))
     }?;
 
+    if let Some(network) = eth2_network.clone().eth2_network.config.config_name {
+        if network == "mainnet" {
+            return Err(
+                "Mainnet is not supported. Please use a testnet configuration.".to_string(),
+            );
+        }
+    }
+
     let mut config = Config::new(eth2_network);
 
     if let Some(datadir) = cli_args.datadir.clone() {

--- a/anchor/client/src/lib.rs
+++ b/anchor/client/src/lib.rs
@@ -84,6 +84,8 @@ const HTTP_GET_DEPOSIT_SNAPSHOT_QUOTIENT: u32 = 4;
 const HTTP_GET_VALIDATOR_BLOCK_TIMEOUT_QUOTIENT: u32 = 4;
 const HTTP_DEFAULT_TIMEOUT_QUOTIENT: u32 = 4;
 
+const MAINNET_GENESIS_FORK_VERSION: [u8; 4] = [0, 0, 0, 0];
+
 pub struct Client {}
 
 impl Client {
@@ -119,6 +121,12 @@ impl Client {
         );
 
         let spec = Arc::new(config.ssv_network.eth2_network.chain_spec::<E>()?);
+
+        if spec.genesis_fork_version == MAINNET_GENESIS_FORK_VERSION {
+            return Err(
+                "Mainnet is not supported. Please use a testnet configuration.".to_string(),
+            );
+        }
 
         let key = read_or_generate_private_key(&config.data_dir.join("key.pem"))?;
         let err = |e| format!("Unable to derive public key: {e:?}");

--- a/anchor/eth/README.md
+++ b/anchor/eth/README.md
@@ -1,5 +1,5 @@
 ## Execution Layer
-This crate implements the execution layer component of the SSV node, responsible for monitoring and processing SSV network events on Ethereum L1 networks (Mainnet and Holesky).
+This crate implements the execution layer component of the SSV node, responsible for monitoring and processing SSV network events on Ethereum L1 testnet networks.
 
 ## Overview
 The execution layer client maintains synchronization with the SSV network contract by:
@@ -32,5 +32,6 @@ event ValidatorExited(address indexed owner, uint64[] operatorIds, bytes publicK
 ```
 
 ## Contract Addresses
-* Mainnet: `0xDD9BC35aE942eF0cFa76930954a156B3fF30a4E1`
 * Holesky: `0x38A4794cCEd47d3baf7370CcC43B560D3a1beEFA`
+
+Note: Mainnet is not supported in this version of Anchor.

--- a/anchor/keysplit/README.md
+++ b/anchor/keysplit/README.md
@@ -44,8 +44,8 @@ anchor keysplit onchain \
   --owner 0x123... \
   --operators 1,2,3,4 \
   --output-path /path/to/output.json \
-  --rpc https://eth-mainnet.provider.com \
-  --network Mainnet
+  --rpc https://eth-hoodi.provider.com \
+  --network Hoodi
 ```
 
 # Command Options
@@ -61,7 +61,7 @@ anchor keysplit onchain \
 - `--public-keys KEYS`: Comma-separated list of RSA public keys for the operators
 ## Onchain Mode Options
 - `--rpc ENDPOINT`: RPC endpoint to access L1 data
-- `--network NETWORK`: Ethereum network (Mainnet or Holesky)
+- `--network NETWORK`: Ethereum network (Holesky or Hoodi - Mainnet is not supported)
 
 # Output
 The tool generates a JSON file compatible with the SSV validator registration webapp.

--- a/anchor/keysplit/src/cli.rs
+++ b/anchor/keysplit/src/cli.rs
@@ -44,7 +44,7 @@ pub struct Onchain {
 
     #[clap(
         long,
-        help = "Mainnet, Holesky or Hoodi",
+        help = "Holesky or Hoodi (Mainnet is not supported)",
         value_name = "NETWORK",
         value_enum
     )]
@@ -53,7 +53,6 @@ pub struct Onchain {
 
 #[derive(clap::ValueEnum, Clone, Debug)]
 pub enum Network {
-    Mainnet,
     Holesky,
     Hoodi,
 }

--- a/anchor/keysplit/src/split.rs
+++ b/anchor/keysplit/src/split.rs
@@ -47,7 +47,6 @@ pub fn onchain_split(
     let split_keys = split_keys(&onchain.shared, secret_key)?;
 
     let network = match onchain.network {
-        Network::Mainnet => String::from("mainnet"),
         Network::Holesky => String::from("holesky"),
         Network::Hoodi => String::from("hoodi"),
     };


### PR DESCRIPTION
## Issue Addressed

https://github.com/sigp/anchor/issues/348

## Proposed Changes

This PR disables mainnet support across the codebase by removing mainnet-specific branches from network matching and updating associated CLI options, configuration checks, and documentation.

- Removed mainnet handling in the onchain split logic.
- Updated CLI help messages and enum definitions to only list supported networks (Holesky and Hoodi).
- Added a configuration check in the client to error out if mainnet is attempted and revised documentation accordingly.


