### PR TITLE
refactor: Switch to let-chains where possible

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG RUST_VERSION=1.85.1
+ARG RUST_VERSION=1.88.0
 FROM rust:${RUST_VERSION}-bullseye AS builder
 RUN apt update && apt dist-upgrade -y && apt install -y cmake libclang-dev
 COPY . anchor

--- a/Dockerfile.devnet
+++ b/Dockerfile.devnet
@@ -1,4 +1,4 @@
-ARG RUST_VERSION=1.85.1
+ARG RUST_VERSION=1.88.0
 FROM rust:${RUST_VERSION}-bullseye AS builder
 RUN apt update && apt dist-upgrade -y && apt install -y cmake libclang-dev
 COPY . anchor

--- a/anchor/Cargo.toml
+++ b/anchor/Cargo.toml
@@ -3,7 +3,7 @@ name = "anchor"
 version = "0.2.0"
 edition = { workspace = true }
 authors = ["Sigma Prime <contact@sigmaprime.io>"]
-rust-version = "1.85.0"
+rust-version = "1.88.0"
 default-run = "anchor"
 
 [features]

--- a/anchor/common/qbft/src/lib.rs
+++ b/anchor/common/qbft/src/lib.rs
@@ -874,23 +874,22 @@ where
             vec![]
         };
 
-        if matches!(msg_type, QbftMessageType::RoundChange) {
-            if let (Some(last_prepared_value), Some(last_prepared_round)) =
+        if matches!(msg_type, QbftMessageType::RoundChange)
+            && let (Some(last_prepared_value), Some(last_prepared_round)) =
                 (self.last_prepared_value, self.last_prepared_round)
-            {
-                return MessageData::new(
-                    last_prepared_round.get() as u64,
-                    self.current_round.get() as u64,
-                    last_prepared_value,
-                    self.data
-                        .get(&last_prepared_value)
-                        .map(|d| d.as_ssz_bytes())
-                        .unwrap_or_else(|| {
-                            warn!("Data misisng for last prepared value");
-                            vec![]
-                        }),
-                );
-            }
+        {
+            return MessageData::new(
+                last_prepared_round.get() as u64,
+                self.current_round.get() as u64,
+                last_prepared_value,
+                self.data
+                    .get(&last_prepared_value)
+                    .map(|d| d.as_ssz_bytes())
+                    .unwrap_or_else(|| {
+                        warn!("Data misisng for last prepared value");
+                        vec![]
+                    }),
+            );
         }
 
         // Standard message data for Proposal, Prepare, and Commit

--- a/anchor/common/qbft/src/msg_container.rs
+++ b/anchor/common/qbft/src/msg_container.rs
@@ -86,13 +86,13 @@ impl MessageContainer {
     /// If we have a quorum for the round, get all of the messages that correspond to that quorum
     pub fn get_quorum_of_messages(&self, round: Round) -> Vec<WrappedQbftMessage> {
         let mut msgs = vec![];
-        if let Some(hash) = self.has_quorum(round) {
-            // collect all of the messages where root = quorum hash
-            if let Some(round_messages) = self.messages.get(&round) {
-                for msg in round_messages.values() {
-                    if msg.qbft_message.root == hash {
-                        msgs.push(msg.clone());
-                    }
+        // collect all of the messages where root = quorum hash
+        if let Some(hash) = self.has_quorum(round)
+            && let Some(round_messages) = self.messages.get(&round)
+        {
+            for msg in round_messages.values() {
+                if msg.qbft_message.root == hash {
+                    msgs.push(msg.clone());
                 }
             }
         }

--- a/anchor/database/src/state.rs
+++ b/anchor/database/src/state.rs
@@ -99,18 +99,18 @@ impl NetworkState {
                 );
 
                 // Process this validators shares
-                if let Some(share_map) = &share_map {
-                    if let Some(shares) = share_map.get(cluster_id) {
-                        for share in shares {
-                            if share.validator_pubkey == validator.public_key {
-                                shares_multi.insert(
-                                    &validator.public_key,
-                                    cluster_id,
-                                    &cluster.owner,
-                                    &cluster.committee_id(),
-                                    share.clone(),
-                                );
-                            }
+                if let Some(share_map) = &share_map
+                    && let Some(shares) = share_map.get(cluster_id)
+                {
+                    for share in shares {
+                        if share.validator_pubkey == validator.public_key {
+                            shares_multi.insert(
+                                &validator.public_key,
+                                cluster_id,
+                                &cluster.owner,
+                                &cluster.committee_id(),
+                                share.clone(),
+                            );
                         }
                     }
                 }

--- a/anchor/http_metrics/src/lib.rs
+++ b/anchor/http_metrics/src/lib.rs
@@ -84,46 +84,46 @@ async fn metrics_handler<E: EthSpec>(
 
     {
         let shared = state.read();
-        if let Some(genesis_time) = shared.genesis_time {
-            if let Ok(now) = SystemTime::now().duration_since(UNIX_EPOCH) {
-                let distance = now.as_secs() as i64 - genesis_time as i64;
-                set_gauge(&GENESIS_DISTANCE, distance);
-            }
+        if let Some(genesis_time) = shared.genesis_time
+            && let Ok(now) = SystemTime::now().duration_since(UNIX_EPOCH)
+        {
+            let distance = now.as_secs() as i64 - genesis_time as i64;
+            set_gauge(&GENESIS_DISTANCE, distance);
         }
 
         // Duties services
-        if let Some(duties_service) = &shared.duties_service {
-            if let Some(slot) = duties_service.slot_clock.now() {
-                let current_epoch = slot.epoch(E::slots_per_epoch());
-                let next_epoch = current_epoch + 1;
+        if let Some(duties_service) = &shared.duties_service
+            && let Some(slot) = duties_service.slot_clock.now()
+        {
+            let current_epoch = slot.epoch(E::slots_per_epoch());
+            let next_epoch = current_epoch + 1;
 
-                set_int_gauge(
-                    &PROPOSER_COUNT,
-                    &[CURRENT_EPOCH],
-                    duties_service.proposer_count(current_epoch) as i64,
-                );
-                set_int_gauge(
-                    &ATTESTER_COUNT,
-                    &[CURRENT_EPOCH],
-                    duties_service.attester_count(current_epoch) as i64,
-                );
-                set_int_gauge(
-                    &ATTESTER_COUNT,
-                    &[NEXT_EPOCH],
-                    duties_service.attester_count(next_epoch) as i64,
-                );
-            }
+            set_int_gauge(
+                &PROPOSER_COUNT,
+                &[CURRENT_EPOCH],
+                duties_service.proposer_count(current_epoch) as i64,
+            );
+            set_int_gauge(
+                &ATTESTER_COUNT,
+                &[CURRENT_EPOCH],
+                duties_service.attester_count(current_epoch) as i64,
+            );
+            set_int_gauge(
+                &ATTESTER_COUNT,
+                &[NEXT_EPOCH],
+                duties_service.attester_count(next_epoch) as i64,
+            );
         }
 
-        if let Some(network_metrics) = &shared.network_registry {
-            // Network metrics
-            if let Err(e) = encode(&mut buffer, network_metrics) {
-                return (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    format!("Failed to encode promethus data: {e}"),
-                )
-                    .into_response();
-            }
+        // Network metrics
+        if let Some(network_metrics) = &shared.network_registry
+            && let Err(e) = encode(&mut buffer, network_metrics)
+        {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("Failed to encode promethus data: {e}"),
+            )
+                .into_response();
         }
     }
 

--- a/anchor/logging/src/tracing_libp2p_discv5_layer.rs
+++ b/anchor/logging/src/tracing_libp2p_discv5_layer.rs
@@ -64,11 +64,11 @@ pub fn create_libp2p_discv5_tracing_layer(
         // Ensure that `tracing_log_path` only contains directories.
         for p in tracing_log_path.clone().iter() {
             tracing_log_path = tracing_log_path.join(p);
-            if let Ok(metadata) = tracing_log_path.metadata() {
-                if !metadata.is_dir() {
-                    tracing_log_path.pop();
-                    break;
-                }
+            if let Ok(metadata) = tracing_log_path.metadata()
+                && !metadata.is_dir()
+            {
+                tracing_log_path.pop();
+                break;
             }
         }
 

--- a/anchor/message_sender/src/network.rs
+++ b/anchor/message_sender/src/network.rs
@@ -129,19 +129,19 @@ impl<S: SlotClock + 'static, D: DutiesProvider> NetworkMessageSender<S, D> {
     fn do_send(&self, message: SignedSSVMessage, committee_id: CommitteeId) {
         let message_bytes = message.as_ssz_bytes();
 
-        if let Some(validator) = self.validator.as_ref() {
-            if let Err(err) = validator.validate(&message_bytes).as_result() {
-                // `Reject` is more severe and can be punished by other peers. We should not have
-                // created this message ever, while `Ignore` can be triggered simply because the
-                // message is irrelevant by now.
-                if let MessageAcceptance::Reject = MessageAcceptance::from(err) {
-                    warn!(?err, "Validation of outgoing message failed (Reject)");
-                    debug!(msg = %message, "Failing message");
-                } else {
-                    debug!(?err, "Validation of outgoing message failed (Ignore)");
-                }
-                return;
+        if let Some(validator) = self.validator.as_ref()
+            && let Err(err) = validator.validate(&message_bytes).as_result()
+        {
+            // `Reject` is more severe and can be punished by other peers. We should not have
+            // created this message ever, while `Ignore` can be triggered simply because the message
+            // is irrelevant by now.
+            if let MessageAcceptance::Reject = MessageAcceptance::from(err) {
+                warn!(?err, "Validation of outgoing message failed (Reject)");
+                debug!(msg = %message, "Failing message");
+            } else {
+                debug!(?err, "Validation of outgoing message failed (Ignore)");
             }
+            return;
         }
 
         let subnet = SubnetId::from_committee(committee_id, self.subnet_count);

--- a/anchor/network/src/network.rs
+++ b/anchor/network/src/network.rs
@@ -230,10 +230,10 @@ impl<R: MessageReceiver> Network<R> {
                 event = self.message_rx.recv() => {
                     match event {
                         Some((subnet_id, message)) => {
-                            if let Err(err) = self.gossipsub().publish(subnet_to_topic(subnet_id), message) {
-                                if !matches!(err, PublishError::Duplicate) {
-                                    error!(?err, "Failed to publish message");
-                                }
+                            if let Err(err) = self.gossipsub().publish(subnet_to_topic(subnet_id), message)
+                                && let PublishError::Duplicate = err
+                            {
+                                error!(?err, "Failed to publish message");
                             }
                         }
                         None => {
@@ -368,10 +368,10 @@ impl<R: MessageReceiver> Network<R> {
 
         // update enr and metadata to new state
         self.discovery().set_subscribed(subnet, subscribed);
-        if let Some(metadata) = &mut self.node_info.metadata {
-            if let Err(err) = metadata.set_subscribed(subnet, subscribed) {
-                error!(?err, "unable to update node info");
-            }
+        if let Some(metadata) = &mut self.node_info.metadata
+            && let Err(err) = metadata.set_subscribed(subnet, subscribed)
+        {
+            error!(?err, "unable to update node info");
         }
     }
 

--- a/anchor/network/src/peer_manager/mod.rs
+++ b/anchor/network/src/peer_manager/mod.rs
@@ -236,10 +236,10 @@ impl NetworkBehaviour for PeerManager {
         }
 
         // Check heartbeat timer
-        if self.heartbeat_manager.poll_tick(cx).is_ready() {
-            if let Some(actions) = self.heartbeat() {
-                return Poll::Ready(ToSwarm::GenerateEvent(Event::ConnectActions(actions)));
-            }
+        if self.heartbeat_manager.poll_tick(cx).is_ready()
+            && let Some(actions) = self.heartbeat()
+        {
+            return Poll::Ready(ToSwarm::GenerateEvent(Event::ConnectActions(actions)));
         }
 
         Poll::Pending

--- a/anchor/processor/src/lib.rs
+++ b/anchor/processor/src/lib.rs
@@ -141,15 +141,15 @@ async fn processor(config: Config, mut receivers: Receivers, executor: TaskExecu
             &[name, received.queue.name()],
         );
 
-        if let Some(expiry) = received.work_item.expiry() {
-            if expiry < &Instant::now() {
-                warn!(task = name, "Processor skipped expired work");
-                metrics::inc_counter_vec(
-                    &metrics::ANCHOR_PROCESSOR_WORK_EVENTS_EXPIRED_COUNT,
-                    &[name],
-                );
-                continue;
-            }
+        if let Some(expiry) = received.work_item.expiry()
+            && expiry < &Instant::now()
+        {
+            warn!(task = name, "Processor skipped expired work");
+            metrics::inc_counter_vec(
+                &metrics::ANCHOR_PROCESSOR_WORK_EVENTS_EXPIRED_COUNT,
+                &[name],
+            );
+            continue;
         }
 
         // update metrics

--- a/anchor/signature_collector/src/lib.rs
+++ b/anchor/signature_collector/src/lib.rs
@@ -481,16 +481,16 @@ async fn signature_collector(mut rx: mpsc::UnboundedReceiver<CollectorMessage>) 
                 } else {
                     // Register the notifier and threshold.
                     notifiers.push(notify);
-                    if let Some(old_threshold) = threshold {
-                        if new_threshold != old_threshold {
-                            // Different tasks expect different thresholds. We can not know which
-                            // is correct, so we exit this instance.
-                            error!(
-                                new_threshold,
-                                old_threshold, "Conflicting thresholds passed!"
-                            );
-                            return;
-                        }
+                    if let Some(old_threshold) = threshold
+                        && new_threshold != old_threshold
+                    {
+                        // Different tasks expect different thresholds. We can not know which is
+                        // correct, so we exit this instance.
+                        error!(
+                            new_threshold,
+                            old_threshold, "Conflicting thresholds passed!"
+                        );
+                        return;
                     }
                     threshold = Some(new_threshold);
                 }
@@ -523,25 +523,25 @@ async fn signature_collector(mut rx: mpsc::UnboundedReceiver<CollectorMessage>) 
             }
         }
 
-        if let Some(threshold) = threshold {
-            if signature_share.len() as u64 >= threshold {
-                let signature = match combine_signatures(mem::take(&mut signature_share)) {
-                    Ok(signature) => Arc::new(signature),
-                    Err(err) => {
-                        error!(?err, "Failed to recover signature");
-                        return;
-                    }
-                };
-
-                debug!(?signature, "Successfully recovered signature");
-
-                for notifier in mem::take(&mut notifiers) {
-                    if notifier.send(Arc::clone(&signature)).is_err() {
-                        warn!("Callback dropped - signature is no longer relevant");
-                    }
+        if let Some(threshold) = threshold
+            && signature_share.len() as u64 >= threshold
+        {
+            let signature = match combine_signatures(mem::take(&mut signature_share)) {
+                Ok(signature) => Arc::new(signature),
+                Err(err) => {
+                    error!(?err, "Failed to recover signature");
+                    return;
                 }
-                full_signature = Some(signature);
+            };
+
+            debug!(?signature, "Successfully recovered signature");
+
+            for notifier in mem::take(&mut notifiers) {
+                if notifier.send(Arc::clone(&signature)).is_err() {
+                    warn!("Callback dropped - signature is no longer relevant");
+                }
             }
+            full_signature = Some(signature);
         }
     }
 }

--- a/anchor/validator_store/src/lib.rs
+++ b/anchor/validator_store/src/lib.rs
@@ -861,16 +861,16 @@ impl<T: SlotClock, E: EthSpec> ValidatorStore for AnchorValidatorStore<T, E> {
                     .validators_per_committee
                     .entry(v.cluster.committee_id())
                     .or_default();
-                if let Some(old_idx) = v.metadata.index {
-                    if old_idx != index {
-                        error!(
-                            ?validator_pubkey,
-                            db=?old_idx,
-                            got=?index,
-                            "Inconsistent validator index - database corrupt?"
-                        );
-                        index_set.remove(&old_idx);
-                    }
+                if let Some(old_idx) = v.metadata.index
+                    && old_idx != index
+                {
+                    error!(
+                        ?validator_pubkey,
+                        db=?old_idx,
+                        got=?index,
+                        "Inconsistent validator index - database corrupt?"
+                    );
+                    index_set.remove(&old_idx);
                 }
                 v.metadata.index = Some(index);
                 index_set.insert(index);


### PR DESCRIPTION
Let-if chains are now available in stable Rust :tada: 

This saves a level of indentation in many cases.

For this, we need to bump MSRV to 1.88.

