### PR TITLE
Fix CI for new docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -47,4 +47,4 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_REGION: 'ap-southeast-2'
-          SOURCE_DIR: 'docs/dist'
+          SOURCE_DIR: 'docs/docs/dist'


### PR DESCRIPTION
I couldn't test the CI directly and assumed errors would be limited. 

The CI broke, this CI path occurs once PRs are merged. I would test more thoroughly however I'm confident this is the last PR we need to correct it. 

If any other PRs are required I'll build a more thorough  testing path and make sure it runs before making more PRs. 