### PR TITLE
Use the correct role and encoding for sync committee contributions

### DIFF
--- a/anchor/common/ssv_types/src/consensus.rs
+++ b/anchor/common/ssv_types/src/consensus.rs
@@ -297,6 +297,44 @@ pub struct Contribution<E: EthSpec> {
     pub contribution: SyncCommitteeContribution<E>,
 }
 
+/// This type is a workaround for the fact that Go-SSV encodes lists of `Contribution` incorrectly:
+/// it treats `Contribution` as if it had a variable length, but it does not. This wrapper
+/// implements `Encode` and `Decode` to set `is_ssz_fixed_len` to `false` and delegates to the
+/// macro impls of `Encode and `Decode` on `Contribution` for the actual serialization and
+/// deserialization.
+#[derive(Clone, Debug, Into, From)]
+pub struct ContributionWrapper<E: EthSpec> {
+    pub contribution: Contribution<E>,
+}
+
+impl<E: EthSpec> Encode for ContributionWrapper<E> {
+    fn is_ssz_fixed_len() -> bool {
+        false
+    }
+
+    fn ssz_append(&self, buf: &mut Vec<u8>) {
+        self.contribution.ssz_append(buf)
+    }
+
+    fn ssz_bytes_len(&self) -> usize {
+        self.contribution.ssz_bytes_len()
+    }
+}
+
+impl<E: EthSpec> Decode for ContributionWrapper<E> {
+    fn is_ssz_fixed_len() -> bool {
+        false
+    }
+
+    fn from_ssz_bytes(bytes: &[u8]) -> Result<Self, DecodeError> {
+        Ok(Self {
+            contribution: Contribution::from_ssz_bytes(bytes)?,
+        })
+    }
+}
+
+pub type Contributions<E> = VariableList<ContributionWrapper<E>, U13>;
+
 #[derive(Clone, Debug, TreeHash, PartialEq, Eq, Encode, Decode)]
 #[cfg_attr(feature = "arbitrary-fuzz", derive(arbitrary::Arbitrary))]
 pub struct BeaconVote {

--- a/anchor/validator_store/src/lib.rs
+++ b/anchor/validator_store/src/lib.rs
@@ -1446,7 +1446,7 @@ impl<T: SlotClock, E: EthSpec> ValidatorStore for AnchorValidatorStore<T, E> {
             let signing_root = message.signing_root(domain_hash);
             self.collect_signature(
                 PartialSignatureKind::PostConsensus,
-                Role::Aggregator,
+                Role::SyncCommittee,
                 None,
                 validator,
                 signing_root,

--- a/anchor/validator_store/src/lib.rs
+++ b/anchor/validator_store/src/lib.rs
@@ -33,7 +33,7 @@ use ssv_types::{
     Cluster, CommitteeId, ValidatorIndex, ValidatorMetadata,
     consensus::{
         BEACON_ROLE_AGGREGATOR, BEACON_ROLE_PROPOSER, BEACON_ROLE_SYNC_COMMITTEE_CONTRIBUTION,
-        BeaconVote, Contribution, QbftData, ValidatorConsensusData, ValidatorDuty,
+        BeaconVote, Contribution, Contributions, QbftData, ValidatorConsensusData, ValidatorDuty,
     },
     msgid::Role,
     partial_sig::PartialSignatureKind,
@@ -51,7 +51,7 @@ use types::{
     AggregateAndProofElectra, BeaconBlockRef, BlindedBeaconBlock, BlindedPayload, ChainSpec,
     ContributionAndProof, Domain, EthSpec, ForkName, FullPayload, Hash256, PublicKeyBytes,
     SecretKey, Signature, SignedBeaconBlock, SignedBlindedBeaconBlock, SignedRoot,
-    SignedVoluntaryExit, SyncAggregatorSelectionData, VariableList, VoluntaryExit,
+    SignedVoluntaryExit, SyncAggregatorSelectionData, VoluntaryExit,
     attestation::Attestation,
     beacon_block::BeaconBlock,
     graffiti::Graffiti,
@@ -64,7 +64,6 @@ use types::{
     sync_committee_message::SyncCommitteeMessage,
     sync_selection_proof::SyncSelectionProof,
     sync_subnet_id::SyncSubnetId,
-    typenum::U13,
     validator_registration_data::{SignedValidatorRegistrationData, ValidatorRegistrationData},
 };
 use validator_metrics::IntCounterVec;
@@ -1355,18 +1354,19 @@ impl<T: SlotClock, E: EthSpec> ValidatorStore for AnchorValidatorStore<T, E> {
                 }
             };
 
-            let data: VariableList<_, U13> = match VariableList::new(
+            let data = Contributions::new(
                 signing_data
                     .iter()
-                    .map(|signing_data| Contribution {
-                        selection_proof_sig: signing_data.selection_proof.clone().into(),
-                        contribution: signing_data.contribution.clone(),
+                    .map(|signing_data| {
+                        Contribution {
+                            selection_proof_sig: signing_data.selection_proof.clone().into(),
+                            contribution: signing_data.contribution.clone(),
+                        }
+                        .into()
                     })
                     .collect(),
-            ) {
-                Ok(data) => data,
-                Err(_) => return Err(SpecificError::TooManySyncSubnetsToSign.into()),
-            };
+            )
+            .map_err(|_| SpecificError::TooManySyncSubnetsToSign)?;
 
             let timer = metrics::start_timer_vec(
                 &metrics::CONSENSUS_TIMES,
@@ -1414,11 +1414,12 @@ impl<T: SlotClock, E: EthSpec> ValidatorStore for AnchorValidatorStore<T, E> {
                 Err(err) => return Err(SpecificError::QbftError(err).into()),
             };
 
-            let data = VariableList::<Contribution<E>, U13>::from_ssz_bytes(&data.data_ssz)
+            let data = Contributions::<E>::from_ssz_bytes(&data.data_ssz)
                 .map_err(|e| Error::from(SpecificError::InvalidQbftData(e)))?;
 
             let data = data
                 .into_iter()
+                .map(Contribution::from)
                 .find(|data| data.contribution.subcommittee_index == subcommittee_index)
                 .ok_or(SpecificError::NoDataAgreed)?;
 

--- a/anchor/validator_store/src/lib.rs
+++ b/anchor/validator_store/src/lib.rs
@@ -33,7 +33,8 @@ use ssv_types::{
     Cluster, CommitteeId, ValidatorIndex, ValidatorMetadata,
     consensus::{
         BEACON_ROLE_AGGREGATOR, BEACON_ROLE_PROPOSER, BEACON_ROLE_SYNC_COMMITTEE_CONTRIBUTION,
-        BeaconVote, Contribution, Contributions, QbftData, ValidatorConsensusData, ValidatorDuty,
+        BeaconVote, Contribution, ContributionWrapper, Contributions, QbftData,
+        ValidatorConsensusData, ValidatorDuty,
     },
     msgid::Role,
     partial_sig::PartialSignatureKind,
@@ -1358,11 +1359,11 @@ impl<T: SlotClock, E: EthSpec> ValidatorStore for AnchorValidatorStore<T, E> {
                 signing_data
                     .iter()
                     .map(|signing_data| {
-                        Contribution {
+                        // Wrap contribution to match Go-SSV's encoding
+                        ContributionWrapper::from(Contribution {
                             selection_proof_sig: signing_data.selection_proof.clone().into(),
                             contribution: signing_data.contribution.clone(),
-                        }
-                        .into()
+                        })
                     })
                     .collect(),
             )

--- a/anchor/validator_store/src/lib.rs
+++ b/anchor/validator_store/src/lib.rs
@@ -38,7 +38,7 @@ use ssv_types::{
     msgid::Role,
     partial_sig::PartialSignatureKind,
 };
-use ssz::{Decode, Encode};
+use ssz::{Decode, DecodeError, Encode};
 use task_executor::TaskExecutor;
 use tokio::{
     select,
@@ -471,14 +471,7 @@ impl<T: SlotClock, E: EthSpec> AnchorValidatorStore<T, E> {
                 FullBlockContents::from_ssz_bytes_for_fork(&completed_data.data_ssz, fork)
                     .map(UnsignedBlock::Full)
             })
-            .map_err(|err| {
-                error!(
-                    %fork,
-                    ?err,
-                    "Failed to deserialize decided block"
-                );
-                Error::SpecificError(SpecificError::InvalidQbftData)
-            })
+            .map_err(|err| Error::SpecificError(SpecificError::InvalidQbftData(err)))
     }
 
     async fn sign_abstract_block(
@@ -737,7 +730,7 @@ pub enum SpecificError {
     ArithError(ArithError),
     QbftError(QbftError),
     Timeout,
-    InvalidQbftData,
+    InvalidQbftData(DecodeError),
     TooManySyncSubnetsToSign,
     NoDataAgreed,
     Metadata,
@@ -1131,12 +1124,12 @@ impl<T: SlotClock, E: EthSpec> ValidatorStore for AnchorValidatorStore<T, E> {
             let message = if ForkName::from(data.version) < ForkName::Electra {
                 AggregateAndProof::Base(
                     AggregateAndProofBase::from_ssz_bytes(&data.data_ssz)
-                        .map_err(|_| Error::SpecificError(SpecificError::InvalidQbftData))?,
+                        .map_err(|e| Error::SpecificError(SpecificError::InvalidQbftData(e)))?,
                 )
             } else {
                 AggregateAndProof::Electra(
                     AggregateAndProofElectra::from_ssz_bytes(&data.data_ssz)
-                        .map_err(|_| Error::SpecificError(SpecificError::InvalidQbftData))?,
+                        .map_err(|e| Error::SpecificError(SpecificError::InvalidQbftData(e)))?,
                 )
             };
 
@@ -1406,7 +1399,7 @@ impl<T: SlotClock, E: EthSpec> ValidatorStore for AnchorValidatorStore<T, E> {
                             validator_committee_index: aggregator_index,
                             validator_sync_committee_indices: Default::default(),
                         },
-                        version: ForkName::Base.into(),
+                        version: ForkName::Altair.into(),
                         data_ssz: data.as_ssz_bytes(),
                     },
                     start_time,
@@ -1422,7 +1415,7 @@ impl<T: SlotClock, E: EthSpec> ValidatorStore for AnchorValidatorStore<T, E> {
             };
 
             let data = VariableList::<Contribution<E>, U13>::from_ssz_bytes(&data.data_ssz)
-                .map_err(|_| Error::from(SpecificError::InvalidQbftData))?;
+                .map_err(|e| Error::from(SpecificError::InvalidQbftData(e)))?;
 
             let data = data
                 .into_iter()


### PR DESCRIPTION
## Issue Addressed

- closes #263 

## Proposed Changes

Use the correct Role for sync committee aggregations. I think I got confused here during implementation.

Additionally, I realized Go-SSV does not encode the data correctly, so I introduced a wrapper that treats the contribution as variable length to fix the encoding
