### PR TITLE
fix: Do not punish peers during sync

### DIFF
--- a/anchor/client/src/lib.rs
+++ b/anchor/client/src/lib.rs
@@ -470,6 +470,7 @@ impl Client {
             qbft_manager.clone(),
             signature_collector.clone(),
             database.watch(),
+            is_synced,
             outcome_tx,
             message_validator,
         );

--- a/anchor/client/src/lib.rs
+++ b/anchor/client/src/lib.rs
@@ -470,7 +470,7 @@ impl Client {
             qbft_manager.clone(),
             signature_collector.clone(),
             database.watch(),
-            is_synced,
+            is_synced.clone(),
             outcome_tx,
             message_validator,
         );

--- a/anchor/message_receiver/src/manager.rs
+++ b/anchor/message_receiver/src/manager.rs
@@ -29,6 +29,7 @@ pub struct NetworkMessageReceiver<S: SlotClock, D: DutiesProvider> {
     qbft_manager: Arc<QbftManager>,
     signature_collector: Arc<SignatureCollectorManager>,
     network_state_rx: watch::Receiver<NetworkState>,
+    is_synced: watch::Receiver<bool>,
     outcome_tx: mpsc::Sender<Outcome>,
     validator: Arc<Validator<S, D>>,
 }
@@ -39,6 +40,7 @@ impl<S: SlotClock + 'static, D: DutiesProvider> NetworkMessageReceiver<S, D> {
         qbft_manager: Arc<QbftManager>,
         signature_collector: Arc<SignatureCollectorManager>,
         network_state_rx: watch::Receiver<NetworkState>,
+        is_synced: watch::Receiver<bool>,
         outcome_tx: mpsc::Sender<Outcome>,
         validator: Arc<Validator<S, D>>,
     ) -> Arc<Self> {
@@ -47,6 +49,7 @@ impl<S: SlotClock + 'static, D: DutiesProvider> NetworkMessageReceiver<S, D> {
             qbft_manager,
             signature_collector,
             network_state_rx,
+            is_synced,
             outcome_tx,
             validator,
         })
@@ -70,10 +73,18 @@ impl<S: SlotClock + 'static, D: DutiesProvider> MessageReceiver
 
                 let result = receiver.validator.validate(&message.data);
 
+                let mut action = MessageAcceptance::from(&result);
+
+                // If we are not synced, do not punish peers to avoid banning peers during
+                // historical sync.
+                if let MessageAcceptance::Reject = action && !*receiver.is_synced.borrow() {
+                    action = MessageAcceptance::Ignore;
+                }
+
                 if let Err(err) = receiver.outcome_tx.try_send(Outcome {
                     message_id: message_id.clone(),
                     propagation_source,
-                    action: MessageAcceptance::from(&result),
+                    action,
                 }) {
                     match err {
                         TrySendError::Closed(_) => {


### PR DESCRIPTION
## Issue Addressed

During sync, we are happily processing messages. This is fine - it is worthwhile to keep up with the network and start peering ASAP. We will never sign anything during this period, but forward messages.

However, as our state might not be up-to-date yet, validation of valid messages might fail. We do not forward these messages and punish those peers.

## Proposed Changes

Do not forward invalid messages but do not punish peers as the messages might actually be valid.

## Additional Info

This contributes to the issues in `v0.3.0`.
