### PR TITLE
Do not warn if a validator is removed before index is set

### DIFF
--- a/anchor/database/src/validator_operations.rs
+++ b/anchor/database/src/validator_operations.rs
@@ -2,7 +2,7 @@ use std::{collections::HashMap, str::FromStr};
 
 use rusqlite::{Transaction, params};
 use ssv_types::ValidatorIndex;
-use tracing::warn;
+use tracing::debug;
 use types::{Address, Graffiti, PublicKeyBytes};
 
 use crate::{
@@ -128,7 +128,7 @@ impl NetworkDatabase {
                         .validator_metadata
                         .update(&public_key, validator);
                 } else {
-                    warn!(?public_key, "Tried to update index of unknown validator");
+                    debug!(?public_key, "Tried to update index of unknown validator");
                 }
             }
         });


### PR DESCRIPTION
## Issue Addressed

If a validator is added, validator index sync is triggered. If the validator is removed again by the time the index has been retrieved, a warning is logged. This happens far more often than anticipated during development, causing log spam during initial sync.

## Proposed Changes

Log it as `debug` instead.
