### PR TITLE
ci: add Claude Code PR review GitHub Action

### DIFF
--- a/.github/README-CLAUDE-ACTION.md
+++ b/.github/README-CLAUDE-ACTION.md
@@ -1,0 +1,61 @@
+# Claude Code PR Review Action - Setup Instructions
+
+This document outlines how to set up and configure the Claude Code PR Review GitHub Action for Anchor.
+
+## Prerequisites
+
+1. **AWS IAM Role**: Create an IAM role with the following permissions:
+   ```
+   {
+     "Version": "2012-10-17",
+     "Statement": [
+       {
+         "Effect": "Allow",
+         "Action": [
+           "bedrock:InvokeModel",
+           "bedrock:InvokeModelWithResponseStream",
+           "bedrock:ListInferenceProfiles"
+         ],
+         "Resource": "*"
+       }
+     ]
+   }
+   ```
+
+2. **GitHub Repository Settings**:
+   - Go to the repository's Settings > Secrets and variables > Actions
+   - Add the following secret:
+     - `AWS_ROLE_ARN`: The ARN of the IAM role created above
+
+## How to Use
+
+Once configured, Claude will automatically review new Pull Requests and respond to mentions:
+
+1. **Automatic PR Reviews**: Claude will analyze new PRs and provide feedback
+2. **Comment-based Interaction**: Mention Claude in PR comments using the trigger phrase `@claude`
+   - Example: `@claude Please explain how this code works`
+   - Example: `@claude Can you suggest improvements to this implementation?`
+
+## Configuration Details
+
+The workflow is configured with the following settings:
+
+- **Triggers**: 
+  - New pull requests
+  - Updated pull requests (synchronize)
+  - Reopened pull requests
+  - Comments containing `@claude`
+  
+- **AWS Bedrock Settings**:
+  - Region: `us-east-1`
+  - Model: `us.anthropic.claude-3-7-sonnet-20250219-v1:0`
+  - Max output tokens: 4096
+
+- **Timeout**: 30 minutes per interaction
+
+## Troubleshooting
+
+If the action fails:
+1. Check the Action logs for error messages
+2. Verify the AWS role has appropriate permissions
+3. Ensure the AWS role trust policy allows GitHub Actions to assume the role

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -47,7 +47,7 @@ jobs:
       
       # Run Claude PR review
       - name: Claude PR Review
-        uses: anthropics/claude-code-pr-action@v1
+        uses: anthropic-ai/claude-code-pr-action@v1
         with:
           trigger_phrase: "@claude"
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -1,0 +1,54 @@
+name: Claude PR Review
+
+# Required permissions for the GitHub Actions workflow
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+  id-token: write
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+
+jobs:
+  claude-review:
+    # Only run on PR comments containing '@claude' or new/updated PRs
+    if: |
+      (github.event_name == 'pull_request') ||
+      ((github.event_name == 'issue_comment' || github.event_name == 'pull_request_review_comment') && 
+       contains(github.event.comment.body, '@claude'))
+    runs-on: ubuntu-latest
+    
+    # Configure AWS Bedrock integration
+    env:
+      CLAUDE_CODE_USE_BEDROCK: 1
+      AWS_REGION: us-east-1
+      ANTHROPIC_MODEL: "us.anthropic.claude-3-7-sonnet-20250219-v1:0"
+      CLAUDE_CODE_MAX_OUTPUT_TOKENS: 4096
+      MAX_THINKING_TOKENS: 1024
+      
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Full git history for better code understanding
+      
+      # Configure AWS credentials for Bedrock
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: us-east-1
+      
+      # Run Claude PR review
+      - name: Claude PR Review
+        uses: anthropics/claude-code-pr-action@v1
+        with:
+          trigger_phrase: "@claude"
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          timeout_minutes: "30"


### PR DESCRIPTION
  ## Issue Addressed

  N/A - This PR adds Claude Code GitHub Action for automated PR reviews

  ## Proposed Changes

  - Add GitHub Actions workflow for automated PR reviews using Claude Code
  - Configure AWS Bedrock integration with appropriate settings
  - Add documentation for setting up the required IAM role and GitHub repository secrets

  ## Additional Info

  This PR requires:
  1. An AWS IAM role with Bedrock permissions
  2. Adding the AWS_ROLE_ARN secret to the repository

  The Claude Code action will automatically review PRs and respond to @claude mentions in comments.
