### PR TITLE
feat: future round validation

### DIFF
--- a/anchor/common/qbft/src/lib.rs
+++ b/anchor/common/qbft/src/lib.rs
@@ -254,6 +254,37 @@ where
             return None;
         }
 
+        // Check for future round
+        if wrapped_msg.qbft_message.round > self.current_round.into() {
+            match wrapped_msg.qbft_message.qbft_message_type {
+                QbftMessageType::RoundChange => {
+                    // Round changes for future rounds are always allowed
+                }
+                QbftMessageType::Proposal => {
+                    // Proposals for future rounds are only allowed with justifications
+                    if wrapped_msg
+                        .qbft_message
+                        .round_change_justification
+                        .is_empty()
+                    {
+                        return None;
+                    }
+                }
+                QbftMessageType::Commit => {
+                    // Single-signature commits from future rounds are not allowed
+                    // But multi-signature commits (decided messages) should be allowed from any
+                    // round
+                    if wrapped_msg.signed_message.operator_ids().len() == 1 {
+                        return None;
+                    }
+                }
+                _ => {
+                    // Prepare messages for future rounds are not allowed
+                    return None;
+                }
+            }
+        }
+
         // Make sure we are at the correct instance height
         if wrapped_msg.qbft_message.height != *self.instance_height as u64 {
             warn!(

--- a/anchor/common/qbft/src/lib.rs
+++ b/anchor/common/qbft/src/lib.rs
@@ -257,24 +257,12 @@ where
         // Check for future round
         if wrapped_msg.qbft_message.round > self.current_round.into() {
             match wrapped_msg.qbft_message.qbft_message_type {
-                QbftMessageType::RoundChange => {
-                    // Round changes for future rounds are always allowed
-                }
-                QbftMessageType::Proposal => {
-                    // Proposals for future rounds are only allowed with justifications
-                    if wrapped_msg
-                        .qbft_message
-                        .round_change_justification
-                        .is_empty()
-                    {
-                        return None;
-                    }
+                QbftMessageType::Proposal | QbftMessageType::RoundChange => {
+                    // Proposals & Round Changes for future rounds are always allowed
                 }
                 QbftMessageType::Commit => {
-                    // Single-signature commits from future rounds are not allowed
-                    // But multi-signature commits (decided messages) should be allowed from any
-                    // round
-                    if wrapped_msg.signed_message.operator_ids().len() == 1 {
+                    // Only decided messages (with quorum) are allowed from future rounds
+                    if wrapped_msg.signed_message.operator_ids().len() < self.config.quorum_size() {
                         return None;
                     }
                 }

--- a/anchor/common/qbft/src/lib.rs
+++ b/anchor/common/qbft/src/lib.rs
@@ -267,7 +267,7 @@ where
                     }
                 }
                 _ => {
-                    // Prepare messages for future rounds are not allowed
+                    // All other message types (including Prepare) for future rounds are not allowed
                     return None;
                 }
             }


### PR DESCRIPTION
## Proposed Changes

Adds in validation for when we receive a message for a future round

1) We should always be accepting a proposals and round changes for future rounds. 
2) Commit message should only be accepted for a future round if it is decided & a prepare should never be accepted 