### PR TITLE
Return references instead of cloning in `MultiIndexMap`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -131,6 +131,7 @@ tokio = { version = "1.39.2", features = [
     "rt-multi-thread",
     "time",
     "signal",
+    "sync",
     "macros",
 ] }
 tower-http = { version = "0.6", features = ["cors"] }

--- a/anchor/database/src/cluster_operations.rs
+++ b/anchor/database/src/cluster_operations.rs
@@ -105,9 +105,8 @@ impl NetworkDatabase {
 
         // Update in memory status of cluster
         self.modify_state(|state| {
-            if let Some(mut cluster) = state.multi_state.clusters.get_by(&cluster_id) {
+            if let Some(cluster) = state.multi_state.clusters.get_mut_by(&cluster_id) {
                 cluster.liquidated = status;
-                state.multi_state.clusters.update(&cluster_id, cluster);
             }
         });
 
@@ -141,6 +140,7 @@ impl NetworkDatabase {
                 .multi_state
                 .validator_metadata
                 .get_all_by(&metadata.cluster_id)
+                .next()
                 .is_none()
             {
                 state.multi_state.clusters.remove(&metadata.cluster_id);

--- a/anchor/database/src/multi_index.rs
+++ b/anchor/database/src/multi_index.rs
@@ -23,12 +23,18 @@ impl NotUnique for NonUniqueTag {}
 
 /// Trait for accessing values through a unique index
 pub trait UniqueIndex<K, V, I> {
-    fn get_by(&self, key: &K) -> Option<V>;
+    fn get_by(&self, key: &K) -> Option<&V>;
+    fn get_mut_by(&mut self, key: &K) -> Option<&mut V>;
 }
 
 /// Trait for accessing values through a non-unique index
 pub trait NonUniqueIndex<K, V, I> {
-    fn get_all_by(&self, key: &K) -> Option<Vec<V>>;
+    fn get_all_by<'a>(&'a self, key: &K) -> impl Iterator<Item = &'a V> + 'a
+    where
+        V: 'a;
+    fn modify_all_by<F>(&mut self, key: &K, f: F)
+    where
+        F: FnMut(&mut V);
 }
 
 /// Inner storage maps for the multi-index map, now supporting a quaternary index.
@@ -90,7 +96,6 @@ where
     K2: Eq + Hash + Clone,
     K3: Eq + Hash + Clone,
     K4: Eq + Hash + Clone,
-    V: Clone,
     U1: 'static,
     U2: 'static,
     U3: 'static,
@@ -117,7 +122,6 @@ where
     K2: Eq + Hash + Clone,
     K3: Eq + Hash + Clone,
     K4: Eq + Hash + Clone,
-    V: Clone,
     U1: 'static,
     U2: 'static,
     U3: 'static,
@@ -250,10 +254,13 @@ where
     K2: Eq + Hash + Clone,
     K3: Eq + Hash + Clone,
     K4: Eq + Hash + Clone,
-    V: Clone,
 {
-    fn get_by(&self, key: &K1) -> Option<V> {
-        self.maps.primary.get(key).cloned()
+    fn get_by(&self, key: &K1) -> Option<&V> {
+        self.maps.primary.get(key)
+    }
+
+    fn get_mut_by(&mut self, key: &K1) -> Option<&mut V> {
+        self.maps.primary.get_mut(key)
     }
 }
 
@@ -265,12 +272,16 @@ where
     K2: Eq + Hash + Clone,
     K3: Eq + Hash + Clone,
     K4: Eq + Hash + Clone,
-    V: Clone,
     U1: Unique,
 {
-    fn get_by(&self, key: &K2) -> Option<V> {
+    fn get_by(&self, key: &K2) -> Option<&V> {
         let primary_key = self.maps.secondary_unique.get(key)?;
-        self.maps.primary.get(primary_key).cloned()
+        self.maps.primary.get(primary_key)
+    }
+
+    fn get_mut_by(&mut self, key: &K2) -> Option<&mut V> {
+        let primary_key = self.maps.secondary_unique.get(key)?.clone();
+        self.maps.primary.get_mut(&primary_key)
     }
 }
 
@@ -282,15 +293,32 @@ where
     K2: Eq + Hash + Clone,
     K3: Eq + Hash + Clone,
     K4: Eq + Hash + Clone,
-    V: Clone,
     U1: NotUnique,
 {
-    fn get_all_by(&self, key: &K2) -> Option<Vec<V>> {
-        self.maps.secondary_multi.get(key).map(|keys| {
-            keys.iter()
-                .filter_map(|k1| self.maps.primary.get(k1).cloned())
-                .collect()
-        })
+    fn get_all_by<'a>(&'a self, key: &K2) -> impl Iterator<Item = &'a V> + 'a
+    where
+        V: 'a,
+    {
+        self.maps
+            .secondary_multi
+            .get(key)
+            .into_iter()
+            .flatten()
+            .flat_map(|key| self.maps.primary.get(key))
+    }
+
+    fn modify_all_by<F>(&mut self, key: &K2, mut f: F)
+    where
+        F: FnMut(&mut V),
+    {
+        if let Some(keys) = self.maps.secondary_multi.get(key) {
+            let keys = keys.clone();
+            for primary_key in keys {
+                if let Some(value) = self.maps.primary.get_mut(&primary_key) {
+                    f(value);
+                }
+            }
+        }
     }
 }
 
@@ -302,12 +330,16 @@ where
     K2: Eq + Hash + Clone,
     K3: Eq + Hash + Clone,
     K4: Eq + Hash + Clone,
-    V: Clone,
     U2: Unique,
 {
-    fn get_by(&self, key: &K3) -> Option<V> {
+    fn get_by(&self, key: &K3) -> Option<&V> {
         let primary_key = self.maps.tertiary_unique.get(key)?;
-        self.maps.primary.get(primary_key).cloned()
+        self.maps.primary.get(primary_key)
+    }
+
+    fn get_mut_by(&mut self, key: &K3) -> Option<&mut V> {
+        let primary_key = self.maps.tertiary_unique.get(key)?.clone();
+        self.maps.primary.get_mut(&primary_key)
     }
 }
 
@@ -319,15 +351,31 @@ where
     K2: Eq + Hash + Clone,
     K3: Eq + Hash + Clone,
     K4: Eq + Hash + Clone,
-    V: Clone,
     U2: NotUnique,
 {
-    fn get_all_by(&self, key: &K3) -> Option<Vec<V>> {
-        self.maps.tertiary_multi.get(key).map(|keys| {
-            keys.iter()
-                .filter_map(|k1| self.maps.primary.get(k1).cloned())
-                .collect()
-        })
+    fn get_all_by<'a>(&'a self, key: &K3) -> impl Iterator<Item = &'a V> + 'a
+    where
+        V: 'a,
+    {
+        self.maps
+            .tertiary_multi
+            .get(key)
+            .into_iter()
+            .flat_map(|keys| keys.iter().filter_map(|k1| self.maps.primary.get(k1)))
+    }
+
+    fn modify_all_by<F>(&mut self, key: &K3, mut f: F)
+    where
+        F: FnMut(&mut V),
+    {
+        if let Some(keys) = self.maps.tertiary_multi.get(key) {
+            let keys = keys.clone();
+            for primary_key in keys {
+                if let Some(value) = self.maps.primary.get_mut(&primary_key) {
+                    f(value);
+                }
+            }
+        }
     }
 }
 
@@ -339,12 +387,16 @@ where
     K2: Eq + Hash + Clone,
     K3: Eq + Hash + Clone,
     K4: Eq + Hash + Clone,
-    V: Clone,
     U3: Unique,
 {
-    fn get_by(&self, key: &K4) -> Option<V> {
+    fn get_by(&self, key: &K4) -> Option<&V> {
         let primary_key = self.maps.quaternary_unique.get(key)?;
-        self.maps.primary.get(primary_key).cloned()
+        self.maps.primary.get(primary_key)
+    }
+
+    fn get_mut_by(&mut self, key: &K4) -> Option<&mut V> {
+        let primary_key = self.maps.quaternary_unique.get(key)?.clone();
+        self.maps.primary.get_mut(&primary_key)
     }
 }
 
@@ -356,15 +408,31 @@ where
     K2: Eq + Hash + Clone,
     K3: Eq + Hash + Clone,
     K4: Eq + Hash + Clone,
-    V: Clone,
     U3: NotUnique,
 {
-    fn get_all_by(&self, key: &K4) -> Option<Vec<V>> {
-        self.maps.quaternary_multi.get(key).map(|keys| {
-            keys.iter()
-                .filter_map(|k1| self.maps.primary.get(k1).cloned())
-                .collect()
-        })
+    fn get_all_by<'a>(&'a self, key: &K4) -> impl Iterator<Item = &'a V> + 'a
+    where
+        V: 'a,
+    {
+        self.maps
+            .quaternary_multi
+            .get(key)
+            .into_iter()
+            .flat_map(|keys| keys.iter().filter_map(|k1| self.maps.primary.get(k1)))
+    }
+
+    fn modify_all_by<F>(&mut self, key: &K4, mut f: F)
+    where
+        F: FnMut(&mut V),
+    {
+        if let Some(keys) = self.maps.quaternary_multi.get(key) {
+            let keys = keys.clone();
+            for primary_key in keys {
+                if let Some(value) = self.maps.primary.get_mut(&primary_key) {
+                    f(value);
+                }
+            }
+        }
     }
 }
 
@@ -401,16 +469,16 @@ mod multi_index_tests {
         map.insert(&1, &"key1".to_string(), &true, &'a', value.clone());
 
         // Test primary key access
-        assert_eq!(map.get_by(&1), Some(value.clone()));
+        assert_eq!(map.get_by(&1), Some(&value));
 
         // Test secondary key access
-        assert_eq!(map.get_by(&"key1".to_string()), Some(value.clone()));
+        assert_eq!(map.get_by(&"key1".to_string()), Some(&value));
 
         // Test tertiary key access
-        assert_eq!(map.get_by(&true), Some(value.clone()));
+        assert_eq!(map.get_by(&true), Some(&value));
 
         // Test quaternary key access
-        assert_eq!(map.get_by(&'a'), Some(value.clone()));
+        assert_eq!(map.get_by(&'a'), Some(&value));
 
         // Test update
         let new_value = TestValue {
@@ -418,7 +486,7 @@ mod multi_index_tests {
             data: "updated".to_string(),
         };
         map.update(&1, new_value.clone());
-        assert_eq!(map.get_by(&1), Some(new_value.clone()));
+        assert_eq!(map.get_by(&1), Some(&new_value));
 
         // Test removal: all indices should be cleaned up
         assert_eq!(map.remove(&1), Some(new_value.clone()));
@@ -456,35 +524,35 @@ mod multi_index_tests {
         map.insert(&2, &"shared_key".to_string(), &true, &'z', value2.clone());
 
         // Test primary key access (still unique)
-        assert_eq!(map.get_by(&1), Some(value1.clone()));
-        assert_eq!(map.get_by(&2), Some(value2.clone()));
+        assert_eq!(map.get_by(&1), Some(&value1));
+        assert_eq!(map.get_by(&2), Some(&value2));
 
         // Test secondary key access (non-unique)
-        let secondary_values = map.get_all_by(&"shared_key".to_string()).unwrap();
+        let secondary_values: Vec<_> = map.get_all_by(&"shared_key".to_string()).collect();
         assert_eq!(secondary_values.len(), 2);
-        assert!(secondary_values.contains(&value1));
-        assert!(secondary_values.contains(&value2));
+        assert!(secondary_values.contains(&&value1));
+        assert!(secondary_values.contains(&&value2));
 
         // Test tertiary key access (non-unique)
-        let tertiary_values = map.get_all_by(&true).unwrap();
+        let tertiary_values: Vec<_> = map.get_all_by(&true).collect();
         assert_eq!(tertiary_values.len(), 2);
-        assert!(tertiary_values.contains(&value1));
-        assert!(tertiary_values.contains(&value2));
+        assert!(tertiary_values.contains(&&value1));
+        assert!(tertiary_values.contains(&&value2));
 
         // Test quaternary key access (non-unique)
-        let quaternary_values = map.get_all_by(&'z').unwrap();
+        let quaternary_values: Vec<_> = map.get_all_by(&'z').collect();
         assert_eq!(quaternary_values.len(), 2);
-        assert!(quaternary_values.contains(&value1));
-        assert!(quaternary_values.contains(&value2));
+        assert!(quaternary_values.contains(&&value1));
+        assert!(quaternary_values.contains(&&value2));
 
         // Test removal maintains other entries
         map.remove(&1);
         assert_eq!(map.get_by(&1), None);
-        assert_eq!(map.get_by(&2), Some(value2.clone()));
+        assert_eq!(map.get_by(&2), Some(&value2));
 
-        let remaining_secondary = map.get_all_by(&"shared_key".to_string()).unwrap();
+        let remaining_secondary: Vec<_> = map.get_all_by(&"shared_key".to_string()).collect();
         assert_eq!(remaining_secondary.len(), 1);
-        assert_eq!(remaining_secondary[0], value2);
+        assert_eq!(remaining_secondary[0], &value2);
     }
 
     #[test]
@@ -516,18 +584,18 @@ mod multi_index_tests {
         map.insert(&2, &"key2".to_string(), &true, &'r', value2.clone());
 
         // Test unique secondary key access
-        assert_eq!(map.get_by(&"key1".to_string()), Some(value1.clone()));
-        assert_eq!(map.get_by(&"key2".to_string()), Some(value2.clone()));
+        assert_eq!(map.get_by(&"key1".to_string()), Some(&value1));
+        assert_eq!(map.get_by(&"key2".to_string()), Some(&value2));
 
         // Test non-unique tertiary key access
-        let tertiary_values = map.get_all_by(&true).unwrap();
+        let tertiary_values: Vec<_> = map.get_all_by(&true).collect();
         assert_eq!(tertiary_values.len(), 2);
-        assert!(tertiary_values.contains(&value1));
-        assert!(tertiary_values.contains(&value2));
+        assert!(tertiary_values.contains(&&value1));
+        assert!(tertiary_values.contains(&&value2));
 
         // Test unique quaternary key access
-        assert_eq!(map.get_by(&'q'), Some(value1.clone()));
-        assert_eq!(map.get_by(&'r'), Some(value2.clone()));
+        assert_eq!(map.get_by(&'q'), Some(&value1));
+        assert_eq!(map.get_by(&'r'), Some(&value2));
     }
 
     #[test]
@@ -558,5 +626,150 @@ mod multi_index_tests {
             data: "test".to_string(),
         };
         assert_eq!(map.update(&1, value), None);
+    }
+
+    #[test]
+    fn test_get_mut_by() {
+        // Using unique indices for all secondary, tertiary, and quaternary keys.
+        let mut map: MultiIndexMap<
+            i32,
+            String,
+            bool,
+            char,
+            TestValue,
+            UniqueTag,
+            UniqueTag,
+            UniqueTag,
+        > = MultiIndexMap::new();
+
+        let value = TestValue {
+            id: 1,
+            data: "original".to_string(),
+        };
+
+        // Test insertion
+        map.insert(&1, &"key1".to_string(), &true, &'a', value.clone());
+
+        // Test mutable access via primary key
+        if let Some(mut_ref) = map.get_mut_by(&1) {
+            mut_ref.data = "modified_primary".to_string();
+        }
+        assert_eq!(map.get_by(&1).unwrap().data, "modified_primary");
+
+        // Test mutable access via secondary key
+        if let Some(mut_ref) = map.get_mut_by(&"key1".to_string()) {
+            mut_ref.data = "modified_secondary".to_string();
+        }
+        assert_eq!(map.get_by(&1).unwrap().data, "modified_secondary");
+
+        // Test mutable access via tertiary key
+        if let Some(mut_ref) = map.get_mut_by(&true) {
+            mut_ref.data = "modified_tertiary".to_string();
+        }
+        assert_eq!(map.get_by(&1).unwrap().data, "modified_tertiary");
+
+        // Test mutable access via quaternary key
+        if let Some(mut_ref) = map.get_mut_by(&'a') {
+            mut_ref.data = "modified_quaternary".to_string();
+        }
+        assert_eq!(map.get_by(&1).unwrap().data, "modified_quaternary");
+
+        // Test that all index access methods see the same modified value
+        assert_eq!(
+            map.get_by(&"key1".to_string()).unwrap().data,
+            "modified_quaternary"
+        );
+        assert_eq!(map.get_by(&true).unwrap().data, "modified_quaternary");
+        assert_eq!(map.get_by(&'a').unwrap().data, "modified_quaternary");
+
+        // Test access to non-existent keys returns None
+        assert!(map.get_mut_by(&2).is_none());
+        assert!(map.get_mut_by(&"nonexistent".to_string()).is_none());
+        assert!(map.get_mut_by(&false).is_none());
+        assert!(map.get_mut_by(&'z').is_none());
+    }
+
+    #[test]
+    fn test_modify_all_by() {
+        // Using non-unique indices for all secondary, tertiary, and quaternary keys.
+        let mut map: MultiIndexMap<
+            i32,
+            String,
+            bool,
+            char,
+            TestValue,
+            NonUniqueTag,
+            NonUniqueTag,
+            NonUniqueTag,
+        > = MultiIndexMap::new();
+
+        let value1 = TestValue {
+            id: 1,
+            data: "original1".to_string(),
+        };
+        let value2 = TestValue {
+            id: 2,
+            data: "original2".to_string(),
+        };
+        let value3 = TestValue {
+            id: 3,
+            data: "original3".to_string(),
+        };
+
+        // Insert values with shared keys
+        map.insert(&1, &"shared_key".to_string(), &true, &'z', value1.clone());
+        map.insert(&2, &"shared_key".to_string(), &true, &'z', value2.clone());
+        map.insert(&3, &"other_key".to_string(), &false, &'y', value3.clone());
+
+        // Test mutable access via secondary key
+        let mut counter = 0;
+        map.modify_all_by(&"shared_key".to_string(), |value| {
+            counter += 1;
+            value.data = format!("modified_secondary_{}", counter);
+        });
+
+        // Verify both values were modified
+        assert!(
+            map.get_by(&1)
+                .unwrap()
+                .data
+                .starts_with("modified_secondary_")
+        );
+        assert!(
+            map.get_by(&2)
+                .unwrap()
+                .data
+                .starts_with("modified_secondary_")
+        );
+        assert_eq!(map.get_by(&3).unwrap().data, "original3"); // Unchanged
+
+        // Test mutable access via tertiary key
+        map.modify_all_by(&true, |value| {
+            value.data = format!("modified_tertiary_{}", value.id);
+        });
+
+        // Verify both values were modified
+        assert_eq!(map.get_by(&1).unwrap().data, "modified_tertiary_1");
+        assert_eq!(map.get_by(&2).unwrap().data, "modified_tertiary_2");
+        assert_eq!(map.get_by(&3).unwrap().data, "original3"); // Unchanged
+
+        // Test mutable access via quaternary key
+        map.modify_all_by(&'z', |value| {
+            value.data = format!("modified_quaternary_{}", value.id);
+        });
+
+        // Verify both values were modified
+        assert_eq!(map.get_by(&1).unwrap().data, "modified_quaternary_1");
+        assert_eq!(map.get_by(&2).unwrap().data, "modified_quaternary_2");
+        assert_eq!(map.get_by(&3).unwrap().data, "original3"); // Unchanged
+
+        // Test access to non-existent keys does nothing
+        map.modify_all_by(&"nonexistent".to_string(), |_value| {
+            panic!("Should not be called for non-existent key");
+        });
+
+        map.modify_all_by(&'x', |_value| {
+            panic!("Should not be called for non-existent key");
+        });
     }
 }

--- a/anchor/database/src/state.rs
+++ b/anchor/database/src/state.rs
@@ -259,8 +259,9 @@ impl NetworkState {
         self.multi_state
             .clusters
             .get_all_by(committee_id)
-            .and_then(|clusters| clusters.first().cloned())
-            .map(|cluster| cluster.cluster_members)
+            .next()
+            .cloned()
+            .map(|cluster| cluster.cluster_members.clone())
     }
 
     pub fn get_cluster_members_for_validator(
@@ -275,19 +276,15 @@ impl NetworkState {
         self.multi_state
             .clusters
             .get_by(&cluster_id)
-            .map(|c| c.cluster_members)
+            .map(|c| c.cluster_members.clone())
     }
 
-    fn get_validator_indices(&self, committee_id: &CommitteeId) -> Option<Vec<ValidatorIndex>> {
+    fn get_validator_indices(&self, committee_id: &CommitteeId) -> Vec<ValidatorIndex> {
         self.multi_state
             .validator_metadata
             .get_all_by(committee_id)
-            .map(|metadata| {
-                metadata
-                    .iter()
-                    .flat_map(|metadata| metadata.index)
-                    .collect::<Vec<_>>()
-            })
+            .flat_map(|metadata| metadata.index)
+            .collect::<Vec<_>>()
     }
 
     /// Get a reference to the shares map
@@ -343,7 +340,7 @@ impl NetworkState {
         let committee_members = self.get_cluster_members(committee_id)?;
 
         // Get validator indices for this committee
-        let validator_indices = self.get_validator_indices(committee_id)?;
+        let validator_indices = self.get_validator_indices(committee_id);
 
         Some(CommitteeInfo {
             committee_members,

--- a/anchor/database/src/tests/state_tests.rs
+++ b/anchor/database/src/tests/state_tests.rs
@@ -56,13 +56,9 @@ mod state_database_tests {
         // Confirm share data, there should be one share in memory for this operator
         assert_eq!(fixture.db.state().shares().length(), 1);
         let pk = &fixture.validator.public_key;
-        let share = fixture
-            .db
-            .state()
-            .shares()
-            .get_by(pk)
-            .expect("The share should exist");
-        assertions::share::exists_in_memory(&fixture.db, pk, &share);
+        let state = fixture.db.state();
+        let share = state.shares().get_by(pk).expect("The share should exist");
+        assertions::share::exists_in_memory(&fixture.db, pk, share);
     }
 
     #[test]

--- a/anchor/database/src/tests/utils.rs
+++ b/anchor/database/src/tests/utils.rs
@@ -394,17 +394,18 @@ pub mod assertions {
         }
         // Verifies that the cluster is in memory
         pub fn exists_in_memory(db: &NetworkDatabase, v: &ValidatorMetadata) {
-            let stored_validator = db
-                .state()
+            let state = db.state();
+            let stored_validator = state
                 .metadata()
                 .get_by(&v.public_key)
                 .expect("Metadata should exist");
-            data(v, &stored_validator);
+            data(v, stored_validator);
         }
 
         // Verifies that the cluster is not in memory
         pub fn exists_not_in_memory(db: &NetworkDatabase, v: &ValidatorMetadata) {
-            let stored_validator = db.state().metadata().get_by(&v.public_key);
+            let state = db.state();
+            let stored_validator = state.metadata().get_by(&v.public_key);
             assert!(stored_validator.is_none());
         }
 
@@ -435,18 +436,19 @@ pub mod assertions {
         // Verifies that the cluster is in memory
         pub fn exists_in_memory(db: &NetworkDatabase, c: &Cluster) {
             assert!(db.state().member_of_cluster(&c.cluster_id));
-            let stored_cluster = db
-                .state()
+            let state = db.state();
+            let stored_cluster = state
                 .clusters()
                 .get_by(&c.cluster_id)
                 .expect("Cluster should exist");
-            data(c, &stored_cluster)
+            data(c, stored_cluster)
         }
 
         // Verifies that the cluster is not in memory
         pub fn exists_not_in_memory(db: &NetworkDatabase, cluster_id: ClusterId) {
             assert!(!db.state().member_of_cluster(&cluster_id));
-            let stored_cluster = db.state().clusters().get_by(&cluster_id);
+            let state = db.state();
+            let stored_cluster = state.clusters().get_by(&cluster_id);
             assert!(stored_cluster.is_none());
         }
 
@@ -485,17 +487,18 @@ pub mod assertions {
             validator_pubkey: &PublicKeyBytes,
             s: &Share,
         ) {
-            let stored_share = db
-                .state()
+            let state = db.state();
+            let stored_share = state
                 .shares()
                 .get_by(validator_pubkey)
                 .expect("Share should exist");
-            data(s, &stored_share);
+            data(s, stored_share);
         }
 
         // Verifies that a share is not in memory
         pub fn exists_not_in_memory(db: &NetworkDatabase, validator_pubkey: &PublicKeyBytes) {
-            let stored_share = db.state().shares().get_by(validator_pubkey);
+            let state = db.state();
+            let stored_share = state.shares().get_by(validator_pubkey);
             assert!(stored_share.is_none());
         }
 

--- a/anchor/database/src/validator_operations.rs
+++ b/anchor/database/src/validator_operations.rs
@@ -26,16 +26,9 @@ impl NetworkDatabase {
             ])?;
 
         self.modify_state(|state| {
-            if let Some(clusters) = state.multi_state.clusters.get_all_by(&owner) {
-                for mut cluster in clusters {
-                    // Update in memory
-                    cluster.fee_recipient = fee_recipient;
-                    state
-                        .multi_state
-                        .clusters
-                        .update(&cluster.cluster_id.clone(), cluster);
-                }
-            }
+            state.multi_state.clusters.modify_all_by(&owner, |cluster| {
+                cluster.fee_recipient = fee_recipient;
+            });
         });
         Ok(())
     }
@@ -83,17 +76,13 @@ impl NetworkDatabase {
             ])?;
 
         self.modify_state(|state| {
-            if let Some(mut validator) = state
+            if let Some(validator) = state
                 .multi_state
                 .validator_metadata
-                .get_by(validator_pubkey)
+                .get_mut_by(validator_pubkey)
             {
                 // Update in memory
                 validator.graffiti = graffiti;
-                state
-                    .multi_state
-                    .validator_metadata
-                    .update(validator_pubkey, validator);
             }
         });
         Ok(())
@@ -118,15 +107,11 @@ impl NetworkDatabase {
 
         self.modify_state(|state| {
             for (public_key, index) in map {
-                if let Some(mut validator) =
-                    state.multi_state.validator_metadata.get_by(&public_key)
+                if let Some(validator) =
+                    state.multi_state.validator_metadata.get_mut_by(&public_key)
                 {
                     // Update in memory
                     validator.index = Some(index);
-                    state
-                        .multi_state
-                        .validator_metadata
-                        .update(&public_key, validator);
                 } else {
                     debug!(?public_key, "Tried to update index of unknown validator");
                 }

--- a/anchor/eth/src/event_processor.rs
+++ b/anchor/eth/src/event_processor.rs
@@ -663,7 +663,8 @@ impl EventProcessor {
         validator_pubkey: &PublicKeyBytes,
     ) -> Result<Option<ValidatorIndex>, ExecutionError> {
         // Get the validator metadata including its index
-        let validator_metadata = match self.db.state().metadata().get_by(validator_pubkey) {
+        let state = self.db.state();
+        let validator_metadata = match state.metadata().get_by(validator_pubkey) {
             Some(metadata) => metadata,
             None => {
                 error!(

--- a/anchor/message_receiver/src/manager.rs
+++ b/anchor/message_receiver/src/manager.rs
@@ -127,17 +127,18 @@ impl<S: SlotClock + 'static, D: DutiesProvider> MessageReceiver
                             return;
                         };
 
-                        let committee = state.clusters().get_all_by(&committee_id);
                         // We only need to check one cluster, as all clusters will have the same set
                         // of operators.
-                        let is_member = committee.clone()
-                            .and_then(|mut v| v.pop())
+                        let is_member = state
+                            .clusters()
+                            .get_all_by(&committee_id)
+                            .next()
                             .map(|c| c.cluster_members.contains(&own_id))
                             .unwrap_or(false);
 
                         if !is_member {
                             // We are not a member for this committee, return without passing.
-                            trace!(gossipsub_message_id = ?message_id, ssv_msg_id = ?msg_id, ?committee, "Not interested");
+                            trace!(gossipsub_message_id = ?message_id, ssv_msg_id = ?msg_id, ?committee_id, "Not interested");
                             return;
                         }
                     }

--- a/anchor/validator_store/src/lib.rs
+++ b/anchor/validator_store/src/lib.rs
@@ -90,7 +90,7 @@ const SYNC_COMMITTEE_CONTRIBUTION_LOG_NAME: &str = "sync committee contribution"
 
 #[derive(Clone)]
 struct InitializedValidator {
-    cluster: Arc<Cluster>,
+    cluster: Cluster,
     metadata: ValidatorMetadata,
     decrypted_key_share: Option<SecretKey>,
 }
@@ -177,35 +177,35 @@ impl<T: SlotClock, E: EthSpec> AnchorValidatorStore<T, E> {
 
         for (cluster, validator) in db_clusters
             .into_iter()
-            .filter_map(|id| state.clusters().get_by(id).map(Arc::new))
+            .filter_map(|id| state.clusters().get_by(id))
             .filter(|cluster| !cluster.liquidated)
             .flat_map(|cluster| {
                 state
                     .metadata()
                     .get_all_by(&cluster.cluster_id)
-                    .unwrap_or_default()
-                    .into_iter()
-                    .map(move |metadata| (cluster.clone(), metadata))
+                    .map(move |metadata| (cluster, metadata))
             })
         {
             if unseen_validators.remove(&validator.public_key) {
                 // Validator was present: check if the cluster has changed
                 if let Some(mut entry) = self.validators.get_mut(&validator.public_key) {
-                    let current_cluster = &entry.value().cluster;
-                    if *current_cluster != cluster {
+                    let current_cluster = &mut entry.value_mut().cluster;
+                    if current_cluster.cluster_id != cluster.cluster_id {
                         // Update the validator with the new cluster
-                        let mut validator_data = entry.value().clone();
-                        validator_data.cluster = cluster;
-                        *entry.value_mut() = validator_data;
+                        *current_cluster = cluster.clone();
                     }
                 }
             } else {
                 // value was not present: add to store
                 if let Ok(secret_key) =
-                    self.get_share_from_state(state, &validator, validator.public_key)
+                    self.get_share_from_state(state, validator, validator.public_key)
                 {
-                    let result =
-                        self.add_validator(validator.public_key, cluster, validator, secret_key);
+                    let result = self.add_validator(
+                        validator.public_key,
+                        cluster,
+                        validator.clone(),
+                        secret_key,
+                    );
                     if let Err(err) = result {
                         error!(?err, "Unable to initialize validator");
                     }
@@ -275,7 +275,7 @@ impl<T: SlotClock, E: EthSpec> AnchorValidatorStore<T, E> {
     fn add_validator(
         &self,
         pubkey_bytes: PublicKeyBytes,
-        cluster: Arc<Cluster>,
+        cluster: &Cluster,
         validator_metadata: ValidatorMetadata,
         decrypted_key_share: Option<SecretKey>,
     ) -> Result<(), Error> {
@@ -289,7 +289,7 @@ impl<T: SlotClock, E: EthSpec> AnchorValidatorStore<T, E> {
         self.validators.insert(
             pubkey_bytes,
             InitializedValidator {
-                cluster,
+                cluster: cluster.clone(),
                 metadata: validator_metadata,
                 decrypted_key_share,
             },


### PR DESCRIPTION
Currently, all accessors of the multi index map returns owned values. However, often, using sites only need a reference for quick access to a value. This causes unnecessary copying of data.

This PR changes the existing `get_by` to return a reference and `get_all_by` to return an iterator over references, avoiding unnecessary allocation of a `Vec`.

Furthermore, we introduce `get_by_mut` and `modify_all_by` to allow in-place modification of values without getting, cloning and reinserting. `modify_all_by` was chosen over `get_all_mut_by` due to lifetime issues.