### PR TITLE
fix: migrate validator store to event-driven architecture

### DIFF
--- a/anchor/client/src/lib.rs
+++ b/anchor/client/src/lib.rs
@@ -394,7 +394,7 @@ impl Client {
                 ws_url: config.execution_nodes_websocket,
                 network: config.global_config.ssv_network.clone(),
             },
-            Some(event_bus.clone()),
+            event_bus.clone(),
         )
         .await
         .map_err(|e| format!("Unable to create syncer: {e}"))?;

--- a/anchor/client/src/lib.rs
+++ b/anchor/client/src/lib.rs
@@ -13,7 +13,8 @@ use std::{
 };
 
 use anchor_validator_store::{
-    AnchorValidatorStore, events::create_shared_event_bus, metadata_service::MetadataService,
+    AnchorValidatorStore, events::create_shared_event_bus, extract_initial_validators,
+    metadata_service::MetadataService,
 };
 use beacon_node_fallback::{
     ApiTopic, BeaconNodeFallback, CandidateBeaconNode, start_fallback_updater_service,
@@ -381,7 +382,7 @@ impl Client {
         let voluntary_exit_tracker = Arc::new(VoluntaryExitTracker::new());
 
         // Create event bus for real-time validator state synchronization
-        let event_bus = create_shared_event_bus();
+        let (event_bus, event_receiver) = create_shared_event_bus();
 
         // Start syncer
         let mut syncer = eth::SsvEventSyncer::new(
@@ -513,8 +514,14 @@ impl Client {
         // Spawn the network listening task
         executor.spawn(network.run::<E>(), "network");
 
+        // Extract initial validators from database state for validator store initialization
+        let initial_validators = extract_initial_validators(
+            &database.state(),
+            config.impostor.is_none().then_some(&key),
+        );
+
         let validator_store = AnchorValidatorStore::<_, E>::new(
-            database.watch(),
+            initial_validators,
             signature_collector,
             qbft_manager,
             slashing_protection,
@@ -522,14 +529,13 @@ impl Client {
             slot_clock.clone(),
             spec.clone(),
             genesis_validators_root,
-            config.impostor.is_none().then_some(key),
             executor.clone(),
             config.gas_limit,
             config.builder_proposals,
             config.builder_boost_factor,
             config.prefer_builder_proposals,
             is_synced.clone(),
-            event_bus,
+            event_receiver,
         );
 
         start_exit_processor(

--- a/anchor/client/src/lib.rs
+++ b/anchor/client/src/lib.rs
@@ -12,7 +12,9 @@ use std::{
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
-use anchor_validator_store::{AnchorValidatorStore, metadata_service::MetadataService};
+use anchor_validator_store::{
+    AnchorValidatorStore, events::create_shared_event_bus, metadata_service::MetadataService,
+};
 use beacon_node_fallback::{
     ApiTopic, BeaconNodeFallback, CandidateBeaconNode, start_fallback_updater_service,
 };
@@ -378,6 +380,9 @@ impl Client {
         let (exit_tx, exit_rx) = unbounded_channel();
         let voluntary_exit_tracker = Arc::new(VoluntaryExitTracker::new());
 
+        // Create event bus for real-time validator state synchronization
+        let event_bus = create_shared_event_bus();
+
         // Start syncer
         let mut syncer = eth::SsvEventSyncer::new(
             database.clone(),
@@ -388,6 +393,7 @@ impl Client {
                 ws_url: config.execution_nodes_websocket,
                 network: config.global_config.ssv_network.clone(),
             },
+            Some(event_bus.clone()),
         )
         .await
         .map_err(|e| format!("Unable to create syncer: {e}"))?;
@@ -523,6 +529,7 @@ impl Client {
             config.builder_boost_factor,
             config.prefer_builder_proposals,
             is_synced.clone(),
+            event_bus,
         );
 
         start_exit_processor(

--- a/anchor/eth/src/event_processor.rs
+++ b/anchor/eth/src/event_processor.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use alloy::{primitives::Address, rpc::types::Log, sol_types::SolEvent};
+use anchor_validator_store::events::{SharedEventBus, ValidatorEvent, emit_event};
 use database::{NetworkDatabase, UniqueIndex};
 use eth2::types::PublicKeyBytes;
 use indexmap::IndexSet;
@@ -28,6 +29,8 @@ pub enum Mode {
         index_sync_tx: index_sync::Tx,
         /// Queue to submit validator exits for processing
         exit_tx: ExitTx,
+        /// Event bus for emitting validator events (minimal fix for state sync issue)
+        event_bus: Option<SharedEventBus>,
     },
     /// Process added validators only by updating the nonce.
     ///
@@ -64,6 +67,9 @@ impl EventProcessor {
         debug!(logs_count = logs.len(), "Starting log processing");
         let timer = metrics::start_timer(&metrics::EXECUTION_LOG_PROCESSING_TIME);
 
+        // Collect events to emit after successful commit
+        let mut events_to_emit = Vec::new();
+
         // Open a transaction for the log batch.
         let mut conn = self
             .db
@@ -94,11 +100,11 @@ impl EventProcessor {
                 }
 
                 SSVContract::ValidatorAdded::SIGNATURE_HASH => {
-                    self.process_validator_added(log, &tx)
+                    self.process_validator_added(log, &tx, &mut events_to_emit)
                 }
 
                 SSVContract::ValidatorRemoved::SIGNATURE_HASH => {
-                    self.process_validator_removed(log, &tx)
+                    self.process_validator_removed(log, &tx, &mut events_to_emit)
                 }
 
                 SSVContract::ClusterLiquidated::SIGNATURE_HASH => {
@@ -141,6 +147,17 @@ impl EventProcessor {
         // Commit everything!
         tx.commit()
             .map_err(|e| ExecutionError::Database(e.to_string()))?;
+
+        // Now that the transaction is committed, emit all collected events
+        if let Mode::Node {
+            event_bus: Some(event_bus),
+            ..
+        } = &self.mode
+        {
+            for event in events_to_emit {
+                emit_event(event_bus, event);
+            }
+        }
 
         debug!(logs_count = logs.len(), "Completed processing logs");
         Ok(())
@@ -247,6 +264,7 @@ impl EventProcessor {
         &self,
         log: &Log,
         tx: &Transaction<'_>,
+        events_to_emit: &mut Vec<ValidatorEvent>,
     ) -> Result<(), ExecutionError> {
         // Parse and destructure log
         let SSVContract::ValidatorAdded {
@@ -331,6 +349,12 @@ impl EventProcessor {
             error!(?err, "Failed to send validator to index lookup");
         }
 
+        // Collect event for emission after successful commit
+        events_to_emit.push(ValidatorEvent::ValidatorAdded {
+            cluster_id,
+            validator_pubkey,
+        });
+
         debug!(
             cluster_id = ?cluster_id,
             validator_pubkey = %validator_pubkey,
@@ -345,6 +369,7 @@ impl EventProcessor {
         &self,
         log: &Log,
         tx: &Transaction<'_>,
+        events_to_emit: &mut Vec<ValidatorEvent>,
     ) -> Result<(), ExecutionError> {
         // Parse and destructure log
         let SSVContract::ValidatorRemoved {
@@ -430,6 +455,12 @@ impl EventProcessor {
                 );
                 ExecutionError::Database(format!("Failed to validator cluster: {e}"))
             })?;
+
+        // Collect event for emission after successful commit
+        events_to_emit.push(ValidatorEvent::ValidatorRemoved {
+            cluster_id,
+            validator_pubkey,
+        });
 
         debug!(
             cluster_id = ?cluster_id,

--- a/anchor/eth/src/event_processor.rs
+++ b/anchor/eth/src/event_processor.rs
@@ -381,7 +381,7 @@ impl EventProcessor {
         // Collect event for emission after successful commit
         events_to_emit.push(ValidatorEvent::ValidatorAdded {
             validator_pubkey,
-            cluster: Box::new(cluster.clone()),
+            cluster: Arc::new(cluster),
             metadata: validator_metadata.clone(),
             decrypted_key_share: None, // Will be handled by validator store from database state
         });

--- a/anchor/eth/src/event_processor.rs
+++ b/anchor/eth/src/event_processor.rs
@@ -1,12 +1,13 @@
 use std::sync::Arc;
 
 use alloy::{primitives::Address, rpc::types::Log, sol_types::SolEvent};
-use anchor_validator_store::events::{SharedEventBus, ValidatorEvent, emit_event};
+use anchor_validator_store::events::{SharedEventBus, ValidatorEvent, emit_event, try_emit_event};
 use database::{NetworkDatabase, UniqueIndex};
 use eth2::types::PublicKeyBytes;
 use indexmap::IndexSet;
 use rusqlite::Transaction;
 use ssv_types::{Cluster, ClusterId, Operator, OperatorId, ValidatorIndex};
+use tokio::sync::mpsc::error::TrySendError;
 use tracing::{debug, error, info, instrument, trace, warn};
 
 use crate::{
@@ -54,6 +55,34 @@ impl EventProcessor {
     /// Construct a new EventProcessor
     pub fn new(db: Arc<NetworkDatabase>, mode: Mode) -> Self {
         Self { db, mode }
+    }
+
+    /// Emit a validator event with try-first-then-block behavior
+    ///
+    /// First attempts non-blocking emit. If channel is full, logs a warning
+    /// and then uses blocking emit to ensure the event is delivered.
+    fn emit_validator_event(&self, event_bus: &SharedEventBus, event: ValidatorEvent) {
+        match try_emit_event(event_bus, event.clone()) {
+            Ok(()) => {
+                // Successfully sent non-blocking
+                trace!("Successfully emitted validator event");
+            }
+            Err(err) => {
+                match err {
+                    TrySendError::Full(_) => {
+                        // Channel is full, log warning and use blocking send
+                        warn!("Event channel is full, using blocking emit to ensure delivery");
+
+                        // Use tokio's Handle to call the async emit function from sync context
+                        let rt = tokio::runtime::Handle::current();
+                        rt.block_on(emit_event(event_bus, event));
+                    }
+                    TrySendError::Closed(_) => {
+                        warn!("Event channel is closed, validator event dropped");
+                    }
+                }
+            }
+        }
     }
 
     /// Process a new set of logs
@@ -108,15 +137,15 @@ impl EventProcessor {
                 }
 
                 SSVContract::ClusterLiquidated::SIGNATURE_HASH => {
-                    self.process_cluster_liquidated(log, &tx)
+                    self.process_cluster_liquidated(log, &tx, &mut events_to_emit)
                 }
 
                 SSVContract::ClusterReactivated::SIGNATURE_HASH => {
-                    self.process_cluster_reactivated(log, &tx)
+                    self.process_cluster_reactivated(log, &tx, &mut events_to_emit)
                 }
 
                 SSVContract::FeeRecipientAddressUpdated::SIGNATURE_HASH => {
-                    self.process_fee_recipient_updated(log, &tx)
+                    self.process_fee_recipient_updated(log, &tx, &mut events_to_emit)
                 }
 
                 SSVContract::ValidatorExited::SIGNATURE_HASH if live => {
@@ -155,7 +184,7 @@ impl EventProcessor {
         } = &self.mode
         {
             for event in events_to_emit {
-                emit_event(event_bus, event);
+                self.emit_validator_event(event_bus, event);
             }
         }
 
@@ -338,7 +367,7 @@ impl EventProcessor {
             cluster_members: IndexSet::from_iter(operator_ids),
         };
         self.db
-            .insert_validator(cluster, &validator_metadata, shares, tx)
+            .insert_validator(cluster.clone(), &validator_metadata, shares, tx)
             .map_err(|e| {
                 debug!(cluster_id = ?cluster_id, error = %e, validator_metadata = ?validator_metadata.public_key, "Failed to insert validator into cluster");
                 ExecutionError::Database(format!("Failed to insert validator into cluster: {e}"))
@@ -351,8 +380,10 @@ impl EventProcessor {
 
         // Collect event for emission after successful commit
         events_to_emit.push(ValidatorEvent::ValidatorAdded {
-            cluster_id,
             validator_pubkey,
+            cluster: Box::new(cluster.clone()),
+            metadata: validator_metadata.clone(),
+            decrypted_key_share: None, // Will be handled by validator store from database state
         });
 
         debug!(
@@ -476,6 +507,7 @@ impl EventProcessor {
         &self,
         log: &Log,
         tx: &Transaction<'_>,
+        events_to_emit: &mut Vec<ValidatorEvent>,
     ) -> Result<(), ExecutionError> {
         let SSVContract::ClusterLiquidated {
             owner,
@@ -497,6 +529,9 @@ impl EventProcessor {
             ExecutionError::Database(format!("Failed to mark cluster as liquidated: {e}"))
         })?;
 
+        // Emit event for validator store
+        events_to_emit.push(ValidatorEvent::ClusterLiquidated { cluster_id });
+
         debug!(
             cluster_id = ?cluster_id,
             owner = ?owner,
@@ -514,6 +549,7 @@ impl EventProcessor {
         &self,
         log: &Log,
         tx: &Transaction<'_>,
+        events_to_emit: &mut Vec<ValidatorEvent>,
     ) -> Result<(), ExecutionError> {
         let SSVContract::ClusterReactivated {
             owner,
@@ -535,6 +571,9 @@ impl EventProcessor {
             ExecutionError::Database(format!("Failed to mark cluster as active: {e}"))
         })?;
 
+        // Emit event for validator store
+        events_to_emit.push(ValidatorEvent::ClusterReactivated { cluster_id });
+
         debug!(
             cluster_id = ?cluster_id,
             owner = ?owner,
@@ -553,11 +592,13 @@ impl EventProcessor {
         &self,
         log: &Log,
         tx: &Transaction<'_>,
+        events_to_emit: &mut Vec<ValidatorEvent>,
     ) -> Result<(), ExecutionError> {
         let SSVContract::FeeRecipientAddressUpdated {
             owner,
             recipientAddress,
         } = SSVContract::FeeRecipientAddressUpdated::decode_from_log(log)?;
+
         // update the fee recipient address in the database
         self.db
             .update_fee_recipient(owner, recipientAddress, tx)
@@ -569,6 +610,23 @@ impl EventProcessor {
                 );
                 ExecutionError::Database(format!("Failed to update fee recipient: {e}"))
             })?;
+
+        // Find all clusters owned by this address and emit a single batched event
+        let state = self.db.state();
+        let cluster_ids: Vec<ClusterId> = state
+            .clusters()
+            .values()
+            .filter(|cluster| cluster.owner == owner)
+            .map(|cluster| cluster.cluster_id)
+            .collect();
+
+        if !cluster_ids.is_empty() {
+            events_to_emit.push(ValidatorEvent::FeeRecipientUpdated {
+                cluster_ids,
+                new_fee_recipient: recipientAddress,
+            });
+        }
+
         debug!(
             owner = ?owner,
             new_recipient = ?recipientAddress,

--- a/anchor/eth/src/event_processor.rs
+++ b/anchor/eth/src/event_processor.rs
@@ -31,7 +31,7 @@ pub enum Mode {
         /// Queue to submit validator exits for processing
         exit_tx: ExitTx,
         /// Event bus for emitting validator events (minimal fix for state sync issue)
-        event_bus: Option<SharedEventBus>,
+        event_bus: SharedEventBus,
     },
     /// Process added validators only by updating the nonce.
     ///
@@ -178,11 +178,7 @@ impl EventProcessor {
             .map_err(|e| ExecutionError::Database(e.to_string()))?;
 
         // Now that the transaction is committed, emit all collected events
-        if let Mode::Node {
-            event_bus: Some(event_bus),
-            ..
-        } = &self.mode
-        {
+        if let Mode::Node { event_bus, .. } = &self.mode {
             for event in events_to_emit {
                 self.emit_validator_event(event_bus, event);
             }

--- a/anchor/eth/src/sync.rs
+++ b/anchor/eth/src/sync.rs
@@ -12,6 +12,7 @@ use alloy::{
     sol_types::SolEvent,
     transports::{RpcError, TransportErrorKind},
 };
+use anchor_validator_store::events::SharedEventBus;
 use database::NetworkDatabase;
 use futures::{FutureExt, StreamExt, stream::FuturesOrdered};
 use reqwest::Url;
@@ -111,13 +112,14 @@ pub struct SsvEventSyncer {
 }
 
 impl SsvEventSyncer {
-    #[instrument(skip(db, config), level = "debug")]
+    #[instrument(skip(db, config, event_bus), level = "debug")]
     /// Create a new SsvEventSyncer to sync all of the events from the chain
     pub async fn new(
         db: Arc<NetworkDatabase>,
         index_sync_tx: index_sync::Tx,
         exit_tx: ExitTx,
         config: Config,
+        event_bus: Option<SharedEventBus>,
     ) -> Result<Self, ExecutionError> {
         info!("Creating new SSV Event Syncer");
 
@@ -138,6 +140,7 @@ impl SsvEventSyncer {
             Mode::Node {
                 index_sync_tx,
                 exit_tx,
+                event_bus,
             },
         );
         debug!("Created event processor - done");

--- a/anchor/eth/src/sync.rs
+++ b/anchor/eth/src/sync.rs
@@ -119,7 +119,7 @@ impl SsvEventSyncer {
         index_sync_tx: index_sync::Tx,
         exit_tx: ExitTx,
         config: Config,
-        event_bus: Option<SharedEventBus>,
+        event_bus: SharedEventBus,
     ) -> Result<Self, ExecutionError> {
         info!("Creating new SSV Event Syncer");
 

--- a/anchor/validator_store/src/events.rs
+++ b/anchor/validator_store/src/events.rs
@@ -1,0 +1,119 @@
+use std::sync::Arc;
+
+use ssv_types::ClusterId;
+use tracing::info;
+use types::PublicKeyBytes;
+
+/// Events that can occur in the validator lifecycle (minimal set for state sync fix)
+#[derive(Debug, Clone)]
+pub enum ValidatorEvent {
+    /// A validator has been added to the network
+    ValidatorAdded {
+        cluster_id: ClusterId,
+        validator_pubkey: PublicKeyBytes,
+    },
+    /// A validator has been removed from the network  
+    ValidatorRemoved {
+        cluster_id: ClusterId,
+        validator_pubkey: PublicKeyBytes,
+    },
+}
+
+/// Minimal event bus for immediate state synchronization during batch processing
+///
+/// This addresses the specific issue where validator state changes during batch
+/// processing weren't immediately visible to other components, causing sync issues.
+#[derive(Debug)]
+pub struct EventBus {
+    /// Broadcast sender for distributing events
+    sender: tokio::sync::broadcast::Sender<ValidatorEvent>,
+}
+
+impl EventBus {
+    /// Create a new event bus
+    pub fn new() -> Self {
+        let (sender, _) = tokio::sync::broadcast::channel(1024);
+        Self { sender }
+    }
+
+    /// Subscribe to validator events
+    pub fn subscribe(&self) -> tokio::sync::broadcast::Receiver<ValidatorEvent> {
+        self.sender.subscribe()
+    }
+
+    /// Emit an event to all subscribers
+    pub fn emit(&self, event: ValidatorEvent) {
+        match self.sender.send(event) {
+            Ok(subscriber_count) => {
+                if subscriber_count > 0 {
+                    info!(
+                        subscribers = subscriber_count,
+                        "Event delivered to subscribers"
+                    );
+                }
+            }
+            Err(_) => {
+                // No subscribers - this is fine during startup
+            }
+        }
+    }
+}
+
+impl Default for EventBus {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// A thread-safe event bus that can be shared across components
+pub type SharedEventBus = Arc<EventBus>;
+
+/// Helper to create a shared event bus
+pub fn create_shared_event_bus() -> SharedEventBus {
+    Arc::new(EventBus::new())
+}
+
+/// Utility to emit events through a shared event bus
+pub fn emit_event(event_bus: &SharedEventBus, event: ValidatorEvent) {
+    event_bus.emit(event);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_event_bus_basic_functionality() {
+        let event_bus = create_shared_event_bus();
+        let mut receiver = event_bus.subscribe();
+
+        // Test event emission and reception
+        let test_event = ValidatorEvent::ValidatorAdded {
+            cluster_id: ClusterId([1u8; 32]),
+            validator_pubkey: types::PublicKeyBytes::empty(),
+        };
+
+        emit_event(&event_bus, test_event.clone());
+
+        // Receive the event
+        let received_event = receiver.recv().await.expect("Should receive event");
+
+        // Verify the event matches
+        match (test_event, received_event) {
+            (
+                ValidatorEvent::ValidatorAdded {
+                    cluster_id: c1,
+                    validator_pubkey: v1,
+                },
+                ValidatorEvent::ValidatorAdded {
+                    cluster_id: c2,
+                    validator_pubkey: v2,
+                },
+            ) => {
+                assert_eq!(c1, c2);
+                assert_eq!(v1, v2);
+            }
+            _ => panic!("Event types don't match"),
+        }
+    }
+}

--- a/anchor/validator_store/src/events.rs
+++ b/anchor/validator_store/src/events.rs
@@ -1,81 +1,189 @@
 use std::sync::Arc;
 
-use ssv_types::ClusterId;
-use tracing::info;
-use types::PublicKeyBytes;
+use ssv_types::{Cluster, ClusterId, ValidatorMetadata};
+use tokio::sync::mpsc::{self, error::TrySendError};
+use tracing::{debug, warn};
+use types::{Address, PublicKeyBytes, SecretKey};
 
-/// Events that can occur in the validator lifecycle (minimal set for state sync fix)
-#[derive(Debug, Clone)]
+/// Default capacity for the validator event channel.
+///
+/// This is a blocking MPSC channel - when full, the event processor will block
+/// until the validator store processes events. This ensures no events are lost.
+///
+/// The capacity is chosen to handle reasonable bursts of validator lifecycle events:
+/// - Validator add/remove events are relatively infrequent in normal operation
+/// - During sync, events may arrive in larger batches from historical blocks
+/// - Each event contains full validator data (~1KB: Cluster + ValidatorMetadata + optional
+///   SecretKey)
+/// - Total memory usage: ~2MB for full buffer
+///
+/// If the validator store falls behind, the event processor will block, providing
+/// natural backpressure to prevent unbounded memory growth.
+const DEFAULT_EVENT_CHANNEL_CAPACITY: usize = 2048;
+
+/// Events that can occur in the validator lifecycle
+///
+/// Each event contains all the data needed by the validator store to update its state
+/// without requiring database access.
+#[derive(Clone)]
 pub enum ValidatorEvent {
     /// A validator has been added to the network
     ValidatorAdded {
-        cluster_id: ClusterId,
         validator_pubkey: PublicKeyBytes,
+        cluster: Box<Cluster>,
+        metadata: ValidatorMetadata,
+        decrypted_key_share: Option<SecretKey>,
     },
     /// A validator has been removed from the network  
     ValidatorRemoved {
-        cluster_id: ClusterId,
         validator_pubkey: PublicKeyBytes,
+        cluster_id: ClusterId,
     },
+    /// Fee recipient has been updated for one or more clusters
+    FeeRecipientUpdated {
+        cluster_ids: Vec<ClusterId>,
+        new_fee_recipient: Address,
+    },
+    /// A cluster has been liquidated
+    ClusterLiquidated { cluster_id: ClusterId },
+    /// A cluster has been reactivated
+    ClusterReactivated { cluster_id: ClusterId },
 }
 
-/// Minimal event bus for immediate state synchronization during batch processing
+impl std::fmt::Debug for ValidatorEvent {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ValidatorEvent::ValidatorAdded {
+                validator_pubkey,
+                cluster,
+                metadata,
+                decrypted_key_share,
+            } => f
+                .debug_struct("ValidatorAdded")
+                .field("validator_pubkey", validator_pubkey)
+                .field("cluster", cluster)
+                .field("metadata", metadata)
+                .field("has_key_share", &decrypted_key_share.is_some())
+                .finish(),
+            ValidatorEvent::ValidatorRemoved {
+                validator_pubkey,
+                cluster_id,
+            } => f
+                .debug_struct("ValidatorRemoved")
+                .field("validator_pubkey", validator_pubkey)
+                .field("cluster_id", cluster_id)
+                .finish(),
+            ValidatorEvent::FeeRecipientUpdated {
+                cluster_ids,
+                new_fee_recipient,
+            } => f
+                .debug_struct("FeeRecipientUpdated")
+                .field("cluster_ids", cluster_ids)
+                .field("new_fee_recipient", new_fee_recipient)
+                .finish(),
+            ValidatorEvent::ClusterLiquidated { cluster_id } => f
+                .debug_struct("ClusterLiquidated")
+                .field("cluster_id", cluster_id)
+                .finish(),
+            ValidatorEvent::ClusterReactivated { cluster_id } => f
+                .debug_struct("ClusterReactivated")
+                .field("cluster_id", cluster_id)
+                .finish(),
+        }
+    }
+}
+
+/// Event bus for reliable delivery of validator lifecycle events
 ///
-/// This addresses the specific issue where validator state changes during batch
-/// processing weren't immediately visible to other components, causing sync issues.
+/// This uses a blocking MPSC channel to ensure no events are ever lost.
+/// When the channel is full, the event processor will block until the
+/// validator store processes more events.
 #[derive(Debug)]
 pub struct EventBus {
-    /// Broadcast sender for distributing events
-    sender: tokio::sync::broadcast::Sender<ValidatorEvent>,
+    /// Sender for distributing events
+    sender: mpsc::Sender<ValidatorEvent>,
 }
 
 impl EventBus {
-    /// Create a new event bus
-    pub fn new() -> Self {
-        let (sender, _) = tokio::sync::broadcast::channel(1024);
-        Self { sender }
+    /// Create a new event bus with default capacity
+    pub fn new() -> (Self, mpsc::Receiver<ValidatorEvent>) {
+        Self::with_capacity(DEFAULT_EVENT_CHANNEL_CAPACITY)
     }
 
-    /// Subscribe to validator events
-    pub fn subscribe(&self) -> tokio::sync::broadcast::Receiver<ValidatorEvent> {
-        self.sender.subscribe()
+    /// Create a new event bus with custom capacity
+    ///
+    /// # Arguments
+    /// * `capacity` - Maximum number of events to buffer before blocking the sender
+    ///
+    /// # Returns
+    /// A tuple of (EventBus, Receiver) where the receiver should be used
+    /// by the validator store to process events
+    pub fn with_capacity(capacity: usize) -> (Self, mpsc::Receiver<ValidatorEvent>) {
+        let (sender, receiver) = mpsc::channel(capacity);
+        (Self { sender }, receiver)
     }
 
-    /// Emit an event to all subscribers
-    pub fn emit(&self, event: ValidatorEvent) {
-        match self.sender.send(event) {
-            Ok(subscriber_count) => {
-                if subscriber_count > 0 {
-                    info!(
-                        subscribers = subscriber_count,
-                        "Event delivered to subscribers"
-                    );
-                }
+    /// Emit an event - will block if channel is full
+    ///
+    /// This ensures no events are ever lost, which is critical for maintaining
+    /// validator store consistency.
+    pub async fn emit(&self, event: ValidatorEvent) {
+        match self.sender.send(event).await {
+            Ok(()) => {
+                // Event successfully sent
+                debug!("Validator event emitted successfully");
             }
             Err(_) => {
-                // No subscribers - this is fine during startup
+                // Receiver was dropped - this is only expected during shutdown
+                warn!("Failed to send validator event: receiver dropped");
             }
         }
+    }
+
+    /// Try to emit an event without blocking
+    ///
+    /// Returns an error if the channel is full. Use this only when you can
+    /// handle the error appropriately or retry.
+    pub fn try_emit(&self, event: ValidatorEvent) -> Result<(), TrySendError<()>> {
+        self.sender.try_send(event).map_err(|e| match e {
+            TrySendError::Full(_) => TrySendError::Full(()),
+            TrySendError::Closed(_) => TrySendError::Closed(()),
+        })
     }
 }
 
 impl Default for EventBus {
     fn default() -> Self {
-        Self::new()
+        Self::new().0
     }
 }
 
 /// A thread-safe event bus that can be shared across components
 pub type SharedEventBus = Arc<EventBus>;
 
-/// Helper to create a shared event bus
-pub fn create_shared_event_bus() -> SharedEventBus {
-    Arc::new(EventBus::new())
+/// Helper to create a shared event bus and receiver
+///
+/// # Returns
+/// A tuple of (SharedEventBus, Receiver) where the receiver should be used
+/// by the validator store to process events
+pub fn create_shared_event_bus() -> (SharedEventBus, mpsc::Receiver<ValidatorEvent>) {
+    let (event_bus, receiver) = EventBus::new();
+    (Arc::new(event_bus), receiver)
 }
 
-/// Utility to emit events through a shared event bus
-pub fn emit_event(event_bus: &SharedEventBus, event: ValidatorEvent) {
-    event_bus.emit(event);
+/// Utility to emit events through a shared event bus (async version)
+pub async fn emit_event(event_bus: &SharedEventBus, event: ValidatorEvent) {
+    event_bus.emit(event).await;
+}
+
+/// Utility to emit events through a shared event bus (non-blocking version)
+///
+/// Use this only when you can handle the TrySendError appropriately.
+pub fn try_emit_event(
+    event_bus: &SharedEventBus,
+    event: ValidatorEvent,
+) -> Result<(), TrySendError<()>> {
+    event_bus.try_emit(event)
 }
 
 #[cfg(test)]
@@ -84,16 +192,28 @@ mod tests {
 
     #[tokio::test]
     async fn test_event_bus_basic_functionality() {
-        let event_bus = create_shared_event_bus();
-        let mut receiver = event_bus.subscribe();
+        let (event_bus, mut receiver) = create_shared_event_bus();
 
         // Test event emission and reception
         let test_event = ValidatorEvent::ValidatorAdded {
-            cluster_id: ClusterId([1u8; 32]),
-            validator_pubkey: types::PublicKeyBytes::empty(),
+            validator_pubkey: PublicKeyBytes::empty(),
+            cluster: Box::new(Cluster {
+                cluster_id: ClusterId([1u8; 32]),
+                owner: Default::default(),
+                fee_recipient: Default::default(),
+                liquidated: false,
+                cluster_members: Default::default(),
+            }),
+            metadata: ValidatorMetadata {
+                public_key: PublicKeyBytes::empty(),
+                cluster_id: ClusterId([1u8; 32]),
+                index: None,
+                graffiti: Default::default(),
+            },
+            decrypted_key_share: None,
         };
 
-        emit_event(&event_bus, test_event.clone());
+        emit_event(&event_bus, test_event.clone()).await;
 
         // Receive the event
         let received_event = receiver.recv().await.expect("Should receive event");
@@ -102,18 +222,86 @@ mod tests {
         match (test_event, received_event) {
             (
                 ValidatorEvent::ValidatorAdded {
-                    cluster_id: c1,
                     validator_pubkey: v1,
+                    cluster: c1,
+                    metadata: m1,
+                    ..
                 },
                 ValidatorEvent::ValidatorAdded {
-                    cluster_id: c2,
                     validator_pubkey: v2,
+                    cluster: c2,
+                    metadata: m2,
+                    ..
                 },
             ) => {
-                assert_eq!(c1, c2);
                 assert_eq!(v1, v2);
+                assert_eq!(c1.cluster_id, c2.cluster_id);
+                assert_eq!(m1.public_key, m2.public_key);
             }
             _ => panic!("Event types don't match"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_blocking_behavior() {
+        // Create a very small capacity bus to test blocking
+        let (sender, receiver) = EventBus::with_capacity(1);
+        let sender = Arc::new(sender);
+
+        // Fill the channel
+        sender
+            .try_emit(ValidatorEvent::ValidatorRemoved {
+                validator_pubkey: PublicKeyBytes::empty(),
+                cluster_id: ClusterId([1u8; 32]),
+            })
+            .expect("First send should succeed");
+
+        // Second send should fail with try_emit
+        assert!(
+            sender
+                .try_emit(ValidatorEvent::ValidatorRemoved {
+                    validator_pubkey: PublicKeyBytes::empty(),
+                    cluster_id: ClusterId([2u8; 32]),
+                })
+                .is_err()
+        );
+
+        // Clean up
+        drop(receiver);
+    }
+
+    #[tokio::test]
+    async fn test_fee_recipient_updated_with_multiple_clusters() {
+        let (event_bus, mut receiver) = create_shared_event_bus();
+
+        // Test fee recipient update with multiple cluster IDs
+        let cluster_ids = vec![
+            ClusterId([1u8; 32]),
+            ClusterId([2u8; 32]),
+            ClusterId([3u8; 32]),
+        ];
+        let new_fee_recipient = Address::from([0x42u8; 20]);
+
+        let test_event = ValidatorEvent::FeeRecipientUpdated {
+            cluster_ids: cluster_ids.clone(),
+            new_fee_recipient,
+        };
+
+        emit_event(&event_bus, test_event.clone()).await;
+
+        // Receive the event
+        let received_event = receiver.recv().await.expect("Should receive event");
+
+        // Verify the event matches
+        match received_event {
+            ValidatorEvent::FeeRecipientUpdated {
+                cluster_ids: received_cluster_ids,
+                new_fee_recipient: received_fee_recipient,
+            } => {
+                assert_eq!(cluster_ids, received_cluster_ids);
+                assert_eq!(new_fee_recipient, received_fee_recipient);
+            }
+            _ => panic!("Expected FeeRecipientUpdated event"),
         }
     }
 }

--- a/anchor/validator_store/src/events.rs
+++ b/anchor/validator_store/src/events.rs
@@ -30,7 +30,7 @@ pub enum ValidatorEvent {
     /// A validator has been added to the network
     ValidatorAdded {
         validator_pubkey: PublicKeyBytes,
-        cluster: Box<Cluster>,
+        cluster: Arc<Cluster>,
         metadata: ValidatorMetadata,
         decrypted_key_share: Option<SecretKey>,
     },
@@ -197,7 +197,7 @@ mod tests {
         // Test event emission and reception
         let test_event = ValidatorEvent::ValidatorAdded {
             validator_pubkey: PublicKeyBytes::empty(),
-            cluster: Box::new(Cluster {
+            cluster: Arc::new(Cluster {
                 cluster_id: ClusterId([1u8; 32]),
                 owner: Default::default(),
                 fee_recipient: Default::default(),

--- a/anchor/validator_store/src/lib.rs
+++ b/anchor/validator_store/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod events;
 pub mod metadata_service;
 mod metrics;
 
@@ -30,7 +31,7 @@ use signature_collector::{
 use slashing_protection::{NotSafe, Safe, SlashingDatabase};
 use slot_clock::SlotClock;
 use ssv_types::{
-    Cluster, CommitteeId, ValidatorIndex, ValidatorMetadata,
+    Cluster, ClusterId, CommitteeId, ValidatorIndex, ValidatorMetadata,
     consensus::{
         BEACON_ROLE_AGGREGATOR, BEACON_ROLE_PROPOSER, BEACON_ROLE_SYNC_COMMITTEE_CONTRIBUTION,
         BeaconVote, Contribution, ContributionWrapper, Contributions, QbftData,
@@ -72,6 +73,8 @@ use validator_store::{
     DoppelgangerStatus, Error as ValidatorStoreError, ProposalData, SignedBlock, UnsignedBlock,
     ValidatorStore,
 };
+
+use crate::events::{SharedEventBus, ValidatorEvent};
 
 /// Number of epochs of slashing protection history to keep.
 ///
@@ -115,6 +118,8 @@ pub struct AnchorValidatorStore<T: SlotClock + 'static, E: EthSpec> {
     builder_boost_factor: Option<u64>,
     prefer_builder_proposals: bool,
     is_synced: watch::Receiver<bool>,
+    /// Event bus for real-time state synchronization during batch processing
+    event_bus: SharedEventBus,
 }
 
 impl<T: SlotClock, E: EthSpec> AnchorValidatorStore<T, E> {
@@ -135,6 +140,7 @@ impl<T: SlotClock, E: EthSpec> AnchorValidatorStore<T, E> {
         builder_boost_factor: Option<u64>,
         prefer_builder_proposals: bool,
         is_synced: watch::Receiver<bool>,
+        event_bus: SharedEventBus,
     ) -> Arc<AnchorValidatorStore<T, E>> {
         let ret = Arc::new(Self {
             validators: DashMap::new(),
@@ -154,28 +160,98 @@ impl<T: SlotClock, E: EthSpec> AnchorValidatorStore<T, E> {
             builder_boost_factor,
             prefer_builder_proposals,
             is_synced,
+            event_bus,
         });
 
+        let event_receiver = ret.event_bus.subscribe();
         task_executor.spawn(
-            Arc::clone(&ret).updater(database_state),
-            "validator_store_updater",
+            Arc::clone(&ret).event_updater(event_receiver, database_state),
+            "validator_store_event_updater",
         );
 
         ret
     }
 
-    async fn updater(self: Arc<Self>, mut database_state: watch::Receiver<NetworkState>) {
-        while database_state.changed().await.is_ok() {
-            self.load_validators(&database_state.borrow());
+    // Event-driven updater that responds to validator lifecycle events
+    async fn event_updater(
+        self: Arc<Self>,
+        mut event_receiver: tokio::sync::broadcast::Receiver<ValidatorEvent>,
+        database_state: watch::Receiver<NetworkState>,
+    ) {
+        // Load initial state from database
+        self.load_validators(&database_state.borrow());
+
+        // Then listen for real-time events
+        while let Ok(event) = event_receiver.recv().await {
+            match event {
+                ValidatorEvent::ValidatorAdded {
+                    validator_pubkey,
+                    cluster_id,
+                } => {
+                    // Only add the specific validator that was added
+                    self.handle_validator_added(
+                        validator_pubkey,
+                        cluster_id,
+                        &database_state.borrow(),
+                    );
+                }
+                ValidatorEvent::ValidatorRemoved {
+                    validator_pubkey,
+                    cluster_id: _,
+                } => {
+                    self.remove_validator(&validator_pubkey);
+                    info!(%validator_pubkey, "Validator removed via event");
+                    let count = self.validators.len() as i64;
+                    validator_metrics::set_gauge(
+                        &validator_metrics::ENABLED_VALIDATORS_COUNT,
+                        count,
+                    );
+                    validator_metrics::set_gauge(&validator_metrics::TOTAL_VALIDATORS_COUNT, count);
+                }
+            }
+        }
+    }
+
+    // Handle a specific validator being added
+    fn handle_validator_added(
+        &self,
+        validator_pubkey: PublicKeyBytes,
+        cluster_id: ClusterId,
+        state: &NetworkState,
+    ) {
+        // Find the specific cluster and validator
+        let Some(cluster) = state.clusters().get_by(&cluster_id) else {
+            warn!(%validator_pubkey, ?cluster_id, "Cluster not found for added validator");
+            return;
+        };
+
+        let Some(validator) = state.metadata().get_by(&validator_pubkey) else {
+            warn!(%validator_pubkey, "Validator metadata not found for added validator");
+            return;
+        };
+
+        // Only add if this is our cluster and the cluster is not liquidated
+        if state.get_own_clusters().contains(&cluster_id) && !cluster.liquidated {
+            if let Ok(secret_key) = self.get_share_from_state(state, validator, validator_pubkey) {
+                let result =
+                    self.add_validator(validator_pubkey, cluster, validator.clone(), secret_key);
+                if let Err(err) = result {
+                    error!(?err, %validator_pubkey, "Unable to initialize added validator");
+                } else {
+                    info!(%validator_pubkey, "Validator added via event");
+                    let count = self.validators.len() as i64;
+                    validator_metrics::set_gauge(
+                        &validator_metrics::ENABLED_VALIDATORS_COUNT,
+                        count,
+                    );
+                    validator_metrics::set_gauge(&validator_metrics::TOTAL_VALIDATORS_COUNT, count);
+                }
+            }
         }
     }
 
     fn load_validators(&self, state: &NetworkState) {
-        let mut unseen_validators = self
-            .validators
-            .iter()
-            .map(|v| *v.key())
-            .collect::<HashSet<_>>();
+        // Load all validators that belong to our clusters
         let db_clusters = state.get_own_clusters().iter().collect::<Vec<_>>();
 
         for (cluster, validator) in db_clusters
@@ -189,36 +265,19 @@ impl<T: SlotClock, E: EthSpec> AnchorValidatorStore<T, E> {
                     .map(move |metadata| (cluster, metadata))
             })
         {
-            if unseen_validators.remove(&validator.public_key) {
-                // Validator was present: check if the cluster has changed
-                if let Some(mut entry) = self.validators.get_mut(&validator.public_key) {
-                    let current_cluster = &mut entry.value_mut().cluster;
-                    if current_cluster.cluster_id != cluster.cluster_id {
-                        // Update the validator with the new cluster
-                        *current_cluster = cluster.clone();
-                    }
-                }
-            } else {
-                // value was not present: add to store
-                if let Ok(secret_key) =
-                    self.get_share_from_state(state, validator, validator.public_key)
-                {
-                    let result = self.add_validator(
-                        validator.public_key,
-                        cluster,
-                        validator.clone(),
-                        secret_key,
-                    );
-                    if let Err(err) = result {
-                        error!(?err, "Unable to initialize validator");
-                    }
+            if let Ok(secret_key) =
+                self.get_share_from_state(state, validator, validator.public_key)
+            {
+                let result = self.add_validator(
+                    validator.public_key,
+                    cluster,
+                    validator.clone(),
+                    secret_key,
+                );
+                if let Err(err) = result {
+                    error!(?err, "Unable to initialize validator");
                 }
             }
-        }
-
-        for validator in unseen_validators {
-            self.remove_validator(&validator);
-            info!(%validator, "Validator disabled");
         }
 
         let count = self.validators.len() as i64;

--- a/anchor/validator_store/src/lib.rs
+++ b/anchor/validator_store/src/lib.rs
@@ -6,7 +6,6 @@ use std::{
     collections::{HashMap, HashSet},
     fmt::Debug,
     future::Future,
-    str::from_utf8,
     sync::{Arc, LazyLock},
     time::Duration,
 };
@@ -14,10 +13,7 @@ use std::{
 use dashmap::DashMap;
 use database::{NetworkState, NonUniqueIndex, UniqueIndex};
 use eth2::types::{BlockContents, FullBlockContents, PublishBlockRequest};
-use openssl::{
-    pkey::Private,
-    rsa::{Padding, Rsa},
-};
+use openssl::{pkey::Private, rsa::Rsa};
 use parking_lot::Mutex;
 use qbft::Completed;
 use qbft_manager::{
@@ -44,7 +40,7 @@ use ssz::{Decode, DecodeError, Encode};
 use task_executor::TaskExecutor;
 use tokio::{
     select,
-    sync::{Barrier, RwLock, watch},
+    sync::{Barrier, RwLock, mpsc, watch},
     time::{Instant, sleep},
 };
 use tracing::{debug, error, info, warn};
@@ -74,7 +70,7 @@ use validator_store::{
     ValidatorStore,
 };
 
-use crate::events::{SharedEventBus, ValidatorEvent};
+use crate::events::ValidatorEvent;
 
 /// Number of epochs of slashing protection history to keep.
 ///
@@ -92,10 +88,10 @@ const SYNC_COMMITTEE_SIGNATURE_LOG_NAME: &str = "sync committee signature";
 const SYNC_COMMITTEE_CONTRIBUTION_LOG_NAME: &str = "sync committee contribution";
 
 #[derive(Clone)]
-struct InitializedValidator {
-    cluster: Cluster,
-    metadata: ValidatorMetadata,
-    decrypted_key_share: Option<SecretKey>,
+pub struct InitializedValidator {
+    pub cluster: Cluster,
+    pub metadata: ValidatorMetadata,
+    pub decrypted_key_share: Option<SecretKey>,
 }
 
 pub struct AnchorValidatorStore<T: SlotClock + 'static, E: EthSpec> {
@@ -109,7 +105,6 @@ pub struct AnchorValidatorStore<T: SlotClock + 'static, E: EthSpec> {
     slot_clock: T,
     spec: Arc<ChainSpec>,
     genesis_validators_root: Hash256,
-    private_key: Option<Rsa<Private>>,
     slot_metadata: watch::Sender<Option<Arc<SlotMetadata<E>>>>,
     gas_limit: u64,
     // MEV configuration is applied at the operator level and applies to all validators this
@@ -118,14 +113,12 @@ pub struct AnchorValidatorStore<T: SlotClock + 'static, E: EthSpec> {
     builder_boost_factor: Option<u64>,
     prefer_builder_proposals: bool,
     is_synced: watch::Receiver<bool>,
-    /// Event bus for real-time state synchronization during batch processing
-    event_bus: SharedEventBus,
 }
 
 impl<T: SlotClock, E: EthSpec> AnchorValidatorStore<T, E> {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
-        database_state: watch::Receiver<NetworkState>,
+        initial_validators: Vec<InitializedValidator>,
         signature_collector: Arc<SignatureCollectorManager>,
         qbft_manager: Arc<QbftManager>,
         slashing_protection: SlashingDatabase,
@@ -133,14 +126,13 @@ impl<T: SlotClock, E: EthSpec> AnchorValidatorStore<T, E> {
         slot_clock: T,
         spec: Arc<ChainSpec>,
         genesis_validators_root: Hash256,
-        private_key: Option<Rsa<Private>>,
         task_executor: TaskExecutor,
         gas_limit: u64,
         builder_proposals: bool,
         builder_boost_factor: Option<u64>,
         prefer_builder_proposals: bool,
         is_synced: watch::Receiver<bool>,
-        event_bus: SharedEventBus,
+        event_receiver: mpsc::Receiver<ValidatorEvent>,
     ) -> Arc<AnchorValidatorStore<T, E>> {
         let ret = Arc::new(Self {
             validators: DashMap::new(),
@@ -153,19 +145,20 @@ impl<T: SlotClock, E: EthSpec> AnchorValidatorStore<T, E> {
             slot_clock,
             spec,
             genesis_validators_root,
-            private_key,
             slot_metadata: watch::channel(None).0,
             gas_limit,
             builder_proposals,
             builder_boost_factor,
             prefer_builder_proposals,
             is_synced,
-            event_bus,
         });
 
-        let event_receiver = ret.event_bus.subscribe();
+        // Load initial validators
+        ret.load_initial_validators(initial_validators);
+
+        // Start event processor
         task_executor.spawn(
-            Arc::clone(&ret).event_updater(event_receiver, database_state),
+            Arc::clone(&ret).event_updater(event_receiver),
             "validator_store_event_updater",
         );
 
@@ -173,27 +166,36 @@ impl<T: SlotClock, E: EthSpec> AnchorValidatorStore<T, E> {
     }
 
     // Event-driven updater that responds to validator lifecycle events
-    async fn event_updater(
-        self: Arc<Self>,
-        mut event_receiver: tokio::sync::broadcast::Receiver<ValidatorEvent>,
-        database_state: watch::Receiver<NetworkState>,
-    ) {
-        // Load initial state from database
-        self.load_validators(&database_state.borrow());
-
-        // Then listen for real-time events
-        while let Ok(event) = event_receiver.recv().await {
+    async fn event_updater(self: Arc<Self>, mut event_receiver: mpsc::Receiver<ValidatorEvent>) {
+        // Process events from the event processor
+        while let Some(event) = event_receiver.recv().await {
             match event {
                 ValidatorEvent::ValidatorAdded {
                     validator_pubkey,
-                    cluster_id,
+                    cluster,
+                    metadata,
+                    decrypted_key_share,
                 } => {
-                    // Only add the specific validator that was added
-                    self.handle_validator_added(
+                    let result = self.add_validator(
                         validator_pubkey,
-                        cluster_id,
-                        &database_state.borrow(),
+                        &cluster,
+                        metadata,
+                        decrypted_key_share,
                     );
+                    if let Err(err) = result {
+                        error!(?err, %validator_pubkey, "Unable to add validator from event");
+                    } else {
+                        info!(%validator_pubkey, "Validator added via event");
+                        let count = self.validators.len() as i64;
+                        validator_metrics::set_gauge(
+                            &validator_metrics::ENABLED_VALIDATORS_COUNT,
+                            count,
+                        );
+                        validator_metrics::set_gauge(
+                            &validator_metrics::TOTAL_VALIDATORS_COUNT,
+                            count,
+                        );
+                    }
                 }
                 ValidatorEvent::ValidatorRemoved {
                     validator_pubkey,
@@ -208,130 +210,25 @@ impl<T: SlotClock, E: EthSpec> AnchorValidatorStore<T, E> {
                     );
                     validator_metrics::set_gauge(&validator_metrics::TOTAL_VALIDATORS_COUNT, count);
                 }
-            }
-        }
-    }
-
-    // Handle a specific validator being added
-    fn handle_validator_added(
-        &self,
-        validator_pubkey: PublicKeyBytes,
-        cluster_id: ClusterId,
-        state: &NetworkState,
-    ) {
-        // Find the specific cluster and validator
-        let Some(cluster) = state.clusters().get_by(&cluster_id) else {
-            warn!(%validator_pubkey, ?cluster_id, "Cluster not found for added validator");
-            return;
-        };
-
-        let Some(validator) = state.metadata().get_by(&validator_pubkey) else {
-            warn!(%validator_pubkey, "Validator metadata not found for added validator");
-            return;
-        };
-
-        // Only add if this is our cluster and the cluster is not liquidated
-        if state.get_own_clusters().contains(&cluster_id) && !cluster.liquidated {
-            if let Ok(secret_key) = self.get_share_from_state(state, validator, validator_pubkey) {
-                let result =
-                    self.add_validator(validator_pubkey, cluster, validator.clone(), secret_key);
-                if let Err(err) = result {
-                    error!(?err, %validator_pubkey, "Unable to initialize added validator");
-                } else {
-                    info!(%validator_pubkey, "Validator added via event");
-                    let count = self.validators.len() as i64;
-                    validator_metrics::set_gauge(
-                        &validator_metrics::ENABLED_VALIDATORS_COUNT,
-                        count,
-                    );
-                    validator_metrics::set_gauge(&validator_metrics::TOTAL_VALIDATORS_COUNT, count);
+                ValidatorEvent::FeeRecipientUpdated {
+                    cluster_ids,
+                    new_fee_recipient,
+                } => {
+                    for cluster_id in &cluster_ids {
+                        self.update_fee_recipient(cluster_id, new_fee_recipient);
+                    }
+                    info!(?cluster_ids, %new_fee_recipient, "Fee recipient updated via event for {} clusters", cluster_ids.len());
+                }
+                ValidatorEvent::ClusterLiquidated { cluster_id } => {
+                    self.handle_cluster_liquidated(&cluster_id);
+                    info!(?cluster_id, "Cluster liquidated via event");
+                }
+                ValidatorEvent::ClusterReactivated { cluster_id } => {
+                    self.handle_cluster_reactivated(&cluster_id);
+                    info!(?cluster_id, "Cluster reactivated via event");
                 }
             }
         }
-    }
-
-    fn load_validators(&self, state: &NetworkState) {
-        // Load all validators that belong to our clusters
-        let db_clusters = state.get_own_clusters().iter().collect::<Vec<_>>();
-
-        for (cluster, validator) in db_clusters
-            .into_iter()
-            .filter_map(|id| state.clusters().get_by(id))
-            .filter(|cluster| !cluster.liquidated)
-            .flat_map(|cluster| {
-                state
-                    .metadata()
-                    .get_all_by(&cluster.cluster_id)
-                    .map(move |metadata| (cluster, metadata))
-            })
-        {
-            if let Ok(secret_key) =
-                self.get_share_from_state(state, validator, validator.public_key)
-            {
-                let result = self.add_validator(
-                    validator.public_key,
-                    cluster,
-                    validator.clone(),
-                    secret_key,
-                );
-                if let Err(err) = result {
-                    error!(?err, "Unable to initialize validator");
-                }
-            }
-        }
-
-        let count = self.validators.len() as i64;
-        validator_metrics::set_gauge(&validator_metrics::ENABLED_VALIDATORS_COUNT, count);
-        validator_metrics::set_gauge(&validator_metrics::TOTAL_VALIDATORS_COUNT, count);
-    }
-
-    fn get_share_from_state(
-        &self,
-        state: &NetworkState,
-        validator: &ValidatorMetadata,
-        pubkey_bytes: PublicKeyBytes,
-    ) -> Result<Option<SecretKey>, ()> {
-        // If we have no private key, we are running in impostor mode - so we can not decrypt the
-        // share. Return `None` to let the signature collector mock the signing.
-        let Some(private_key) = &self.private_key else {
-            return Ok(None);
-        };
-
-        let share = state
-            .shares()
-            .get_by(&validator.public_key)
-            .ok_or_else(|| warn!(validator = %pubkey_bytes, "Key share not found"))?;
-
-        // the buffer size must be larger than or equal the modulus size
-        let mut key_hex = [0; 2048 / 8];
-        let length = private_key
-            .private_decrypt(&share.encrypted_private_key, &mut key_hex, Padding::PKCS1)
-            .map_err(|e| error!(?e, validator = %pubkey_bytes, "Share decryption failed"))?;
-
-        let key_hex = from_utf8(&key_hex[..length]).map_err(|err| {
-            error!(
-                ?err,
-                validator = %pubkey_bytes,
-                "Share decryption yielded non-utf8 data"
-            )
-        })?;
-
-        let mut secret_key = [0; 32];
-        hex::decode_to_slice(
-            key_hex.strip_prefix("0x").unwrap_or(key_hex),
-            &mut secret_key,
-        )
-        .map_err(|err| {
-            error!(
-                ?err,
-                validator = %pubkey_bytes,
-                "Decrypted share is not a hex string of size 64"
-            )
-        })?;
-
-        SecretKey::deserialize(&secret_key)
-            .map(Some)
-            .map_err(|err| error!(?err, validator = %pubkey_bytes, "Invalid secret key decrypted"))
     }
 
     fn add_validator(
@@ -694,6 +591,74 @@ impl<T: SlotClock, E: EthSpec> AnchorValidatorStore<T, E> {
 
         Ok(signed_exit)
     }
+
+    // Load initial validators at startup
+    fn load_initial_validators(&self, validators: Vec<InitializedValidator>) {
+        for validator in validators {
+            let pubkey = validator.metadata.public_key;
+            let result = self.add_validator(
+                pubkey,
+                &validator.cluster,
+                validator.metadata,
+                validator.decrypted_key_share,
+            );
+            if let Err(err) = result {
+                error!(?err, %pubkey, "Unable to initialize validator");
+            }
+        }
+
+        let count = self.validators.len() as i64;
+        validator_metrics::set_gauge(&validator_metrics::ENABLED_VALIDATORS_COUNT, count);
+        validator_metrics::set_gauge(&validator_metrics::TOTAL_VALIDATORS_COUNT, count);
+        info!(count, "Loaded initial validators");
+    }
+
+    // Update fee recipient for all validators in a cluster
+    fn update_fee_recipient(&self, cluster_id: &ClusterId, new_fee_recipient: types::Address) {
+        let mut updated_count = 0;
+        for mut entry in self.validators.iter_mut() {
+            if entry.cluster.cluster_id == *cluster_id {
+                entry.cluster.fee_recipient = new_fee_recipient;
+                updated_count += 1;
+            }
+        }
+        debug!(
+            ?cluster_id,
+            %new_fee_recipient,
+            updated_count,
+            "Updated fee recipient for cluster validators"
+        );
+    }
+
+    // Handle cluster liquidation
+    fn handle_cluster_liquidated(&self, cluster_id: &ClusterId) {
+        let mut updated_count = 0;
+        for mut entry in self.validators.iter_mut() {
+            if entry.cluster.cluster_id == *cluster_id {
+                entry.cluster.liquidated = true;
+                updated_count += 1;
+            }
+        }
+        debug!(
+            ?cluster_id,
+            updated_count, "Marked cluster validators as liquidated"
+        );
+    }
+
+    // Handle cluster reactivation
+    fn handle_cluster_reactivated(&self, cluster_id: &ClusterId) {
+        let mut updated_count = 0;
+        for mut entry in self.validators.iter_mut() {
+            if entry.cluster.cluster_id == *cluster_id {
+                entry.cluster.liquidated = false;
+                updated_count += 1;
+            }
+        }
+        debug!(
+            ?cluster_id,
+            updated_count, "Marked cluster validators as reactivated"
+        );
+    }
 }
 
 /// # Arguments
@@ -799,6 +764,7 @@ pub enum SpecificError {
     MissingIndex,
     SlotClock,
     NotSynced,
+    KeyShareOperation,
 }
 
 impl From<CollectionError> for SpecificError {
@@ -1601,6 +1567,104 @@ impl<T: SlotClock, E: EthSpec> ValidatorStore for AnchorValidatorStore<T, E> {
             builder_proposals: self.builder_proposals,
         })
     }
+}
+
+/// Extract initial validators from database state for validator store initialization
+pub fn extract_initial_validators(
+    state: &NetworkState,
+    private_key: Option<&Rsa<Private>>,
+) -> Vec<InitializedValidator> {
+    let db_clusters = state.get_own_clusters().iter().collect::<Vec<_>>();
+
+    db_clusters
+        .into_iter()
+        .filter_map(|id| state.clusters().get_by(id))
+        .filter(|cluster| !cluster.liquidated)
+        .flat_map(|cluster| {
+            state
+                .metadata()
+                .get_all_by(&cluster.cluster_id)
+                .map(move |metadata| (cluster, metadata))
+        })
+        .filter_map(|(cluster, validator)| {
+            let decrypted_key_share = match get_share_from_state(state, validator, private_key) {
+                Ok(share) => share,
+                Err(_) => {
+                    warn!(validator = %validator.public_key, "Failed to decrypt key share");
+                    return None;
+                }
+            };
+
+            Some(InitializedValidator {
+                cluster: cluster.clone(),
+                metadata: validator.clone(),
+                decrypted_key_share,
+            })
+        })
+        .collect()
+}
+
+/// Helper function to decrypt validator key share from database state
+pub fn get_share_from_state(
+    state: &NetworkState,
+    validator: &ValidatorMetadata,
+    private_key: Option<&Rsa<Private>>,
+) -> Result<Option<SecretKey>, SpecificError> {
+    // If we have no private key, we are running in impostor mode
+    let Some(private_key) = private_key else {
+        return Ok(None);
+    };
+
+    let share = state
+        .shares()
+        .get_by(&validator.public_key)
+        .ok_or_else(|| {
+            warn!(validator = %validator.public_key, "Key share not found");
+            SpecificError::KeyShareOperation
+        })?;
+
+    // the buffer size must be larger than or equal the modulus size
+    let mut key_hex = [0; 2048 / 8];
+    let length = private_key
+        .private_decrypt(
+            &share.encrypted_private_key,
+            &mut key_hex,
+            openssl::rsa::Padding::PKCS1,
+        )
+        .map_err(|e| {
+            error!(?e, validator = %validator.public_key, "Share decryption failed");
+            SpecificError::KeyShareOperation
+        })?;
+
+    let key_hex = std::str::from_utf8(&key_hex[..length]).map_err(|err| {
+        error!(
+            ?err,
+            validator = %validator.public_key,
+            "Share decryption yielded non-utf8 data"
+        );
+        SpecificError::KeyShareOperation
+    })?;
+
+    let mut secret_key = [0; 32];
+    hex::decode_to_slice(
+        key_hex.strip_prefix("0x").unwrap_or(key_hex),
+        &mut secret_key,
+    )
+    .map_err(|err| {
+        error!(
+            ?err,
+            validator = %validator.public_key,
+            "Decrypted share is not a hex string of size 64"
+        );
+        SpecificError::KeyShareOperation
+    })?;
+
+    SecretKey::deserialize(&secret_key)
+        .map(Some)
+        .map_err(|err| {
+            error!(?err, validator = %validator.public_key, "Invalid secret key decrypted");
+            SpecificError::KeyShareOperation
+        })
 }
 
 trait SignableBlock<E: EthSpec>: Debug + Encode {


### PR DESCRIPTION
## Issue Addressed

This fixes the bug where validator state changes during batch processing were not immediately visible to the validator store, as the DB watcher only saw the final state after all transactions completed.

## Proposed Changes

- Add minimal event bus with ValidatorAdded/ValidatorRemoved events
- Update event processor to emit events after successful DB commits
- Refactor validator store to use event bus instead of DB watcher
- Implement incremental event handling for better performance
- Wire up event bus through client and syncer components

## Additional Info

Please provide any additional information. For example, future considerations
or information useful for reviewers.
