### PR TITLE
fix: prepare justification fetching

### DIFF
--- a/anchor/common/qbft/src/lib.rs
+++ b/anchor/common/qbft/src/lib.rs
@@ -1115,8 +1115,6 @@ where
         if let Some((_, prepared_value, highest_rc)) = highest_prepared {
             // Extract the prepare messages from the round change message's justifications
             // These are stored in the round_change_justification field of the RoundChange
-            let mut prepare_msgs = Vec::new();
-
             let prepares = &highest_rc.qbft_message.round_change_justification;
 
             // Verify we have quorum of prepares

--- a/anchor/common/qbft/src/lib.rs
+++ b/anchor/common/qbft/src/lib.rs
@@ -1080,13 +1080,10 @@ where
         let potential_prepare_just = self.get_round_change_prepare_justifications();
         if !potential_prepare_just.is_empty() {
             if let Some(last_prepared) = self.last_prepared_value {
-                return (
-                    potential_prepare_just,
-                    Some(last_prepared),
-                );
+                return (potential_prepare_just, Some(last_prepared));
             } else {
-                // Invariant violated: potential_prepare_just is not empty but no last_prepared_value
-                // Handle gracefully: return no justification
+                // Invariant violated: potential_prepare_just is not empty but no
+                // last_prepared_value Handle gracefully: return no justification
                 return (vec![], None);
             }
         }
@@ -1109,10 +1106,7 @@ where
                 let prepared_round = Round::from(rc_msg.qbft_message.data_round);
 
                 // Update if this is the highest we've seen
-                if match highest_prepared {
-                    None => true,
-                    Some((round, _, _)) => prepared_round > round,
-                } {
+                if highest_prepared.is_none_or(|(round, _, _)| prepared_round > round) {
                     highest_prepared = Some((prepared_round, rc_msg.qbft_message.root, rc_msg));
                 }
             }

--- a/anchor/common/qbft/src/lib.rs
+++ b/anchor/common/qbft/src/lib.rs
@@ -1064,7 +1064,7 @@ where
 
     // Get all of the prepare justifications for proposals
     fn get_prepare_justifications(&self) -> (Vec<SignedSSVMessage>, Option<Hash256>) {
-        // No justifications needed for round 0
+        // No justifications needed for round 1
         if self.current_round == Round::default() {
             return (vec![], None);
         }

--- a/anchor/common/qbft/src/lib.rs
+++ b/anchor/common/qbft/src/lib.rs
@@ -1084,6 +1084,7 @@ where
             } else {
                 // Invariant violated: potential_prepare_just is not empty but no
                 // last_prepared_value Handle gracefully: return no justification
+                error!("prepare justifications exists but no last prepared value was found");
                 return (vec![], None);
             }
         }

--- a/anchor/common/qbft/src/lib.rs
+++ b/anchor/common/qbft/src/lib.rs
@@ -1079,10 +1079,16 @@ where
         // don't reflect it (e.g., other nodes didn't prepare)
         let potential_prepare_just = self.get_round_change_prepare_justifications();
         if !potential_prepare_just.is_empty() {
-            return (
-                potential_prepare_just,
-                Some(self.last_prepared_value.unwrap()),
-            );
+            if let Some(last_prepared) = self.last_prepared_value {
+                return (
+                    potential_prepare_just,
+                    Some(last_prepared),
+                );
+            } else {
+                // Invariant violated: potential_prepare_just is not empty but no last_prepared_value
+                // Handle gracefully: return no justification
+                return (vec![], None);
+            }
         }
 
         // Get all round change messages for current round

--- a/anchor/common/qbft/src/lib.rs
+++ b/anchor/common/qbft/src/lib.rs
@@ -1103,9 +1103,10 @@ where
                 let prepared_round = Round::from(rc_msg.qbft_message.data_round);
 
                 // Update if this is the highest we've seen
-                if highest_prepared.is_none()
-                    || prepared_round > highest_prepared.as_ref().unwrap().0
-                {
+                if match highest_prepared {
+                    None => true,
+                    Some((round, _, _)) => prepared_round > round,
+                } {
                     highest_prepared = Some((prepared_round, rc_msg.qbft_message.root, rc_msg));
                 }
             }

--- a/anchor/common/qbft/src/lib.rs
+++ b/anchor/common/qbft/src/lib.rs
@@ -1053,56 +1053,68 @@ where
 
     // Get all of the prepare justifications for proposals
     fn get_prepare_justifications(&self) -> (Vec<SignedSSVMessage>, Option<Hash256>) {
-        // No justifications if we are in the first round
-        if self.current_round <= Round::default() {
+        // No justifications needed for round 0
+        if self.current_round == Round::default() {
             return (vec![], None);
         }
 
-        // We only send prepare justifications with for proposal messages. If we are in the
-        // state AwaitingProposal and sending a message, we know this is a proposal. This will
-        // happen when we have come to a consensus of round change messages and have started a
-        // new round
-        if matches!(self.state, InstanceState::AwaitingProposal) {
-            // Get all of the round change messages for the current round and make sure we have
-            // a quorum of them.
-            let round_change_msg = self
-                .round_change_container
-                .get_messages_for_round(self.current_round);
-            if round_change_msg.len() < self.config.quorum_size() {
-                return (vec![], None);
-            }
+        // Only needed when we're the proposer
+        if !matches!(self.state, InstanceState::AwaitingProposal) {
+            return (vec![], None);
+        }
 
-            // Go through each message and see if any have a value that was already prepared
-            // Just want to take the first one that is valid and has a prepared value
-            for wrapped_round_change in round_change_msg {
-                // Deserialize into a qbft message for sanity checks
-                let round_change: QbftMessage = match QbftMessage::from_ssz_bytes(
-                    wrapped_round_change.signed_message.ssv_message().data(),
-                ) {
-                    Ok(data) => data,
-                    Err(_) => return (vec![], None),
-                };
+        // Check if we have our own prepared value that should be proposed
+        // This handles the case where we prepared a value but the RoundChange messages
+        // don't reflect it (e.g., other nodes didn't prepare)
+        let potential_prepare_just = self.get_round_change_prepare_justifications();
+        if !potential_prepare_just.is_empty() {
+            return (
+                potential_prepare_just,
+                Some(self.last_prepared_value.unwrap()),
+            );
+        }
 
-                // Round sanity check
-                let current_round_proposal = self.proposal_accepted_for_current_round
-                    && self.current_round.get() as u64 == round_change.round;
-                let future_round_proposal = round_change.round > self.current_round.get() as u64;
-                if !current_round_proposal && !future_round_proposal {
-                    continue;
-                }
+        // Get all round change messages for current round
+        let round_changes = self
+            .round_change_container
+            .get_messages_for_round(self.current_round);
 
-                // Validate the proposal, if this is a valid proposal then this is our prepare
-                // justification
-                if self.validate_justifications(wrapped_round_change) {
-                    return (
-                        vec![wrapped_round_change.signed_message.clone()],
-                        Some(round_change.root),
-                    );
+        if round_changes.len() < self.config.quorum_size() {
+            return (vec![], None);
+        }
+
+        // Find the highest prepared round among all round changes
+        let mut highest_prepared: Option<(Round, Hash256, &WrappedQbftMessage)> = None;
+
+        for rc_msg in &round_changes {
+            // Check if this round change has a prepared value
+            if rc_msg.qbft_message.data_round > 0 {
+                let prepared_round = Round::from(rc_msg.qbft_message.data_round);
+
+                // Update if this is the highest we've seen
+                if highest_prepared.is_none()
+                    || prepared_round > highest_prepared.as_ref().unwrap().0
+                {
+                    highest_prepared = Some((prepared_round, rc_msg.qbft_message.root, rc_msg));
                 }
             }
         }
 
-        // Not sending a proposal
+        // If we found a highest prepared value, extract its prepare justifications
+        if let Some((_, prepared_value, highest_rc)) = highest_prepared {
+            // Extract the prepare messages from the round change message's justifications
+            // These are stored in the round_change_justification field of the RoundChange
+            let mut prepare_msgs = Vec::new();
+
+            let prepares = &highest_rc.qbft_message.round_change_justification;
+
+            // Verify we have quorum of prepares
+            if prepares.len() >= self.config.quorum_size() {
+                return (prepares.clone(), Some(prepared_value));
+            }
+        }
+
+        // No prepared value found, proposer can choose new value
         (vec![], None)
     }
 


### PR DESCRIPTION
## Issue Addressed

This pr addresses prepare justification fetching for proposal messages. 

Using round change prepare justification fetching, we first check to see if we have our own prepared value and if so grab all of those messages to return.

Otherwise, we go through all of the round change justifications for the round, find the one with the highest prepared value, and extract its prepare justifications

