### PR TITLE
fix: Remove error log for missing operators

### DIFF
--- a/anchor/eth/src/event_processor.rs
+++ b/anchor/eth/src/event_processor.rs
@@ -127,10 +127,14 @@ impl EventProcessor {
 
             // Handle any errors from the event processing
             if let Err(e) = result {
+                let tx_hash = log
+                    .transaction_hash
+                    .map(|hash| hash.to_string())
+                    .unwrap_or_else(|| "unknown".to_string());
                 if live {
-                    warn!("Malformed event: {e}");
+                    warn!(tx_hash, "Malformed event: {e}");
                 } else {
-                    debug!("Malformed event: {e}");
+                    debug!(tx_hash, "Malformed event: {e}");
                 }
                 continue;
             }

--- a/anchor/eth/src/util.rs
+++ b/anchor/eth/src/util.rs
@@ -11,7 +11,7 @@ use reqwest::Client;
 use sensitive_url::SensitiveUrl;
 use ssv_types::{ClusterId, ENCRYPTED_KEY_LENGTH, OperatorId, Share, ValidatorMetadata};
 use tower::ServiceBuilder;
-use tracing::{debug, error, trace};
+use tracing::{debug, trace};
 use types::{Graffiti, PublicKeyBytes, Signature};
 
 use crate::{error::ExecutionError, sync::MAX_OPERATORS};

--- a/anchor/eth/src/util.rs
+++ b/anchor/eth/src/util.rs
@@ -168,7 +168,6 @@ pub fn validate_operators(
         .iter()
         .any(|id| !network_state.operator_exists(id))
     {
-        error!(cluster_id = ?cluster_id, "One or more operators do not exist");
         return Err(ExecutionError::Database(
             "One or more operators do not exist".to_string(),
         ));


### PR DESCRIPTION
## Issue Addressed

In this function we log an error regarding missing operators even though we also return one.

As there is an event triggering this on mainnet, we have the unfortunate sideeffect to always log an ERROR during historic sync on mainnet. This is to be avoided.

## Proposed Changes

Remove the log.