### PR TITLE
refactor: Create `QbftDataValidator` for flexible QBFT data validation

### DIFF
--- a/anchor/common/qbft/src/lib.rs
+++ b/anchor/common/qbft/src/lib.rs
@@ -9,7 +9,7 @@ pub use qbft_types::{
 };
 use ssv_types::{
     OperatorId, Round,
-    consensus::{QbftData, QbftMessage, QbftMessageType, UnsignedSSVMessage},
+    consensus::{QbftData, QbftDataValidator, QbftMessage, QbftMessageType, UnsignedSSVMessage},
     message::{MsgType, SSVMessage, SignedSSVMessage},
     msgid::MessageId,
 };
@@ -125,6 +125,8 @@ where
 
     /// Message sender callback to instruct managing code to send a message
     message_sender: S,
+
+    data_validator: Box<dyn QbftDataValidator<D>>,
 }
 
 impl<F, D, S> Qbft<F, D, S>
@@ -140,7 +142,13 @@ where
     /// - `start_data`: The initial data that will be proposed if this node is the leader.
     /// - `identifier`: The message identifier for this QBFT instance's outgoing messages.
     /// - `message_sender`: A callback used by the instance to trigger message sending.
-    pub fn new(config: Config<F>, start_data: D, identifier: MessageId, message_sender: S) -> Self {
+    pub fn new(
+        config: Config<F>,
+        start_data: D,
+        data_validator: Box<dyn QbftDataValidator<D>>,
+        identifier: MessageId,
+        message_sender: S,
+    ) -> Self {
         let instance_height = *config.instance_height();
         let current_round = config.round();
         let quorum_size = config.quorum_size();
@@ -177,6 +185,7 @@ where
             aggregated_commit: None,
 
             message_sender,
+            data_validator,
         };
         qbft.data
             .insert(qbft.start_data_hash, qbft.start_data.clone());
@@ -296,8 +305,7 @@ where
             }
         };
 
-        if !data.validate() {
-            warn!("Data failed validation");
+        if !self.data_validator.validate(&data, &self.start_data) {
             return None;
         }
 

--- a/anchor/common/qbft/src/tests.rs
+++ b/anchor/common/qbft/src/tests.rs
@@ -12,6 +12,7 @@ use qbft_types::DefaultLeaderFunction;
 use sha2::{Digest, Sha256};
 use ssv_types::{
     OperatorId,
+    consensus::NoDataValidation,
     message::{RSA_SIGNATURE_SIZE, SignedSSVMessage},
 };
 use ssz_derive::{Decode, Encode};
@@ -39,10 +40,6 @@ impl QbftData for TestData {
         hasher.update(self.0.to_le_bytes());
         let hash: [u8; 32] = hasher.finalize().into();
         Hash256::from(hash)
-    }
-
-    fn validate(&self) -> bool {
-        true
     }
 }
 
@@ -134,6 +131,7 @@ fn construct_and_run_committee<D: QbftData<Hash = Hash256>>(
         let instance = Qbft::new(
             config.clone().build().expect("test config is valid"),
             validated_data.clone(),
+            Box::new(NoDataValidation),
             MessageId::from([0; 56]),
             move |message| msg_queue.borrow_mut().push_back((id, message)),
         );

--- a/anchor/common/ssv_types/src/consensus.rs
+++ b/anchor/common/ssv_types/src/consensus.rs
@@ -34,7 +34,18 @@ pub trait QbftData: Debug + Clone + Encode + Decode {
     type Hash: Debug + Clone + Eq + Hash;
 
     fn hash(&self) -> Self::Hash;
-    fn validate(&self) -> bool;
+}
+
+pub trait QbftDataValidator<D: QbftData>: Send + Sync {
+    fn validate(&self, value: &D, start_value: &D) -> bool;
+}
+
+#[derive(Debug)]
+pub struct NoDataValidation;
+impl<D: QbftData> QbftDataValidator<D> for NoDataValidation {
+    fn validate(&self, _value: &D, _start_value: &D) -> bool {
+        true
+    }
 }
 
 /// A SSV Message that has not been signed yet.
@@ -180,12 +191,6 @@ impl QbftData for ValidatorConsensusData {
         hasher.update(bytes);
         let hash: [u8; 32] = hasher.finalize().into();
         Hash256::from(hash)
-    }
-
-    fn validate(&self) -> bool {
-        // TODO: validate proposed values
-        // https://github.com/sigp/anchor/issues/258
-        true
     }
 }
 
@@ -353,11 +358,5 @@ impl QbftData for BeaconVote {
         hasher.update(bytes);
         let hash: [u8; 32] = hasher.finalize().into();
         Hash256::from(hash)
-    }
-
-    fn validate(&self) -> bool {
-        // TODO: validate proposed values
-        // https://github.com/sigp/anchor/issues/258
-        true
     }
 }

--- a/anchor/qbft_manager/src/instance.rs
+++ b/anchor/qbft_manager/src/instance.rs
@@ -127,6 +127,7 @@ impl Uninitialized {
         let mut instance = Box::new(Qbft::new(
             init.config,
             init.initial,
+            init.validator,
             init.message_id,
             MessageCallback {
                 sent_by_us_tx,

--- a/anchor/qbft_manager/src/lib.rs
+++ b/anchor/qbft_manager/src/lib.rs
@@ -11,7 +11,7 @@ use qbft::{
 use slot_clock::SlotClock;
 use ssv_types::{
     Cluster, CommitteeId,
-    consensus::{BeaconVote, QbftData, ValidatorConsensusData},
+    consensus::{BeaconVote, QbftData, QbftDataValidator, ValidatorConsensusData},
     domain_type::DomainType,
     message::SignedSSVMessage,
     msgid::{DutyExecutor, MessageId, Role},
@@ -66,15 +66,12 @@ pub enum ValidatorDutyKind {
 }
 
 // Message that is passed around the QbftManager
-#[derive(Debug)]
 pub struct QbftMessage<D: QbftData> {
     pub kind: QbftMessageKind<D>,
     pub drop_on_finish: Option<DropOnFinish>,
 }
 
 // Type of the QBFT Message
-#[derive(Debug)]
-#[allow(clippy::large_enum_variant)] // clippy is confused and thinks the first variant is 0 bytes
 pub enum QbftMessageKind<D: QbftData> {
     // Initialize a new qbft instance with some initial data,
     // the configuration for the instance, and a channel to send the final data on
@@ -86,10 +83,11 @@ pub enum QbftMessageKind<D: QbftData> {
 }
 
 /// Represents the initialization data required to start a new QBFT instance.
-#[derive(Debug)]
 pub struct QbftInitialization<D: QbftData> {
     /// The data to use when we are the leader.
     initial: D,
+    /// The context needed for validation of other's data.
+    validator: Box<dyn QbftDataValidator<D>>,
     /// The message id to be embedded into outgoing messages.
     message_id: MessageId,
     /// The time when the first round is supposed to start. Rounds will be advanced based on this.
@@ -151,6 +149,7 @@ impl QbftManager {
         &self,
         id: D::Id,
         initial: D,
+        validator: Box<dyn QbftDataValidator<D>>,
         start_time: Instant,
         committee: &Cluster,
     ) -> Result<Completed<D>, QbftError> {
@@ -187,6 +186,7 @@ impl QbftManager {
                 let _ = sender.send(QbftMessage {
                     kind: QbftMessageKind::Initialize(QbftInitialization {
                         initial,
+                        validator,
                         message_id,
                         start_time,
                         config,

--- a/anchor/qbft_manager/src/tests.rs
+++ b/anchor/qbft_manager/src/tests.rs
@@ -10,7 +10,7 @@ use qbft::InstanceHeight;
 use slot_clock::{ManualSlotClock, SlotClock};
 use ssv_types::{
     Cluster, ClusterId, CommitteeId, IndexSet, OperatorId,
-    consensus::{BeaconVote, QbftMessage, QbftMessageType},
+    consensus::{BeaconVote, NoDataValidation, QbftMessage, QbftMessageType},
     domain_type::DomainType,
     message::SignedSSVMessage,
     msgid::{DutyExecutor, MessageId, Role},
@@ -388,7 +388,13 @@ where
                         sleep(delay_initialization).await;
                         // Operator is online, start the instance
                         let result = manager_clone
-                            .decide_instance(id_clone, data_clone.clone(), start_time, &cluster)
+                            .decide_instance(
+                                id_clone,
+                                data_clone.clone(),
+                                Box::new(NoDataValidation),
+                                start_time,
+                                &cluster,
+                            )
                             .await;
                         let _ = tx_clone.send((data_clone.hash(), result));
                     },
@@ -932,6 +938,7 @@ async fn test_timeout(round_timeout_to_test: usize) {
         .send(crate::QbftMessage {
             kind: QbftMessageKind::Initialize(QbftInitialization {
                 initial: manager_tests::generate_test_data(0).0,
+                validator: Box::new(NoDataValidation),
                 message_id: MessageId::new(
                     &DomainType::default(),
                     Role::Committee,

--- a/anchor/validator_store/src/lib.rs
+++ b/anchor/validator_store/src/lib.rs
@@ -34,7 +34,7 @@ use ssv_types::{
     Cluster, ClusterId, ENCRYPTED_KEY_LENGTH, ValidatorIndex, ValidatorMetadata,
     consensus::{
         BEACON_ROLE_AGGREGATOR, BEACON_ROLE_PROPOSER, BEACON_ROLE_SYNC_COMMITTEE_CONTRIBUTION,
-        BeaconVote, Contribution, ContributionWrapper, Contributions, QbftData,
+        BeaconVote, Contribution, ContributionWrapper, Contributions, NoDataValidation, QbftData,
         ValidatorConsensusData, ValidatorDuty,
     },
     msgid::Role,
@@ -336,7 +336,13 @@ impl<T: SlotClock, E: EthSpec> AnchorValidatorStore<T, E> {
         // Initiate QBFT consensus for this block proposal
         let completed = self
             .qbft_manager
-            .decide_instance(instance_id, consensus_data, start_time, cluster)
+            .decide_instance(
+                instance_id,
+                consensus_data,
+                Box::new(NoDataValidation),
+                start_time,
+                cluster,
+            )
             .await
             .map_err(SpecificError::from)?;
         drop(timer);
@@ -922,6 +928,7 @@ impl<T: SlotClock, E: EthSpec> ValidatorStore for AnchorValidatorStore<T, E> {
                         source: attestation.data().source,
                         target: attestation.data().target,
                     },
+                    Box::new(NoDataValidation),
                     start_time,
                     &cluster,
                 )
@@ -1078,6 +1085,7 @@ impl<T: SlotClock, E: EthSpec> ValidatorStore for AnchorValidatorStore<T, E> {
                         version,
                         data_ssz: message.as_ssz_bytes(),
                     },
+                    Box::new(NoDataValidation),
                     start_time,
                     &cluster,
                 )
@@ -1250,6 +1258,7 @@ impl<T: SlotClock, E: EthSpec> ValidatorStore for AnchorValidatorStore<T, E> {
                         instance_height: slot.as_usize().into(),
                     },
                     metadata.beacon_vote.clone(),
+                    Box::new(NoDataValidation),
                     start_time,
                     &cluster,
                 )
@@ -1371,6 +1380,7 @@ impl<T: SlotClock, E: EthSpec> ValidatorStore for AnchorValidatorStore<T, E> {
                         version: ForkName::Altair.into(),
                         data_ssz: data.as_ssz_bytes(),
                     },
+                    Box::new(NoDataValidation),
                     start_time,
                     &cluster,
                 )


### PR DESCRIPTION
## Issue Addressed

This is prerequisite for the proper implementation of:

- #418 
- #436

## Proposed Changes

Instead of having a `validate` function on `QbftData`, create a new trait for validation. This allows using contextual data for validation
