### PR TITLE
fix: Disconnect peers on handshake failure

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -307,6 +307,13 @@ Anchor aims for high test coverage with different types of tests:
    - Use trait mocking when needed
    - Consider dependency injection for easier testing
 
+6. **Testing Production Code Paths**:
+   - **NEVER add production logic directly in test code** - tests should call actual production functions and verify their behavior
+   - It's acceptable to mock external dependencies (databases, network calls, etc.) to isolate the code under test
+   - However, avoid duplicating or simulating the actual business logic being tested within the test itself
+   - If production code has a behavior (like disconnecting peers on handshake failure), the test should call the production code that performs this behavior, not implement the disconnection logic in the test
+   - When tests bypass certain system layers, consider restructuring the test to go through the actual production code paths rather than adding the bypassed logic to the test
+
 ## Contribution Workflow
 
 When contributing to Anchor, follow these steps to ensure high-quality code that meets project standards:

--- a/anchor/network/src/network.rs
+++ b/anchor/network/src/network.rs
@@ -231,10 +231,7 @@ impl<R: MessageReceiver> Network<R> {
                                     .peers_to_disconnect_due_to_subnets();
 
                                 for peer_id in to_disconnect {
-                                    match self.swarm.disconnect_peer_id(peer_id) {
-                                        Ok(_) => debug!(%peer_id, "Disconnected peer due to no subnets"),
-                                        Err(_) => trace!(%peer_id, "Peer was already disconnected"),
-                                    }
+                                    self.disconnect_peer(&peer_id, "No longer subscribed to any needed subnets");
                                 }
                             }
                             _ => {
@@ -519,6 +516,9 @@ impl<R: MessageReceiver> Network<R> {
             }
             Err(handshake::Failed { peer_id, error }) => {
                 debug!(%peer_id, ?error, "Handshake failed");
+
+                // Disconnect the peer on handshake failure
+                self.disconnect_peer(&peer_id, "Handshake failed");
             }
         }
     }
@@ -555,7 +555,7 @@ impl<R: MessageReceiver> Network<R> {
 
         for peer_id in &peers_to_block_and_disconnect {
             self.swarm.behaviour_mut().peer_manager.block_peer(*peer_id);
-            self.disconnect_peer(peer_id);
+            self.disconnect_peer(peer_id, "Blocking peer due to low score");
         }
 
         if excess > 0 {
@@ -567,21 +567,21 @@ impl<R: MessageReceiver> Network<R> {
                 .map(|(p, _)| *p);
 
             for peer_id in to_disconnect {
-                self.disconnect_peer(&peer_id);
+                self.disconnect_peer(&peer_id, "Pruning excess peers by score");
             }
-        }
-    }
-
-    fn disconnect_peer(&mut self, peer_id: &PeerId) {
-        match self.swarm.disconnect_peer_id(*peer_id) {
-            Ok(_) => debug!(%peer_id, "Disconnected peer due to low score"),
-            Err(_) => trace!(%peer_id, "Peer was already disconnected"),
         }
     }
 
     fn dial(&mut self, opts: DialOpts) {
         if let Err(err) = self.swarm.dial(opts) {
             debug!(%err, "Failed to dial peer");
+        }
+    }
+
+    fn disconnect_peer(&mut self, peer_id: &PeerId, reason: &str) {
+        match self.swarm.disconnect_peer_id(*peer_id) {
+            Ok(_) => debug!(%peer_id, reason = %reason, "Disconnected peer"),
+            Err(_) => trace!(%peer_id, "Peer was already disconnected"),
         }
     }
 }


### PR DESCRIPTION
## Issue Addressed

https://github.com/sigp/anchor/issues/438

## Proposed Changes

- **Add explicit peer disconnection**: When a handshake fails (e.g., due to network mismatch), the network layer now explicitly disconnects the peer via `disconnect_peer_id()`
- **Improve disconnection timing**: Instead of relying on keep-alive timeouts (~10 seconds), peers are disconnected immediately upon handshake failure
- **Preserve existing test**: The handshake test continues to validate failure detection; disconnection behavior will be naturally tested through integration tests that use the full network stack
- **Add testing best practices**: Updated CLAUDE.md with guidance about not simulating production behavior in tests

## Technical Details

The change is made in `Network::handle_handshake_result()` where handshake failures are processed. When a handshake fails, we now call `self.swarm.disconnect_peer_id(peer_id)` to immediately disconnect the peer, rather than waiting for keep-alive timeouts.

This ensures faster and more deterministic peer disconnection on handshake failures, improving network behavior and reducing connection overhead.