### PR TITLE
fix: Remove full data fomr justifications on send

### DIFF
--- a/anchor/common/qbft/src/lib.rs
+++ b/anchor/common/qbft/src/lib.rs
@@ -971,10 +971,18 @@ where
         &self,
         msg_type: QbftMessageType,
         data_hash: D::Hash,
-        round_change_justification: Vec<SignedSSVMessage>,
-        prepare_justification: Vec<SignedSSVMessage>,
+        mut round_change_justification: Vec<SignedSSVMessage>,
+        mut prepare_justification: Vec<SignedSSVMessage>,
     ) -> UnsignedWrappedQbftMessage {
         let data = self.get_message_data(&msg_type, data_hash);
+
+        // Clear full_data from justifications as these do not store full data.
+        for round_change_justification in &mut round_change_justification {
+            round_change_justification.set_full_data(vec![]);
+        }
+        for prepare_justification in &mut prepare_justification {
+            prepare_justification.set_full_data(vec![]);
+        }
 
         // Create the QBFT message
         let qbft_message = QbftMessage {

--- a/anchor/common/qbft/src/msg_container.rs
+++ b/anchor/common/qbft/src/msg_container.rs
@@ -42,19 +42,12 @@ impl MessageContainer {
             return false;
         }
 
-        let mut msg = msg.clone();
-        // We no longer have need for full data in these messages, as the hash is stored the QBFT
-        // state. The messages are here only used for quorum checking, and for justifications. For
-        // both the data is not needed.
-        msg.signed_message.set_full_data(vec![]);
+        self.messages.entry(round).or_default().push(msg.clone());
 
         self.values_by_round
             .entry(round)
             .or_default()
             .insert(msg.qbft_message.root);
-
-        // Add message and track its value
-        self.messages.entry(round).or_default().push(msg);
 
         true
     }


### PR DESCRIPTION
## Issue Addressed

We actually need to keep the full data with messages in the message containers.

## Proposed Changes

- Revert #538 
- In `new_unsigned_message`, call `prepare_justification.set_full_data(vec![]);` on all passed justifications.

## Additional Info
Idea stolen from @Zacholme7 
