### PR TITLE
ci: Add CI checks for conventional commits

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1,7 +1,7 @@
 name: Pull Request
 
 on:
-  pull_request:
+  pull_request_target:
     types:
       - opened
       - reopened

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1,0 +1,99 @@
+name: Pull Request
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - edited
+      - synchronize
+
+permissions:
+  pull-requests: read
+  contents: read
+
+concurrency:
+  # Have a lock per ref to avoid multiple runs on the same branch.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  # Only the latest workflow run will be kept in progress.
+  cancel-in-progress: true
+
+jobs:
+  target-branch-check:
+    name: target-branch-check
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Check that the pull request is not targeting the stable branch
+        run: |
+          if [[ "${{ github.base_ref }}" == "stable" && "${{ github.head_ref }}" != "unstable" ]]; then
+            echo "Pull requests to the stable branch can only come from the unstable branch."
+            exit 1
+          fi
+  conventional-title:
+    name: Validate PR title is Conventional Commit
+    runs-on: ubuntu-22.04
+    timeout-minutes: 5
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Check title
+        id: lint_pr_title
+        uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            fix
+            feat
+            chore
+            test
+            perf
+            refactor
+            docs
+            ci
+            revert
+        continue-on-error: true
+      - name: Add PR Comment for Invalid Title
+        if: steps.lint_pr_title.outcome == 'failure'
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: pr-title-lint-error
+          message: |
+            Your PR title doesn't follow the Conventional Commit guidelines.
+
+            **Example of valid titles:**
+            - `feat: add new user login`
+            - `fix: correct button size`
+            - `docs: update README`
+
+            **Usage:**
+            - `feat`: Introduces a new feature
+            - `fix`: Patches a bug
+            - `chore`: General maintenance tasks or updates
+            - `test`: Adding new tests or modifying existing tests
+            - `perf`: Performance improvements
+            - `refactor`: Changes to improve code structure
+            - `docs`: Documentation updates
+            - `ci`: Changes to CI/CD configurations
+            - `revert`: Reverts a previously merged PR
+
+            **Breaking Changes**
+
+            Breaking changes are noted by using an exclamation mark. For example:
+            - `feat!: changed the API`
+            - `chore(node)!: Removed unused public function`
+
+            **Help**
+
+            For more information, follow the guidelines here: https://www.conventionalcommits.org/en/v1.0.0/
+
+      - name: Remove Comment for Valid Title
+        if: steps.lint_pr_title.outcome == 'success'
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: pr-title-lint-error
+          delete: true
+
+      - name: Fail workflow if title invalid
+        if: steps.lint_pr_title.outcome == 'failure'
+        run: exit 1

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -53,18 +53,6 @@ jobs:
            fi
          done
          echo "skip_ci=$SKIP_CI" >> $GITHUB_OUTPUT
-
-  target-branch-check:
-    name: target-branch-check
-    runs-on: ubuntu-22.04
-    if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
-    steps:
-        - name: Check that the pull request is not targeting the stable branch
-          run: |
-            if [[ "${{ github.base_ref }}" == "stable" && "${{ github.head_ref }}" != "unstable" ]]; then
-              echo "Pull requests to the stable branch can only come from the unstable branch."
-              exit 1
-            fi
   release-tests-ubuntu:
     name: release-tests-ubuntu
     needs: [check-labels]
@@ -248,7 +236,6 @@ jobs:
     runs-on: ubuntu-latest
     needs: [
       'check-labels',
-      'target-branch-check',
       'release-tests-ubuntu',
       'debug-tests-ubuntu',
       'check-fmt',


### PR DESCRIPTION
## Issue Addressed

-  #349 

## Proposed Changes

Add CI for enforcing conventional commit PR titles

## Additional Info

This intentionally targets stable - we need to use `on: pull_request_target`  (which reads the CI definition from the default branch) so that the CI can post a comment if the title is incorrect. `on: pull_request` can't.

I also moved the merge target check to that new workflow to bundle all workflows that inspect the PR state instead of the code.