### PR TITLE
Merge immediately if branch is up to date and passes tests

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -82,14 +82,35 @@ pull_request_rules:
       review:
         type: APPROVE
 
-  - name: Add ready-to-merge labeled PRs to merge queue
+  - name: Add ready-to-merge labeled PRs that are not up to date with target to merge queue
     conditions:
       # All branch protection rules are implicit: https://docs.mergify.com/conditions/#about-branch-protection
       - base!=stable
       - label=ready-for-merge
       - label!=do-not-merge
+      - "#commits-behind > 0"
     actions:
       queue:
+
+  - name: Directly merge ready-to-merge labeled PRs that are up to date with target
+    conditions:
+      # All branch protection rules are implicit: https://docs.mergify.com/conditions/#about-branch-protection
+      - base!=stable
+      - label=ready-for-merge
+      - label!=do-not-merge
+      - check-success=test-suite-success
+      - "#approved-reviews-by >= 1"
+      - "#commits-behind == 0"
+    actions:
+      merge:
+        method: squash
+        commit_message_template: |
+          {{ title }} (#{{ number }})
+    
+            {{ body | get_section("## Issue Addressed", "") }}
+    
+    
+            {{ body | get_section("## Proposed Changes", "") }}
 
 queue_rules:
   - name: default

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -82,7 +82,7 @@ pull_request_rules:
       review:
         type: APPROVE
 
-  - name: Add ready-to-merge labeled PRs that are not up to date with target to merge queue
+  - name: Add outdated, ready-to-merge PRs to merge queue
     conditions:
       # All branch protection rules are implicit: https://docs.mergify.com/conditions/#about-branch-protection
       - base!=stable
@@ -92,7 +92,7 @@ pull_request_rules:
     actions:
       queue:
 
-  - name: Directly merge ready-to-merge labeled PRs that are up to date with target
+  - name: Merge up to date, ready-to-merge PRs
     conditions:
       # All branch protection rules are implicit: https://docs.mergify.com/conditions/#about-branch-protection
       - base!=stable


### PR DESCRIPTION
## Issue Addressed

Mergify, in it's current config, adds PRs to the merge queue even if it is tested and up to date with the current branch. That is unfortunate because it adds additional waiting time for us.

## Proposed Changes

Only add a PR to the merge queue if it is behind the target branch. 

Otherwise, wait until tests have passed, and then merge directly.

## Additional Info

CC @diegomrsantos 
