### PR TITLE
fix: store messages without full data

### DIFF
--- a/anchor/common/qbft/src/msg_container.rs
+++ b/anchor/common/qbft/src/msg_container.rs
@@ -43,6 +43,10 @@ impl MessageContainer {
             return false; // Duplicate message
         }
 
+        let mut msg = msg.clone();
+        // We have no longer have need for full data in these messages
+        msg.signed_message.set_full_data(vec![]);
+
         // Add message and track its value
         self.messages
             .entry(round)

--- a/anchor/common/qbft/src/msg_container.rs
+++ b/anchor/common/qbft/src/msg_container.rs
@@ -43,7 +43,7 @@ impl MessageContainer {
         }
 
         let mut msg = msg.clone();
-        // We have no longer have need for full data in these messages
+        // We no longer have need for full data in these messages
         msg.signed_message.set_full_data(vec![]);
 
         self.values_by_round

--- a/anchor/common/qbft/src/msg_container.rs
+++ b/anchor/common/qbft/src/msg_container.rs
@@ -43,7 +43,9 @@ impl MessageContainer {
         }
 
         let mut msg = msg.clone();
-        // We no longer have need for full data in these messages
+        // We no longer have need for full data in these messages, as the hash is stored the QBFT
+        // state. The messages are here only used for quorum checking, and for justifications. For
+        // both the data is not needed.
         msg.signed_message.set_full_data(vec![]);
 
         self.values_by_round


### PR DESCRIPTION
## Issue Addressed

We do not need to store full data in the message containers - we store it separately in the instance. Not storing the full data with the message avoids sending it the message with full data when sending message with justifications.

## Proposed Changes

Replace the fulldata with an empty vec on send,