### PR TITLE
fix: Do not log exit event as unknown during historic sync

### DIFF
--- a/anchor/common/ssv_types/src/cluster.rs
+++ b/anchor/common/ssv_types/src/cluster.rs
@@ -1,6 +1,6 @@
 use std::fmt::Debug;
 
-use derive_more::{Deref, From};
+use derive_more::{Deref, Display, From};
 use indexmap::IndexSet;
 use ssz_derive::{Decode, Encode};
 use types::{Address, Graffiti, PublicKeyBytes};
@@ -66,7 +66,9 @@ pub struct ClusterMember {
 }
 
 /// Index of the validator in the validator registry.
-#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Hash, From, Deref, Encode, Decode)]
+#[derive(
+    Clone, Copy, Display, Debug, Default, Eq, PartialEq, Hash, From, Deref, Encode, Decode,
+)]
 #[ssz(struct_behaviour = "transparent")]
 pub struct ValidatorIndex(pub usize);
 

--- a/anchor/eth/src/event_processor.rs
+++ b/anchor/eth/src/event_processor.rs
@@ -116,8 +116,12 @@ impl EventProcessor {
                     self.process_fee_recipient_updated(log, &tx)
                 }
 
-                SSVContract::ValidatorExited::SIGNATURE_HASH if live => {
-                    self.process_validator_exited(log)
+                SSVContract::ValidatorExited::SIGNATURE_HASH => {
+                    if live {
+                        self.process_validator_exited(log)
+                    } else {
+                        Ok(())
+                    }
                 }
                 _ => {
                     debug!(?topic0, "Unknown event signature, skipping");

--- a/anchor/eth/src/event_processor.rs
+++ b/anchor/eth/src/event_processor.rs
@@ -602,12 +602,12 @@ impl EventProcessor {
 
         if !live {
             if is_our_validator {
-                warn!(
+                debug!(
                     %validator_index,
                     "Ignoring historic validator exit for validator assigned to us"
                 );
             } else {
-                debug!(%validator_index, "Ignoring historic validator exit");
+                trace!(%validator_index, "Ignoring historic validator exit");
             }
             return Ok(());
         }

--- a/anchor/eth/src/event_processor.rs
+++ b/anchor/eth/src/event_processor.rs
@@ -117,11 +117,7 @@ impl EventProcessor {
                 }
 
                 SSVContract::ValidatorExited::SIGNATURE_HASH => {
-                    if live {
-                        self.process_validator_exited(log)
-                    } else {
-                        Ok(())
-                    }
+                    self.process_validator_exited(log, live)
                 }
                 _ => {
                     debug!(?topic0, "Unknown event signature, skipping");
@@ -570,7 +566,7 @@ impl EventProcessor {
     }
 
     // A validator has exited the beacon chain
-    fn process_validator_exited(&self, log: &Log) -> Result<(), ExecutionError> {
+    fn process_validator_exited(&self, log: &Log, live: bool) -> Result<(), ExecutionError> {
         // In KeySplit mode, we don't need to process validator exits
         let Mode::Node { exit_tx, .. } = &self.mode else {
             return Ok(());
@@ -603,6 +599,18 @@ impl EventProcessor {
         };
 
         let is_our_validator = self.is_our_validator(&validator_pubkey);
+
+        if !live {
+            if is_our_validator {
+                warn!(
+                    %validator_index,
+                    "Ignoring historic validator exit for validator assigned to us"
+                );
+            } else {
+                debug!(%validator_index, "Ignoring historic validator exit");
+            }
+            return Ok(());
+        }
 
         // Send to exit processor instead of handling in-place
         let request = ExitRequest {


### PR DESCRIPTION
## Issue Addressed

During historic sync, we get a lot of "Unknown event signature, skipping", which are actually `ValidatorExited` events.

## Proposed Changes

Pull the `if live` into the variant to avoid triggering the fallback variant below.