### PR TITLE
fix: proposal validation

### DIFF
--- a/anchor/common/qbft/src/lib.rs
+++ b/anchor/common/qbft/src/lib.rs
@@ -434,6 +434,7 @@ where
 
         // Make sure this is from the leader
         if !self.check_leader(&operator_id) {
+            warn!(from = ?operator_id, "PROPOSE message received from non-leader operator");
             return;
         }
 
@@ -442,6 +443,7 @@ where
         if round > Round::default() {
             // validate the justifications
             if !self.validate_justifications(&wrapped_msg) {
+                warn!(from = ?operator_id, "Justification validation failed for proposal");
                 return;
             }
         }

--- a/anchor/common/qbft/src/lib.rs
+++ b/anchor/common/qbft/src/lib.rs
@@ -427,17 +427,24 @@ where
         wrapped_msg: WrappedQbftMessage,
     ) {
         // Make sure that we are actually waiting for a proposal
-        if !matches!(self.state, InstanceState::AwaitingProposal) {
+        if round == self.current_round && !matches!(self.state, InstanceState::AwaitingProposal) {
             debug!(from=?operator_id, ?self.state, "PROPOSE message while in invalid state");
             return;
         }
 
         // If we are passed the first round, make sure that the justifications actually justify the
         // received proposal
-        if round > Round::default() && !self.validate_justifications(&wrapped_msg) {
-            warn!(from = ?operator_id, "Justification verifiction failed");
-            return;
-        }
+        if round > Round::default() {
+            // validate the justifications
+            if !self.validate_justifications(&wrapped_msg) {
+                return;
+            }
+        } else {
+            // Make sure this is from the leader
+            if !self.check_leader(&operator_id) {
+                return;
+            }
+        };
 
         // Fulldata is included in propose messages
         let data = match valid_data.data {
@@ -460,10 +467,17 @@ where
             return;
         }
 
-        // Make sure we have not already accepted another proposal for this round.
-        if self.proposal_accepted_for_current_round {
+        // Only reject if we've already accepted a proposal for THIS round
+        // Allow proposals for future rounds even if we have a proposal for current round
+        if self.proposal_accepted_for_current_round && round == self.current_round {
             warn!(from = ?operator_id, "Proposal has already been accepted for this round");
             return;
+        }
+
+        // If this is a future round proposal, update our round to match
+        if round > self.current_round {
+            debug!(old_round = ?self.current_round, new_round = ?round, "Updating to future round from proposal");
+            self.current_round = round;
         }
 
         // Accept this proposal

--- a/anchor/common/qbft/src/lib.rs
+++ b/anchor/common/qbft/src/lib.rs
@@ -432,6 +432,11 @@ where
             return;
         }
 
+        // Make sure this is from the leader
+        if !self.check_leader(&operator_id) {
+            return;
+        }
+
         // If we are passed the first round, make sure that the justifications actually justify the
         // received proposal
         if round > Round::default() {
@@ -439,12 +444,7 @@ where
             if !self.validate_justifications(&wrapped_msg) {
                 return;
             }
-        } else {
-            // Make sure this is from the leader
-            if !self.check_leader(&operator_id) {
-                return;
-            }
-        };
+        }
 
         // Fulldata is included in propose messages
         let data = match valid_data.data {


### PR DESCRIPTION
## Issue Addressed

This PR does require us to think more carefully, I will try to justify each change and give the spec test that fails if it is removed

1) The first `round == self.current_round`. this corresponds to [proposal future round prev prepared](https://github.com/ssvlabs/ssv-spec/blob/d4c734909677b5fd3304e1d9220963cc9d794f09/qbft/spectest/generate/tests/tests.MsgProcessingSpecTest_qbft_message_processing_proposal_future_round_prev_prepared.json#L4). This is to say if the proposal is for our current round and we are not waiting for one, reject it. If the proposal is for a future round, continue on and potentially accept it
2) If we are past the first round, validate justifications. Otherwise just make the proposal is from the leader.
3) The second `round == self.current_round` corresponds to the same test as earlier. say we are in round 1 and accept a proposal for round 1 and move to the prepare state. we then get a message for a proposal for round 10. we will pass the first check (10 != 1) and need to also pass the second check as we are accepting a new proposal
4) the fourth change just follows suit that we need to update our round with this new proposal