### PR TITLE
fix: Do not log duplicate errors, instead of only

### DIFF
--- a/anchor/network/src/network.rs
+++ b/anchor/network/src/network.rs
@@ -269,7 +269,7 @@ impl<R: MessageReceiver> Network<R> {
                     match event {
                         Some((subnet_id, message)) => {
                             if let Err(err) = self.gossipsub().publish(subnet_to_topic(subnet_id), message)
-                                && let PublishError::Duplicate = err
+                                && !matches!(err, PublishError::Duplicate)
                             {
                                 error!(?err, "Failed to publish message");
                             }


### PR DESCRIPTION
## Issue Addressed

During #435, I accidentally flipped a condition - causing us to only log duplicate publish errors, instead of avoiding them.

## Proposed Changes

Unflip the condition.
