### PR TITLE
Add role to ExcessiveDutyCount error

### DIFF
--- a/anchor/message_validator/src/lib.rs
+++ b/anchor/message_validator/src/lib.rs
@@ -186,6 +186,7 @@ pub enum ValidationFailure {
     ExcessiveDutyCount {
         got: u64,
         limit: u64,
+        role: Role,
     },
     SyncCommitteePeriodCalculationFailure,
     UnexpectedFailure {
@@ -622,6 +623,7 @@ pub(crate) fn validate_duty_count(
             return Err(ValidationFailure::ExcessiveDutyCount {
                 got: duty_count,
                 limit,
+                role: validation_context.role,
             });
         }
     }


### PR DESCRIPTION
## Issue Addressed

On an `ExcessiveDutyCount` error, we currently can't see the role tha caused it.

## Proposed Changes

Add the role to the enum variant
