### PR TITLE
fix: Specify an empty list on index fetch for Teku compat

### DIFF
--- a/anchor/eth/src/index_sync.rs
+++ b/anchor/eth/src/index_sync.rs
@@ -111,7 +111,7 @@ async fn validator_index_syncer(
                         .collect::<Vec<_>>();
                     async move {
                         client
-                            .post_beacon_states_validators(StateId::Head, Some(batch), None)
+                            .post_beacon_states_validators(StateId::Head, Some(batch), Some(vec![]))
                             .await
                     }
                 })


### PR DESCRIPTION
## Issue Addressed

Teku does not conform to the Beacon API spec: https://github.com/Consensys/teku/issues/9687

Violated line: https://github.com/ethereum/beacon-APIs/blob/69d2feb12a6047c4f21e628dea8b0135b7e9013a/apis/beacon/states/validators.yaml#L107

## Proposed Changes

Instead rely on the behaviour described here: https://github.com/ethereum/beacon-APIs/blob/69d2feb12a6047c4f21e628dea8b0135b7e9013a/apis/beacon/states/validators.yaml#L130

That is, supply an empty list instead of null/None.

## Further information

This is not a fix for Anchor, but rather a workaround.
