### PR TITLE
Set default hardcoded network to Hoodi

### DIFF
--- a/anchor/client/src/config.rs
+++ b/anchor/client/src/config.rs
@@ -18,7 +18,7 @@ pub const DEFAULT_EXECUTION_NODE_WS: &str = "ws://localhost:8546/";
 /// The default Data directory, relative to the users home directory
 pub const DEFAULT_ROOT_DIR: &str = ".anchor";
 /// Default network, used to partition the data storage
-pub const DEFAULT_HARDCODED_NETWORK: &str = "holesky";
+pub const DEFAULT_HARDCODED_NETWORK: &str = "hoodi";
 /// Base directory name for unnamed testnets passed through the --testnet-dir flag
 pub const CUSTOM_TESTNET_DIR: &str = "custom";
 


### PR DESCRIPTION
As Holesky is deprecated by SSV, set the default hardcoded network to Hoodi.