### PR TITLE
refactor: Remove pre-genesis polling

### DIFF
--- a/anchor/client/src/lib.rs
+++ b/anchor/client/src/lib.rs
@@ -42,8 +42,9 @@ use subnet_service::{SUBNET_COUNT, SubnetId, start_subnet_service};
 use task_executor::TaskExecutor;
 use tokio::{
     net::TcpListener,
+    select,
     sync::{mpsc, mpsc::unbounded_channel},
-    time::sleep,
+    time::{interval, sleep},
 };
 use tracing::{debug, error, info, warn};
 use types::{EthSpec, Hash256};
@@ -764,7 +765,19 @@ async fn wait_for_genesis(genesis_time: u64) -> Result<(), String> {
             "Starting node prior to genesis",
         );
 
-        sleep(genesis_time - now).await;
+        let genesis_sleep = sleep(genesis_time - now);
+        tokio::pin!(genesis_sleep);
+        let mut log_interval = interval(Duration::from_secs(30));
+
+        loop {
+            select! {
+                _ = &mut genesis_sleep => break,
+                _ = log_interval.tick() => info!(
+                    seconds_to_wait = (genesis_time - now).as_secs(),
+                    "Waiting for genesis",
+                ),
+            }
+        }
 
         info!("Genesis has occurred");
     } else {

--- a/anchor/client/src/lib.rs
+++ b/anchor/client/src/lib.rs
@@ -761,14 +761,13 @@ async fn wait_for_genesis(genesis_time: u64) -> Result<(), String> {
     //
     // If the validator client starts before genesis, it will get errors from
     // the slot clock.
-    let now = get_now()?;
-    if now < genesis_time {
+    if get_now()? < genesis_time {
         info!(
-            seconds_to_wait = (genesis_time - now).as_secs(),
+            seconds_to_wait = (genesis_time - get_now()?).as_secs(),
             "Starting node prior to genesis",
         );
 
-        let genesis_sleep = sleep(genesis_time - now);
+        let genesis_sleep = sleep(genesis_time - get_now()?);
         tokio::pin!(genesis_sleep);
         let mut log_interval = interval(Duration::from_secs(30));
 

--- a/anchor/client/src/lib.rs
+++ b/anchor/client/src/lib.rs
@@ -749,9 +749,11 @@ async fn init_from_beacon_node<E: EthSpec>(
 }
 
 async fn wait_for_genesis(genesis_time: u64) -> Result<(), String> {
-    let now = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map_err(|e| format!("Unable to read system time: {e:?}"))?;
+    let get_now = || {
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map_err(|e| format!("Unable to read system time: {e:?}"))
+    };
     let genesis_time = Duration::from_secs(genesis_time);
 
     // If the time now is less than (prior to) genesis, then delay until the
@@ -759,6 +761,7 @@ async fn wait_for_genesis(genesis_time: u64) -> Result<(), String> {
     //
     // If the validator client starts before genesis, it will get errors from
     // the slot clock.
+    let now = get_now()?;
     if now < genesis_time {
         info!(
             seconds_to_wait = (genesis_time - now).as_secs(),
@@ -773,7 +776,7 @@ async fn wait_for_genesis(genesis_time: u64) -> Result<(), String> {
             select! {
                 _ = &mut genesis_sleep => break,
                 _ = log_interval.tick() => info!(
-                    seconds_to_wait = (genesis_time - now).as_secs(),
+                    seconds_to_wait = (genesis_time - get_now()?).as_secs(),
                     "Waiting for genesis",
                 ),
             }

--- a/anchor/client/src/lib.rs
+++ b/anchor/client/src/lib.rs
@@ -63,9 +63,6 @@ use crate::{key::read_or_generate_private_key, notifier::spawn_notifier};
 /// The filename within the `validators` directory that contains the slashing protection DB.
 const SLASHING_PROTECTION_FILENAME: &str = "slashing_protection.sqlite";
 
-/// The time between polls when waiting for genesis.
-const WAITING_FOR_GENESIS_POLL_TIME: Duration = Duration::from_secs(12);
-
 /// Specific timeout constants for HTTP requests involved in different validator duties.
 /// This can help ensure that proper endpoint fallback occurs.
 const HTTP_ATTESTATION_TIMEOUT_QUOTIENT: u32 = 4;
@@ -367,7 +364,7 @@ impl Client {
         start_fallback_updater_service::<_, E>(executor.clone(), proposer_nodes.clone())?;
 
         // Wait until genesis has occurred.
-        wait_for_genesis(&beacon_nodes, genesis_time).await?;
+        wait_for_genesis(genesis_time).await?;
 
         // Start validator index syncer
         let index_sync_tx =
@@ -750,10 +747,7 @@ async fn init_from_beacon_node<E: EthSpec>(
     Ok((genesis.genesis_time, genesis.genesis_validators_root))
 }
 
-async fn wait_for_genesis(
-    beacon_nodes: &BeaconNodeFallback<SystemTimeSlotClock>,
-    genesis_time: u64,
-) -> Result<(), String> {
+async fn wait_for_genesis(genesis_time: u64) -> Result<(), String> {
     let now = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .map_err(|e| format!("Unable to read system time: {e:?}"))?;
@@ -770,17 +764,9 @@ async fn wait_for_genesis(
             "Starting node prior to genesis",
         );
 
-        // Start polling the node for pre-genesis information, cancelling the polling as soon as the
-        // timer runs out.
-        tokio::select! {
-            result = poll_whilst_waiting_for_genesis(beacon_nodes, genesis_time) => result?,
-            () = sleep(genesis_time - now) => ()
-        }
+        sleep(genesis_time - now).await;
 
-        info!(
-            ms_since_genesis = (genesis_time - now).as_millis(),
-            "Genesis has occurred",
-        );
+        info!("Genesis has occurred");
     } else {
         info!(
             seconds_ago = (now - genesis_time).as_secs(),
@@ -789,52 +775,6 @@ async fn wait_for_genesis(
     }
 
     Ok(())
-}
-
-/// Request the version from the node, looping back and trying again on failure. Exit once the node
-/// has been contacted.
-async fn poll_whilst_waiting_for_genesis(
-    beacon_nodes: &BeaconNodeFallback<SystemTimeSlotClock>,
-    genesis_time: Duration,
-) -> Result<(), String> {
-    loop {
-        match beacon_nodes
-            .first_success(|beacon_node| async move { beacon_node.get_lighthouse_staking().await })
-            .await
-        {
-            Ok(is_staking) => {
-                let now = SystemTime::now()
-                    .duration_since(UNIX_EPOCH)
-                    .map_err(|e| format!("Unable to read system time: {e:?}"))?;
-
-                if !is_staking {
-                    error!(
-                        msg = "this will caused missed duties",
-                        info = "see the --staking CLI flag on the beacon node",
-                        "Staking is disabled for beacon node"
-                    );
-                }
-
-                if now < genesis_time {
-                    info!(
-                        bn_staking_enabled = is_staking,
-                        seconds_to_wait = (genesis_time - now).as_secs(),
-                        "Waiting for genesis"
-                    );
-                } else {
-                    break Ok(());
-                }
-            }
-            Err(e) => {
-                error!(
-                    error = ?e.0,
-                    "Error polling beacon node",
-                );
-            }
-        }
-
-        sleep(WAITING_FOR_GENESIS_POLL_TIME).await;
-    }
 }
 
 pub fn load_pem_certificate<P: AsRef<Path>>(pem_path: P) -> Result<Certificate, String> {

--- a/anchor/client/src/lib.rs
+++ b/anchor/client/src/lib.rs
@@ -44,7 +44,7 @@ use tokio::{
     net::TcpListener,
     select,
     sync::{mpsc, mpsc::unbounded_channel},
-    time::{interval, sleep},
+    time::{Instant, interval, sleep},
 };
 use tracing::{debug, error, info, warn};
 use types::{EthSpec, Hash256};
@@ -749,46 +749,28 @@ async fn init_from_beacon_node<E: EthSpec>(
 }
 
 async fn wait_for_genesis(genesis_time: u64) -> Result<(), String> {
-    let get_now = || {
-        SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .map_err(|e| format!("Unable to read system time: {e:?}"))
-    };
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_err(|e| format!("Unable to read system time: {e:?}"))?;
     let genesis_time = Duration::from_secs(genesis_time);
 
-    // If the time now is less than (prior to) genesis, then delay until the
-    // genesis instant.
-    //
-    // If the validator client starts before genesis, it will get errors from
-    // the slot clock.
-    if get_now()? < genesis_time {
-        info!(
-            seconds_to_wait = (genesis_time - get_now()?).as_secs(),
-            "Starting node prior to genesis",
-        );
+    // Sleep until genesis, or not at all if `now >= genesis_time`
+    let genesis_sleep = sleep(genesis_time.saturating_sub(now));
+    tokio::pin!(genesis_sleep);
+    let mut log_interval = interval(Duration::from_secs(30));
 
-        let genesis_sleep = sleep(genesis_time - get_now()?);
-        tokio::pin!(genesis_sleep);
-        let mut log_interval = interval(Duration::from_secs(30));
-
-        loop {
-            select! {
-                _ = &mut genesis_sleep => break,
-                _ = log_interval.tick() => info!(
-                    seconds_to_wait = (genesis_time - get_now()?).as_secs(),
-                    "Waiting for genesis",
-                ),
-            }
+    loop {
+        select! {
+            biased;
+            _ = &mut genesis_sleep => break,
+            _ = log_interval.tick() => {
+                let seconds_to_wait = genesis_sleep.deadline().duration_since(Instant::now()).as_secs();
+                info!(seconds_to_wait, "Waiting for genesis");
+            },
         }
-
-        info!("Genesis has occurred");
-    } else {
-        info!(
-            seconds_ago = (get_now()? - genesis_time).as_secs(),
-            "Genesis has already occurred",
-        );
     }
 
+    info!("Genesis has occurred");
     Ok(())
 }
 

--- a/anchor/client/src/lib.rs
+++ b/anchor/client/src/lib.rs
@@ -784,7 +784,7 @@ async fn wait_for_genesis(genesis_time: u64) -> Result<(), String> {
         info!("Genesis has occurred");
     } else {
         info!(
-            seconds_ago = (now - genesis_time).as_secs(),
+            seconds_ago = (get_now()? - genesis_time).as_secs(),
             "Genesis has already occurred",
         );
     }


### PR DESCRIPTION
## Proposed Changes

Replace `poll_whilst_waiting_for_genesis` with a simple sleep to genesis. This function will never be useful in production, as SSV requires an already existing network to bootstrap the SSV contract (and then supply the address of that contract to Anchor). The only reason against removing `wait_for_genesis` altogether is that someone might pre-deploy the contracts in a local devnet and spin up the node before genesis has occurred. However, this scenario does not require the extensive logging offered by `poll_whilst_waiting_for_genesis`.

## Additional Info

This is useful for updating dependencies in a later step as `get_lighthouse_staking` was removed upstream. (see #452)