### PR TITLE
fix: preserve order in message containers

### DIFF
--- a/anchor/common/qbft/src/msg_container.rs
+++ b/anchor/common/qbft/src/msg_container.rs
@@ -97,12 +97,9 @@ impl MessageContainer {
 
     /// Gets all messages for a specific round
     pub fn get_messages_for_round(&self, round: Round) -> Vec<&WrappedQbftMessage> {
-        let result: Vec<&WrappedQbftMessage> = self
-            .messages
+        self.messages
             .get(&round)
             .map(|round_messages| round_messages.iter().collect())
-            .unwrap_or_default();
-
-        result
+            .unwrap_or_default()
     }
 }

--- a/anchor/common/qbft/src/msg_container.rs
+++ b/anchor/common/qbft/src/msg_container.rs
@@ -8,8 +8,10 @@ use crate::{Round, WrappedQbftMessage};
 /// Message container with strong typing and validation
 #[derive(Default)]
 pub struct MessageContainer {
-    /// Messages indexed by round and then by sender
-    messages: HashMap<Round, HashMap<OperatorId, WrappedQbftMessage>>,
+    /// Messages stored as a Vec per round to preserve insertion order
+    messages: HashMap<Round, Vec<WrappedQbftMessage>>,
+    /// Track which operators have sent messages for each round
+    senders_by_round: HashMap<Round, HashSet<OperatorId>>,
     /// Track unique values per round
     values_by_round: HashMap<Round, HashSet<Hash256>>,
     /// The quorum size for the qbft instance
@@ -22,6 +24,7 @@ impl MessageContainer {
         Self {
             quorum_size,
             messages: HashMap::new(),
+            senders_by_round: HashMap::new(),
             values_by_round: HashMap::new(),
         }
     }
@@ -34,20 +37,13 @@ impl MessageContainer {
         msg: &WrappedQbftMessage,
     ) -> bool {
         // Check if we already have a message from this sender for this round
-        if self
-            .messages
-            .get(&round)
-            .and_then(|msgs| msgs.get(&sender))
-            .is_some()
-        {
+        let senders = self.senders_by_round.entry(round).or_default();
+        if senders.contains(&sender) {
             return false; // Duplicate message
         }
 
-        // Add message and track its value
-        self.messages
-            .entry(round)
-            .or_default()
-            .insert(sender, msg.clone());
+        senders.insert(sender);
+        self.messages.entry(round).or_default().push(msg.clone());
 
         self.values_by_round
             .entry(round)
@@ -64,7 +60,7 @@ impl MessageContainer {
 
         // Count occurrences of each value
         let mut value_counts: HashMap<Hash256, usize> = HashMap::new();
-        for msg in round_messages.values() {
+        for msg in round_messages {
             *value_counts.entry(msg.qbft_message.root).or_default() += 1;
         }
 
@@ -90,7 +86,7 @@ impl MessageContainer {
         if let Some(hash) = self.has_quorum(round)
             && let Some(round_messages) = self.messages.get(&round)
         {
-            for msg in round_messages.values() {
+            for msg in round_messages {
                 if msg.qbft_message.root == hash {
                     msgs.push(msg.clone());
                 }
@@ -101,14 +97,12 @@ impl MessageContainer {
 
     /// Gets all messages for a specific round
     pub fn get_messages_for_round(&self, round: Round) -> Vec<&WrappedQbftMessage> {
-        // If we have messages for this round in our container, return them all
-        // If not, return an empty vector
-        self.messages
+        let result: Vec<&WrappedQbftMessage> = self
+            .messages
             .get(&round)
-            .map(|round_messages| {
-                // Convert the values of the HashMap into a Vec
-                round_messages.values().collect()
-            })
-            .unwrap_or_default()
+            .map(|round_messages| round_messages.iter().collect())
+            .unwrap_or_default();
+
+        result
     }
 }

--- a/anchor/common/qbft/src/msg_container.rs
+++ b/anchor/common/qbft/src/msg_container.rs
@@ -38,11 +38,10 @@ impl MessageContainer {
     ) -> bool {
         // Check if we already have a message from this sender for this round
         let senders = self.senders_by_round.entry(round).or_default();
-        if senders.contains(&sender) {
-            return false; // Duplicate message
+        if !senders.insert(sender) {
+            return false;
         }
 
-        senders.insert(sender);
         self.messages.entry(round).or_default().push(msg.clone());
 
         self.values_by_round


### PR DESCRIPTION
## Issue Addressed

Messages must be stored in the order that they arrive in. This is important for the resulting signatures as even if we have the same messages, if they are not in the expected order this results in different encodings and signatures. 

go-ssv just does this through a [slice](https://github.com/ssvlabs/ssv-spec/blob/d4c734909677b5fd3304e1d9220963cc9d794f09/qbft/message_container.go#L9)
