### PR TITLE
fix: Retrieve validator indices omitting status filter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1345,7 +1345,7 @@ checksum = "55248b47b0caf0546f7988906588779981c43bb1bc9d0c44087278f80cdb44ba"
 [[package]]
 name = "beacon_node_fallback"
 version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?rev=0450cfc#0450cfc1afa9da3e33124e262cd617e1de742085"
+source = "git+https://github.com/sigp/lighthouse?rev=d22af875#d22af875ba9322f2af75bbf2c4b6960f7c6bff67"
 dependencies = [
  "clap",
  "eth2",
@@ -1453,7 +1453,7 @@ dependencies = [
 [[package]]
 name = "bls"
 version = "0.2.0"
-source = "git+https://github.com/sigp/lighthouse?rev=0450cfc#0450cfc1afa9da3e33124e262cd617e1de742085"
+source = "git+https://github.com/sigp/lighthouse?rev=d22af875#d22af875ba9322f2af75bbf2c4b6960f7c6bff67"
 dependencies = [
  "alloy-primitives 1.3.0",
  "arbitrary",
@@ -1813,7 +1813,7 @@ checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 [[package]]
 name = "compare_fields"
 version = "0.2.0"
-source = "git+https://github.com/sigp/lighthouse?rev=0450cfc#0450cfc1afa9da3e33124e262cd617e1de742085"
+source = "git+https://github.com/sigp/lighthouse?rev=d22af875#d22af875ba9322f2af75bbf2c4b6960f7c6bff67"
 dependencies = [
  "itertools 0.10.5",
 ]
@@ -1821,7 +1821,7 @@ dependencies = [
 [[package]]
 name = "compare_fields_derive"
 version = "0.2.0"
-source = "git+https://github.com/sigp/lighthouse?rev=0450cfc#0450cfc1afa9da3e33124e262cd617e1de742085"
+source = "git+https://github.com/sigp/lighthouse?rev=d22af875#d22af875ba9322f2af75bbf2c4b6960f7c6bff67"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -1884,7 +1884,7 @@ checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 [[package]]
 name = "context_deserialize"
 version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?rev=0450cfc#0450cfc1afa9da3e33124e262cd617e1de742085"
+source = "git+https://github.com/sigp/lighthouse?rev=d22af875#d22af875ba9322f2af75bbf2c4b6960f7c6bff67"
 dependencies = [
  "milhouse",
  "serde",
@@ -1894,7 +1894,7 @@ dependencies = [
 [[package]]
 name = "context_deserialize_derive"
 version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?rev=0450cfc#0450cfc1afa9da3e33124e262cd617e1de742085"
+source = "git+https://github.com/sigp/lighthouse?rev=d22af875#d22af875ba9322f2af75bbf2c4b6960f7c6bff67"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -2721,7 +2721,7 @@ dependencies = [
 [[package]]
 name = "eth2"
 version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?rev=0450cfc#0450cfc1afa9da3e33124e262cd617e1de742085"
+source = "git+https://github.com/sigp/lighthouse?rev=d22af875#d22af875ba9322f2af75bbf2c4b6960f7c6bff67"
 dependencies = [
  "derivative",
  "either",
@@ -2753,7 +2753,7 @@ dependencies = [
 [[package]]
 name = "eth2_config"
 version = "0.2.0"
-source = "git+https://github.com/sigp/lighthouse?rev=0450cfc#0450cfc1afa9da3e33124e262cd617e1de742085"
+source = "git+https://github.com/sigp/lighthouse?rev=d22af875#d22af875ba9322f2af75bbf2c4b6960f7c6bff67"
 dependencies = [
  "paste",
  "types",
@@ -2762,7 +2762,7 @@ dependencies = [
 [[package]]
 name = "eth2_interop_keypairs"
 version = "0.2.0"
-source = "git+https://github.com/sigp/lighthouse?rev=0450cfc#0450cfc1afa9da3e33124e262cd617e1de742085"
+source = "git+https://github.com/sigp/lighthouse?rev=d22af875#d22af875ba9322f2af75bbf2c4b6960f7c6bff67"
 dependencies = [
  "bls",
  "ethereum_hashing",
@@ -2775,7 +2775,7 @@ dependencies = [
 [[package]]
 name = "eth2_key_derivation"
 version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?rev=0450cfc#0450cfc1afa9da3e33124e262cd617e1de742085"
+source = "git+https://github.com/sigp/lighthouse?rev=d22af875#d22af875ba9322f2af75bbf2c4b6960f7c6bff67"
 dependencies = [
  "bls",
  "num-bigint-dig",
@@ -2787,7 +2787,7 @@ dependencies = [
 [[package]]
 name = "eth2_keystore"
 version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?rev=0450cfc#0450cfc1afa9da3e33124e262cd617e1de742085"
+source = "git+https://github.com/sigp/lighthouse?rev=d22af875#d22af875ba9322f2af75bbf2c4b6960f7c6bff67"
 dependencies = [
  "aes 0.7.5",
  "bls",
@@ -2809,7 +2809,7 @@ dependencies = [
 [[package]]
 name = "eth2_network_config"
 version = "0.2.0"
-source = "git+https://github.com/sigp/lighthouse?rev=0450cfc#0450cfc1afa9da3e33124e262cd617e1de742085"
+source = "git+https://github.com/sigp/lighthouse?rev=d22af875#d22af875ba9322f2af75bbf2c4b6960f7c6bff67"
 dependencies = [
  "bytes",
  "discv5",
@@ -3008,7 +3008,7 @@ dependencies = [
 [[package]]
 name = "filesystem"
 version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?rev=0450cfc#0450cfc1afa9da3e33124e262cd617e1de742085"
+source = "git+https://github.com/sigp/lighthouse?rev=d22af875#d22af875ba9322f2af75bbf2c4b6960f7c6bff67"
 dependencies = [
  "winapi",
  "windows-acl",
@@ -3029,7 +3029,7 @@ dependencies = [
 [[package]]
 name = "fixed_bytes"
 version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?rev=0450cfc#0450cfc1afa9da3e33124e262cd617e1de742085"
+source = "git+https://github.com/sigp/lighthouse?rev=d22af875#d22af875ba9322f2af75bbf2c4b6960f7c6bff67"
 dependencies = [
  "alloy-primitives 1.3.0",
  "safe_arith",
@@ -3339,7 +3339,7 @@ dependencies = [
 [[package]]
 name = "graffiti_file"
 version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?rev=0450cfc#0450cfc1afa9da3e33124e262cd617e1de742085"
+source = "git+https://github.com/sigp/lighthouse?rev=d22af875#d22af875ba9322f2af75bbf2c4b6960f7c6bff67"
 dependencies = [
  "bls",
  "serde",
@@ -3456,7 +3456,7 @@ dependencies = [
 [[package]]
 name = "health_metrics"
 version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?rev=0450cfc#0450cfc1afa9da3e33124e262cd617e1de742085"
+source = "git+https://github.com/sigp/lighthouse?rev=d22af875#d22af875ba9322f2af75bbf2c4b6960f7c6bff67"
 dependencies = [
  "eth2",
  "metrics",
@@ -4084,7 +4084,7 @@ dependencies = [
 [[package]]
 name = "int_to_bytes"
 version = "0.2.0"
-source = "git+https://github.com/sigp/lighthouse?rev=0450cfc#0450cfc1afa9da3e33124e262cd617e1de742085"
+source = "git+https://github.com/sigp/lighthouse?rev=d22af875#d22af875ba9322f2af75bbf2c4b6960f7c6bff67"
 dependencies = [
  "bytes",
 ]
@@ -4276,7 +4276,7 @@ dependencies = [
 [[package]]
 name = "kzg"
 version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?rev=0450cfc#0450cfc1afa9da3e33124e262cd617e1de742085"
+source = "git+https://github.com/sigp/lighthouse?rev=d22af875#d22af875ba9322f2af75bbf2c4b6960f7c6bff67"
 dependencies = [
  "arbitrary",
  "c-kzg",
@@ -4810,7 +4810,7 @@ dependencies = [
 [[package]]
 name = "logging"
 version = "0.2.0"
-source = "git+https://github.com/sigp/lighthouse?rev=0450cfc#0450cfc1afa9da3e33124e262cd617e1de742085"
+source = "git+https://github.com/sigp/lighthouse?rev=d22af875#d22af875ba9322f2af75bbf2c4b6960f7c6bff67"
 dependencies = [
  "chrono",
  "logroller",
@@ -4887,7 +4887,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 [[package]]
 name = "lru_cache"
 version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?rev=0450cfc#0450cfc1afa9da3e33124e262cd617e1de742085"
+source = "git+https://github.com/sigp/lighthouse?rev=d22af875#d22af875ba9322f2af75bbf2c4b6960f7c6bff67"
 dependencies = [
  "fnv",
 ]
@@ -4957,7 +4957,7 @@ dependencies = [
 [[package]]
 name = "merkle_proof"
 version = "0.2.0"
-source = "git+https://github.com/sigp/lighthouse?rev=0450cfc#0450cfc1afa9da3e33124e262cd617e1de742085"
+source = "git+https://github.com/sigp/lighthouse?rev=d22af875#d22af875ba9322f2af75bbf2c4b6960f7c6bff67"
 dependencies = [
  "alloy-primitives 1.3.0",
  "ethereum_hashing",
@@ -5053,7 +5053,7 @@ dependencies = [
 [[package]]
 name = "metrics"
 version = "0.2.0"
-source = "git+https://github.com/sigp/lighthouse?rev=0450cfc#0450cfc1afa9da3e33124e262cd617e1de742085"
+source = "git+https://github.com/sigp/lighthouse?rev=d22af875#d22af875ba9322f2af75bbf2c4b6960f7c6bff67"
 dependencies = [
  "prometheus",
 ]
@@ -5323,7 +5323,7 @@ dependencies = [
 [[package]]
 name = "network_utils"
 version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?rev=0450cfc#0450cfc1afa9da3e33124e262cd617e1de742085"
+source = "git+https://github.com/sigp/lighthouse?rev=d22af875#d22af875ba9322f2af75bbf2c4b6960f7c6bff67"
 dependencies = [
  "discv5",
  "libp2p-identity",
@@ -5916,7 +5916,7 @@ dependencies = [
 [[package]]
 name = "pretty_reqwest_error"
 version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?rev=0450cfc#0450cfc1afa9da3e33124e262cd617e1de742085"
+source = "git+https://github.com/sigp/lighthouse?rev=d22af875#d22af875ba9322f2af75bbf2c4b6960f7c6bff67"
 dependencies = [
  "reqwest 0.11.27",
  "sensitive_url",
@@ -6063,7 +6063,7 @@ dependencies = [
 [[package]]
 name = "proto_array"
 version = "0.2.0"
-source = "git+https://github.com/sigp/lighthouse?rev=0450cfc#0450cfc1afa9da3e33124e262cd617e1de742085"
+source = "git+https://github.com/sigp/lighthouse?rev=d22af875#d22af875ba9322f2af75bbf2c4b6960f7c6bff67"
 dependencies = [
  "ethereum_ssz",
  "ethereum_ssz_derive",
@@ -6881,7 +6881,7 @@ checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 [[package]]
 name = "safe_arith"
 version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?rev=0450cfc#0450cfc1afa9da3e33124e262cd617e1de742085"
+source = "git+https://github.com/sigp/lighthouse?rev=d22af875#d22af875ba9322f2af75bbf2c4b6960f7c6bff67"
 
 [[package]]
 name = "salsa20"
@@ -7063,7 +7063,7 @@ checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
 [[package]]
 name = "sensitive_url"
 version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?rev=0450cfc#0450cfc1afa9da3e33124e262cd617e1de742085"
+source = "git+https://github.com/sigp/lighthouse?rev=d22af875#d22af875ba9322f2af75bbf2c4b6960f7c6bff67"
 dependencies = [
  "serde",
  "url",
@@ -7304,7 +7304,7 @@ checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
 [[package]]
 name = "slashing_protection"
 version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?rev=0450cfc#0450cfc1afa9da3e33124e262cd617e1de742085"
+source = "git+https://github.com/sigp/lighthouse?rev=d22af875#d22af875ba9322f2af75bbf2c4b6960f7c6bff67"
 dependencies = [
  "arbitrary",
  "ethereum_serde_utils 0.8.0",
@@ -7322,7 +7322,7 @@ dependencies = [
 [[package]]
 name = "slot_clock"
 version = "0.2.0"
-source = "git+https://github.com/sigp/lighthouse?rev=0450cfc#0450cfc1afa9da3e33124e262cd617e1de742085"
+source = "git+https://github.com/sigp/lighthouse?rev=d22af875#d22af875ba9322f2af75bbf2c4b6960f7c6bff67"
 dependencies = [
  "metrics",
  "parking_lot",
@@ -7562,7 +7562,7 @@ dependencies = [
 [[package]]
 name = "swap_or_not_shuffle"
 version = "0.2.0"
-source = "git+https://github.com/sigp/lighthouse?rev=0450cfc#0450cfc1afa9da3e33124e262cd617e1de742085"
+source = "git+https://github.com/sigp/lighthouse?rev=d22af875#d22af875ba9322f2af75bbf2c4b6960f7c6bff67"
 dependencies = [
  "alloy-primitives 1.3.0",
  "ethereum_hashing",
@@ -7692,7 +7692,7 @@ checksum = "c63f48baada5c52e65a29eef93ab4f8982681b67f9e8d29c7b05abcfec2b9ffe"
 [[package]]
 name = "task_executor"
 version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?rev=0450cfc#0450cfc1afa9da3e33124e262cd617e1de742085"
+source = "git+https://github.com/sigp/lighthouse?rev=d22af875#d22af875ba9322f2af75bbf2c4b6960f7c6bff67"
 dependencies = [
  "async-channel 1.9.0",
  "futures",
@@ -7727,7 +7727,7 @@ dependencies = [
 [[package]]
 name = "test_random_derive"
 version = "0.2.0"
-source = "git+https://github.com/sigp/lighthouse?rev=0450cfc#0450cfc1afa9da3e33124e262cd617e1de742085"
+source = "git+https://github.com/sigp/lighthouse?rev=d22af875#d22af875ba9322f2af75bbf2c4b6960f7c6bff67"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -8177,7 +8177,7 @@ checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
 [[package]]
 name = "types"
 version = "0.2.1"
-source = "git+https://github.com/sigp/lighthouse?rev=0450cfc#0450cfc1afa9da3e33124e262cd617e1de742085"
+source = "git+https://github.com/sigp/lighthouse?rev=d22af875#d22af875ba9322f2af75bbf2c4b6960f7c6bff67"
 dependencies = [
  "alloy-primitives 1.3.0",
  "alloy-rlp",
@@ -8379,7 +8379,7 @@ dependencies = [
 [[package]]
 name = "validator_metrics"
 version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?rev=0450cfc#0450cfc1afa9da3e33124e262cd617e1de742085"
+source = "git+https://github.com/sigp/lighthouse?rev=d22af875#d22af875ba9322f2af75bbf2c4b6960f7c6bff67"
 dependencies = [
  "metrics",
 ]
@@ -8387,7 +8387,7 @@ dependencies = [
 [[package]]
 name = "validator_services"
 version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?rev=0450cfc#0450cfc1afa9da3e33124e262cd617e1de742085"
+source = "git+https://github.com/sigp/lighthouse?rev=d22af875#d22af875ba9322f2af75bbf2c4b6960f7c6bff67"
 dependencies = [
  "beacon_node_fallback",
  "bls",
@@ -8411,7 +8411,7 @@ dependencies = [
 [[package]]
 name = "validator_store"
 version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?rev=0450cfc#0450cfc1afa9da3e33124e262cd617e1de742085"
+source = "git+https://github.com/sigp/lighthouse?rev=d22af875#d22af875ba9322f2af75bbf2c4b6960f7c6bff67"
 dependencies = [
  "eth2",
  "slashing_protection",
@@ -9161,7 +9161,7 @@ dependencies = [
 [[package]]
 name = "workspace_members"
 version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?rev=0450cfc#0450cfc1afa9da3e33124e262cd617e1de742085"
+source = "git+https://github.com/sigp/lighthouse?rev=d22af875#d22af875ba9322f2af75bbf2c4b6960f7c6bff67"
 dependencies = [
  "cargo_metadata",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,24 +64,24 @@ ssv_types = { path = "anchor/common/ssv_types" }
 subnet_service = { path = "anchor/subnet_service" }
 version = { path = "anchor/common/version" }
 
-beacon_node_fallback = { git = "https://github.com/sigp/lighthouse", rev = "0450cfc" }
-bls = { git = "https://github.com/sigp/lighthouse", rev = "0450cfc" }
-eth2 = { git = "https://github.com/sigp/lighthouse", rev = "0450cfc" }
-eth2_keystore = { git = "https://github.com/sigp/lighthouse", rev = "0450cfc" }
-eth2_network_config = { git = "https://github.com/sigp/lighthouse", rev = "0450cfc" }
-health_metrics = { git = "https://github.com/sigp/lighthouse", rev = "0450cfc" }
-metrics = { git = "https://github.com/sigp/lighthouse", rev = "0450cfc" }
-network_utils = { git = "https://github.com/sigp/lighthouse", rev = "0450cfc" }
-safe_arith = { git = "https://github.com/sigp/lighthouse", rev = "0450cfc" }
-sensitive_url = { git = "https://github.com/sigp/lighthouse", rev = "0450cfc" }
-slashing_protection = { git = "https://github.com/sigp/lighthouse", rev = "0450cfc" }
-slot_clock = { git = "https://github.com/sigp/lighthouse", rev = "0450cfc" }
-task_executor = { git = "https://github.com/sigp/lighthouse", rev = "0450cfc" }
-types = { git = "https://github.com/sigp/lighthouse", rev = "0450cfc" }
-validator_metrics = { git = "https://github.com/sigp/lighthouse", rev = "0450cfc" }
-validator_services = { git = "https://github.com/sigp/lighthouse", rev = "0450cfc" }
-validator_store = { git = "https://github.com/sigp/lighthouse", rev = "0450cfc" }
-workspace_members = { git = "https://github.com/sigp/lighthouse", rev = "0450cfc" }
+beacon_node_fallback = { git = "https://github.com/sigp/lighthouse", rev = "d22af875" }
+bls = { git = "https://github.com/sigp/lighthouse", rev = "d22af875" }
+eth2 = { git = "https://github.com/sigp/lighthouse", rev = "d22af875" }
+eth2_keystore = { git = "https://github.com/sigp/lighthouse", rev = "d22af875" }
+eth2_network_config = { git = "https://github.com/sigp/lighthouse", rev = "d22af875" }
+health_metrics = { git = "https://github.com/sigp/lighthouse", rev = "d22af875" }
+metrics = { git = "https://github.com/sigp/lighthouse", rev = "d22af875" }
+network_utils = { git = "https://github.com/sigp/lighthouse", rev = "d22af875" }
+safe_arith = { git = "https://github.com/sigp/lighthouse", rev = "d22af875" }
+sensitive_url = { git = "https://github.com/sigp/lighthouse", rev = "d22af875" }
+slashing_protection = { git = "https://github.com/sigp/lighthouse", rev = "d22af875" }
+slot_clock = { git = "https://github.com/sigp/lighthouse", rev = "d22af875" }
+task_executor = { git = "https://github.com/sigp/lighthouse", rev = "d22af875" }
+types = { git = "https://github.com/sigp/lighthouse", rev = "d22af875" }
+validator_metrics = { git = "https://github.com/sigp/lighthouse", rev = "d22af875" }
+validator_services = { git = "https://github.com/sigp/lighthouse", rev = "d22af875" }
+validator_store = { git = "https://github.com/sigp/lighthouse", rev = "d22af875" }
+workspace_members = { git = "https://github.com/sigp/lighthouse", rev = "d22af875" }
 
 alloy = { version = "1.0.22", features = [
     "sol-types",

--- a/anchor/eth/src/index_sync.rs
+++ b/anchor/eth/src/index_sync.rs
@@ -111,7 +111,7 @@ async fn validator_index_syncer(
                         .collect::<Vec<_>>();
                     async move {
                         client
-                            .post_beacon_states_validators(StateId::Head, Some(batch), Some(vec![]))
+                            .post_beacon_states_validators(StateId::Head, Some(batch), None)
                             .await
                     }
                 })


### PR DESCRIPTION
## Issue Addressed

Previously, we were Teku incompatible by sending 

```json
{
  "ids": [
    "0x..."
  ],
  "statuses": null
}
```

to retrieve validator indices. This caused an error response.

Now we are sending

```json
{
  "ids": [
    "0x..."
  ],
  "statuses": []
}
```

which is incompatible with Lighthouse. It causes an always-empty.

Both approaches should work; the mentioned clients deviate from the spec here.

## Proposed Changes

Send 

```json
{
  "ids": [
    "0x..."
  ]
}
```

We achieve this by setting `#[serde(skip_serializing_if = "Option::is_none")]` on the `statuses` field in `eth2`, and supplying `None` to the field in Anchor.

## Additional Info

This was manually confirmed to work with all CL clients (using kurtosis).
