### PR TITLE
ci: Remove x86 Apple from the release builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,6 @@ jobs:
             matrix:
                 arch: [aarch64-unknown-linux-gnu,
                        x86_64-unknown-linux-gnu,
-                       x86_64-apple-darwin,
                        aarch64-apple-darwin]
                        
                 include:
@@ -32,9 +31,6 @@ jobs:
                         profile: maxperf
                     -   arch: x86_64-unknown-linux-gnu
                         runner: 'ubuntu-24.04'
-                        profile: maxperf
-                    -   arch: x86_64-apple-darwin
-                        runner: macos-13
                         profile: maxperf
                     -   arch: aarch64-apple-darwin
                         runner: macos-14
@@ -67,10 +63,6 @@ jobs:
             - name: Move cross-compiled binary
               if:  contains(matrix.arch, 'unknown-linux-gnu')
               run: mv target/${{ matrix.arch }}/${{ matrix.profile }}/anchor ~/.cargo/bin/anchor
-
-            - name: Build Anchor for x86_64-apple-darwin
-              if:   matrix.arch == 'x86_64-apple-darwin'
-              run:  cargo install --path anchor --force --locked --features portable --profile ${{ matrix.profile }}
 
             - name: Build Anchor for aarch64-apple-darwin
               if:   matrix.arch == 'aarch64-apple-darwin'
@@ -185,7 +177,6 @@ jobs:
 
                   | System | Architecture | Binary | PGP Signature |
                   |:---:|:---:|:---:|:---|
-                  | <picture> <source media="(prefers-color-scheme: dark)" srcset="https://cdn.simpleicons.org/apple/white" > <source media="(prefers-color-scheme: light)" srcset="https://cdn.simpleicons.org/apple" ><img src="https://cdn.simpleicons.org/apple" width="32" alt="Apple logo">  </picture> | x86_64 | [anchor-${{ env.VERSION }}-x86_64-apple-darwin.tar.gz](https://github.com/${{ env.REPO_NAME }}/releases/download/${{ env.VERSION }}/anchor-${{ env.VERSION }}-x86_64-apple-darwin.tar.gz) | [PGP Signature](https://github.com/${{ env.REPO_NAME }}/releases/download/${{ env.VERSION }}/anchor-${{ env.VERSION }}-x86_64-apple-darwin.tar.gz.asc) |
                   | <picture> <source media="(prefers-color-scheme: dark)" srcset="https://cdn.simpleicons.org/apple/white" > <source media="(prefers-color-scheme: light)" srcset="https://cdn.simpleicons.org/apple" ><img src="https://cdn.simpleicons.org/apple" width="32" alt="Apple logo">  </picture> | aarch64 | [anchor-${{ env.VERSION }}-aarch64-apple-darwin.tar.gz](https://github.com/${{ env.REPO_NAME }}/releases/download/${{ env.VERSION }}/anchor-${{ env.VERSION }}-aarch64-apple-darwin.tar.gz) | [PGP Signature](https://github.com/${{ env.REPO_NAME }}/releases/download/${{ env.VERSION }}/anchor-${{ env.VERSION }}-aarch64-apple-darwin.tar.gz.asc) |
                   | <picture> <source media="(prefers-color-scheme: dark)" srcset="https://cdn.simpleicons.org/linux/white" > <source media="(prefers-color-scheme: light)" srcset="https://cdn.simpleicons.org/linux/black" ><img src="https://cdn.simpleicons.org/linux" width="32" alt="Linux logo"> </picture> | x86_64 | [anchor-${{ env.VERSION }}-x86_64-unknown-linux-gnu.tar.gz](https://github.com/${{ env.REPO_NAME }}/releases/download/${{ env.VERSION }}/anchor-${{ env.VERSION }}-x86_64-unknown-linux-gnu.tar.gz) | [PGP Signature](https://github.com/${{ env.REPO_NAME }}/releases/download/${{ env.VERSION }}/anchor-${{ env.VERSION }}-x86_64-unknown-linux-gnu.tar.gz.asc) |
                   | <picture> <source media="(prefers-color-scheme: dark)" srcset="https://cdn.simpleicons.org/raspberrypi/white" > <source media="(prefers-color-scheme: light)" srcset="https://cdn.simpleicons.org/raspberrypi/black" > <img src="https://cdn.simpleicons.org/raspberrypi" width="32" alt="Raspberrypi logo"> </picture> | aarch64 | [anchor-${{ env.VERSION }}-aarch64-unknown-linux-gnu.tar.gz](https://github.com/${{ env.REPO_NAME }}/releases/download/${{ env.VERSION }}/anchor-${{ env.VERSION }}-aarch64-unknown-linux-gnu.tar.gz) | [PGP Signature](https://github.com/${{ env.REPO_NAME }}/releases/download/${{ env.VERSION }}/anchor-${{ env.VERSION }}-aarch64-unknown-linux-gnu.tar.gz.asc) |

--- a/docs/docs/pages/index.mdx
+++ b/docs/docs/pages/index.mdx
@@ -56,7 +56,7 @@ anchor --help
 ```
 
 ```bash [From Release]
-# Specify the platform i.e x86_64-apple-darwin (for apple) x86_64-unknown-linux-gnu.tar.gz
+# Specify the platform i.e aarch64-apple-darwin (for apple) x86_64-unknown-linux-gnu.tar.gz
 wget https://github.com/sigp/anchor/releases/download/v0.2.0/anchor-<platform>.tar.gz
 # Extract the file
 tar -xvf anchor-<platform>.tar.gz


### PR DESCRIPTION
## Issue Addressed

Github is winding down support for x86 apple runners: https://github.blog/changelog/2025-07-11-upcoming-changes-to-macos-hosted-runners-macos-latest-migration-and-xcode-support-policy-updates/#macos-13-is-closing-down
Rust is demoting x86 apple to a tier 2 target soon: https://blog.rust-lang.org/2025/08/07/Rust-1.89.0/#demoting-x86-64-apple-darwin-to-tier-2-with-host-tools

## Proposed Changes

- Do not create pre-built binaries for x86 apple anymore.