### PR TITLE
fix: prepare validation

### DIFF
--- a/anchor/common/qbft/src/lib.rs
+++ b/anchor/common/qbft/src/lib.rs
@@ -665,11 +665,9 @@ where
 
             // Success! We have come to a prepare consensus on a value
 
-            // Move the state forward since we have a prepare quorum (only if not already in Commit
-            // state)
+            // Move the state forward since we have a prepare quorum
             self.state = InstanceState::Commit { proposal_root };
 
-            // Move the state forward since we have a prepare quorum
             debug!(state = ?self.state, "Reached a PREPARE consensus. State updated to COMMIT");
 
             // Record that we have come to a consensus on this value
@@ -679,7 +677,7 @@ where
             self.last_prepared_value = Some(hash);
             self.last_prepared_round = Some(self.current_round);
 
-            // Send a commit message for the prepare quorum data (only if we just transitioned)
+            // Send a commit message for the prepare quorum data
             self.send_commit(hash);
         }
     }

--- a/anchor/common/qbft/src/lib.rs
+++ b/anchor/common/qbft/src/lib.rs
@@ -639,11 +639,10 @@ where
         }
 
         // Check that the prepare message is for the accepted proposal
-        if let Some(accepted_root) = self.proposal_root {
-            if wrapped_msg.qbft_message.root != accepted_root {
+        if let Some(accepted_root) = self.proposal_root
+            && wrapped_msg.qbft_message.root != accepted_root {
                 return;
             }
-        }
 
         // Check if we have reached a prepare quorum for this round, if so send the commit message
         if let Some(hash) = self.prepare_container.has_quorum(round) {

--- a/anchor/common/qbft/src/lib.rs
+++ b/anchor/common/qbft/src/lib.rs
@@ -667,7 +667,6 @@ where
 
             // Move the state forward since we have a prepare quorum
             self.state = InstanceState::Commit { proposal_root };
-
             debug!(state = ?self.state, "Reached a PREPARE consensus. State updated to COMMIT");
 
             // Record that we have come to a consensus on this value

--- a/anchor/common/qbft/src/lib.rs
+++ b/anchor/common/qbft/src/lib.rs
@@ -601,7 +601,7 @@ where
         round: Round,
         wrapped_msg: WrappedQbftMessage,
     ) {
-        // If we are already done, ignore (matches received_commit behavior)
+        // If we are already done
         if self.completed.is_some() {
             return;
         }
@@ -640,16 +640,16 @@ where
 
         // Check that the prepare message is for the accepted proposal
         if let Some(accepted_root) = self.proposal_root
-            && wrapped_msg.qbft_message.root != accepted_root {
-                return;
-            }
+            && wrapped_msg.qbft_message.root != accepted_root
+        {
+            return;
+        }
 
         // Check if we have reached a prepare quorum for this round, if so send the commit message
         if let Some(hash) = self.prepare_container.has_quorum(round) {
             // Make sure we are in the correct state
             let proposal_root = match self.state {
                 InstanceState::Prepare { proposal_root } => proposal_root,
-                InstanceState::Commit { proposal_root } => proposal_root,
                 _ => {
                     debug!(from=?operator_id, ?self.state, "Not in PREPARE state");
                     return;
@@ -667,14 +667,7 @@ where
 
             // Move the state forward since we have a prepare quorum (only if not already in Commit
             // state)
-            let should_send_commit = match self.state {
-                InstanceState::Prepare { .. } => {
-                    self.state = InstanceState::Commit { proposal_root };
-                    debug!(state = ?self.state, "Reached a PREPARE consensus. State updated to COMMIT");
-                    true // Send commit message when transitioning to Commit state
-                }
-                _ => false,
-            };
+            self.state = InstanceState::Commit { proposal_root };
 
             // Move the state forward since we have a prepare quorum
             debug!(state = ?self.state, "Reached a PREPARE consensus. State updated to COMMIT");
@@ -687,9 +680,7 @@ where
             self.last_prepared_round = Some(self.current_round);
 
             // Send a commit message for the prepare quorum data (only if we just transitioned)
-            if should_send_commit {
-                self.send_commit(hash);
-            }
+            self.send_commit(hash);
         }
     }
 

--- a/anchor/common/qbft/src/lib.rs
+++ b/anchor/common/qbft/src/lib.rs
@@ -642,6 +642,7 @@ where
         if let Some(accepted_root) = self.proposal_root
             && wrapped_msg.qbft_message.root != accepted_root
         {
+            warn!(from=?operator_id, "PREPARE message for different root than accepted proposal");
             return;
         }
 

--- a/anchor/common/qbft/src/lib.rs
+++ b/anchor/common/qbft/src/lib.rs
@@ -601,6 +601,11 @@ where
         round: Round,
         wrapped_msg: WrappedQbftMessage,
     ) {
+        // If we are already done, ignore (matches received_commit behavior)
+        if self.completed.is_some() {
+            return;
+        }
+
         // Check that we are in the correct state. We do not have to be in the PREPARE state right
         // now as this message may have been delayed
         if u8::from(self.state) >= u8::from(InstanceState::SentRoundChange) {
@@ -633,11 +638,19 @@ where
             return;
         }
 
+        // Check that the prepare message is for the accepted proposal
+        if let Some(accepted_root) = self.proposal_root {
+            if wrapped_msg.qbft_message.root != accepted_root {
+                return;
+            }
+        }
+
         // Check if we have reached a prepare quorum for this round, if so send the commit message
         if let Some(hash) = self.prepare_container.has_quorum(round) {
             // Make sure we are in the correct state
             let proposal_root = match self.state {
                 InstanceState::Prepare { proposal_root } => proposal_root,
+                InstanceState::Commit { proposal_root } => proposal_root,
                 _ => {
                     debug!(from=?operator_id, ?self.state, "Not in PREPARE state");
                     return;
@@ -653,8 +666,18 @@ where
 
             // Success! We have come to a prepare consensus on a value
 
+            // Move the state forward since we have a prepare quorum (only if not already in Commit
+            // state)
+            let should_send_commit = match self.state {
+                InstanceState::Prepare { .. } => {
+                    self.state = InstanceState::Commit { proposal_root };
+                    debug!(state = ?self.state, "Reached a PREPARE consensus. State updated to COMMIT");
+                    true // Send commit message when transitioning to Commit state
+                }
+                _ => false,
+            };
+
             // Move the state forward since we have a prepare quorum
-            self.state = InstanceState::Commit { proposal_root };
             debug!(state = ?self.state, "Reached a PREPARE consensus. State updated to COMMIT");
 
             // Record that we have come to a consensus on this value
@@ -664,8 +687,10 @@ where
             self.last_prepared_value = Some(hash);
             self.last_prepared_round = Some(self.current_round);
 
-            // Send a commit message for the prepare quorum data
-            self.send_commit(hash);
+            // Send a commit message for the prepare quorum data (only if we just transitioned)
+            if should_send_commit {
+                self.send_commit(hash);
+            }
         }
     }
 


### PR DESCRIPTION
This adds in some more prepare validation. 

1) If we are already completed we just want to ignore the message
2) If we have accepted a proposal, we should only be processing prepares that match the proposal