### PR TITLE
Block-list for peers based on gossipsub score

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ perf.data*
 
 # cross
 /zcross
+
+# macOS
+.DS_Store

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4423,9 +4423,9 @@ dependencies = [
  "futures",
  "futures-timer",
  "getrandom 0.2.16",
- "libp2p-allow-block-list",
+ "libp2p-allow-block-list 0.5.0",
  "libp2p-connection-limits",
- "libp2p-core",
+ "libp2p-core 0.43.0",
  "libp2p-dns",
  "libp2p-identify",
  "libp2p-identity",
@@ -4436,7 +4436,7 @@ dependencies = [
  "libp2p-plaintext",
  "libp2p-quic",
  "libp2p-request-response",
- "libp2p-swarm",
+ "libp2p-swarm 0.46.0",
  "libp2p-tcp",
  "libp2p-upnp",
  "libp2p-yamux",
@@ -4448,13 +4448,25 @@ dependencies = [
 
 [[package]]
 name = "libp2p-allow-block-list"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1027ccf8d70320ed77e984f273bc8ce952f623762cb9bf2d126df73caef8041"
+dependencies = [
+ "libp2p-core 0.42.0",
+ "libp2p-identity",
+ "libp2p-swarm 0.45.1",
+ "void",
+]
+
+[[package]]
+name = "libp2p-allow-block-list"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38944b7cb981cc93f2f0fb411ff82d0e983bd226fbcc8d559639a3a73236568b"
 dependencies = [
- "libp2p-core",
+ "libp2p-core 0.43.0",
  "libp2p-identity",
- "libp2p-swarm",
+ "libp2p-swarm 0.46.0",
 ]
 
 [[package]]
@@ -4463,9 +4475,37 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "efe9323175a17caa8a2ed4feaf8a548eeef5e0b72d03840a0eab4bcb0210ce1c"
 dependencies = [
- "libp2p-core",
+ "libp2p-core 0.43.0",
  "libp2p-identity",
- "libp2p-swarm",
+ "libp2p-swarm 0.46.0",
+]
+
+[[package]]
+name = "libp2p-core"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a61f26c83ed111104cd820fe9bc3aaabbac5f1652a1d213ed6e900b7918a1298"
+dependencies = [
+ "either",
+ "fnv",
+ "futures",
+ "futures-timer",
+ "libp2p-identity",
+ "multiaddr",
+ "multihash",
+ "multistream-select",
+ "once_cell",
+ "parking_lot",
+ "pin-project",
+ "quick-protobuf",
+ "rand 0.8.5",
+ "rw-stream-sink",
+ "smallvec",
+ "thiserror 1.0.69",
+ "tracing",
+ "unsigned-varint 0.8.0",
+ "void",
+ "web-time",
 ]
 
 [[package]]
@@ -4503,7 +4543,7 @@ dependencies = [
  "async-trait",
  "futures",
  "hickory-resolver",
- "libp2p-core",
+ "libp2p-core 0.43.0",
  "libp2p-identity",
  "parking_lot",
  "smallvec",
@@ -4527,9 +4567,9 @@ dependencies = [
  "getrandom 0.2.16",
  "hashlink 0.9.1",
  "hex_fmt",
- "libp2p-core",
+ "libp2p-core 0.43.0",
  "libp2p-identity",
- "libp2p-swarm",
+ "libp2p-swarm 0.46.0",
  "prometheus-client",
  "quick-protobuf",
  "quick-protobuf-codec",
@@ -4551,9 +4591,9 @@ dependencies = [
  "futures",
  "futures-bounded",
  "futures-timer",
- "libp2p-core",
+ "libp2p-core 0.43.0",
  "libp2p-identity",
- "libp2p-swarm",
+ "libp2p-swarm 0.46.0",
  "quick-protobuf",
  "quick-protobuf-codec",
  "smallvec",
@@ -4592,9 +4632,9 @@ dependencies = [
  "futures",
  "hickory-proto",
  "if-watch",
- "libp2p-core",
+ "libp2p-core 0.43.0",
  "libp2p-identity",
- "libp2p-swarm",
+ "libp2p-swarm 0.46.0",
  "rand 0.8.5",
  "smallvec",
  "socket2",
@@ -4609,11 +4649,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ce58c64292e87af624fcb86465e7dd8342e46a388d71e8fec0ab37ee789630a"
 dependencies = [
  "futures",
- "libp2p-core",
+ "libp2p-core 0.43.0",
  "libp2p-identify",
  "libp2p-identity",
  "libp2p-ping",
- "libp2p-swarm",
+ "libp2p-swarm 0.46.0",
  "pin-project",
  "prometheus-client",
  "web-time",
@@ -4628,7 +4668,7 @@ dependencies = [
  "asynchronous-codec",
  "bytes",
  "futures",
- "libp2p-core",
+ "libp2p-core 0.43.0",
  "libp2p-identity",
  "nohash-hasher",
  "parking_lot",
@@ -4647,7 +4687,7 @@ dependencies = [
  "asynchronous-codec",
  "bytes",
  "futures",
- "libp2p-core",
+ "libp2p-core 0.43.0",
  "libp2p-identity",
  "multiaddr",
  "multihash",
@@ -4667,8 +4707,8 @@ name = "libp2p-peer-store"
 version = "0.1.0"
 source = "git+https://github.com/libp2p/rust-libp2p.git?rev=082eb16#082eb166f5ca06b4baaaad1b6bb9c4cdb9dcdc14"
 dependencies = [
- "libp2p-core",
- "libp2p-swarm",
+ "libp2p-core 0.43.0",
+ "libp2p-swarm 0.46.0",
  "lru 0.12.5",
 ]
 
@@ -4680,9 +4720,9 @@ checksum = "7b2529993ff22deb2504c0130a58b60fb77f036be555053922db1a0490b5798b"
 dependencies = [
  "futures",
  "futures-timer",
- "libp2p-core",
+ "libp2p-core 0.43.0",
  "libp2p-identity",
- "libp2p-swarm",
+ "libp2p-swarm 0.46.0",
  "rand 0.8.5",
  "tracing",
  "web-time",
@@ -4697,7 +4737,7 @@ dependencies = [
  "asynchronous-codec",
  "bytes",
  "futures",
- "libp2p-core",
+ "libp2p-core 0.43.0",
  "libp2p-identity",
  "quick-protobuf",
  "quick-protobuf-codec",
@@ -4713,7 +4753,7 @@ dependencies = [
  "futures",
  "futures-timer",
  "if-watch",
- "libp2p-core",
+ "libp2p-core 0.43.0",
  "libp2p-identity",
  "libp2p-tls",
  "quinn",
@@ -4735,12 +4775,34 @@ dependencies = [
  "async-trait",
  "futures",
  "futures-bounded",
- "libp2p-core",
+ "libp2p-core 0.43.0",
  "libp2p-identity",
- "libp2p-swarm",
+ "libp2p-swarm 0.46.0",
  "rand 0.8.5",
  "smallvec",
  "tracing",
+]
+
+[[package]]
+name = "libp2p-swarm"
+version = "0.45.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7dd6741793d2c1fb2088f67f82cf07261f25272ebe3c0b0c311e0c6b50e851a"
+dependencies = [
+ "either",
+ "fnv",
+ "futures",
+ "futures-timer",
+ "libp2p-core 0.42.0",
+ "libp2p-identity",
+ "lru 0.12.5",
+ "multistream-select",
+ "once_cell",
+ "rand 0.8.5",
+ "smallvec",
+ "tracing",
+ "void",
+ "web-time",
 ]
 
 [[package]]
@@ -4754,7 +4816,7 @@ dependencies = [
  "fnv",
  "futures",
  "futures-timer",
- "libp2p-core",
+ "libp2p-core 0.43.0",
  "libp2p-identity",
  "libp2p-swarm-derive",
  "lru 0.12.5",
@@ -4788,10 +4850,10 @@ dependencies = [
  "async-trait",
  "futures",
  "futures-timer",
- "libp2p-core",
+ "libp2p-core 0.43.0",
  "libp2p-identity",
  "libp2p-plaintext",
- "libp2p-swarm",
+ "libp2p-swarm 0.46.0",
  "libp2p-tcp",
  "libp2p-yamux",
  "tracing",
@@ -4808,7 +4870,7 @@ dependencies = [
  "futures-timer",
  "if-watch",
  "libc",
- "libp2p-core",
+ "libp2p-core 0.43.0",
  "socket2",
  "tokio",
  "tracing",
@@ -4822,7 +4884,7 @@ checksum = "42bbf5084fb44133267ad4caaa72a253d68d709edd2ed1cf9b42431a8ead8fd5"
 dependencies = [
  "futures",
  "futures-rustls",
- "libp2p-core",
+ "libp2p-core 0.43.0",
  "libp2p-identity",
  "rcgen",
  "ring",
@@ -4842,8 +4904,8 @@ dependencies = [
  "futures",
  "futures-timer",
  "igd-next",
- "libp2p-core",
- "libp2p-swarm",
+ "libp2p-core 0.43.0",
+ "libp2p-swarm 0.46.0",
  "tokio",
  "tracing",
 ]
@@ -4856,7 +4918,7 @@ checksum = "f15df094914eb4af272acf9adaa9e287baa269943f32ea348ba29cfb9bfc60d8"
 dependencies = [
  "either",
  "futures",
- "libp2p-core",
+ "libp2p-core 0.43.0",
  "thiserror 2.0.12",
  "tracing",
  "yamux 0.12.1",
@@ -5524,6 +5586,7 @@ dependencies = [
  "futures",
  "hex",
  "libp2p",
+ "libp2p-allow-block-list 0.4.0",
  "libp2p-gossipsub",
  "libp2p-peer-store",
  "libp2p-swarm-test",
@@ -8765,6 +8828,12 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "void"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
 name = "vsss-rs"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4423,9 +4423,9 @@ dependencies = [
  "futures",
  "futures-timer",
  "getrandom 0.2.16",
- "libp2p-allow-block-list 0.5.0",
+ "libp2p-allow-block-list",
  "libp2p-connection-limits",
- "libp2p-core 0.43.0",
+ "libp2p-core",
  "libp2p-dns",
  "libp2p-identify",
  "libp2p-identity",
@@ -4436,7 +4436,7 @@ dependencies = [
  "libp2p-plaintext",
  "libp2p-quic",
  "libp2p-request-response",
- "libp2p-swarm 0.46.0",
+ "libp2p-swarm",
  "libp2p-tcp",
  "libp2p-upnp",
  "libp2p-yamux",
@@ -4448,25 +4448,13 @@ dependencies = [
 
 [[package]]
 name = "libp2p-allow-block-list"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1027ccf8d70320ed77e984f273bc8ce952f623762cb9bf2d126df73caef8041"
-dependencies = [
- "libp2p-core 0.42.0",
- "libp2p-identity",
- "libp2p-swarm 0.45.1",
- "void",
-]
-
-[[package]]
-name = "libp2p-allow-block-list"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38944b7cb981cc93f2f0fb411ff82d0e983bd226fbcc8d559639a3a73236568b"
 dependencies = [
- "libp2p-core 0.43.0",
+ "libp2p-core",
  "libp2p-identity",
- "libp2p-swarm 0.46.0",
+ "libp2p-swarm",
 ]
 
 [[package]]
@@ -4475,37 +4463,9 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "efe9323175a17caa8a2ed4feaf8a548eeef5e0b72d03840a0eab4bcb0210ce1c"
 dependencies = [
- "libp2p-core 0.43.0",
+ "libp2p-core",
  "libp2p-identity",
- "libp2p-swarm 0.46.0",
-]
-
-[[package]]
-name = "libp2p-core"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a61f26c83ed111104cd820fe9bc3aaabbac5f1652a1d213ed6e900b7918a1298"
-dependencies = [
- "either",
- "fnv",
- "futures",
- "futures-timer",
- "libp2p-identity",
- "multiaddr",
- "multihash",
- "multistream-select",
- "once_cell",
- "parking_lot",
- "pin-project",
- "quick-protobuf",
- "rand 0.8.5",
- "rw-stream-sink",
- "smallvec",
- "thiserror 1.0.69",
- "tracing",
- "unsigned-varint 0.8.0",
- "void",
- "web-time",
+ "libp2p-swarm",
 ]
 
 [[package]]
@@ -4543,7 +4503,7 @@ dependencies = [
  "async-trait",
  "futures",
  "hickory-resolver",
- "libp2p-core 0.43.0",
+ "libp2p-core",
  "libp2p-identity",
  "parking_lot",
  "smallvec",
@@ -4567,9 +4527,9 @@ dependencies = [
  "getrandom 0.2.16",
  "hashlink 0.9.1",
  "hex_fmt",
- "libp2p-core 0.43.0",
+ "libp2p-core",
  "libp2p-identity",
- "libp2p-swarm 0.46.0",
+ "libp2p-swarm",
  "prometheus-client",
  "quick-protobuf",
  "quick-protobuf-codec",
@@ -4591,9 +4551,9 @@ dependencies = [
  "futures",
  "futures-bounded",
  "futures-timer",
- "libp2p-core 0.43.0",
+ "libp2p-core",
  "libp2p-identity",
- "libp2p-swarm 0.46.0",
+ "libp2p-swarm",
  "quick-protobuf",
  "quick-protobuf-codec",
  "smallvec",
@@ -4632,9 +4592,9 @@ dependencies = [
  "futures",
  "hickory-proto",
  "if-watch",
- "libp2p-core 0.43.0",
+ "libp2p-core",
  "libp2p-identity",
- "libp2p-swarm 0.46.0",
+ "libp2p-swarm",
  "rand 0.8.5",
  "smallvec",
  "socket2",
@@ -4649,11 +4609,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ce58c64292e87af624fcb86465e7dd8342e46a388d71e8fec0ab37ee789630a"
 dependencies = [
  "futures",
- "libp2p-core 0.43.0",
+ "libp2p-core",
  "libp2p-identify",
  "libp2p-identity",
  "libp2p-ping",
- "libp2p-swarm 0.46.0",
+ "libp2p-swarm",
  "pin-project",
  "prometheus-client",
  "web-time",
@@ -4668,7 +4628,7 @@ dependencies = [
  "asynchronous-codec",
  "bytes",
  "futures",
- "libp2p-core 0.43.0",
+ "libp2p-core",
  "libp2p-identity",
  "nohash-hasher",
  "parking_lot",
@@ -4687,7 +4647,7 @@ dependencies = [
  "asynchronous-codec",
  "bytes",
  "futures",
- "libp2p-core 0.43.0",
+ "libp2p-core",
  "libp2p-identity",
  "multiaddr",
  "multihash",
@@ -4707,8 +4667,8 @@ name = "libp2p-peer-store"
 version = "0.1.0"
 source = "git+https://github.com/libp2p/rust-libp2p.git?rev=082eb16#082eb166f5ca06b4baaaad1b6bb9c4cdb9dcdc14"
 dependencies = [
- "libp2p-core 0.43.0",
- "libp2p-swarm 0.46.0",
+ "libp2p-core",
+ "libp2p-swarm",
  "lru 0.12.5",
 ]
 
@@ -4720,9 +4680,9 @@ checksum = "7b2529993ff22deb2504c0130a58b60fb77f036be555053922db1a0490b5798b"
 dependencies = [
  "futures",
  "futures-timer",
- "libp2p-core 0.43.0",
+ "libp2p-core",
  "libp2p-identity",
- "libp2p-swarm 0.46.0",
+ "libp2p-swarm",
  "rand 0.8.5",
  "tracing",
  "web-time",
@@ -4737,7 +4697,7 @@ dependencies = [
  "asynchronous-codec",
  "bytes",
  "futures",
- "libp2p-core 0.43.0",
+ "libp2p-core",
  "libp2p-identity",
  "quick-protobuf",
  "quick-protobuf-codec",
@@ -4753,7 +4713,7 @@ dependencies = [
  "futures",
  "futures-timer",
  "if-watch",
- "libp2p-core 0.43.0",
+ "libp2p-core",
  "libp2p-identity",
  "libp2p-tls",
  "quinn",
@@ -4775,34 +4735,12 @@ dependencies = [
  "async-trait",
  "futures",
  "futures-bounded",
- "libp2p-core 0.43.0",
+ "libp2p-core",
  "libp2p-identity",
- "libp2p-swarm 0.46.0",
+ "libp2p-swarm",
  "rand 0.8.5",
  "smallvec",
  "tracing",
-]
-
-[[package]]
-name = "libp2p-swarm"
-version = "0.45.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7dd6741793d2c1fb2088f67f82cf07261f25272ebe3c0b0c311e0c6b50e851a"
-dependencies = [
- "either",
- "fnv",
- "futures",
- "futures-timer",
- "libp2p-core 0.42.0",
- "libp2p-identity",
- "lru 0.12.5",
- "multistream-select",
- "once_cell",
- "rand 0.8.5",
- "smallvec",
- "tracing",
- "void",
- "web-time",
 ]
 
 [[package]]
@@ -4816,7 +4754,7 @@ dependencies = [
  "fnv",
  "futures",
  "futures-timer",
- "libp2p-core 0.43.0",
+ "libp2p-core",
  "libp2p-identity",
  "libp2p-swarm-derive",
  "lru 0.12.5",
@@ -4850,10 +4788,10 @@ dependencies = [
  "async-trait",
  "futures",
  "futures-timer",
- "libp2p-core 0.43.0",
+ "libp2p-core",
  "libp2p-identity",
  "libp2p-plaintext",
- "libp2p-swarm 0.46.0",
+ "libp2p-swarm",
  "libp2p-tcp",
  "libp2p-yamux",
  "tracing",
@@ -4870,7 +4808,7 @@ dependencies = [
  "futures-timer",
  "if-watch",
  "libc",
- "libp2p-core 0.43.0",
+ "libp2p-core",
  "socket2",
  "tokio",
  "tracing",
@@ -4884,7 +4822,7 @@ checksum = "42bbf5084fb44133267ad4caaa72a253d68d709edd2ed1cf9b42431a8ead8fd5"
 dependencies = [
  "futures",
  "futures-rustls",
- "libp2p-core 0.43.0",
+ "libp2p-core",
  "libp2p-identity",
  "rcgen",
  "ring",
@@ -4904,8 +4842,8 @@ dependencies = [
  "futures",
  "futures-timer",
  "igd-next",
- "libp2p-core 0.43.0",
- "libp2p-swarm 0.46.0",
+ "libp2p-core",
+ "libp2p-swarm",
  "tokio",
  "tracing",
 ]
@@ -4918,7 +4856,7 @@ checksum = "f15df094914eb4af272acf9adaa9e287baa269943f32ea348ba29cfb9bfc60d8"
 dependencies = [
  "either",
  "futures",
- "libp2p-core 0.43.0",
+ "libp2p-core",
  "thiserror 2.0.12",
  "tracing",
  "yamux 0.12.1",
@@ -5586,7 +5524,6 @@ dependencies = [
  "futures",
  "hex",
  "libp2p",
- "libp2p-allow-block-list 0.4.0",
  "libp2p-gossipsub",
  "libp2p-peer-store",
  "libp2p-swarm-test",
@@ -8828,12 +8765,6 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
-
-[[package]]
-name = "void"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
 name = "vsss-rs"

--- a/anchor/network/Cargo.toml
+++ b/anchor/network/Cargo.toml
@@ -24,6 +24,7 @@ libp2p = { workspace = true, default-features = false, features = [
   "ping",
   "request-response",
 ] }
+libp2p-allow-block-list = "0.4.0"
 lighthouse_network = { workspace = true }
 message_receiver = { workspace = true }
 peer-store = { package = "libp2p-peer-store", git = "https://github.com/libp2p/rust-libp2p.git", rev = "082eb16" }

--- a/anchor/network/Cargo.toml
+++ b/anchor/network/Cargo.toml
@@ -24,7 +24,6 @@ libp2p = { workspace = true, default-features = false, features = [
   "ping",
   "request-response",
 ] }
-libp2p-allow-block-list = "0.4.0"
 lighthouse_network = { workspace = true }
 message_receiver = { workspace = true }
 peer-store = { package = "libp2p-peer-store", git = "https://github.com/libp2p/rust-libp2p.git", rev = "082eb16" }

--- a/anchor/network/Cargo.toml
+++ b/anchor/network/Cargo.toml
@@ -45,5 +45,5 @@ version = { workspace = true }
 [dev-dependencies]
 libp2p-swarm-test = "0.5.0"
 message_receiver = { workspace = true }
-tokio = { workspace = true, features = ["rt", "macros", "time"] }
+tokio = { workspace = true, features = ["rt", "macros", "time", "test-util"] }
 tracing-subscriber = { workspace = true }

--- a/anchor/network/src/behaviour.rs
+++ b/anchor/network/src/behaviour.rs
@@ -129,7 +129,12 @@ impl AnchorBehaviour {
             discovery
         };
 
-        let peer_manager = PeerManager::new(network_config);
+        let peer_manager = {
+            let slots_per_epoch = E::slots_per_epoch();
+            let slot_duration = Duration::from_secs(spec.seconds_per_slot);
+            let one_epoch_duration = slot_duration * slots_per_epoch as u32;
+            PeerManager::new(network_config, one_epoch_duration)
+        };
 
         let handshake = handshake::create_behaviour(local_keypair);
 

--- a/anchor/network/src/network.rs
+++ b/anchor/network/src/network.rs
@@ -400,20 +400,6 @@ impl<R: MessageReceiver> Network<R> {
         &mut self.swarm.behaviour_mut().discovery
     }
 
-    /// Block a peer from connecting to the node.
-    /// All existing connections to this peer will be immediately closed.
-    pub fn block_peer(&mut self, peer_id: PeerId) -> bool {
-        info!(%peer_id, "Blocking peer");
-        let was_inserted = self.swarm.behaviour_mut().peer_manager.block_peer(peer_id);
-
-        // Close any existing connections to this peer
-        if self.swarm.is_connected(&peer_id) {
-            let _ = self.swarm.disconnect_peer_id(peer_id);
-        }
-
-        was_inserted
-    }
-
     /// Unblock a peer, allowing it to connect again.
     pub fn unblock_peer(&mut self, peer_id: PeerId) -> bool {
         info!(%peer_id, "Unblocking peer");

--- a/anchor/network/src/network.rs
+++ b/anchor/network/src/network.rs
@@ -3,7 +3,7 @@ use std::{
     num::{NonZeroU8, NonZeroUsize},
     pin::Pin,
     sync::Arc,
-    time::{Duration, Instant},
+    time::Instant,
 };
 
 use futures::StreamExt;
@@ -22,10 +22,7 @@ use ssv_types::domain_type::DomainType;
 use subnet_service::{SUBNET_COUNT, SubnetEvent, SubnetId};
 use task_executor::TaskExecutor;
 use thiserror::Error;
-use tokio::{
-    sync::mpsc,
-    time::{MissedTickBehavior, interval},
-};
+use tokio::sync::mpsc;
 use tracing::{debug, error, info, trace, warn};
 use types::{ChainSpec, EthSpec};
 use version::version_with_platform;
@@ -79,8 +76,6 @@ pub struct Network<R: MessageReceiver> {
     domain_type: DomainType,
     metrics_registry: Option<Registry>,
     spec: Arc<ChainSpec>,
-    /// Timer for periodic peer score checks
-    peer_score_check_timer: tokio::time::Interval,
 }
 
 impl<R: MessageReceiver> Network<R> {
@@ -118,9 +113,6 @@ impl<R: MessageReceiver> Network<R> {
             }),
         );
 
-        let mut peer_score_check_timer = interval(Duration::from_secs(30)); // Check every 30 seconds
-        peer_score_check_timer.set_missed_tick_behavior(MissedTickBehavior::Delay);
-
         let mut network = Network {
             swarm: build_swarm(
                 executor.clone(),
@@ -138,7 +130,6 @@ impl<R: MessageReceiver> Network<R> {
             domain_type: config.domain_type.clone(),
             metrics_registry: Some(metrics_registry),
             spec,
-            peer_score_check_timer,
         };
 
         info!(%peer_id, "Network starting");
@@ -210,8 +201,13 @@ impl<R: MessageReceiver> Network<R> {
                                     self.handle_handshake_result(result);
                                 }
                             }
-                            AnchorBehaviourEvent::PeerManager(peer_manager::Event::ConnectActions(actions)) => {
-                                self.handle_connect_actions(actions);
+                            AnchorBehaviourEvent::PeerManager(peer_manager::Event::PeerManagerHeartbeat(heartbeat)) => {
+                                if let Some(actions) = heartbeat.connect_actions {
+                                    self.handle_connect_actions(actions);
+                                }
+                                if heartbeat.check_peer_scores {
+                                    self.check_and_block_peers_by_score();
+                                }
                             }
                             _ => {
                                 trace!(event = ?behaviour_event, "Unhandled behaviour event");
@@ -266,10 +262,6 @@ impl<R: MessageReceiver> Network<R> {
                             return;
                         }
                     }
-                }
-                _ = self.peer_score_check_timer.tick() => {
-                    // Periodic peer score checks
-                    self.check_and_block_peers_by_score();
                 }
             }
         }

--- a/anchor/network/src/network.rs
+++ b/anchor/network/src/network.rs
@@ -3,7 +3,7 @@ use std::{
     num::{NonZeroU8, NonZeroUsize},
     pin::Pin,
     sync::Arc,
-    time::Instant,
+    time::{Duration, Instant},
 };
 
 use futures::StreamExt;
@@ -22,7 +22,10 @@ use ssv_types::domain_type::DomainType;
 use subnet_service::{SUBNET_COUNT, SubnetEvent, SubnetId};
 use task_executor::TaskExecutor;
 use thiserror::Error;
-use tokio::sync::mpsc;
+use tokio::{
+    sync::mpsc,
+    time::{MissedTickBehavior, interval},
+};
 use tracing::{debug, error, info, trace, warn};
 use types::{ChainSpec, EthSpec};
 use version::version_with_platform;
@@ -76,6 +79,8 @@ pub struct Network<R: MessageReceiver> {
     domain_type: DomainType,
     metrics_registry: Option<Registry>,
     spec: Arc<ChainSpec>,
+    /// Timer for periodic peer score checks
+    peer_score_check_timer: tokio::time::Interval,
 }
 
 impl<R: MessageReceiver> Network<R> {
@@ -113,6 +118,9 @@ impl<R: MessageReceiver> Network<R> {
             }),
         );
 
+        let mut peer_score_check_timer = interval(Duration::from_secs(30)); // Check every 30 seconds
+        peer_score_check_timer.set_missed_tick_behavior(MissedTickBehavior::Delay);
+
         let mut network = Network {
             swarm: build_swarm(
                 executor.clone(),
@@ -130,6 +138,7 @@ impl<R: MessageReceiver> Network<R> {
             domain_type: config.domain_type.clone(),
             metrics_registry: Some(metrics_registry),
             spec,
+            peer_score_check_timer,
         };
 
         info!(%peer_id, "Network starting");
@@ -258,6 +267,10 @@ impl<R: MessageReceiver> Network<R> {
                         }
                     }
                 }
+                _ = self.peer_score_check_timer.tick() => {
+                    // Periodic peer score checks
+                    self.check_and_block_peers_by_score();
+                }
             }
         }
     }
@@ -385,6 +398,76 @@ impl<R: MessageReceiver> Network<R> {
 
     fn discovery(&mut self) -> &mut Discovery {
         &mut self.swarm.behaviour_mut().discovery
+    }
+
+    /// Block a peer from connecting to the node.
+    /// All existing connections to this peer will be immediately closed.
+    pub fn block_peer(&mut self, peer_id: PeerId) -> bool {
+        info!(%peer_id, "Blocking peer");
+        let was_inserted = self.swarm.behaviour_mut().peer_manager.block_peer(peer_id);
+
+        // Close any existing connections to this peer
+        if self.swarm.is_connected(&peer_id) {
+            let _ = self.swarm.disconnect_peer_id(peer_id);
+        }
+
+        was_inserted
+    }
+
+    /// Unblock a peer, allowing it to connect again.
+    pub fn unblock_peer(&mut self, peer_id: PeerId) -> bool {
+        info!(%peer_id, "Unblocking peer");
+        self.swarm
+            .behaviour_mut()
+            .peer_manager
+            .unblock_peer(peer_id)
+    }
+
+    /// Get the list of currently blocked peers.
+    pub fn blocked_peers(&self) -> &std::collections::HashSet<PeerId> {
+        self.swarm.behaviour().peer_manager.blocked_peers()
+    }
+
+    /// Check if a peer is currently blocked.
+    pub fn is_peer_blocked(&self, peer_id: &PeerId) -> bool {
+        self.blocked_peers().contains(peer_id)
+    }
+
+    /// Check gossipsub peer scores and block peers with scores below graylist threshold
+    pub fn check_and_block_peers_by_score(&mut self) {
+        use crate::scoring::peer_score_config::GRAYLIST_THRESHOLD;
+
+        let gossipsub = &self.swarm.behaviour().gossipsub;
+
+        // Get all peers with poor scores that should be blocked
+        let peers_to_block: Vec<PeerId> = self
+            .swarm
+            .connected_peers()
+            .filter_map(|peer_id| {
+                if let Some(score) = gossipsub.peer_score(peer_id) {
+                    if score < GRAYLIST_THRESHOLD && !self.is_peer_blocked(peer_id) {
+                        Some(*peer_id)
+                    } else {
+                        None
+                    }
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        // Block the peers and disconnect them
+        for peer_id in peers_to_block {
+            self.swarm
+                .behaviour_mut()
+                .peer_manager
+                .block_peer_for_poor_score(peer_id);
+
+            // Disconnect immediately
+            if self.swarm.is_connected(&peer_id) {
+                let _ = self.swarm.disconnect_peer_id(peer_id);
+            }
+        }
     }
 
     fn handle_connect_actions(&mut self, connect_actions: ConnectActions) {

--- a/anchor/network/src/peer_manager.rs
+++ b/anchor/network/src/peer_manager.rs
@@ -60,7 +60,7 @@ pub struct PeerManager {
     /// Block list behaviour for actual connection denial
     block_list: allow_block_list::Behaviour<allow_block_list::BlockedPeers>,
     /// Tracking when peers were blocked for automatic unblocking
-    blocked_peers_info: HashMap<PeerId, tokio::time::Instant>,
+    blocked_peers_timestamps: HashMap<PeerId, tokio::time::Instant>,
     /// One epoch duration for calculating retain_score timeout
     one_epoch_duration: Duration,
 }
@@ -106,7 +106,7 @@ impl PeerManager {
             max_with_priority_peers: max_priority_peers,
             heartbeat,
             block_list: allow_block_list::Behaviour::<allow_block_list::BlockedPeers>::default(),
-            blocked_peers_info: HashMap::new(),
+            blocked_peers_timestamps: HashMap::new(),
             one_epoch_duration,
         }
     }
@@ -131,7 +131,7 @@ impl PeerManager {
     /// Block a peer based on poor gossipsub score
     pub fn block_peer_for_poor_score(&mut self, peer_id: PeerId) {
         if self.block_list.block_peer(peer_id) {
-            self.blocked_peers_info
+            self.blocked_peers_timestamps
                 .insert(peer_id, tokio::time::Instant::now());
             debug!(?peer_id, "Blocked peer due to poor gossipsub score");
         }
@@ -141,7 +141,7 @@ impl PeerManager {
     pub fn unblock_peer(&mut self, peer_id: PeerId) -> bool {
         let was_removed = self.block_list.unblock_peer(peer_id);
         if was_removed {
-            self.blocked_peers_info.remove(&peer_id);
+            self.blocked_peers_timestamps.remove(&peer_id);
             debug!(?peer_id, "Unblocked peer after retain_score duration");
         }
         was_removed
@@ -158,7 +158,7 @@ impl PeerManager {
         let now = tokio::time::Instant::now();
 
         let peers_to_unblock: Vec<PeerId> = self
-            .blocked_peers_info
+            .blocked_peers_timestamps
             .iter()
             .filter_map(|(&peer_id, &blocked_at)| {
                 if now.duration_since(blocked_at) >= retain_score_duration {
@@ -236,7 +236,7 @@ impl PeerManager {
         info!(
             subnets = self.needed_subnets.len(),
             peers = self.connected.len(),
-            blocked_peers = self.blocked_peers_info.len(),
+            blocked_peers = self.blocked_peers_timestamps.len(),
             "Network status"
         );
 
@@ -601,17 +601,17 @@ mod tests {
 
         // Initially, peer should not be blocked
         assert!(!peer_manager.blocked_peers().contains(&peer_id));
-        assert!(peer_manager.blocked_peers_info.is_empty());
+        assert!(peer_manager.blocked_peers_timestamps.is_empty());
 
         // Block the peer for poor score
         peer_manager.block_peer_for_poor_score(peer_id);
 
         // Verify peer is now blocked
         assert!(peer_manager.blocked_peers().contains(&peer_id));
-        assert!(peer_manager.blocked_peers_info.contains_key(&peer_id));
+        assert!(peer_manager.blocked_peers_timestamps.contains_key(&peer_id));
 
         // Verify the block time was recorded (should be at the current paused time)
-        let block_time = peer_manager.blocked_peers_info.get(&peer_id).unwrap();
+        let block_time = peer_manager.blocked_peers_timestamps.get(&peer_id).unwrap();
         let expected_time = tokio::time::Instant::now();
         assert_eq!(*block_time, expected_time);
     }
@@ -634,7 +634,7 @@ mod tests {
 
         // Verify peer is now unblocked
         assert!(!peer_manager.blocked_peers().contains(&peer_id));
-        assert!(!peer_manager.blocked_peers_info.contains_key(&peer_id));
+        assert!(!peer_manager.blocked_peers_timestamps.contains_key(&peer_id));
     }
 
     #[tokio::test(start_paused = true)]
@@ -655,7 +655,7 @@ mod tests {
 
         // Verify peer is still blocked
         assert!(peer_manager.blocked_peers().contains(&peer_id));
-        assert!(peer_manager.blocked_peers_info.contains_key(&peer_id));
+        assert!(peer_manager.blocked_peers_timestamps.contains_key(&peer_id));
     }
 
     #[tokio::test(start_paused = true)]
@@ -677,7 +677,7 @@ mod tests {
 
         // Verify all are blocked
         assert_eq!(peer_manager.blocked_peers().len(), 3);
-        assert_eq!(peer_manager.blocked_peers_info.len(), 3);
+        assert_eq!(peer_manager.blocked_peers_timestamps.len(), 3);
 
         // Advance time enough to unblock only peer_1 (it was blocked earlier)
         let retain_score_duration = peer_manager.one_epoch_duration * RETAIN_SCORE_EPOCH_MULTIPLIER;
@@ -691,7 +691,7 @@ mod tests {
         assert!(peer_manager.blocked_peers().contains(&peer_id_2));
         assert!(peer_manager.blocked_peers().contains(&peer_id_3));
         assert_eq!(peer_manager.blocked_peers().len(), 2);
-        assert_eq!(peer_manager.blocked_peers_info.len(), 2);
+        assert_eq!(peer_manager.blocked_peers_timestamps.len(), 2);
     }
 
     #[tokio::test(start_paused = true)]
@@ -709,7 +709,7 @@ mod tests {
 
         // Verify peer is now unblocked
         assert!(!peer_manager.blocked_peers().contains(&peer_id));
-        assert!(!peer_manager.blocked_peers_info.contains_key(&peer_id));
+        assert!(!peer_manager.blocked_peers_timestamps.contains_key(&peer_id));
 
         // Trying to unblock again should return false
         let was_unblocked_again = peer_manager.unblock_peer(peer_id);

--- a/anchor/network/src/peer_manager.rs
+++ b/anchor/network/src/peer_manager.rs
@@ -136,11 +136,6 @@ impl PeerManager {
         }
     }
 
-    /// Block a peer (generic method for use by Network)
-    pub fn block_peer(&mut self, peer_id: PeerId) -> bool {
-        self.block_list.block_peer(peer_id)
-    }
-
     /// Unblock a peer and remove from tracking
     pub fn unblock_peer(&mut self, peer_id: PeerId) -> bool {
         let was_removed = self.block_list.unblock_peer(peer_id);

--- a/anchor/network/src/peer_manager.rs
+++ b/anchor/network/src/peer_manager.rs
@@ -1,7 +1,7 @@
 use std::{
     collections::{HashMap, HashSet, hash_map::Entry},
     task::{Context, Poll},
-    time::{Duration, Instant},
+    time::Duration,
 };
 
 use discv5::{libp2p_identity::PeerId, multiaddr::Multiaddr};
@@ -60,7 +60,7 @@ pub struct PeerManager {
     /// Block list behaviour for actual connection denial
     block_list: allow_block_list::Behaviour<allow_block_list::BlockedPeers>,
     /// Tracking when peers were blocked for automatic unblocking
-    blocked_peers_info: HashMap<PeerId, Instant>,
+    blocked_peers_info: HashMap<PeerId, tokio::time::Instant>,
     /// One epoch duration for calculating retain_score timeout
     one_epoch_duration: Duration,
 }
@@ -131,7 +131,8 @@ impl PeerManager {
     /// Block a peer based on poor gossipsub score
     pub fn block_peer_for_poor_score(&mut self, peer_id: PeerId) {
         if self.block_list.block_peer(peer_id) {
-            self.blocked_peers_info.insert(peer_id, Instant::now());
+            self.blocked_peers_info
+                .insert(peer_id, tokio::time::Instant::now());
             debug!(?peer_id, "Blocked peer due to poor gossipsub score");
         }
     }
@@ -154,12 +155,13 @@ impl PeerManager {
     /// Check and unblock peers that have been blocked long enough
     pub fn check_and_unblock_expired_peers(&mut self) {
         let retain_score_duration = self.one_epoch_duration * RETAIN_SCORE_EPOCH_MULTIPLIER;
+        let now = tokio::time::Instant::now();
 
         let peers_to_unblock: Vec<PeerId> = self
             .blocked_peers_info
             .iter()
             .filter_map(|(&peer_id, &blocked_at)| {
-                if blocked_at.elapsed() >= retain_score_duration {
+                if now.duration_since(blocked_at) >= retain_score_duration {
                     Some(peer_id)
                 } else {
                     None
@@ -554,5 +556,153 @@ impl NetworkBehaviour for PeerManager {
         }
 
         Poll::Pending
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use libp2p::identity::Keypair;
+
+    use super::*;
+    use crate::Config;
+
+    /// Test helper to create a test PeerManager
+    fn create_test_peer_manager() -> PeerManager {
+        let config = Config {
+            target_peers: 10,
+            ..Config::default()
+        };
+        let one_epoch_duration = Duration::from_secs(384); // 32 slots * 12 seconds
+        PeerManager::new(&config, one_epoch_duration)
+    }
+
+    /// Test helper to create a test peer ID
+    fn create_test_peer_id() -> PeerId {
+        let keypair = Keypair::generate_ed25519();
+        keypair.public().to_peer_id()
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_peer_blocking_for_poor_score() {
+        let mut peer_manager = create_test_peer_manager();
+        let peer_id = create_test_peer_id();
+
+        // Initially, peer should not be blocked
+        assert!(!peer_manager.blocked_peers().contains(&peer_id));
+        assert!(peer_manager.blocked_peers_info.is_empty());
+
+        // Block the peer for poor score
+        peer_manager.block_peer_for_poor_score(peer_id);
+
+        // Verify peer is now blocked
+        assert!(peer_manager.blocked_peers().contains(&peer_id));
+        assert!(peer_manager.blocked_peers_info.contains_key(&peer_id));
+
+        // Verify the block time was recorded (should be at the current paused time)
+        let block_time = peer_manager.blocked_peers_info.get(&peer_id).unwrap();
+        let expected_time = tokio::time::Instant::now();
+        assert_eq!(*block_time, expected_time);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_peer_unblocking_after_timeout() {
+        let mut peer_manager = create_test_peer_manager();
+        let peer_id = create_test_peer_id();
+
+        // Block the peer
+        peer_manager.block_peer_for_poor_score(peer_id);
+        assert!(peer_manager.blocked_peers().contains(&peer_id));
+
+        // Advance time beyond the retain_score period
+        let retain_score_duration = peer_manager.one_epoch_duration * RETAIN_SCORE_EPOCH_MULTIPLIER;
+        tokio::time::advance(retain_score_duration + Duration::from_secs(1)).await;
+
+        // Check and unblock expired peers
+        peer_manager.check_and_unblock_expired_peers();
+
+        // Verify peer is now unblocked
+        assert!(!peer_manager.blocked_peers().contains(&peer_id));
+        assert!(!peer_manager.blocked_peers_info.contains_key(&peer_id));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_peer_not_unblocked_before_timeout() {
+        let mut peer_manager = create_test_peer_manager();
+        let peer_id = create_test_peer_id();
+
+        // Block the peer
+        peer_manager.block_peer_for_poor_score(peer_id);
+        assert!(peer_manager.blocked_peers().contains(&peer_id));
+
+        // Advance time but not enough to trigger unblocking
+        let retain_score_duration = peer_manager.one_epoch_duration * RETAIN_SCORE_EPOCH_MULTIPLIER;
+        tokio::time::advance(retain_score_duration - Duration::from_secs(10)).await;
+
+        // Check and unblock expired peers
+        peer_manager.check_and_unblock_expired_peers();
+
+        // Verify peer is still blocked
+        assert!(peer_manager.blocked_peers().contains(&peer_id));
+        assert!(peer_manager.blocked_peers_info.contains_key(&peer_id));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_multiple_peers_blocking_and_unblocking() {
+        let mut peer_manager = create_test_peer_manager();
+        let peer_id_1 = create_test_peer_id();
+        let peer_id_2 = create_test_peer_id();
+        let peer_id_3 = create_test_peer_id();
+
+        // Block peer_1 first
+        peer_manager.block_peer_for_poor_score(peer_id_1);
+
+        // Advance time a bit
+        tokio::time::advance(Duration::from_secs(100)).await;
+
+        // Block peer_2 and peer_3
+        peer_manager.block_peer_for_poor_score(peer_id_2);
+        peer_manager.block_peer_for_poor_score(peer_id_3);
+
+        // Verify all are blocked
+        assert_eq!(peer_manager.blocked_peers().len(), 3);
+        assert_eq!(peer_manager.blocked_peers_info.len(), 3);
+
+        // Advance time enough to unblock only peer_1 (it was blocked earlier)
+        let retain_score_duration = peer_manager.one_epoch_duration * RETAIN_SCORE_EPOCH_MULTIPLIER;
+        tokio::time::advance(retain_score_duration - Duration::from_secs(50)).await;
+
+        // Check and unblock expired peers
+        peer_manager.check_and_unblock_expired_peers();
+
+        // Only peer_1 should be unblocked
+        assert!(!peer_manager.blocked_peers().contains(&peer_id_1));
+        assert!(peer_manager.blocked_peers().contains(&peer_id_2));
+        assert!(peer_manager.blocked_peers().contains(&peer_id_3));
+        assert_eq!(peer_manager.blocked_peers().len(), 2);
+        assert_eq!(peer_manager.blocked_peers_info.len(), 2);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_manual_unblock_peer() {
+        let mut peer_manager = create_test_peer_manager();
+        let peer_id = create_test_peer_id();
+
+        // Block the peer
+        peer_manager.block_peer_for_poor_score(peer_id);
+        assert!(peer_manager.blocked_peers().contains(&peer_id));
+
+        // Manually unblock the peer
+        let was_unblocked = peer_manager.unblock_peer(peer_id);
+        assert!(was_unblocked);
+
+        // Verify peer is now unblocked
+        assert!(!peer_manager.blocked_peers().contains(&peer_id));
+        assert!(!peer_manager.blocked_peers_info.contains_key(&peer_id));
+
+        // Trying to unblock again should return false
+        let was_unblocked_again = peer_manager.unblock_peer(peer_id);
+        assert!(!was_unblocked_again);
     }
 }

--- a/anchor/network/src/peer_manager.rs
+++ b/anchor/network/src/peer_manager.rs
@@ -343,9 +343,15 @@ impl ConnectActions {
 }
 
 #[derive(Debug)]
+pub struct HeartbeatEvent {
+    pub connect_actions: Option<ConnectActions>,
+    pub check_peer_scores: bool,
+}
+
+#[derive(Debug)]
 pub enum Event {
     PeerStore(peer_store::Event<memory_store::Event>),
-    ConnectActions(ConnectActions),
+    PeerManagerHeartbeat(HeartbeatEvent),
 }
 
 impl NetworkBehaviour for PeerManager {
@@ -550,9 +556,13 @@ impl NetworkBehaviour for PeerManager {
 
         // Check heartbeat timer
         if self.heartbeat.poll_tick(cx).is_ready() {
-            if let Some(actions) = self.heartbeat() {
-                return Poll::Ready(ToSwarm::GenerateEvent(Event::ConnectActions(actions)));
-            }
+            let connect_actions = self.heartbeat();
+            return Poll::Ready(ToSwarm::GenerateEvent(Event::PeerManagerHeartbeat(
+                HeartbeatEvent {
+                    connect_actions,
+                    check_peer_scores: true,
+                },
+            )));
         }
 
         Poll::Pending

--- a/anchor/network/src/peer_manager.rs
+++ b/anchor/network/src/peer_manager.rs
@@ -1,12 +1,12 @@
 use std::{
     collections::{HashMap, HashSet, hash_map::Entry},
     task::{Context, Poll},
-    time::Duration,
+    time::{Duration, Instant},
 };
 
 use discv5::{libp2p_identity::PeerId, multiaddr::Multiaddr};
 use libp2p::{
-    connection_limits,
+    allow_block_list, connection_limits,
     connection_limits::ConnectionLimits,
     core::{Endpoint, transport::PortUse},
     swarm::{
@@ -28,7 +28,7 @@ use subnet_service::SubnetId;
 use tokio::time::{MissedTickBehavior, interval};
 use tracing::{debug, info};
 
-use crate::{Config, Enr, discovery};
+use crate::{Config, Enr, discovery, scoring::peer_score_config::RETAIN_SCORE_EPOCH_MULTIPLIER};
 
 const MIN_PEERS_PER_SUBNET: usize = 6;
 
@@ -57,10 +57,16 @@ pub struct PeerManager {
     target_peers: usize,
     max_with_priority_peers: usize,
     heartbeat: tokio::time::Interval,
+    /// Block list behaviour for actual connection denial
+    block_list: allow_block_list::Behaviour<allow_block_list::BlockedPeers>,
+    /// Tracking when peers were blocked for automatic unblocking
+    blocked_peers_info: HashMap<PeerId, Instant>,
+    /// One epoch duration for calculating retain_score timeout
+    one_epoch_duration: Duration,
 }
 
 impl PeerManager {
-    pub fn new(config: &Config) -> Self {
+    pub fn new(config: &Config, one_epoch_duration: Duration) -> Self {
         let peer_store =
             peer_store::Behaviour::new(MemoryStore::new(memory_store::Config::default()));
 
@@ -99,6 +105,9 @@ impl PeerManager {
             target_peers: config.target_peers,
             max_with_priority_peers: max_priority_peers,
             heartbeat,
+            block_list: allow_block_list::Behaviour::<allow_block_list::BlockedPeers>::default(),
+            blocked_peers_info: HashMap::new(),
+            one_epoch_duration,
         }
     }
 
@@ -117,6 +126,55 @@ impl PeerManager {
 
         // dial
         dial.then(|| self.peer_to_dial_opts(id))
+    }
+
+    /// Block a peer based on poor gossipsub score
+    pub fn block_peer_for_poor_score(&mut self, peer_id: PeerId) {
+        if self.block_list.block_peer(peer_id) {
+            self.blocked_peers_info.insert(peer_id, Instant::now());
+            debug!(?peer_id, "Blocked peer due to poor gossipsub score");
+        }
+    }
+
+    /// Block a peer (generic method for use by Network)
+    pub fn block_peer(&mut self, peer_id: PeerId) -> bool {
+        self.block_list.block_peer(peer_id)
+    }
+
+    /// Unblock a peer and remove from tracking
+    pub fn unblock_peer(&mut self, peer_id: PeerId) -> bool {
+        let was_removed = self.block_list.unblock_peer(peer_id);
+        if was_removed {
+            self.blocked_peers_info.remove(&peer_id);
+            debug!(?peer_id, "Unblocked peer after retain_score duration");
+        }
+        was_removed
+    }
+
+    /// Get list of currently blocked peers
+    pub fn blocked_peers(&self) -> &HashSet<PeerId> {
+        self.block_list.blocked_peers()
+    }
+
+    /// Check and unblock peers that have been blocked long enough
+    pub fn check_and_unblock_expired_peers(&mut self) {
+        let retain_score_duration = self.one_epoch_duration * RETAIN_SCORE_EPOCH_MULTIPLIER;
+
+        let peers_to_unblock: Vec<PeerId> = self
+            .blocked_peers_info
+            .iter()
+            .filter_map(|(&peer_id, &blocked_at)| {
+                if blocked_at.elapsed() >= retain_score_duration {
+                    Some(peer_id)
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        for peer_id in peers_to_unblock {
+            self.unblock_peer(peer_id);
+        }
     }
 
     /// Join subnet and dial peers for it. Returns true if we need to discover peers for it
@@ -177,12 +235,16 @@ impl PeerManager {
         actions.discover.extend(subnet_needs.into_keys());
     }
 
-    pub fn heartbeat(&self) -> Option<ConnectActions> {
+    pub fn heartbeat(&mut self) -> Option<ConnectActions> {
         info!(
             subnets = self.needed_subnets.len(),
             peers = self.connected.len(),
+            blocked_peers = self.blocked_peers_info.len(),
             "Network status"
         );
+
+        // Check and unblock peers that have been blocked long enough
+        self.check_and_unblock_expired_peers();
 
         let mut actions = ConnectActions::none();
         self.determine_actions_for_subnets(
@@ -299,6 +361,13 @@ impl NetworkBehaviour for PeerManager {
         local_addr: &Multiaddr,
         remote_addr: &Multiaddr,
     ) -> Result<(), ConnectionDenied> {
+        // Check block list first
+        self.block_list.handle_pending_inbound_connection(
+            connection_id,
+            local_addr,
+            remote_addr,
+        )?;
+
         // we call the peer store here first to remember the peer regardless of whether we accept a
         // connection with it right now.
         self.peer_store.handle_pending_inbound_connection(
@@ -320,6 +389,14 @@ impl NetworkBehaviour for PeerManager {
         local_addr: &Multiaddr,
         remote_addr: &Multiaddr,
     ) -> Result<THandler<Self>, ConnectionDenied> {
+        // Check block list first
+        self.block_list.handle_established_inbound_connection(
+            connection_id,
+            peer,
+            local_addr,
+            remote_addr,
+        )?;
+
         self.peer_store.handle_established_inbound_connection(
             connection_id,
             peer,
@@ -353,6 +430,14 @@ impl NetworkBehaviour for PeerManager {
         addresses: &[Multiaddr],
         effective_role: Endpoint,
     ) -> Result<Vec<Multiaddr>, ConnectionDenied> {
+        // Check block list first
+        self.block_list.handle_pending_outbound_connection(
+            connection_id,
+            maybe_peer,
+            addresses,
+            effective_role,
+        )?;
+
         self.connection_limits.handle_pending_outbound_connection(
             connection_id,
             maybe_peer,
@@ -375,6 +460,15 @@ impl NetworkBehaviour for PeerManager {
         role_override: Endpoint,
         port_use: PortUse,
     ) -> Result<THandler<Self>, ConnectionDenied> {
+        // Check block list first
+        self.block_list.handle_established_outbound_connection(
+            connection_id,
+            peer,
+            addr,
+            role_override,
+            port_use,
+        )?;
+
         self.peer_store.handle_established_outbound_connection(
             connection_id,
             peer,
@@ -405,6 +499,9 @@ impl NetworkBehaviour for PeerManager {
     }
 
     fn on_swarm_event(&mut self, event: FromSwarm) {
+        // Handle block list events first
+        self.block_list.on_swarm_event(event);
+
         // `changed` is `true` only when the set actually grew or shrank.
         let changed_connected = match event {
             FromSwarm::ConnectionEstablished(ConnectionEstablished { peer_id, .. }) => {
@@ -439,17 +536,28 @@ impl NetworkBehaviour for PeerManager {
         &mut self,
         cx: &mut Context<'_>,
     ) -> Poll<ToSwarm<Self::ToSwarm, THandlerInEvent<Self>>> {
+        // Check block list events first (although it typically doesn't generate events)
+        if let Poll::Ready(e) = self.block_list.poll(cx) {
+            return Poll::Ready(e.map_out(|never| match never {}));
+        }
+
+        // Check connection limits
         if let Poll::Ready(e) = self.connection_limits.poll(cx) {
             return Poll::Ready(e.map_out(|never| match never {}));
         }
+
+        // Check peer store events
         if let Poll::Ready(e) = self.peer_store.poll(cx) {
             return Poll::Ready(e.map_out(Event::PeerStore));
         }
+
+        // Check heartbeat timer
         if self.heartbeat.poll_tick(cx).is_ready() {
             if let Some(actions) = self.heartbeat() {
                 return Poll::Ready(ToSwarm::GenerateEvent(Event::ConnectActions(actions)));
             }
         }
+
         Poll::Pending
     }
 }


### PR DESCRIPTION
## Proposed Changes

Introduces a peer block-list based on libp2p gossipsub scores with automatic unblocking after a configurable epoch and exposes manual block/unblock APIs.

- Integrates `allow_block_list` in `PeerManager` to deny connections and track block timestamps.
- Adds periodic score checks in `Network` to auto-block low-scoring peers and disconnect them.
- Updates `PeerManager::new` signature to accept epoch duration, adjusts behaviour initialization, and adds tests.


