### PR TITLE
fix: Bump round on future justified proposal

### DIFF
--- a/anchor/common/qbft/src/lib.rs
+++ b/anchor/common/qbft/src/lib.rs
@@ -474,6 +474,11 @@ where
         };
         debug!(state = ?self.state, "State updated to PREPARE");
 
+        // A future justified proposal should bump us into future round
+        if round > self.current_round {
+            self.current_round = round;
+        }
+
         // Create and send prepare message
         self.send_prepare(wrapped_msg.qbft_message.root);
     }


### PR DESCRIPTION
## Issue Addressed

[A justified future proposal should bump our own round](https://github.com/ssvlabs/ssv/blob/7999b26308990b3f364d60e1618a8b6cf5b2d3e6/protocol/v2/qbft/instance/proposal.go#L35-L39)

## Proposed Changes

Bump the round by simply setting it to `current_round`. We do not want to use `start_round` as we got the proposal already. The timer is automatically adjusted as the qbft manager recalculates the appropriate timeout after each message.