### PR TITLE
Switch to Go-SSV default ports

### DIFF
--- a/anchor/client/src/cli.rs
+++ b/anchor/client/src/cli.rs
@@ -232,7 +232,7 @@ pub struct Node {
                       The discovery UDP port will be set to this value and the Quic UDP port will be set to this value + 1. The discovery port can be modified by the \
                       --discovery-port flag and the quic port can be modified by the --quic-port flag. If listening over both IPv4 and IPv6 the --port flag \
                       will apply to the IPv4 address and --port6 to the IPv6 address.",
-        default_value = "9100",
+        default_value = "13001",
         action = ArgAction::Set,
     )]
     pub port: u16,
@@ -249,7 +249,8 @@ pub struct Node {
     #[clap(
         long,
         value_name = "PORT",
-        help = "The UDP port that discovery will listen on. Defaults to `port`",
+        help = "The UDP port that discovery will listen on. Defaults to `12001`",
+        default_value = "12001",
         action = ArgAction::Set,
     )]
     pub discovery_port: Option<u16>,
@@ -258,7 +259,7 @@ pub struct Node {
         long,
         value_name = "PORT",
         help = "The UDP port that discovery will listen on over IPv6 if listening over \
-                      both IPv4 and IPv6. Defaults to `port6`",
+                      both IPv4 and IPv6. Defaults to `discovery_port`",
         action = ArgAction::Set,
     )]
     pub discovery_port6: Option<u16>,

--- a/anchor/client/src/config.rs
+++ b/anchor/client/src/config.rs
@@ -446,7 +446,7 @@ pub fn parse_listening_addresses(cli_args: &Node) -> Result<ListenAddress, Strin
                 .then(unused_port::unused_udp6_port)
                 .transpose()?
                 .or(cli_args.discovery_port6)
-                .unwrap_or(ipv6_tcp_port);
+                .unwrap_or(ipv4_disc_port);
             let ipv6_quic_port = cli_args
                 .use_zero_ports
                 .then(unused_port::unused_udp6_port)

--- a/anchor/network/src/config.rs
+++ b/anchor/network/src/config.rs
@@ -13,9 +13,9 @@ use ssv_types::domain_type::DomainType;
 const DEFAULT_NETWORK_DIR: &str = ".anchor/network";
 
 pub const DEFAULT_IPV4_ADDRESS: Ipv4Addr = Ipv4Addr::UNSPECIFIED;
-pub const DEFAULT_TCP_PORT: u16 = 9100u16;
-pub const DEFAULT_DISC_PORT: u16 = 9100u16;
-pub const DEFAULT_QUIC_PORT: u16 = 9101u16;
+pub const DEFAULT_TCP_PORT: u16 = 13001;
+pub const DEFAULT_DISC_PORT: u16 = 12001;
+pub const DEFAULT_QUIC_PORT: u16 = 13002;
 
 /// Configuration for setting up the p2p network.
 #[derive(Clone)]

--- a/book/src/advanced_networking.md
+++ b/book/src/advanced_networking.md
@@ -5,6 +5,6 @@ Anchor's networking stack is closely based on Lighthouse's. We refer to
 but want to outline several important differences:
 
 - Currently, Anchor does not support UPnP.
-- Anchor uses ports 9100 (TCP and UDP) and 9101 (UDP only) by default.
+- Anchor uses ports 12001 (UDP), 13001 (TCP), and 9101 (UDP) by default.
 - Anchor does not yet support ENR auto-update - we therefore recommend manually setting publicly reachable ports via the
   `--enr*-port` CLI parameters to advertise your node as reachable on the network.

--- a/book/src/cli.md
+++ b/book/src/cli.md
@@ -64,17 +64,17 @@ anchor node [OPTIONS]
 | --- | --- | ---|
 | `--metrics` | Enable metrics server | Disabled |
 | `--metrics-address <ADDRESS>` | Listen address for metrics server | `127.0.0.1` if `--metrics` is set |
-| `--metrics-port <PORT>` | Listen port for metrics server | `5164` if `--metrics` is set |
+| `--metrics-port <PORT>` | Listen port for metrics server | `15000` if `--metrics` is set |
 
 #### Network Options
 
 | Option | Description | Default |
 | --- | --- | ---|
 | `--listen-address <ADDRESS>` | Network address to listen for UDP & TCP connections | `0.0.0.0` |
-| `--port <PORT>` | Base port for all network connections | `9100` |
+| `--port <PORT>` | Base port for all network connections | `13001` |
 | `--port6 <PORT>` | Base port for IPv6 network connections | Same as `--port` |
-| `--discovery-port <PORT>` | UDP port for discovery | Same as `--port` |
-| `--discovery-port6 <PORT>` | UDP port for IPv6 discovery | Same as `--port6` |
+| `--discovery-port <PORT>` | UDP port for discovery | `12001` |
+| `--discovery-port6 <PORT>` | UDP port for IPv6 discovery | Same as `--discovery-port` |
 | `--quic-port <PORT>` | UDP port for QUIC protocol | `--port` + 1 |
 | `--quic-port6 <PORT>` | UDP port for IPv6 QUIC protocol | `--port6` + 1 |
 | `--boot-nodes <NODES>` | Comma-separated ENRs or Multiaddrs to bootstrap the network | None|


### PR DESCRIPTION
- 12001 UDP for discv5
- 13001 TCP for libp2p
- 13002 UDP for libp2p via QUIC
- 15000 TCP for metrics
