### PR TITLE
fix: Pass in slot metadata to avoid errors on late collection start

### DIFF
--- a/anchor/validator_store/src/lib.rs
+++ b/anchor/validator_store/src/lib.rs
@@ -200,7 +200,7 @@ impl<T: SlotClock, E: EthSpec> AnchorValidatorStore<T, E> {
         &self,
         signature_kind: PartialSignatureKind,
         role: Role,
-        base_hash: Option<Hash256>,
+        collection_mode: CollectionMode<E>,
         validator: &ValidatorMetadata,
         cluster: &Cluster,
         signing_root: Hash256,
@@ -219,31 +219,44 @@ impl<T: SlotClock, E: EthSpec> AnchorValidatorStore<T, E> {
             committee_id,
         };
 
-        let slot_metadata = self.get_slot_metadata(slot).await?;
-        let (num_signatures_to_collect, encrypted_private_key) = {
+        let (requester, encrypted_private_key) = {
             let state = self.database.state();
-            let num_signatures_to_collect = state
-                .metadata()
-                .get_all_by(&committee_id)
-                .map(|validator| {
-                    let mut duties = 0;
-                    if let Some(idx) = &validator.index {
-                        if slot_metadata.attesting_validator_indices.contains(idx) {
-                            duties += 1;
-                        }
-                        if slot_metadata.sync_validators.contains(idx) {
-                            duties += 1;
-                        }
+            let requester = match collection_mode {
+                CollectionMode::SingleValidator => SignatureRequester::SingleValidator {
+                    pubkey: validator.public_key,
+                },
+                CollectionMode::Committee {
+                    slot_metadata,
+                    base_hash,
+                } => {
+                    let num_signatures_to_collect = state
+                        .metadata()
+                        .get_all_by(&committee_id)
+                        .map(|validator| {
+                            let mut duties = 0;
+                            if let Some(idx) = &validator.index {
+                                if slot_metadata.attesting_validator_indices.contains(idx) {
+                                    duties += 1;
+                                }
+                                if slot_metadata.sync_validators.contains(idx) {
+                                    duties += 1;
+                                }
+                            }
+                            duties
+                        })
+                        .sum();
+                    SignatureRequester::Committee {
+                        num_signatures_to_collect,
+                        base_hash,
                     }
-                    duties
-                })
-                .sum();
+                }
+            };
             let encrypted_private_key = state
                 .shares()
                 .get_by(&validator.public_key)
                 .ok_or(Error::UnknownPubkey(validator.public_key))?
                 .encrypted_private_key;
-            (num_signatures_to_collect, encrypted_private_key)
+            (requester, encrypted_private_key)
         };
 
         let decrypted_key_share = if let Some(operator_key) = &self.private_key {
@@ -259,17 +272,6 @@ impl<T: SlotClock, E: EthSpec> AnchorValidatorStore<T, E> {
         } else {
             // We are in imposter mode and cannot decrypt the share.
             None
-        };
-
-        let requester = if let Some(base_hash) = base_hash {
-            SignatureRequester::Committee {
-                num_signatures_to_collect,
-                base_hash,
-            }
-        } else {
-            SignatureRequester::SingleValidator {
-                pubkey: validator.public_key,
-            }
         };
 
         let signing_data = ValidatorSigningData {
@@ -404,7 +406,7 @@ impl<T: SlotClock, E: EthSpec> AnchorValidatorStore<T, E> {
             .collect_signature(
                 PartialSignatureKind::PostConsensus,
                 Role::Proposer,
-                None,
+                CollectionMode::SingleValidator,
                 validator,
                 cluster,
                 signing_root,
@@ -509,7 +511,7 @@ impl<T: SlotClock, E: EthSpec> AnchorValidatorStore<T, E> {
             .collect_signature(
                 PartialSignatureKind::VoluntaryExit,
                 Role::VoluntaryExit,
-                None,
+                CollectionMode::SingleValidator,
                 &validator,
                 &cluster,
                 signing_root,
@@ -694,6 +696,14 @@ pub struct ContributionAndProofSigningData<E: EthSpec> {
     selection_proof: SyncSelectionProof,
 }
 
+enum CollectionMode<E: EthSpec> {
+    SingleValidator,
+    Committee {
+        slot_metadata: Arc<SlotMetadata<E>>,
+        base_hash: Hash256,
+    },
+}
+
 #[derive(Debug, Clone)]
 pub enum SpecificError {
     Unsupported,
@@ -825,7 +835,7 @@ impl<T: SlotClock, E: EthSpec> ValidatorStore for AnchorValidatorStore<T, E> {
             self.collect_signature(
                 PartialSignatureKind::RandaoPartialSig,
                 Role::Proposer,
-                None,
+                CollectionMode::SingleValidator,
                 &validator,
                 &cluster,
                 signing_root,
@@ -1010,7 +1020,10 @@ impl<T: SlotClock, E: EthSpec> ValidatorStore for AnchorValidatorStore<T, E> {
                 .collect_signature(
                     PartialSignatureKind::PostConsensus,
                     Role::Committee,
-                    Some(data_hash),
+                    CollectionMode::Committee {
+                        slot_metadata,
+                        base_hash: data_hash,
+                    },
                     &validator,
                     &cluster,
                     signing_root,
@@ -1059,7 +1072,7 @@ impl<T: SlotClock, E: EthSpec> ValidatorStore for AnchorValidatorStore<T, E> {
                 .collect_signature(
                     PartialSignatureKind::ValidatorRegistration,
                     Role::ValidatorRegistration,
-                    None,
+                    CollectionMode::SingleValidator,
                     &validator,
                     &cluster,
                     signing_root,
@@ -1172,7 +1185,7 @@ impl<T: SlotClock, E: EthSpec> ValidatorStore for AnchorValidatorStore<T, E> {
                 .collect_signature(
                     PartialSignatureKind::PostConsensus,
                     Role::Aggregator,
-                    None,
+                    CollectionMode::SingleValidator,
                     &validator,
                     &cluster,
                     signing_root,
@@ -1216,7 +1229,7 @@ impl<T: SlotClock, E: EthSpec> ValidatorStore for AnchorValidatorStore<T, E> {
                     self.collect_signature(
                         PartialSignatureKind::SelectionProofPartialSig,
                         Role::Aggregator,
-                        None,
+                        CollectionMode::SingleValidator,
                         &validator,
                         &cluster,
                         signing_root,
@@ -1263,7 +1276,7 @@ impl<T: SlotClock, E: EthSpec> ValidatorStore for AnchorValidatorStore<T, E> {
                     self.collect_signature(
                         PartialSignatureKind::ContributionProofs,
                         Role::SyncCommittee,
-                        None,
+                        CollectionMode::SingleValidator,
                         &validator,
                         &cluster,
                         signing_root,
@@ -1329,7 +1342,10 @@ impl<T: SlotClock, E: EthSpec> ValidatorStore for AnchorValidatorStore<T, E> {
                 .collect_signature(
                     PartialSignatureKind::PostConsensus,
                     Role::Committee,
-                    Some(data.hash()),
+                    CollectionMode::Committee {
+                        slot_metadata: metadata,
+                        base_hash: data.hash(),
+                    },
                     &validator,
                     &cluster,
                     signing_root,
@@ -1472,7 +1488,7 @@ impl<T: SlotClock, E: EthSpec> ValidatorStore for AnchorValidatorStore<T, E> {
             self.collect_signature(
                 PartialSignatureKind::PostConsensus,
                 Role::SyncCommittee,
-                None,
+                CollectionMode::SingleValidator,
                 &validator,
                 &cluster,
                 signing_root,

--- a/anchor/validator_store/src/lib.rs
+++ b/anchor/validator_store/src/lib.rs
@@ -416,6 +416,11 @@ impl<T: SlotClock, E: EthSpec> AnchorValidatorStore<T, E> {
         Ok(signable_block.to_signed_block(signature))
     }
 
+    /// Get the [`SlotMetadata`] for the given [`Slot`], waiting for it to become available if
+    /// necessary. If the requested slot has already passed, an error is returned.
+    ///
+    /// IMPORTANT: The slot metadata is computed starting at 1/3rd into the slot - so do not try
+    /// to retrieve it if sleeping until then is not tolerable.
     async fn get_slot_metadata(&self, slot: Slot) -> Result<Arc<SlotMetadata<E>>, Error> {
         let Some(metadata) = self
             .slot_metadata


### PR DESCRIPTION
## Issue Addressed

Fetching the `slot_metadata` in `collect_signature` is problematic: As the preceding QBFT instance may terminate only after the slot, the slot metadata may be expired by then. This causes "`ERROR anchor_validator_store: Got newer metadata - performance issues?`"

## Proposed Changes

Instead, have the caller fetch the slot metadata early and pass it in. Only require this when collecting in a `Committee` context - for single validator collection it is unneeded.

## Additional Info

This PR has the added benefit of only fetching the metadata when it is needed - this e.g. shortens the critical path for block proposals!
