### PR TITLE
chore: Enable topic scoring by default

### DIFF
--- a/anchor/client/src/cli.rs
+++ b/anchor/client/src/cli.rs
@@ -527,13 +527,7 @@ pub struct Node {
     )]
     pub disable_gossipsub_peer_scoring: bool,
 
-    #[clap(
-        long,
-        help = "Disables gossipsub topic scoring.",
-        action = ArgAction::Set,
-        default_value = "true",
-        hide = true
-    )]
+    #[clap(long, help = "Disables gossipsub topic scoring.", hide = true)]
     pub disable_gossipsub_topic_scoring: bool,
 
     #[clap(flatten)]


### PR DESCRIPTION
Enable gossipsub topic scoring by default. Keep the flag hidden, we can advise users to use it if we think it might fix things.
