### PR TITLE
fix: Unmark subnet as needed in peer manager

### DIFF
--- a/anchor/network/src/network.rs
+++ b/anchor/network/src/network.rs
@@ -456,6 +456,7 @@ impl<R: MessageReceiver> Network<R> {
             }
             SubnetEvent::Leave(subnet) => {
                 self.gossipsub().unsubscribe(&subnet_to_topic(subnet));
+                self.peer_manager().leave_subnet(subnet);
                 (subnet, false)
             }
             SubnetEvent::RateUpdate(subnet, message_rate) => {

--- a/anchor/network/src/peer_manager/mod.rs
+++ b/anchor/network/src/peer_manager/mod.rs
@@ -80,6 +80,11 @@ impl PeerManager {
         )
     }
 
+    /// Leave subnet
+    pub fn leave_subnet(&mut self, subnet_id: SubnetId) {
+        self.needed_subnets.remove(&subnet_id);
+    }
+
     /// Perform heartbeat and return actions if needed
     pub fn heartbeat(&mut self) -> Option<ConnectActions> {
         info!(


### PR DESCRIPTION
## Issue Addressed

When getting a `Leave` event form the subnet service, we tell Gossipsub to unsubscribe, but do not the peer manager, who keeps searching peers for it.

## Proposed Changes

Remove the subnet from `needed_subnets`.

## Additional Info

We can also drop irrelevant peers here, but as we will do that on the next heartbeat anyway, I omitted it for this PR.
