### PR TITLE
fix: commit validation

### DIFF
--- a/anchor/common/qbft/src/lib.rs
+++ b/anchor/common/qbft/src/lib.rs
@@ -730,6 +730,7 @@ where
                         warn!("COMMIT quorum root does not match accepted PROPOSAL root");
                         return;
                     }
+                    return;
                 }
                 InstanceState::Prepare { proposal_root } => {
                     // Transition to Commit state first

--- a/anchor/common/qbft/src/lib.rs
+++ b/anchor/common/qbft/src/lib.rs
@@ -746,16 +746,6 @@ where
                     }
                     self.state = InstanceState::Commit { proposal_root };
                 }
-                InstanceState::AwaitingProposal => {
-                    // Catch-up scenario: we have commit quorum without seeing proposal
-                    // This is valid - we can decide based on commit quorum alone
-                    // Transition directly to Commit state
-                    debug!("Received commit quorum without proposal - catch-up scenario");
-                    self.state = InstanceState::Commit {
-                        proposal_root: hash,
-                    };
-                    self.proposal_root = Some(hash);
-                }
                 _ => return,
             }
 

--- a/anchor/common/qbft/src/lib.rs
+++ b/anchor/common/qbft/src/lib.rs
@@ -696,11 +696,18 @@ where
             return;
         }
 
-        // Make sure that we have accepted a proposal for this round
-        if !self.proposal_accepted_for_current_round {
-            warn!(from=?operator_id, ?self.state, "Have not accepted Proposal for current round yet");
+        // If we have accepted a proposal, check that the commit matches it
+        // But allow commits without proposal (for catch-up scenarios)
+        if self.proposal_accepted_for_current_round {
+            if let Some(accepted_root) = self.proposal_root {
+                if wrapped_msg.qbft_message.root != accepted_root {
+                    return;
+                }
+            }
+        } else {
+            debug!(from=?operator_id, ?self.state, "Have not accepted Proposal for current round yet");
             return;
-        }
+        };
 
         debug!(from = ?operator_id, state = ?self.state, "COMMIT received");
 
@@ -716,17 +723,33 @@ where
         if let Some(hash) = self.commit_container.has_quorum(round) {
             // Make sure that the root of the data that we have come to a commit consensus on
             // matches the root of the proposal that we have accepted
-            let proposal_root = match self.state {
-                InstanceState::Prepare { proposal_root } => proposal_root,
-                InstanceState::Commit { proposal_root } => proposal_root,
-                _ => {
-                    warn!(from=?operator_id, ?self.state, "Not in PREPARE or COMMIT state");
-                    return;
+            match self.state {
+                InstanceState::Commit { proposal_root } => {
+                    // We already accepted a proposal and are in commit state
+                    if hash != proposal_root {
+                        warn!("COMMIT quorum root does not match accepted PROPOSAL root");
+                        return;
+                    }
                 }
-            };
-            if hash != proposal_root {
-                warn!("COMMIT quorum root does not match accepted PROPOSAL root");
-                return;
+                InstanceState::Prepare { proposal_root } => {
+                    // Transition to Commit state first
+                    if hash != proposal_root {
+                        warn!("COMMIT quorum root does not match accepted PROPOSAL root");
+                        return;
+                    }
+                    self.state = InstanceState::Commit { proposal_root };
+                }
+                InstanceState::AwaitingProposal => {
+                    // Catch-up scenario: we have commit quorum without seeing proposal
+                    // This is valid - we can decide based on commit quorum alone
+                    // Transition directly to Commit state
+                    debug!("Received commit quorum without proposal - catch-up scenario");
+                    self.state = InstanceState::Commit {
+                        proposal_root: hash,
+                    };
+                    self.proposal_root = Some(hash);
+                }
+                _ => return,
             }
 
             // Aggregate all of the commit messages

--- a/anchor/common/qbft/src/lib.rs
+++ b/anchor/common/qbft/src/lib.rs
@@ -699,10 +699,10 @@ where
         // If we have accepted a proposal, check that the commit matches it
         // But allow commits without proposal (for catch-up scenarios)
         if self.proposal_accepted_for_current_round {
-            if let Some(accepted_root) = self.proposal_root {
-                if wrapped_msg.qbft_message.root != accepted_root {
-                    return;
-                }
+            if let Some(accepted_root) = self.proposal_root
+                && wrapped_msg.qbft_message.root != accepted_root
+            {
+                return;
             }
         } else {
             debug!(from=?operator_id, ?self.state, "Have not accepted Proposal for current round yet");
@@ -730,7 +730,6 @@ where
                         warn!("COMMIT quorum root does not match accepted PROPOSAL root");
                         return;
                     }
-                    return;
                 }
                 InstanceState::Prepare { proposal_root } => {
                     // Transition to Commit state first

--- a/anchor/common/qbft/src/lib.rs
+++ b/anchor/common/qbft/src/lib.rs
@@ -696,18 +696,25 @@ where
             return;
         }
 
-        // If we have accepted a proposal, check that the commit matches it
-        // But allow commits without proposal (for catch-up scenarios)
-        if self.proposal_accepted_for_current_round {
-            if let Some(accepted_root) = self.proposal_root
-                && wrapped_msg.qbft_message.root != accepted_root
-            {
+        // Handle commit message, checking proposal acceptance and catch-up scenarios.
+
+        // If we have NOT accepted a proposal for this round, this is a catch-up scenario.
+        // We allow commits without having seen a proposal in this case.
+        if !self.proposal_accepted_for_current_round {
+            debug!(from=?operator_id, ?self.state, "Have not accepted Proposal for current round yet (catch-up scenario)");
+            return;
+        }
+
+        // Proposal accepted: ensure commit matches the accepted proposal root.
+        if let Some(accepted_root) = self.proposal_root {
+            if wrapped_msg.qbft_message.root != accepted_root {
+                warn!(from=?operator_id, ?self.state, "Commit root does not match accepted Proposal root");
                 return;
             }
         } else {
-            debug!(from=?operator_id, ?self.state, "Have not accepted Proposal for current round yet");
+            warn!(from=?operator_id, ?self.state, "Proposal accepted, but no proposal root found");
             return;
-        };
+        }
 
         debug!(from = ?operator_id, state = ?self.state, "COMMIT received");
 

--- a/anchor/common/qbft/src/lib.rs
+++ b/anchor/common/qbft/src/lib.rs
@@ -779,20 +779,13 @@ where
             // Make sure that the root of the data that we have come to a commit consensus on
             // matches the root of the proposal that we have accepted
             match self.state {
-                InstanceState::Commit { proposal_root } => {
+                InstanceState::Prepare { proposal_root }
+                | InstanceState::Commit { proposal_root } => {
                     // We already accepted a proposal and are in commit state
                     if hash != proposal_root {
                         warn!("COMMIT quorum root does not match accepted PROPOSAL root");
                         return;
                     }
-                }
-                InstanceState::Prepare { proposal_root } => {
-                    // Transition to Commit state first
-                    if hash != proposal_root {
-                        warn!("COMMIT quorum root does not match accepted PROPOSAL root");
-                        return;
-                    }
-                    self.state = InstanceState::Commit { proposal_root };
                 }
                 _ => return,
             }


### PR DESCRIPTION
## Issue Addressed

1) if we have accepted a proposal, we also have to check that the root of the commit message matches the accepted proposal root
2) If we have a quorum of commit messages
- if we are in commit state just make sure it matches the proposal root
- if we are in prepare state, make sure it matches proposal root and move into commit state
- if we are still awaiting a proposal, a quorum of commits moves us into the commit state