### PR TITLE
Increase default logfile parameters

### DIFF
--- a/anchor/logging/src/logging.rs
+++ b/anchor/logging/src/logging.rs
@@ -12,8 +12,8 @@ pub use crate::tracing_libp2p_discv5_layer::{
     Libp2pDiscv5TracingLayer, create_libp2p_discv5_tracing_layer,
 };
 
-const MAX_LOG_SIZE: u64 = 20;
-const MAX_LOG_NUMBER: usize = 5;
+const MAX_LOG_SIZE: u64 = 50;
+const MAX_LOG_NUMBER: usize = 100;
 const DEFAULT_DEBUG_LEVEL: Level = Level::INFO;
 
 #[derive(Clone)]
@@ -83,7 +83,7 @@ pub struct LoggingFlags {
         global = true,
         value_name = "SIZE",
         help = "Maximum size of each log file in MB",
-        default_value_t = 20
+        default_value_t = 50
     )]
     pub logfile_max_size: u64,
 
@@ -92,7 +92,7 @@ pub struct LoggingFlags {
         global = true,
         value_name = "NUMBER",
         help = "Maximum number of log files to keep",
-        default_value_t = 5
+        default_value_t = 100
     )]
     pub logfile_max_number: usize,
 

--- a/book/src/cli.md
+++ b/book/src/cli.md
@@ -116,8 +116,8 @@ anchor node [OPTIONS]
 | --- | --- | ---|
 | `--debug-level <LEVEL>` | Verbosity for terminal logs | `info` |
 | `--logfile-debug-level <LEVEL>` | Verbosity for file logs | `debug` |
-| `--logfile-max-size <SIZE>` | Maximum size of each log file in MB | `20` |
-| `--logfile-max-number <NUMBER>` | Maximum number of log files to keep | `5` |
+| `--logfile-max-size <SIZE>` | Maximum size of each log file in MB | `50` |
+| `--logfile-max-number <NUMBER>` | Maximum number of log files to keep | `100` |
 | `--logfile-dir <DIR>` | Directory to store log files | Same as `--datadir` |
 | `--logfile-compression` | Compress old log files | Disabled |
 


### PR DESCRIPTION
Increase logfile parameters. With current logging, the new values of 100 files with 50MB each approximately equals to 3 days worth of logs for an operator with 1000 validators. Note that logfile compression reduces the actual disk consumption by a factor of ~10.

I think we should get this into the release to ensure that people have the opportunity to copy logs before deletion if an issue occurs.