### PR TITLE
ci: Fix rust version in docker workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -14,7 +14,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-    RUST_VERSION: '1.87.0'
+    RUST_VERSION: '1.88.0'
     # Deny warnings in CI
     RUSTFLAGS: "-D warnings -C debuginfo=0"
     # Prevent Github API rate limiting


### PR DESCRIPTION
## Issue Addressed

During #435 I forgot to update the Rust version to `1.88.0` in one location. This causes the "on push to unstable" CI to fail.

## Proposed Changes

update the Rust version to `1.88.0` in the docker workflow