### PR TITLE
Avoid unnecessary allocations and conversions in database

### DIFF
--- a/anchor/common/ssv_types/src/operator.rs
+++ b/anchor/common/ssv_types/src/operator.rs
@@ -41,7 +41,7 @@ pub struct Operator {
 
 impl Operator {
     /// Creates a new operator from its OperatorId and PEM-encoded public key string
-    pub fn new(pem_data: &str, operator_id: OperatorId, owner: Address) -> Result<Self, String> {
+    pub fn new(pem_data: &[u8], operator_id: OperatorId, owner: Address) -> Result<Self, String> {
         let rsa_pubkey = parse_rsa(pem_data)?;
         Ok(Self::new_with_pubkey(rsa_pubkey, operator_id, owner))
     }
@@ -67,7 +67,7 @@ mod operator_tests {
         let operator_id = 1141;
         let address = Address::random();
 
-        let operator = Operator::new(pem_data, operator_id.into(), address);
+        let operator = Operator::new(pem_data.as_bytes(), operator_id.into(), address);
         assert!(operator.is_ok());
 
         if let Ok(op) = operator {

--- a/anchor/common/ssv_types/src/util.rs
+++ b/anchor/common/ssv_types/src/util.rs
@@ -2,7 +2,7 @@ use base64::prelude::*;
 use openssl::{pkey::Public, rsa::Rsa};
 
 // Parse from a RSA public key string into the associated RSA representation
-pub fn parse_rsa(pem_data: &str) -> Result<Rsa<Public>, String> {
+pub fn parse_rsa(pem_data: &[u8]) -> Result<Rsa<Public>, String> {
     // First decode the base64 data
     let pem_decoded = BASE64_STANDARD
         .decode(pem_data)

--- a/anchor/common/ssv_types/src/util.rs
+++ b/anchor/common/ssv_types/src/util.rs
@@ -8,20 +8,8 @@ pub fn parse_rsa(pem_data: &[u8]) -> Result<Rsa<Public>, String> {
         .decode(pem_data)
         .map_err(|e| format!("Unable to decode base64 pem data: {e}"))?;
 
-    // Convert the decoded data to a string
-    let mut pem_string = String::from_utf8(pem_decoded)
-        .map_err(|e| format!("Unable to convert decoded pem data into a string: {e}"))?;
-
-    // Fix the header - replace PKCS1 header with PKCS8 header
-    pem_string = pem_string
-        .replace(
-            "-----BEGIN RSA PUBLIC KEY-----",
-            "-----BEGIN PUBLIC KEY-----",
-        )
-        .replace("-----END RSA PUBLIC KEY-----", "-----END PUBLIC KEY-----");
-
     // Parse the PEM string into an RSA public key using PKCS8 format
-    let rsa_pubkey = Rsa::public_key_from_pem(pem_string.as_bytes())
+    let rsa_pubkey = Rsa::public_key_from_pem_pkcs1(&pem_decoded)
         .map_err(|e| format!("Failed to parse RSA public key: {e}"))?;
 
     Ok(rsa_pubkey)

--- a/anchor/common/ssv_types/src/util.rs
+++ b/anchor/common/ssv_types/src/util.rs
@@ -8,8 +8,20 @@ pub fn parse_rsa(pem_data: &[u8]) -> Result<Rsa<Public>, String> {
         .decode(pem_data)
         .map_err(|e| format!("Unable to decode base64 pem data: {e}"))?;
 
+    // Convert the decoded data to a string
+    let mut pem_string = String::from_utf8(pem_decoded)
+        .map_err(|e| format!("Unable to convert decoded pem data into a string: {e}"))?;
+
+    // Fix the header - replace PKCS1 header with PKCS8 header
+    pem_string = pem_string
+        .replace(
+            "-----BEGIN RSA PUBLIC KEY-----",
+            "-----BEGIN PUBLIC KEY-----",
+        )
+        .replace("-----END RSA PUBLIC KEY-----", "-----END PUBLIC KEY-----");
+
     // Parse the PEM string into an RSA public key using PKCS8 format
-    let rsa_pubkey = Rsa::public_key_from_pem_pkcs1(&pem_decoded)
+    let rsa_pubkey = Rsa::public_key_from_pem(pem_string.as_bytes())
         .map_err(|e| format!("Failed to parse RSA public key: {e}"))?;
 
     Ok(rsa_pubkey)

--- a/anchor/database/src/cluster_operations.rs
+++ b/anchor/database/src/cluster_operations.rs
@@ -11,7 +11,7 @@ impl NetworkDatabase {
     pub fn insert_validator(
         &self,
         cluster: Cluster,
-        validator: ValidatorMetadata,
+        validator: &ValidatorMetadata,
         shares: Vec<Share>,
         tx: &Transaction<'_>,
     ) -> Result<(), DatabaseError> {

--- a/anchor/database/src/operator_operations.rs
+++ b/anchor/database/src/operator_operations.rs
@@ -25,7 +25,7 @@ impl NetworkDatabase {
             .rsa_pubkey
             .public_key_to_pem()
             .expect("Failed to encode RsaPublicKey");
-        let encoded = BASE64_STANDARD.encode(pem_key.clone());
+        let encoded = BASE64_STANDARD.encode(&pem_key);
 
         // Insert into the database
         tx.prepare_cached(SQL[&SqlStatement::InsertOperator])?

--- a/anchor/database/src/tests/cluster_tests.rs
+++ b/anchor/database/src/tests/cluster_tests.rs
@@ -79,7 +79,7 @@ mod cluster_database_tests {
         let tx = conn.transaction().unwrap();
         fixture
             .db
-            .insert_validator(cluster, metadata, shares, &tx)
+            .insert_validator(cluster, &metadata, shares, &tx)
             .expect_err("Insertion should fail");
     }
 
@@ -112,7 +112,7 @@ mod cluster_database_tests {
         let tx = conn.transaction().unwrap();
         fixture
             .db
-            .insert_validator(fixture.cluster, fixture.validator, fixture.shares, &tx)
+            .insert_validator(fixture.cluster, &fixture.validator, fixture.shares, &tx)
             .expect_err("Expected failure when inserting cluster that already exists");
     }
 

--- a/anchor/database/src/tests/state_tests.rs
+++ b/anchor/database/src/tests/state_tests.rs
@@ -84,7 +84,7 @@ mod state_database_tests {
         let tx = conn.transaction().unwrap();
         fixture
             .db
-            .insert_validator(cluster, new_validator, shares, &tx)
+            .insert_validator(cluster, &new_validator, shares, &tx)
             .expect("Insert should not fail");
         tx.commit().unwrap();
 

--- a/anchor/database/src/tests/utils.rs
+++ b/anchor/database/src/tests/utils.rs
@@ -64,7 +64,7 @@ impl TestFixture {
             .map(|op| generators::share::random(cluster.cluster_id, op.id, &validator.public_key))
             .collect();
 
-        db.insert_validator(cluster.clone(), validator.clone(), shares.clone(), &tx)
+        db.insert_validator(cluster.clone(), &validator, shares.clone(), &tx)
             .expect("Failed to insert cluster");
 
         tx.commit().unwrap();

--- a/anchor/eth/src/event_processor.rs
+++ b/anchor/eth/src/event_processor.rs
@@ -167,33 +167,25 @@ impl EventProcessor {
             )));
         }
 
-        // Parse ABI encoded public key string and trim off 0x prefix for hex decoding
-        let public_key_str = publicKey.to_string();
-        let public_key_str = public_key_str.trim_start_matches("0x");
-        let data = hex::decode(public_key_str).map_err(|e| {
-            debug!(operator_id = ?operator_id, error = %e, "Failed to decode public key data from hex");
-            ExecutionError::InvalidEvent(
-                format!("Failed to decode public key data from hex: {e}")
-            )
-        })?;
+        let data = publicKey.as_ref();
 
         // If the data is 704 bytes, remove the ssv encoding. Else, just parse the key
         let data = if data.len() == 704 {
             let data = &data[64..];
-            let data = String::from_utf8(data.to_vec()).map_err(|e| {
+            let data = str::from_utf8(data).map_err(|e| {
                 debug!(operator_id = ?operator_id, error = %e, "Failed to convert to UTF8 String");
                 ExecutionError::InvalidEvent(format!("Failed to convert to UTF8 String: {e}"))
             })?;
-            data.trim_matches(char::from(0)).to_string()
+            data.trim_matches(char::from(0))
         } else {
-            String::from_utf8(data.to_vec()).map_err(|e| {
+            str::from_utf8(data).map_err(|e| {
                 debug!(operator_id = ?operator_id, error = %e, "Failed to convert to UTF8 String");
                 ExecutionError::InvalidEvent(format!("Failed to convert to UTF8 String: {e}"))
             })?
         };
 
         // Construct the Operator and insert it into the database
-        let operator = Operator::new(&data, operator_id, owner).map_err(|e| {
+        let operator = Operator::new(data, operator_id, owner).map_err(|e| {
             debug!(
                 operator_pubkey = ?publicKey,
                 operator_id = ?operator_id,
@@ -290,8 +282,8 @@ impl EventProcessor {
 
         // Process data into a usable form
         let validator_pubkey = parse_validator_pubkey(&publicKey)?;
-        let cluster_id = compute_cluster_id(owner, operatorIds.clone());
-        let operator_ids: Vec<OperatorId> = operatorIds.iter().map(|id| OperatorId(*id)).collect();
+        let cluster_id = compute_cluster_id(owner, &operatorIds);
+        let operator_ids: Vec<_> = operatorIds.into_iter().map(OperatorId).collect();
 
         // Perform verification on the operator set and make sure they are all registered in the
         // network
@@ -299,16 +291,11 @@ impl EventProcessor {
 
         // Parse the share byte stream into a list of valid Shares and then verify the signature
         debug!(cluster_id = ?cluster_id, "Parsing and verifying shares");
-        let (signature, shares) = parse_shares(
-            shares.to_vec(),
-            &operator_ids,
-            &cluster_id,
-            &validator_pubkey,
-        )
-        .map_err(|e| {
-            debug!(cluster_id = ?cluster_id, error = %e, "Failed to parse shares");
-            ExecutionError::InvalidEvent(format!("Failed to parse shares. {e}"))
-        })?;
+        let (signature, shares) =
+            parse_shares(&shares, &operator_ids, &cluster_id, &validator_pubkey).map_err(|e| {
+                debug!(cluster_id = ?cluster_id, error = %e, "Failed to parse shares");
+                ExecutionError::InvalidEvent(format!("Failed to parse shares. {e}"))
+            })?;
 
         if !verify_signature(signature, nonce, &owner, &validator_pubkey) {
             debug!(cluster_id = ?cluster_id, "Signature verification failed");
@@ -339,7 +326,7 @@ impl EventProcessor {
             cluster_members: IndexSet::from_iter(operator_ids),
         };
         self.db
-            .insert_validator(cluster, validator_metadata.clone(), shares, tx)
+            .insert_validator(cluster, &validator_metadata, shares, tx)
             .map_err(|e| {
                 debug!(cluster_id = ?cluster_id, error = %e, validator_metadata = ?validator_metadata.public_key, "Failed to insert validator into cluster");
                 ExecutionError::Database(format!("Failed to insert validator into cluster: {e}"))
@@ -383,7 +370,7 @@ impl EventProcessor {
         let validator_pubkey = parse_validator_pubkey(&publicKey)?;
 
         // Compute the cluster id
-        let cluster_id = compute_cluster_id(owner, operatorIds.clone());
+        let cluster_id = compute_cluster_id(owner, &operatorIds);
 
         let state = self.db.state();
         // Get the metadata for this validator
@@ -477,7 +464,7 @@ impl EventProcessor {
             ..
         } = SSVContract::ClusterLiquidated::decode_from_log(log)?;
 
-        let cluster_id = compute_cluster_id(owner, operator_ids);
+        let cluster_id = compute_cluster_id(owner, &operator_ids);
 
         debug!(cluster_id = ?cluster_id, "Processing cluster liquidation");
 
@@ -516,7 +503,7 @@ impl EventProcessor {
             ..
         } = SSVContract::ClusterReactivated::decode_from_log(log)?;
 
-        let cluster_id = compute_cluster_id(owner, operator_ids);
+        let cluster_id = compute_cluster_id(owner, &operator_ids);
 
         debug!(cluster_id = ?cluster_id, "Processing cluster reactivation");
 
@@ -591,7 +578,7 @@ impl EventProcessor {
         } = SSVContract::ValidatorExited::decode_from_log(log)?;
 
         let validator_pubkey = parse_validator_pubkey(&publicKey)?;
-        let computed_cluster_id = compute_cluster_id(owner, operatorIds.clone());
+        let computed_cluster_id = compute_cluster_id(owner, &operatorIds);
 
         self.verify_validator_owner(&owner, &validator_pubkey, &computed_cluster_id)?;
 

--- a/anchor/eth/src/event_processor.rs
+++ b/anchor/eth/src/event_processor.rs
@@ -171,17 +171,14 @@ impl EventProcessor {
 
         // If the data is 704 bytes, remove the ssv encoding. Else, just parse the key
         let data = if data.len() == 704 {
-            let data = &data[64..];
-            let data = str::from_utf8(data).map_err(|e| {
-                debug!(operator_id = ?operator_id, error = %e, "Failed to convert to UTF8 String");
-                ExecutionError::InvalidEvent(format!("Failed to convert to UTF8 String: {e}"))
-            })?;
-            data.trim_matches(char::from(0))
+            let mut data = &data[64..];
+            // while there is a 0 at the end of the data, remove it
+            while let [rest @ .., 0] = data {
+                data = rest;
+            }
+            data
         } else {
-            str::from_utf8(data).map_err(|e| {
-                debug!(operator_id = ?operator_id, error = %e, "Failed to convert to UTF8 String");
-                ExecutionError::InvalidEvent(format!("Failed to convert to UTF8 String: {e}"))
-            })?
+            data
         };
 
         // Construct the Operator and insert it into the database

--- a/anchor/eth/src/sync.rs
+++ b/anchor/eth/src/sync.rs
@@ -2,7 +2,7 @@ use std::{
     cmp::{max, min},
     collections::{BTreeMap, HashMap},
     sync::{
-        Arc, LazyLock,
+        Arc,
         atomic::{AtomicBool, Ordering},
     },
 };
@@ -36,39 +36,35 @@ use crate::{
 };
 
 /// SSV contract events needed to come up to date with the network
-static SSV_EVENTS: LazyLock<Vec<String>> = LazyLock::new(|| {
-    vec![
-        // event OperatorAdded(uint64 indexed operatorId, address indexed owner, bytes publicKey,
-        // uint256 fee);
-        SSVContract::OperatorAdded::SIGNATURE.to_string(),
-        // event OperatorRemoved(uint64 indexed operatorId);
-        SSVContract::OperatorRemoved::SIGNATURE.to_string(),
-        // event ValidatorAdded(address indexed owner, uint64[] operatorIds, bytes publicKey, bytes
-        // shares, Cluster cluster);
-        SSVContract::ValidatorAdded::SIGNATURE.to_string(),
-        // event ValidatorRemoved(address indexed owner, uint64[] operatorIds, bytes publicKey,
-        // Cluster cluster);
-        SSVContract::ValidatorRemoved::SIGNATURE.to_string(),
-        // event ClusterLiquidated(address indexed owner, uint64[] operatorIds, Cluster cluster);
-        SSVContract::ClusterLiquidated::SIGNATURE.to_string(),
-        // event ClusterReactivated(address indexed owner, uint64[] operatorIds, Cluster cluster);
-        SSVContract::ClusterReactivated::SIGNATURE.to_string(),
-        // event FeeRecipientAddressUpdated(address indexed owner, address recipientAddress);
-        SSVContract::FeeRecipientAddressUpdated::SIGNATURE.to_string(),
-        // event ValidatorExited(address indexed owner, uint64[] operatorIds, bytes publicKey);
-        SSVContract::ValidatorExited::SIGNATURE.to_string(),
-    ]
-});
+const SSV_EVENTS: &[&str] = &[
+    // event OperatorAdded(uint64 indexed operatorId, address indexed owner, bytes publicKey,
+    // uint256 fee);
+    SSVContract::OperatorAdded::SIGNATURE,
+    // event OperatorRemoved(uint64 indexed operatorId);
+    SSVContract::OperatorRemoved::SIGNATURE,
+    // event ValidatorAdded(address indexed owner, uint64[] operatorIds, bytes publicKey, bytes
+    // shares, Cluster cluster);
+    SSVContract::ValidatorAdded::SIGNATURE,
+    // event ValidatorRemoved(address indexed owner, uint64[] operatorIds, bytes publicKey,
+    // Cluster cluster);
+    SSVContract::ValidatorRemoved::SIGNATURE,
+    // event ClusterLiquidated(address indexed owner, uint64[] operatorIds, Cluster cluster);
+    SSVContract::ClusterLiquidated::SIGNATURE,
+    // event ClusterReactivated(address indexed owner, uint64[] operatorIds, Cluster cluster);
+    SSVContract::ClusterReactivated::SIGNATURE,
+    // event FeeRecipientAddressUpdated(address indexed owner, address recipientAddress);
+    SSVContract::FeeRecipientAddressUpdated::SIGNATURE,
+    // event ValidatorExited(address indexed owner, uint64[] operatorIds, bytes publicKey);
+    SSVContract::ValidatorExited::SIGNATURE,
+];
 
 /// SSV contract events that provide information for keysplitting
-static KEYSPLIT_EVENTS: LazyLock<Vec<String>> = LazyLock::new(|| {
-    vec![
-        // Provides operator information
-        SSVContract::OperatorAdded::SIGNATURE.to_string(),
-        // Provides nonce information
-        SSVContract::ValidatorAdded::SIGNATURE.to_string(),
-    ]
-});
+const KEYSPLIT_EVENTS: &[&str] = &[
+    // Provides operator information
+    SSVContract::OperatorAdded::SIGNATURE,
+    // Provides nonce information
+    SSVContract::ValidatorAdded::SIGNATURE,
+];
 
 /// Batch size for log fetching
 const BATCH_SIZE: u64 = 10000;
@@ -138,15 +134,9 @@ impl SsvEventSyncer {
 
         // Construct Websocket Provider
         let ws = WsConnect::new(config.ws_url.full.as_str());
-        let ws_client = ProviderBuilder::default()
-            .on_ws(ws.clone())
-            .await
-            .map_err(|e| {
-                ExecutionError::SyncError(format!(
-                    "Failed to bind to WS: {}, {}",
-                    &config.ws_url, e
-                ))
-            })?;
+        let ws_client = ProviderBuilder::default().on_ws(ws).await.map_err(|e| {
+            ExecutionError::SyncError(format!("Failed to bind to WS: {}, {}", &config.ws_url, e))
+        })?;
         debug!("Created ws client");
 
         // Construct an EventProcessor with access to the DB
@@ -214,7 +204,7 @@ impl SsvEventSyncer {
         // Historical sync with disconnect handling
         loop {
             match self
-                .historical_sync(contract_address, deployment_block, KEYSPLIT_EVENTS.clone())
+                .historical_sync(contract_address, deployment_block, KEYSPLIT_EVENTS)
                 .await
             {
                 Ok(_) => return,
@@ -337,7 +327,7 @@ impl SsvEventSyncer {
         deployment_block: u64,
     ) -> Result<(), ExecutionError> {
         info!("Starting historical sync");
-        self.historical_sync(contract_address, deployment_block, SSV_EVENTS.clone())
+        self.historical_sync(contract_address, deployment_block, SSV_EVENTS)
             .await?;
 
         self.historic_finished_notify.take().map(|x| x.send(()));
@@ -362,7 +352,7 @@ impl SsvEventSyncer {
         &self,
         contract_address: Address,
         deployment_block: u64,
-        events: Vec<String>,
+        events: &[&str],
     ) -> Result<(), ExecutionError> {
         // Start from the contract deployment block or the last block that has been processed
         let last_processed_block = self.event_processor.db.state().get_last_processed_block();
@@ -404,7 +394,7 @@ impl SsvEventSyncer {
                 .step_by(BATCH_SIZE as usize)
                 .map(|start| {
                     let (start, end) = (start, std::cmp::min(start + BATCH_SIZE - 1, end_block));
-                    self.fetch_logs(start, end, contract_address, events.clone())
+                    self.fetch_logs(start, end, contract_address, events)
                 })
                 .collect();
 
@@ -482,15 +472,15 @@ impl SsvEventSyncer {
         from_block: u64,
         to_block: u64,
         deployment_address: Address,
-        events: Vec<String>,
-    ) -> impl Future<Output = Result<Vec<Log>, ExecutionError>> + Send + use<'_> {
+        events: &[&str],
+    ) -> impl Future<Output = Result<Vec<Log>, ExecutionError>> + Send {
         // Setup filter and rpc client
         let rpc_client = self.rpc_client.clone();
         let filter = Filter::new()
             .address(deployment_address)
             .from_block(from_block)
             .to_block(to_block)
-            .events(&events);
+            .events(events);
 
         // Try to fetch logs with a retry upon error. Try up to MAX_RETRIES times and error if we
         // exceed this as we can assume there is some underlying connection issue
@@ -543,7 +533,7 @@ impl SsvEventSyncer {
         from_block: u64,
         to_block: u64,
         deployment_address: Address,
-        events: Vec<String>,
+        events: &[&str],
         subdivision_factor: u64,
     ) -> Result<Vec<Log>, ExecutionError> {
         info!("Subdividing log retrieval");
@@ -556,7 +546,7 @@ impl SsvEventSyncer {
         while current <= to_block {
             let to = min(current + (target_size - 1), to_block);
             let logs = self
-                .fetch_logs(current, to, deployment_address, events.clone())
+                .fetch_logs(current, to, deployment_address, events)
                 .await?;
             result.extend(logs);
             current = to + 1;
@@ -660,12 +650,7 @@ impl SsvEventSyncer {
                 );
 
                 let mut logs = self
-                    .fetch_logs(
-                        relevant_block,
-                        relevant_block,
-                        contract_address,
-                        SSV_EVENTS.clone(),
-                    )
+                    .fetch_logs(relevant_block, relevant_block, contract_address, SSV_EVENTS)
                     .await?;
 
                 self.set_block_timestamps(&mut logs).await?;

--- a/anchor/eth/src/util.rs
+++ b/anchor/eth/src/util.rs
@@ -1,7 +1,7 @@
-use std::{collections::HashSet, num::NonZeroUsize, str::FromStr, time::Duration};
+use std::{borrow::Cow, collections::HashSet, num::NonZeroUsize, time::Duration};
 
 use alloy::{
-    primitives::{Address, Bytes, keccak256},
+    primitives::{Address, Bytes, Keccak256, keccak256},
     providers::{ProviderBuilder, RootProvider},
     rpc::client::RpcClient,
     transports::{Transport, http::Http, layers::FallbackLayer},
@@ -24,12 +24,12 @@ const PUBLIC_KEY_LENGTH: usize = 48;
 // Parses shares from a ValidatorAdded event
 // Event contains a bytes stream of the form
 // [signature | public keys | encrypted keys].
-pub fn parse_shares(
-    shares: Vec<u8>,
+pub fn parse_shares<'s>(
+    shares: &'s [u8],
     operator_ids: &[OperatorId],
     cluster_id: &ClusterId,
     validator_pubkey: &PublicKeyBytes,
-) -> Result<(Vec<u8>, Vec<Share>), String> {
+) -> Result<(&'s [u8], Vec<Share>), String> {
     let operator_count = operator_ids.len();
 
     // Calculate offsets for different components within the shares
@@ -47,26 +47,18 @@ pub fn parse_shares(
     }
 
     // Extract all of the components
-    let signature = shares[..signature_offset].to_vec();
-    let share_public_keys = split_bytes(
-        &shares[signature_offset..pub_keys_offset],
-        PUBLIC_KEY_LENGTH,
-    );
-    let encrypted_keys: Vec<Vec<u8>> =
-        split_bytes(&shares[pub_keys_offset..], ENCRYPTED_KEY_LENGTH);
+    let signature = &shares[..signature_offset];
+    let share_public_keys = shares[signature_offset..pub_keys_offset].chunks(PUBLIC_KEY_LENGTH);
+    let encrypted_keys = shares[pub_keys_offset..].chunks(ENCRYPTED_KEY_LENGTH);
 
     // Create the shares from the share public keys and the encrypted private keys
     let shares: Vec<Share> = share_public_keys
-        .into_iter()
         .zip(encrypted_keys)
         .zip(operator_ids)
         .map(|((public, encrypted), operator_id)| {
-            // Add 0x prefix to the hex encoded public key
-            let public_key_hex = format!("0x{}", hex::encode(&public));
-
             // Create public key
-            let share_pubkey = PublicKeyBytes::from_str(&public_key_hex)
-                .map_err(|e| format!("Failed to create public key: {e}"))?;
+            let share_pubkey = PublicKeyBytes::deserialize(public)
+                .map_err(|e| format!("Failed to create public key: {e:?}"))?;
 
             // Convert encrypted key into fixed array
             let encrypted_array: [u8; 256] = encrypted
@@ -84,13 +76,6 @@ pub fn parse_shares(
         .collect::<Result<Vec<_>, String>>()?;
 
     Ok((signature, shares))
-}
-
-// Splits a byte slice into chunks of specified size
-fn split_bytes(data: &[u8], chunk_size: usize) -> Vec<Vec<u8>> {
-    data.chunks(chunk_size)
-        .map(|chunk| chunk.to_vec())
-        .collect()
 }
 
 // Construct the metadata for the newly added validator
@@ -116,7 +101,7 @@ pub fn construct_validator_metadata(
 
 // Verify that the signature over the share data is correct
 pub fn verify_signature(
-    signature: Vec<u8>,
+    signature: &[u8],
     nonce: u16,
     owner: &Address,
     public_key: &PublicKeyBytes,
@@ -126,7 +111,7 @@ pub fn verify_signature(
     let hash = keccak256(data);
 
     // Deserialize the signature
-    let signature = match Signature::deserialize(&signature) {
+    let signature = match Signature::deserialize(signature) {
         Ok(sig) => sig,
         Err(_) => return false,
     };
@@ -194,41 +179,31 @@ pub fn validate_operators(
 
 /// Helper function to parse validator public keys
 pub fn parse_validator_pubkey(pubkey: &Bytes) -> Result<PublicKeyBytes, ExecutionError> {
-    let pubkey_str = pubkey.to_string();
-    PublicKeyBytes::from_str(&pubkey_str).map_err(|e| {
+    PublicKeyBytes::deserialize(pubkey).map_err(|e| {
         debug!(
-            validator_pubkey = %pubkey_str,
-            error = %e,
+            validator_pubkey = %pubkey,
+            error = ?e,
             "Failed to parse validator public key"
         );
-        ExecutionError::InvalidEvent(format!("Failed to parse validator public key: {e}"))
+        ExecutionError::InvalidEvent(format!("Failed to parse validator public key: {e:?}"))
     })
 }
 
 // Compute an identifier from the cluster from the owners and the chosen operators
-pub fn compute_cluster_id(owner: Address, mut operator_ids: Vec<u64>) -> ClusterId {
-    // Sort the operator IDs
-    operator_ids.sort();
-    // 20 bytes for the address and num ids * 32 for ids
-    let data_size = 20 + (operator_ids.len() * 32);
-    let mut data: Vec<u8> = Vec::with_capacity(data_size);
+pub fn compute_cluster_id(owner: Address, operator_ids: &[u64]) -> ClusterId {
+    let mut operator_ids = Cow::Borrowed(operator_ids);
 
-    // Add the address bytes
-    data.extend_from_slice(owner.as_slice());
-
-    // Add the operator IDs as 32 byte values
-    for id in operator_ids {
-        let mut id_bytes = [0u8; 32];
-        id_bytes[24..].copy_from_slice(&id.to_be_bytes());
-        data.extend_from_slice(&id_bytes);
+    // Sort the operator IDs if necessary
+    if !operator_ids.is_sorted() {
+        operator_ids.to_mut().sort_unstable();
     }
 
-    // Hash it all
-    let hashed_data: [u8; 32] = keccak256(data)
-        .as_slice()
-        .try_into()
-        .expect("Conversion Failed");
-    ClusterId(hashed_data)
+    let mut hasher = Keccak256::new();
+    hasher.update(owner.as_slice());
+    for id in operator_ids.as_ref() {
+        hasher.update(id.to_be_bytes());
+    }
+    ClusterId(hasher.finalize().0)
 }
 
 // Create a http provider with fallbacks
@@ -267,6 +242,8 @@ fn provider_from_transports(
 
 #[cfg(test)]
 mod eth_util_tests {
+    use std::str::FromStr;
+
     use alloy::primitives::address;
 
     use super::*;
@@ -278,8 +255,8 @@ mod eth_util_tests {
         let operator_ids = vec![1, 3, 4, 2];
         let operator_ids_mixed = vec![4, 2, 3, 1];
 
-        let cluster_id_1 = compute_cluster_id(owner, operator_ids);
-        let cluster_id_2 = compute_cluster_id(owner, operator_ids_mixed);
+        let cluster_id_1 = compute_cluster_id(owner, &operator_ids);
+        let cluster_id_2 = compute_cluster_id(owner, &operator_ids_mixed);
         assert_eq!(cluster_id_1, cluster_id_2);
     }
 
@@ -290,7 +267,7 @@ mod eth_util_tests {
         let onchain = "a3d1e25b31cb6da1b9636568a221b0d7ae1a57a7f14ace5c97d1093ebf6b786c";
         let operator_ids = vec![62, 256, 259, 282];
         let owner = address!("E1b2308852F0e85D9F23278A6A80131ac8901dBF");
-        let cluster_id = compute_cluster_id(owner, operator_ids);
+        let cluster_id = compute_cluster_id(owner, &operator_ids);
         let cluster_id_hex = hex::encode(*cluster_id);
         assert_eq!(onchain, cluster_id_hex);
     }
@@ -309,10 +286,9 @@ mod eth_util_tests {
             170, 143, 204, 45, 71, 59, 76, 131, 220, 199, 179, 219, 47, 115, 45, 162, 168, 163,
             223, 110, 38, 9, 166, 82, 34, 227, 53, 50, 31, 105, 74, 122, 179, 172, 22, 245, 89, 32,
             214, 69,
-        ]
-        .to_vec();
+        ];
         assert!(verify_signature(
-            signature_data.clone(),
+            &signature_data,
             nonce,
             &owner,
             &public_key
@@ -320,7 +296,7 @@ mod eth_util_tests {
 
         // make sure that a wrong nonce fails the signature check
         assert!(!verify_signature(
-            signature_data,
+            &signature_data,
             nonce + 1,
             &owner,
             &public_key
@@ -337,7 +313,7 @@ mod eth_util_tests {
         let cluster_id = ClusterId([0u8; 32]);
         let pubkey = PublicKeyBytes::from_str("0xb1d97447eeb16cffa0464040860db6f12ac0af6a1583a45f4f07fb61e1470f3733f8b7ec8e3c9ff4a9da83086d342ba1").expect("Failed to create public key");
 
-        let (_, shares) = parse_shares(share_data, &operator_ids, &cluster_id, &pubkey)
+        let (_, shares) = parse_shares(&share_data, &operator_ids, &cluster_id, &pubkey)
             .expect("Failed to parse shares");
         assert_eq!(shares.len(), 4);
     }
@@ -353,7 +329,7 @@ mod eth_util_tests {
         let owner = address!("0x000000633b68f5d8d3a86593ebb815b4663bcbe0");
         let nonce = 0;
 
-        let (signature, shares) = parse_shares(share_data, &operator_ids, &cluster_id, &pubkey)
+        let (signature, shares) = parse_shares(&share_data, &operator_ids, &cluster_id, &pubkey)
             .expect("Failed to parse shares");
 
         assert_eq!(shares.len(), 4);

--- a/anchor/eth/src/util.rs
+++ b/anchor/eth/src/util.rs
@@ -201,6 +201,7 @@ pub fn compute_cluster_id(owner: Address, operator_ids: &[u64]) -> ClusterId {
     let mut hasher = Keccak256::new();
     hasher.update(owner.as_slice());
     for id in operator_ids.as_ref() {
+        hasher.update([0; 24]);
         hasher.update(id.to_be_bytes());
     }
     ClusterId(hasher.finalize().0)

--- a/anchor/keysplit/src/cli.rs
+++ b/anchor/keysplit/src/cli.rs
@@ -68,7 +68,7 @@ pub struct Manual {
     pub nonce: u64,
 
     #[clap(long, help = "RSA public keys for the operators", value_name = "KEYS",
-       value_parser = parse_rsa,
+        value_parser = |s: &str| parse_rsa(s.as_bytes()),
         required = true,
         num_args = 1..,
         value_delimiter = ',')]


### PR DESCRIPTION
There are a bunch of allocations and conversion in the database that can be avoided.