### PR TITLE
fix: Validation for prepared round changes before insertion

### DIFF
--- a/anchor/common/qbft/src/lib.rs
+++ b/anchor/common/qbft/src/lib.rs
@@ -811,7 +811,6 @@ where
 
         let qbft_msg = &wrapped_msg.qbft_message;
         // If this is a "prepared" round change, we have to check the justifications.
-        // see https://github.com/ssvlabs/ssv/blob/7999b26308990b3f364d60e1618a8b6cf5b2d3e6/protocol/v2/qbft/instance/round_change.go#L304
         if qbft_msg.data_round > 0 {
             if !self.check_quorum(&qbft_msg.round_change_justification) {
                 debug!(

--- a/anchor/common/qbft/src/lib.rs
+++ b/anchor/common/qbft/src/lib.rs
@@ -834,11 +834,17 @@ where
             }
 
             for justification in qbft_msg.round_change_justification.iter() {
-                self.is_valid_prepare_justification_for_round_and_root(
+                if !self.is_valid_prepare_justification_for_round_and_root(
                     justification,
                     round,
                     &qbft_msg.root,
-                );
+                ) {
+                    debug!(
+                        from = *operator_id,
+                        "ROUNDCHANGE has invalid prepare justification"
+                    );
+                    return;
+                }
             }
         }
 

--- a/anchor/common/qbft/src/lib.rs
+++ b/anchor/common/qbft/src/lib.rs
@@ -1,4 +1,7 @@
-use std::{collections::HashMap, sync::Arc};
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+};
 
 // Re-Exports for Manager
 pub use config::{Config, ConfigBuilder};
@@ -234,6 +237,16 @@ where
         self.config.committee_members().contains(operator_id)
     }
 
+    /// Checks if we have a quorum of unique committee operators from these messages.
+    fn check_quorum<'a>(&self, msgs: impl IntoIterator<Item = &'a SignedSSVMessage>) -> bool {
+        let unique_operators = msgs
+            .into_iter()
+            .flat_map(|justification| justification.operator_ids())
+            .filter(|operator_id| self.check_committee(operator_id))
+            .collect::<HashSet<_>>();
+        unique_operators.len() >= self.config.quorum_size()
+    }
+
     // Perform base QBFT relevant message verification. This verfiication is applicable to all QBFT
     // message types
     // Return type expresses that we either have
@@ -434,7 +447,7 @@ where
 
         // If we are passed the first round, make sure that the justifications actually justify the
         // received proposal
-        if round > Round::default() && !self.validate_justifications(&wrapped_msg) {
+        if round > Round::default() && !self.validate_proposal_justifications(&wrapped_msg) {
             warn!(from = ?operator_id, "Justification verifiction failed");
             return;
         }
@@ -484,14 +497,13 @@ where
     // A QBFT Message contains fields to a list of round change justifications and prepare
     // justifications. We must go through each of these individually and verify the validity of each
     // one
-    fn validate_justifications(&self, msg: &WrappedQbftMessage) -> bool {
+    fn validate_proposal_justifications(&self, msg: &WrappedQbftMessage) -> bool {
         // Record if any of the round change messages have a value that was prepared
-        let mut previously_prepared = false;
         let mut max_prepared_round = 0;
         let mut max_prepared_msg = None;
 
         // Make sure we have a quorum of round change messages
-        if msg.qbft_message.round_change_justification.len() < self.config.quorum_size() {
+        if !self.check_quorum(&msg.qbft_message.round_change_justification) {
             warn!("Did not receive a quorum of round change messages");
             return false;
         }
@@ -526,8 +538,6 @@ where
 
             // If the data_round > 1, that means we have prepared a value in previous rounds
             if round_change.data_round > 1 {
-                previously_prepared = true;
-
                 // also track the max prepared value and round
                 if round_change.data_round > max_prepared_round {
                     max_prepared_round = round_change.data_round;
@@ -538,9 +548,9 @@ where
 
         // If there was a value that was also previously prepared, we must also verify all of the
         // prepare justifications
-        if previously_prepared {
+        if let Some(max_prepared_msg) = max_prepared_msg {
             // Make sure we have a quorum of prepare messages
-            if msg.qbft_message.prepare_justification.len() < self.config.quorum_size() {
+            if self.check_quorum(&msg.qbft_message.prepare_justification) {
                 warn!(
                     num_justifications = msg.qbft_message.prepare_justification.len(),
                     "Not enough prepare messages for quorum"
@@ -549,48 +559,59 @@ where
             }
 
             // Make sure that the roots match
-            if msg.qbft_message.root
-                != max_prepared_msg
-                    .clone()
-                    .expect("Exists as we have a previously prepared value")
-                    .root
-            {
+            if msg.qbft_message.root != max_prepared_msg.root {
                 warn!("Highest prepared does not match proposed data");
                 return false;
             }
 
             // Validate each prepare message matches highest prepared round/value
             for signed_prepare in &msg.qbft_message.prepare_justification {
-                // The qbft message is represented as Vec<u8> in the signed message, deserialize
-                // this into a qbft message
-                let prepare = match QbftMessage::from_ssz_bytes(signed_prepare.ssv_message().data())
-                {
-                    Ok(data) => data,
-                    Err(_) => return false,
-                };
-
-                // Make sure this is a prepare message
-                if prepare.qbft_message_type != QbftMessageType::Prepare {
-                    warn!("Expected a prepare message");
-                    return false;
-                }
-
-                let wrapped = WrappedQbftMessage {
-                    signed_message: signed_prepare.clone(),
-                    qbft_message: prepare.clone(),
-                };
-
-                if self.validate_message(&wrapped).is_none() {
-                    warn!("PREPARE message validation failed");
-                    return false;
-                }
-
-                if prepare.root != msg.qbft_message.root {
-                    warn!("Proposed data mismatch");
+                if !self.is_valid_prepare_justification_for_round_and_root(
+                    signed_prepare,
+                    max_prepared_msg.data_round.into(),
+                    &max_prepared_msg.root,
+                ) {
                     return false;
                 }
             }
         }
+        true
+    }
+
+    fn is_valid_prepare_justification_for_round_and_root(
+        &self,
+        justification: &SignedSSVMessage,
+        round: Round,
+        root: &Hash256,
+    ) -> bool {
+        // The qbft message is represented as Vec<u8> in the signed message, deserialize this into
+        // a qbft message
+        let Ok(prepare) = QbftMessage::from_ssz_bytes(justification.ssv_message().data()) else {
+            warn!("Undecodable justification");
+            return false;
+        };
+
+        // Make sure this is a prepare message
+        if prepare.qbft_message_type != QbftMessageType::Prepare {
+            warn!("Expected a prepare message");
+            return false;
+        }
+
+        if prepare.height != *self.instance_height as u64 {
+            warn!("PREPARE height incorrect");
+            return false;
+        }
+
+        if prepare.round != round.get() as u64 {
+            warn!("PREPARE round incorrect");
+            return false;
+        }
+
+        if &prepare.root != root {
+            warn!("Proposed data mismatch");
+            return false;
+        }
+
         true
     }
 
@@ -786,6 +807,39 @@ where
         if u8::from(self.state) >= u8::from(InstanceState::Complete) {
             debug!(from=*operator_id, ?self.state, "ROUNDCHANGE message while in invalid state");
             return;
+        }
+
+        let qbft_msg = &wrapped_msg.qbft_message;
+        // If this is a "prepared" round change, we have to check the justifications.
+        // see https://github.com/ssvlabs/ssv/blob/7999b26308990b3f364d60e1618a8b6cf5b2d3e6/protocol/v2/qbft/instance/round_change.go#L304
+        if qbft_msg.data_round > 0 {
+            if !self.check_quorum(&qbft_msg.round_change_justification) {
+                debug!(
+                    from = *operator_id,
+                    justifications = qbft_msg.round_change_justification.len(),
+                    quorum = self.config.quorum_size(),
+                    "prepared ROUNDCHANGE has no quorum"
+                );
+                return;
+            }
+
+            if qbft_msg.data_round > qbft_msg.round {
+                debug!(
+                    from = *operator_id,
+                    data_round = qbft_msg.data_round,
+                    round = qbft_msg.round,
+                    "ROUNDCHANGE has prepared round after round"
+                );
+                return;
+            }
+
+            for justification in qbft_msg.round_change_justification.iter() {
+                self.is_valid_prepare_justification_for_round_and_root(
+                    justification,
+                    round,
+                    &qbft_msg.root,
+                );
+            }
         }
 
         debug!(from = ?operator_id, state = ?self.state, "ROUNDCHANGE received");
@@ -1044,7 +1098,7 @@ where
 
                 // Validate the proposal, if this is a valid proposal then this is our prepare
                 // justification
-                if self.validate_justifications(wrapped_round_change) {
+                if self.validate_proposal_justifications(wrapped_round_change) {
                     return (
                         vec![wrapped_round_change.signed_message.clone()],
                         Some(round_change.root),

--- a/anchor/common/qbft/src/lib.rs
+++ b/anchor/common/qbft/src/lib.rs
@@ -550,7 +550,7 @@ where
         // prepare justifications
         if let Some(max_prepared_msg) = max_prepared_msg {
             // Make sure we have a quorum of prepare messages
-            if self.check_quorum(&msg.qbft_message.prepare_justification) {
+            if !self.check_quorum(&msg.qbft_message.prepare_justification) {
                 warn!(
                     num_justifications = msg.qbft_message.prepare_justification.len(),
                     "Not enough prepare messages for quorum"

--- a/anchor/common/qbft/src/lib.rs
+++ b/anchor/common/qbft/src/lib.rs
@@ -678,7 +678,7 @@ where
         // The qbft message is represented as Vec<u8> in the signed message, deserialize this into
         // a qbft message
         let Ok(prepare) = QbftMessage::from_ssz_bytes(justification.ssv_message().data()) else {
-            warn!("Undecodable justification");
+            warn!("Failed to decode prepare justification message");
             return false;
         };
 

--- a/anchor/common/qbft/src/lib.rs
+++ b/anchor/common/qbft/src/lib.rs
@@ -594,7 +594,7 @@ where
             // If the data_round > 0, that means we have prepared a value in previous rounds
             // We also have to go through all of the prepare justifications in the round change to
             // ensure that they are well formed and properly justify the prepared value
-            if round_change.data_round > 1 {
+            if round_change.data_round > 0 {
                 // also track the max prepared value and round
                 if round_change.data_round > max_prepared_round {
                     max_prepared_round = round_change.data_round;

--- a/anchor/common/qbft/src/lib.rs
+++ b/anchor/common/qbft/src/lib.rs
@@ -601,9 +601,24 @@ where
                     max_prepared_msg = Some(round_change.clone());
                 }
 
+                // Check that prepared round is not greater than current round
+                if round_change.data_round > round_change.round {
+                    warn!(
+                        "Round change has prepared round {} > round {}",
+                        round_change.data_round, round_change.round
+                    );
+                    return false;
+                }
+
+                // Verify that if round change has full data, it matches the root
+                if msg.qbft_message.root != round_change.root {
+                    warn!("Proposal root doesn't match round change prepared root");
+                    return false;
+                }
+
                 if !self.check_quorum(&round_change.round_change_justification) {
                     warn!(
-                        num_justifications = msg.qbft_message.prepare_justification.len(),
+                        num_justifications = round_change.round_change_justification.len(),
                         "Not enough prepare messages for quorum"
                     );
                     return false;
@@ -925,7 +940,7 @@ where
             for justification in qbft_msg.round_change_justification.iter() {
                 if !self.is_valid_prepare_justification_for_round_and_root(
                     justification,
-                    round,
+                    qbft_msg.data_round.into(),
                     &qbft_msg.root,
                 ) {
                     debug!(

--- a/anchor/common/qbft/src/lib.rs
+++ b/anchor/common/qbft/src/lib.rs
@@ -526,12 +526,19 @@ where
         self.send_prepare(wrapped_msg.qbft_message.root);
     }
 
-    // Validate the round change and prepare justifications. Returns true if the justifications
-    // correctly justify the proposal
+    // Validate the round change and prepare justifications for proposal.
+    // Returns true if the justifications correctly justify the proposal
     //
     // A QBFT Message contains fields to a list of round change justifications and prepare
     // justifications. We must go through each of these individually and verify the validity of each
     // one
+    //
+    // Proposal
+    // - round change justifications
+    //  - list of round change messages
+    //      - each round change message has list of prepare messages if it prepared a value
+    // - prepare justifications
+    //  - list of prepare messages to
     fn validate_proposal_justifications(&self, msg: &WrappedQbftMessage) -> bool {
         // Record if any of the round change messages have a value that was prepared
         let mut max_prepared_round = 0;
@@ -546,6 +553,18 @@ where
         // There was a quorum of round change justifications. We need to go though and verify each
         // one. Each will be a SignedSSVMessage
         for signed_round_change in &msg.qbft_message.round_change_justification {
+            // Check for multi-signers - round change messages should only have 1 signer
+            if signed_round_change.operator_ids().len() > 1 {
+                return false;
+            }
+
+            // make sure all signers in committee
+            for signer in signed_round_change.operator_ids() {
+                if !self.check_committee(signer) {
+                    return false;
+                }
+            }
+
             // The qbft message is represented as a Vec<u8> in the signed message, deserialize this
             // into a proper QbftMessage
             let round_change: QbftMessage =
@@ -560,23 +579,45 @@ where
                 return false;
             }
 
-            // Convert to a wrapped message and perform verification
-            let wrapped = WrappedQbftMessage {
-                signed_message: signed_round_change.clone(),
-                qbft_message: round_change.clone(),
-            };
-
-            if self.validate_message(&wrapped).is_none() {
-                warn!("ROUNDCHANGE message validation failed");
+            // make sure the round change matches the round of the message
+            if round_change.round != msg.qbft_message.round {
                 return false;
             }
 
-            // If the data_round > 1, that means we have prepared a value in previous rounds
+            // For round change justifications, we need special validation that doesn't check
+            // against current round since they're justifications from the proposal's round
+            // Check height
+            if round_change.height != *self.instance_height as u64 {
+                return false;
+            }
+
+            // If the data_round > 0, that means we have prepared a value in previous rounds
+            // We also have to go through all of the prepare justifications in the round change to
+            // ensure that they are well formed and properly justify the prepared value
             if round_change.data_round > 1 {
                 // also track the max prepared value and round
                 if round_change.data_round > max_prepared_round {
                     max_prepared_round = round_change.data_round;
-                    max_prepared_msg = Some(round_change);
+                    max_prepared_msg = Some(round_change.clone());
+                }
+
+                if !self.check_quorum(&round_change.round_change_justification) {
+                    warn!(
+                        num_justifications = msg.qbft_message.prepare_justification.len(),
+                        "Not enough prepare messages for quorum"
+                    );
+                    return false;
+                }
+
+                // go through all of the round changes prepare justifications
+                for signed_prepare in &round_change.round_change_justification {
+                    if !self.is_valid_prepare_justification_for_round_and_root(
+                        signed_prepare,
+                        round_change.data_round.into(),
+                        &round_change.root,
+                    ) {
+                        return false;
+                    }
                 }
             }
         }

--- a/anchor/common/qbft/src/tests.rs
+++ b/anchor/common/qbft/src/tests.rs
@@ -281,7 +281,7 @@ fn test_round_change_validation_skips_round_one_prepared_values() {
 
     // Create signed round change messages (need quorum of 3 for 3-node committee)
     let mut signed_round_changes = vec![];
-    for operator_id in config.operators.iter().map(|op| op.id) {
+    for operator_id in [1, 2, 3] {
         // Create the SSVMessage properly
         let ssv_message = SSVMessage::new(
             MsgType::SSVConsensusMsgType,

--- a/anchor/common/qbft/src/tests.rs
+++ b/anchor/common/qbft/src/tests.rs
@@ -281,7 +281,7 @@ fn test_round_change_validation_skips_round_one_prepared_values() {
 
     // Create signed round change messages (need quorum of 3 for 3-node committee)
     let mut signed_round_changes = vec![];
-    for operator_id in [1, 2, 3] {
+    for operator_id in config.operators.iter().map(|op| op.id) {
         // Create the SSVMessage properly
         let ssv_message = SSVMessage::new(
             MsgType::SSVConsensusMsgType,

--- a/anchor/common/qbft/src/tests.rs
+++ b/anchor/common/qbft/src/tests.rs
@@ -223,3 +223,136 @@ fn test_node_recovery() {
     let num_consensus = test_instance.wait_until_end();
     assert_eq!(num_consensus, 5); // Should reach full consensus after recovery
 }
+
+#[test]
+/// Test that FAILS if round change validation doesn't require prepare justifications for
+/// data_round=1
+///
+/// This test creates a proposal with round change messages claiming preparation in round 1
+/// (data_round=1) but provides NO prepare justifications.
+/// The test FAILS if the validation doesn't reject the proposal as it should.
+fn test_round_change_validation_skips_round_one_prepared_values() {
+    if ENABLE_TEST_LOGGING {
+        let env_filter = EnvFilter::new("debug");
+        let _ = tracing_subscriber::fmt()
+            .compact()
+            .with_env_filter(env_filter)
+            .try_init();
+    }
+
+    use ssv_types::{
+        consensus::QbftMessage,
+        message::{MsgType, RSA_SIGNATURE_SIZE, SSVMessage, SignedSSVMessage},
+    };
+
+    // Create QBFT instance
+    let config = ConfigBuilder::<DefaultLeaderFunction>::new(
+        1.into(),
+        InstanceHeight::default(),
+        (1..4).map(OperatorId::from).collect(), // 3 nodes, quorum = 3
+    )
+    .with_operator_id(OperatorId::from(1))
+    .build()
+    .expect("config should be valid");
+
+    let test_data = TestData(123);
+    let qbft_instance = Qbft::new(
+        config,
+        test_data.clone(),
+        Box::new(NoDataValidation),
+        MessageId::from([0; 56]),
+        |_| {},
+    );
+
+    // Create a MALICIOUS round change message:
+    // - Claims to have prepared a value in round 1 (data_round = 1)
+    // - But provides NO prepare justifications (empty prepare_justification)
+    // This should be REJECTED but the bug allows it through
+    let malicious_round_change = QbftMessage {
+        qbft_message_type: QbftMessageType::RoundChange,
+        height: 0,
+        round: 2,
+        identifier: [0; 56].to_vec().into(),
+        root: test_data.hash(),
+        data_round: 1, // Claims preparation in round 1 - this is the bug trigger!
+        round_change_justification: vec![],
+        prepare_justification: vec![], // INVALID: No justifications for claimed preparation!
+    };
+
+    // Create signed round change messages (need quorum of 3 for 3-node committee)
+    let mut signed_round_changes = vec![];
+    for operator_id in [1, 2, 3] {
+        // Create the SSVMessage properly
+        let ssv_message = SSVMessage::new(
+            MsgType::SSVConsensusMsgType,
+            MessageId::from([0; 56]),
+            malicious_round_change.as_ssz_bytes(),
+        )
+        .expect("should create SSVMessage");
+
+        let signed_rc = SignedSSVMessage::new(
+            vec![vec![0; RSA_SIGNATURE_SIZE]],
+            vec![OperatorId::from(operator_id)],
+            ssv_message,
+            vec![], // no full_data for round change
+        )
+        .expect("should create signed message");
+        signed_round_changes.push(signed_rc);
+    }
+
+    // Create proposal that includes these invalid round changes
+    let proposal = QbftMessage {
+        qbft_message_type: QbftMessageType::Proposal,
+        height: 0,
+        round: 2,
+        identifier: [0; 56].to_vec().into(),
+        root: test_data.hash(),
+        data_round: 1, // Proposing the "prepared" value from round 1
+        round_change_justification: signed_round_changes,
+        prepare_justification: vec![], // Proposals don't need prepare justifications
+    };
+
+    // Create the SSVMessage for the proposal
+    let proposal_ssv_message = SSVMessage::new(
+        MsgType::SSVConsensusMsgType,
+        MessageId::from([0; 56]),
+        proposal.as_ssz_bytes(),
+    )
+    .expect("should create proposal SSVMessage");
+
+    let signed_proposal = SignedSSVMessage::new(
+        vec![vec![0; RSA_SIGNATURE_SIZE]],
+        vec![OperatorId::from(2)], // From operator 2 (leader for round 2)
+        proposal_ssv_message,
+        test_data.as_ssz_bytes(), // full_data for proposal
+    )
+    .expect("should create signed proposal");
+
+    let wrapped_proposal = WrappedQbftMessage {
+        signed_message: signed_proposal,
+        qbft_message: proposal,
+    };
+
+    // Call the actual buggy validation function
+    let validation_result = qbft_instance.validate_justifications(&wrapped_proposal);
+
+    // The validation should REJECT this proposal because:
+    // - Round change messages claim data_round=1 (prepared in round 1)
+    // - But they provide NO prepare justifications to prove this claim
+
+    println!(
+        "Validation result for malicious proposal: {}",
+        validation_result
+    );
+    println!("This proposal should be REJECTED because round change messages");
+    println!("claim preparation in round 1 but provide no prepare justifications.");
+
+    // This assertion will FAIL if a buggy code returns true (accepts invalid proposal)
+    assert!(
+        !validation_result,
+        "BUG: validate_justifications() accepted an invalid proposal! \
+         Round change messages claim data_round=1 (prepared in round 1) but provide no \
+         prepare justifications. This should be rejected but the validation logic \
+         incorrectly skips prepare justification checking for round 1 preparations."
+    );
+}


### PR DESCRIPTION
## Issue Addressed

If we have prepared a value, we include it in a round change messages and include the quorum of prepare justifications proving that value was prepared in the round_change_justifications field. These round change messages have to have the round_change_justifications prepare messages validated to ensure that these messages actually prove that the value was prepared. Otherwise, you could claim to prepare some value but not properly be able to support/prove it.

## Proposed Changes

Implement the missing validation and change existing code a bit to be able to reuse `is_valid_prepare_justification_for_round_and_root`. 
