### PR TITLE
fix: disconnect blocked peers

### DIFF
--- a/anchor/network/src/network.rs
+++ b/anchor/network/src/network.rs
@@ -534,7 +534,7 @@ impl<R: MessageReceiver> Network<R> {
 
         // ---------- first pass (read-only) ----------
         let mut peer_scores = Vec::new();
-        let mut peers_to_block = HashSet::new();
+        let mut peers_to_block_and_disconnect = HashSet::new();
 
         {
             // borrow `self.swarm` immutably only inside this block
@@ -542,7 +542,7 @@ impl<R: MessageReceiver> Network<R> {
             for peer_id in self.swarm.connected_peers().cloned() {
                 if let Some(score) = behaviour.gossipsub.peer_score(&peer_id) {
                     if score < GRAYLIST_THRESHOLD {
-                        peers_to_block.insert(peer_id);
+                        peers_to_block_and_disconnect.insert(peer_id);
                     }
                     peer_scores.push((peer_id, score));
                 }
@@ -553,24 +553,29 @@ impl<R: MessageReceiver> Network<R> {
         let target = self.swarm.behaviour().peer_manager.target_peers();
         let excess = self.swarm.connected_peers().count().saturating_sub(target);
 
-        for peer in &peers_to_block {
-            self.swarm.behaviour_mut().peer_manager.block_peer(*peer);
+        for peer_id in &peers_to_block_and_disconnect {
+            self.swarm.behaviour_mut().peer_manager.block_peer(*peer_id);
+            self.disconnect_peer(peer_id);
         }
 
         if excess > 0 {
             peer_scores.sort_by(|a, b| a.1.total_cmp(&b.1));
             let to_disconnect = peer_scores
                 .iter()
-                .filter(|(p, _)| !peers_to_block.contains(p))
+                .filter(|(p, _)| !peers_to_block_and_disconnect.contains(p))
                 .take(excess)
                 .map(|(p, _)| *p);
 
             for peer_id in to_disconnect {
-                match self.swarm.disconnect_peer_id(peer_id) {
-                    Ok(_) => debug!(%peer_id, "Disconnected peer due to low score"),
-                    Err(_) => trace!(%peer_id, "Peer was already disconnected"),
-                }
+                self.disconnect_peer(&peer_id);
             }
+        }
+    }
+
+    fn disconnect_peer(&mut self, peer_id: &PeerId) {
+        match self.swarm.disconnect_peer_id(*peer_id) {
+            Ok(_) => debug!(%peer_id, "Disconnected peer due to low score"),
+            Err(_) => trace!(%peer_id, "Peer was already disconnected"),
         }
     }
 


### PR DESCRIPTION
## Issue Addressed

This PR fixes an issue where blocked peers were not being disconnected from the network. The change ensures that peers with low scores are both blocked and immediately disconnected, rather than just being blocked.

## Proposed Changes

- Renamed variable for clarity and added immediate disconnection of blocked peers
- Extracted peer disconnection logic into a reusable helper method
- Ensured blocked peers are properly disconnected from the swarm
