### PR TITLE
Set bls_lagrange rand dependency to workspace.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1559,7 +1559,7 @@ dependencies = [
  "bls",
  "blst",
  "blstrs_plus",
- "rand 0.8.5",
+ "rand 0.9.1",
  "vsss-rs",
  "zeroize",
 ]

--- a/anchor/common/bls_lagrange/Cargo.toml
+++ b/anchor/common/bls_lagrange/Cargo.toml
@@ -14,7 +14,7 @@ blst_single_thread = ["blst"]
 bls = { workspace = true }
 blst = { workspace = true, optional = true }
 blstrs_plus = { workspace = true, optional = true }
-rand = "0.8.5"
+rand = { workspace = true }
 vsss-rs = { workspace = true, optional = true }
 zeroize = { workspace = true }
 

--- a/anchor/common/bls_lagrange/src/lib.rs
+++ b/anchor/common/bls_lagrange/src/lib.rs
@@ -27,12 +27,12 @@ pub fn split(
     threshold: u64,
     ids: impl IntoIterator<Item = KeyId>,
 ) -> Result<Vec<(KeyId, SecretKey)>, Error> {
-    split_with_rng(key, threshold, ids, &mut thread_rng())
+    split_with_rng(key, threshold, ids, &mut rand::rng())
 }
 
 #[cfg(any(feature = "blst", test))]
 pub(crate) fn random_key(rng: &mut (impl CryptoRng + Rng)) -> Result<SecretKey, Error> {
-    let ikm = zeroize::Zeroizing::new(rng.r#gen::<[u8; 32]>());
+    let ikm = zeroize::Zeroizing::new(rng.random::<[u8; 32]>());
     let sk =
         ::blst::min_pk::SecretKey::key_gen(ikm.as_ref(), &[]).map_err(|_| Error::InternalError)?;
     // By passing a reference here, we drop "sk", zeroizing it.
@@ -57,8 +57,8 @@ mod tests {
     }
 
     fn test_basic(rng: &mut (impl CryptoRng + Rng)) {
-        let total = rng.gen_range(2..=13);
-        let threshold = rng.gen_range(2..=total);
+        let total = rng.random_range(2..=13);
+        let threshold = rng.random_range(2..=total);
 
         let master = random_key(rng).unwrap();
         let pk = master.public_key();
@@ -81,7 +81,7 @@ mod tests {
         let mut data = [0u8; 32];
         rng.fill(&mut data);
 
-        let signers = rng.gen_range(2..=total);
+        let signers = rng.random_range(2..=total);
 
         let signatures = keys
             .into_iter()


### PR DESCRIPTION
Update to rand@0.9 and replace deprecated names.

## Issue Addressed

Fixes #461 

## Proposed Changes

Use rand 0.9 and set to workspace version.

## Additional Info

Its a very small change, understandable if you don't want to accept it :)