### PR TITLE
Correctly use the workspace edition everywhere

### DIFF
--- a/anchor/common/bls_lagrange/Cargo.toml
+++ b/anchor/common/bls_lagrange/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "bls_lagrange"
 version = "0.1.0"
-edition = "2021"
+edition = { workspace = true }
+authors = ["Sigma Prime <contact@sigmaprime.io>"]
 
 [features]
 default = ["blst_single_thread"]

--- a/anchor/common/bls_lagrange/src/blsful.rs
+++ b/anchor/common/bls_lagrange/src/blsful.rs
@@ -3,8 +3,8 @@ use std::num::NonZeroU64;
 use blstrs_plus::{G2Projective, Scalar};
 use rand::{CryptoRng, Rng};
 use vsss_rs::{
-    elliptic_curve::Field, shamir, IdentifierPrimeField, ParticipantIdGeneratorType,
-    ReadableShareSet, ValueGroup,
+    IdentifierPrimeField, ParticipantIdGeneratorType, ReadableShareSet, ValueGroup,
+    elliptic_curve::Field, shamir,
 };
 use zeroize::Zeroizing;
 

--- a/anchor/common/bls_lagrange/src/blst.rs
+++ b/anchor/common/bls_lagrange/src/blst.rs
@@ -10,7 +10,7 @@ use bls::Signature;
 use blst::{min_pk::SecretKey, *};
 use rand::prelude::*;
 
-use crate::{random_key, Error};
+use crate::{Error, random_key};
 
 #[derive(Debug, Clone)]
 pub struct KeyId {

--- a/anchor/common/bls_lagrange/src/lib.rs
+++ b/anchor/common/bls_lagrange/src/lib.rs
@@ -209,11 +209,13 @@ mod tests {
     fn test_zero_key() {
         let rng = &mut StdRng::seed_from_u64(0x12345EED55500000);
         // it's not easy to get a zero key in the first place...
-        let key = SecretKey::from_point(unsafe {
+        let key = unsafe {
             let mut scalar = blst_scalar::default();
             blst_scalar_from_le_bytes(&mut scalar, &0u8, 1);
-            &mem::transmute::<blst_scalar, ::blst::min_pk::SecretKey>(scalar)
-        });
+            SecretKey::from_point(&mem::transmute::<blst_scalar, ::blst::min_pk::SecretKey>(
+                scalar,
+            ))
+        };
         assert!(matches!(
             split_with_rng(
                 &key,

--- a/anchor/common/version/Cargo.toml
+++ b/anchor/common/version/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "version"
 version = "0.1.0"
-edition = "2021"
+edition = { workspace = true }
+authors = ["Sigma Prime <contact@sigmaprime.io>"]
 
 [dependencies]
 git-version = "0.3.9"

--- a/anchor/fuzz/Cargo.toml
+++ b/anchor/fuzz/Cargo.toml
@@ -2,7 +2,8 @@
 name = "anchor-fuzz"
 version = "0.0.0"
 publish = false
-edition = "2021"
+edition = { workspace = true }
+authors = ["Sigma Prime <contact@sigmaprime.io>"]
 
 [package.metadata]
 cargo-fuzz = true

--- a/anchor/fuzz/fuzz_targets/qbft_target.rs
+++ b/anchor/fuzz/fuzz_targets/qbft_target.rs
@@ -7,10 +7,10 @@ use qbft::WrappedQbftMessage;
 use setup::QBFT;
 use sha2::{Digest, Sha256};
 use ssv_types::{
-    consensus::{BeaconVote, QbftMessage, QbftMessageType},
-    message::{MsgType, SSVMessage, SignedSSVMessage, RSA_SIGNATURE_SIZE},
-    msgid::MessageId,
     IndexSet, OperatorId,
+    consensus::{BeaconVote, QbftMessage, QbftMessageType},
+    message::{MsgType, RSA_SIGNATURE_SIZE, SSVMessage, SignedSSVMessage},
+    msgid::MessageId,
 };
 use ssz::Encode;
 use types::Hash256;

--- a/anchor/fuzz/fuzz_targets/receive_target.rs
+++ b/anchor/fuzz/fuzz_targets/receive_target.rs
@@ -6,8 +6,8 @@ use arbitrary::{Arbitrary, Result, Unstructured};
 use gossipsub::{Message, MessageId, TopicHash};
 use libfuzzer_sys::fuzz_target;
 use libp2p::{
-    identity::{ed25519, PublicKey},
     PeerId,
+    identity::{PublicKey, ed25519},
 };
 use message_receiver::MessageReceiver;
 use setup::{RECEIVER, RUNTIME};

--- a/anchor/fuzz/fuzz_targets/setup.rs
+++ b/anchor/fuzz/fuzz_targets/setup.rs
@@ -19,7 +19,7 @@ use qbft_manager::QbftManager;
 use signature_collector::SignatureCollectorManager;
 use slot_clock::{ManualSlotClock, SlotClock};
 use ssv_types::{
-    consensus::BeaconVote, domain_type::DomainType, msgid::MessageId, OperatorId, ValidatorIndex,
+    OperatorId, ValidatorIndex, consensus::BeaconVote, domain_type::DomainType, msgid::MessageId,
 };
 use subnet_tracker::SubnetId;
 use task_executor::TaskExecutor;
@@ -127,8 +127,8 @@ pub fn setup_test_message_validator() -> Arc<Validator<ManualSlotClock, MockDuti
 }
 
 // Sets up a real NetworkMessageReceiver for fuzzing
-pub fn setup_test_message_receiver(
-) -> Arc<NetworkMessageReceiver<ManualSlotClock, MockDutiesProvider>> {
+pub fn setup_test_message_receiver()
+-> Arc<NetworkMessageReceiver<ManualSlotClock, MockDutiesProvider>> {
     let handle = tokio::runtime::Handle::current();
     let (_signal, exit) = async_channel::bounded(1);
     let (shutdown_tx, _) = futures::channel::mpsc::channel(1);

--- a/anchor/http_metrics/Cargo.toml
+++ b/anchor/http_metrics/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "http_metrics"
 version = "0.1.0"
-edition = "2021"
+edition = { workspace = true }
+authors = ["Sigma Prime <contact@sigmaprime.io>"]
 
 [dependencies]
 anchor_validator_store = { workspace = true }

--- a/anchor/http_metrics/src/lib.rs
+++ b/anchor/http_metrics/src/lib.rs
@@ -12,12 +12,12 @@ use std::{
 
 use anchor_validator_store::AnchorValidatorStore;
 use axum::{
+    Router,
     body::Body,
     extract::State,
     http::{Method, StatusCode},
     response::{IntoResponse, Response},
     routing::get,
-    Router,
 };
 use lighthouse_network::{libp2p::metrics::Registry, prometheus_client::encoding::text::encode};
 use parking_lot::RwLock;


### PR DESCRIPTION
## Issue Addressed

During https://github.com/sigp/anchor/pull/279, I missed updating some crates that did not use `edition = { workspace = true }`

## Proposed Changes

This PR updates these crates to use the workspace edition and performs a `cargo fmt`. Furthermore, a test needed to be fixed. 
