### PR TITLE
fix: round change data

### DIFF
--- a/anchor/common/qbft/src/lib.rs
+++ b/anchor/common/qbft/src/lib.rs
@@ -874,22 +874,32 @@ where
             vec![]
         };
 
-        if matches!(msg_type, QbftMessageType::RoundChange)
-            && let (Some(last_prepared_value), Some(last_prepared_round)) =
+        if matches!(msg_type, QbftMessageType::RoundChange) {
+            if let (Some(last_prepared_value), Some(last_prepared_round)) =
                 (self.last_prepared_value, self.last_prepared_round)
-        {
-            return MessageData::new(
-                last_prepared_round.get() as u64,
-                self.current_round.get() as u64,
-                last_prepared_value,
-                self.data
-                    .get(&last_prepared_value)
-                    .map(|d| d.as_ssz_bytes())
-                    .unwrap_or_else(|| {
-                        warn!("Data misisng for last prepared value");
-                        vec![]
-                    }),
-            );
+            {
+                // When we have prepare justifications - use hash of last prepared value
+                return MessageData::new(
+                    last_prepared_round.get() as u64,
+                    self.current_round.get() as u64,
+                    last_prepared_value,
+                    self.data
+                        .get(&last_prepared_value)
+                        .map(|d| d.as_ssz_bytes())
+                        .unwrap_or_else(|| {
+                            warn!("Data missing for last prepared value");
+                            vec![]
+                        }),
+                );
+            } else {
+                // When we DON'T have prepare justifications - use empty root
+                return MessageData::new(
+                    0, // NoRound
+                    self.current_round.get() as u64,
+                    Hash256::default(),
+                    vec![],
+                );
+            }
         }
 
         // Standard message data for Proposal, Prepare, and Commit


### PR DESCRIPTION
## Issue Addressed
N/A

## Proposed Changes

When we are getting the round change data, if there is no last prepared round and no last prepared value, we should be returning empty data 

[here](https://github.com/ssvlabs/ssv-spec/blob/17192762564b2fed35e8c237122c24861bfb248d/qbft/round_change.go#L369-L384) is the corresponding go code

