### PR TITLE
fix: COMMIT and PREPARE must be of the exact current round

### DIFF
--- a/anchor/common/qbft/src/lib.rs
+++ b/anchor/common/qbft/src/lib.rs
@@ -617,6 +617,15 @@ where
             return;
         }
 
+        if round != self.current_round {
+            debug!(
+                from=?operator_id,
+                %round,
+                current_round=%self.current_round,
+                "Received PREPARE for incorrect round"
+            );
+        }
+
         debug!(from = ?operator_id, state = ?self.state, "PREPARE received");
 
         // Store the prepare message
@@ -694,6 +703,15 @@ where
         )) {
             warn!(from=?operator_id, "Expected a COMMIT message");
             return;
+        }
+
+        if round != self.current_round {
+            debug!(
+                from=?operator_id,
+                %round,
+                current_round=%self.current_round,
+                "Received COMMIT for incorrect round"
+            );
         }
 
         // Make sure that we have accepted a proposal for this round

--- a/anchor/common/qbft/src/lib.rs
+++ b/anchor/common/qbft/src/lib.rs
@@ -229,6 +229,18 @@ where
         )
     }
 
+    fn check_same_round(&self, round: Round) -> bool {
+        if round != self.current_round {
+            debug!(
+                %round,
+                current_round=%self.current_round,
+                "Received message for incorrect round"
+            );
+            return false;
+        }
+        true
+    }
+
     /// Checks to make sure any given operator is in this instance's comittee.
     fn check_committee(&self, operator_id: &OperatorId) -> bool {
         self.config.committee_members().contains(operator_id)
@@ -617,13 +629,8 @@ where
             return;
         }
 
-        if round != self.current_round {
-            debug!(
-                from=?operator_id,
-                %round,
-                current_round=%self.current_round,
-                "Received PREPARE for incorrect round"
-            );
+        if !self.check_same_round(round) {
+            return;
         }
 
         debug!(from = ?operator_id, state = ?self.state, "PREPARE received");
@@ -705,13 +712,8 @@ where
             return;
         }
 
-        if round != self.current_round {
-            debug!(
-                from=?operator_id,
-                %round,
-                current_round=%self.current_round,
-                "Received COMMIT for incorrect round"
-            );
+        if !self.check_same_round(round) {
+            return;
         }
 
         // Make sure that we have accepted a proposal for this round


### PR DESCRIPTION
## Issue Addressed

[Prepares](https://github.com/ssvlabs/ssv/blob/7999b26308990b3f364d60e1618a8b6cf5b2d3e6/protocol/v2/qbft/instance/prepare.go#L118-L120) and [Commits](https://github.com/ssvlabs/ssv/blob/7999b26308990b3f364d60e1618a8b6cf5b2d3e6/protocol/v2/qbft/instance/commit.go#L195-L197) need to be in the EXACT current round.

## Proposed Changes

Add validation to the respective handlers.
