### PR TITLE
fix: Decode correct type for sync committee contributions in QBFT check

### DIFF
--- a/anchor/common/ssv_types/src/consensus.rs
+++ b/anchor/common/ssv_types/src/consensus.rs
@@ -293,7 +293,7 @@ impl<E: EthSpec> ValidatorConsensusDataValidator<E> {
             BEACON_ROLE_SYNC_COMMITTEE_CONTRIBUTION => {
                 // There is nothing special to check for sync committee contributions.
                 // We just need to ensure that the data is valid.
-                SyncCommitteeContribution::<E>::from_ssz_bytes(value.data_ssz.as_slice())?;
+                Contributions::<E>::from_ssz_bytes(value.data_ssz.as_slice())?;
             }
             other => return Err(DataValidationError::InvalidDutyType(other)),
         };


### PR DESCRIPTION
## Issue Addressed

Incorrectly, we try to decode the proposed data on role `BEACON_ROLE_SYNC_COMMITTEE_CONTRIBUTION` to `SyncCommitteeContribution`.

## Proposed Changes

Decode to `Contributions` instead, matching the decoding of the completed value: https://github.com/sigp/anchor/blob/94aacac9d4d26877c3b9ee4a4417ccf36e0bfb51/anchor/validator_store/src/lib.rs#L1484