### PR TITLE
Release v0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "anchor"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "async-channel 1.9.0",
  "bls",
@@ -1852,7 +1852,7 @@ dependencies = [
 
 [[package]]
 name = "client"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anchor_validator_store",
  "beacon_node_fallback",
@@ -4323,7 +4323,7 @@ dependencies = [
 
 [[package]]
 name = "keygen"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -4339,7 +4339,7 @@ dependencies = [
 
 [[package]]
 name = "keysplit"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "aes 0.8.4",
  "alloy",

--- a/anchor/Cargo.toml
+++ b/anchor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "anchor"
-version = "0.1.0"
+version = "0.2.0"
 edition = { workspace = true }
 authors = ["Sigma Prime <contact@sigmaprime.io>"]
 rust-version = "1.85.0"

--- a/anchor/client/Cargo.toml
+++ b/anchor/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "client"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Sigma Prime <contact@sigmaprime.io"]
 edition = { workspace = true }
 

--- a/anchor/common/version/src/lib.rs
+++ b/anchor/common/version/src/lib.rs
@@ -17,8 +17,8 @@ pub const VERSION: &str = git_version!(
         // NOTE: using --match instead of --exclude for compatibility with old Git
         "--match=thiswillnevermatchlol"
     ],
-    prefix = "Anchor/v0.1.0-",
-    fallback = "Anchor/v0.1.0"
+    prefix = "Anchor/v0.2.0-",
+    fallback = "Anchor/v0.2.0"
 );
 
 /// Returns the first eight characters of the latest commit hash for this build.

--- a/anchor/keygen/Cargo.toml
+++ b/anchor/keygen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "keygen"
-version = "0.1.0"
+version = "0.2.0"
 edition = { workspace = true }
 authors = ["Sigma Prime <contact@sigmaprime.io>"]
 

--- a/anchor/keysplit/Cargo.toml
+++ b/anchor/keysplit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "keysplit"
-version = "0.1.0"
+version = "0.2.0"
 edition = { workspace = true }
 authors = ["Sigma Prime <contact@sigmaprime.io>"]
 


### PR DESCRIPTION
## Proposed Changes

Bump the relevant version numbers for the v0.2.0 release.

## Additional Info

Comparably to Lighthouse, this only sets the version numbers in `Cargo.toml` files of binaries and subcommands: see https://github.com/sigp/lighthouse/pull/7609