### PR TITLE
fix: Allow reaching consensus in PREPARE state

### DIFF
--- a/anchor/common/qbft/src/lib.rs
+++ b/anchor/common/qbft/src/lib.rs
@@ -717,9 +717,10 @@ where
             // Make sure that the root of the data that we have come to a commit consensus on
             // matches the root of the proposal that we have accepted
             let proposal_root = match self.state {
+                InstanceState::Prepare { proposal_root } => proposal_root,
                 InstanceState::Commit { proposal_root } => proposal_root,
                 _ => {
-                    warn!(from=?operator_id, ?self.state, "Not in COMMIT state");
+                    warn!(from=?operator_id, ?self.state, "Not in PREPARE or COMMIT state");
                     return;
                 }
             };


### PR DESCRIPTION
## Issue Addressed

Fuzzer found that go-ssv allows going directly from propose to decided state. This seems to make sense.

## Proposed Changes

Simple fix for now: Allow `InstanceState::Prepare` when checking the state on received message.

## Additional Info

We should review for future versions whether `InstanceState` makes sense as is.
