### PR TITLE
fix: partial roundchange quorum

### DIFF
--- a/anchor/common/qbft/src/lib.rs
+++ b/anchor/common/qbft/src/lib.rs
@@ -816,14 +816,15 @@ where
         } else {
             // 2. If we receive f+1 round change messages, we need to send our own round-change
             //    message
-            let num_messages_for_round = self.round_change_container.num_messages_for_round(round);
-            if num_messages_for_round > self.config.get_f()
+            let round = self
+                .round_change_container
+                .first_partial_quorum_above_round(round, self.config.get_f() + 1);
+            if let Some(round) = round
                 && !(matches!(self.state, InstanceState::SentRoundChange))
             {
-                // Set the state so SendRoundChange so we include Round + 1 in message
                 self.state = InstanceState::SentRoundChange;
 
-                self.send_round_change(Hash256::default());
+                self.send_round_change(Hash256::default(), Some(round));
             }
         }
     }
@@ -864,7 +865,7 @@ where
         // Set the state so SendRoundChange so we include Round + 1 in message
         self.state = InstanceState::SentRoundChange;
 
-        self.send_round_change(Hash256::default());
+        self.send_round_change(Hash256::default(), None);
         self.start_round();
     }
 
@@ -922,6 +923,7 @@ where
         data_hash: D::Hash,
         round_change_justification: Vec<SignedSSVMessage>,
         prepare_justification: Vec<SignedSSVMessage>,
+        round_override: Option<Round>,
     ) -> UnsignedWrappedQbftMessage {
         let data = self.get_message_data(&msg_type, data_hash);
 
@@ -929,7 +931,7 @@ where
         let qbft_message = QbftMessage {
             qbft_message_type: msg_type,
             height: *self.instance_height as u64,
-            round: data.round,
+            round: round_override.map(|r| r.get() as u64).unwrap_or(data.round),
             identifier: (&self.identifier).into(),
             root: data.root,
             data_round: data.data_round,
@@ -1081,6 +1083,7 @@ where
             value_to_propose,
             round_change_justifications,
             prepare_justifications,
+            None,
         );
 
         self.message_sender.send(unsigned_msg);
@@ -1096,7 +1099,7 @@ where
 
         // Construct unsigned prepare
         let unsigned_msg =
-            self.new_unsigned_message(QbftMessageType::Prepare, data_hash, vec![], vec![]);
+            self.new_unsigned_message(QbftMessageType::Prepare, data_hash, vec![], vec![], None);
 
         self.message_sender.send(unsigned_msg);
     }
@@ -1105,13 +1108,13 @@ where
     fn send_commit(&mut self, data_hash: D::Hash) {
         // Construct unsigned commit
         let unsigned_msg =
-            self.new_unsigned_message(QbftMessageType::Commit, data_hash, vec![], vec![]);
+            self.new_unsigned_message(QbftMessageType::Commit, data_hash, vec![], vec![], None);
 
         self.message_sender.send(unsigned_msg);
     }
 
     // Send a new qbft round change message
-    fn send_round_change(&mut self, data_hash: D::Hash) {
+    fn send_round_change(&mut self, data_hash: D::Hash, round_override: Option<Round>) {
         // For Round Change messages
         // round_change_justification: list of prepare messages
         let round_change_justifications = self.get_round_change_justifications();
@@ -1123,6 +1126,7 @@ where
             data_hash,
             round_change_justifications,
             vec![],
+            round_override,
         );
 
         // forget that we accpeted a proposal

--- a/anchor/common/qbft/src/lib.rs
+++ b/anchor/common/qbft/src/lib.rs
@@ -821,7 +821,6 @@ where
                 .highest_partial_quorum_above_round(self.current_round, self.config.get_f() + 1);
             if let Some(round) = round
                 && round > self.current_round
-                && !(matches!(self.state, InstanceState::SentRoundChange))
             {
                 self.state = InstanceState::SentRoundChange;
                 self.current_round = round;

--- a/anchor/common/qbft/src/lib.rs
+++ b/anchor/common/qbft/src/lib.rs
@@ -818,7 +818,7 @@ where
             //    message
             let round = self
                 .round_change_container
-                .first_partial_quorum_above_round(round, self.config.get_f() + 1);
+                .first_partial_quorum_above_round(self.current_round, self.config.get_f() + 1);
             if let Some(round) = round
                 && !(matches!(self.state, InstanceState::SentRoundChange))
             {

--- a/anchor/common/qbft/src/lib.rs
+++ b/anchor/common/qbft/src/lib.rs
@@ -818,13 +818,15 @@ where
             //    message
             let round = self
                 .round_change_container
-                .first_partial_quorum_above_round(self.current_round, self.config.get_f() + 1);
+                .highest_partial_quorum_above_round(self.current_round, self.config.get_f() + 1);
             if let Some(round) = round
+                && round > self.current_round
                 && !(matches!(self.state, InstanceState::SentRoundChange))
             {
                 self.state = InstanceState::SentRoundChange;
-
-                self.send_round_change(Hash256::default(), Some(round));
+                self.current_round = round;
+                self.proposal_accepted_for_current_round = false;
+                self.send_round_change(Hash256::default());
             }
         }
     }
@@ -865,7 +867,7 @@ where
         // Set the state so SendRoundChange so we include Round + 1 in message
         self.state = InstanceState::SentRoundChange;
 
-        self.send_round_change(Hash256::default(), None);
+        self.send_round_change(Hash256::default());
         self.start_round();
     }
 
@@ -923,7 +925,6 @@ where
         data_hash: D::Hash,
         round_change_justification: Vec<SignedSSVMessage>,
         prepare_justification: Vec<SignedSSVMessage>,
-        round_override: Option<Round>,
     ) -> UnsignedWrappedQbftMessage {
         let data = self.get_message_data(&msg_type, data_hash);
 
@@ -931,7 +932,7 @@ where
         let qbft_message = QbftMessage {
             qbft_message_type: msg_type,
             height: *self.instance_height as u64,
-            round: round_override.map(|r| r.get() as u64).unwrap_or(data.round),
+            round: data.round,
             identifier: (&self.identifier).into(),
             root: data.root,
             data_round: data.data_round,
@@ -1083,7 +1084,6 @@ where
             value_to_propose,
             round_change_justifications,
             prepare_justifications,
-            None,
         );
 
         self.message_sender.send(unsigned_msg);
@@ -1099,7 +1099,7 @@ where
 
         // Construct unsigned prepare
         let unsigned_msg =
-            self.new_unsigned_message(QbftMessageType::Prepare, data_hash, vec![], vec![], None);
+            self.new_unsigned_message(QbftMessageType::Prepare, data_hash, vec![], vec![]);
 
         self.message_sender.send(unsigned_msg);
     }
@@ -1108,13 +1108,13 @@ where
     fn send_commit(&mut self, data_hash: D::Hash) {
         // Construct unsigned commit
         let unsigned_msg =
-            self.new_unsigned_message(QbftMessageType::Commit, data_hash, vec![], vec![], None);
+            self.new_unsigned_message(QbftMessageType::Commit, data_hash, vec![], vec![]);
 
         self.message_sender.send(unsigned_msg);
     }
 
     // Send a new qbft round change message
-    fn send_round_change(&mut self, data_hash: D::Hash, round_override: Option<Round>) {
+    fn send_round_change(&mut self, data_hash: D::Hash) {
         // For Round Change messages
         // round_change_justification: list of prepare messages
         let round_change_justifications = self.get_round_change_justifications();
@@ -1126,7 +1126,6 @@ where
             data_hash,
             round_change_justifications,
             vec![],
-            round_override,
         );
 
         // forget that we accpeted a proposal

--- a/anchor/common/qbft/src/msg_container.rs
+++ b/anchor/common/qbft/src/msg_container.rs
@@ -76,16 +76,28 @@ impl MessageContainer {
         round: Round,
         partial: usize,
     ) -> Option<Round> {
-        let mut operators_seen = HashSet::new();
-        for (&round, operators) in self.senders_by_round.range((round + 1)..).rev() {
-            for &operator in operators {
-                operators_seen.insert(operator);
+        // Collect all operators from rounds > round
+        let mut all_operators = HashSet::new();
+        let mut min_future_round = None;
+
+        for (&r, operators) in self.senders_by_round.range((round + 1)..) {
+            // Track minimum round
+            if min_future_round.is_none() {
+                min_future_round = Some(r);
             }
-            if operators_seen.len() >= partial {
-                return Some(round);
+
+            // Add all operators from this round
+            for &operator in operators {
+                all_operators.insert(operator);
             }
         }
-        None
+
+        // If we have partial quorum, return the minimum round
+        if all_operators.len() >= partial {
+            min_future_round
+        } else {
+            None
+        }
     }
 
     /// If we have a quorum for the round, get all of the messages that correspond to that quorum

--- a/anchor/common/qbft/src/msg_container.rs
+++ b/anchor/common/qbft/src/msg_container.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 
 use ssv_types::OperatorId;
 use types::Hash256;
@@ -9,7 +9,7 @@ use crate::{Round, WrappedQbftMessage};
 #[derive(Default)]
 pub struct MessageContainer {
     /// Messages indexed by round and then by sender
-    messages: HashMap<Round, HashMap<OperatorId, WrappedQbftMessage>>,
+    messages: BTreeMap<Round, HashMap<OperatorId, WrappedQbftMessage>>,
     /// Track unique values per round
     values_by_round: HashMap<Round, HashSet<Hash256>>,
     /// The quorum size for the qbft instance
@@ -21,7 +21,7 @@ impl MessageContainer {
     pub fn new(quorum_size: usize) -> Self {
         Self {
             quorum_size,
-            messages: HashMap::new(),
+            messages: BTreeMap::new(),
             values_by_round: HashMap::new(),
         }
     }
@@ -76,11 +76,17 @@ impl MessageContainer {
     }
 
     /// Count the number of messages we have received for this round
-    pub fn num_messages_for_round(&self, round: Round) -> usize {
-        self.messages
-            .get(&round)
-            .map(|msgs| msgs.len())
-            .unwrap_or(0)
+    pub fn first_partial_quorum_above_round(&self, round: Round, partial: usize) -> Option<Round> {
+        let mut operators_seen = HashSet::new();
+        for (&round, msgs) in self.messages.range((round + 1)..) {
+            for &operator in msgs.keys() {
+                operators_seen.insert(operator);
+            }
+            if partial >= self.quorum_size {
+                return Some(round);
+            }
+        }
+        None
     }
 
     /// If we have a quorum for the round, get all of the messages that correspond to that quorum

--- a/anchor/common/qbft/src/msg_container.rs
+++ b/anchor/common/qbft/src/msg_container.rs
@@ -82,7 +82,7 @@ impl MessageContainer {
             for &operator in msgs.keys() {
                 operators_seen.insert(operator);
             }
-            if partial >= self.quorum_size {
+            if operators_seen.len() >= partial {
                 return Some(round);
             }
         }

--- a/anchor/common/qbft/src/msg_container.rs
+++ b/anchor/common/qbft/src/msg_container.rs
@@ -78,7 +78,7 @@ impl MessageContainer {
     /// Count the number of messages we have received for this round
     pub fn first_partial_quorum_above_round(&self, round: Round, partial: usize) -> Option<Round> {
         let mut operators_seen = HashSet::new();
-        for (&round, msgs) in self.messages.range((round + 1)..) {
+        for (&round, msgs) in self.messages.range((round + 1)..).rev() {
             for &operator in msgs.keys() {
                 operators_seen.insert(operator);
             }

--- a/anchor/common/qbft/src/msg_container.rs
+++ b/anchor/common/qbft/src/msg_container.rs
@@ -76,7 +76,11 @@ impl MessageContainer {
     }
 
     /// Count the number of messages we have received for this round
-    pub fn first_partial_quorum_above_round(&self, round: Round, partial: usize) -> Option<Round> {
+    pub fn highest_partial_quorum_above_round(
+        &self,
+        round: Round,
+        partial: usize,
+    ) -> Option<Round> {
         let mut operators_seen = HashSet::new();
         for (&round, msgs) in self.messages.range((round + 1)..).rev() {
             for &operator in msgs.keys() {


### PR DESCRIPTION
Partial round change quorums work by getting the lowest round which achieves partial quorum using all rounds above.
Additionally, the `current_round` is already set.