### PR TITLE
fix: use proposal hash if not justified

### DIFF
--- a/anchor/common/qbft/src/lib.rs
+++ b/anchor/common/qbft/src/lib.rs
@@ -1278,11 +1278,8 @@ where
         let (prepare_justifications, value_to_propose) = self.get_prepare_justifications();
 
         // Determine the value that should be proposed based off of justification. If we have a
-        // prepare justification, we want to propose that value. Else, just propose the start data
-        let value_to_propose = match value_to_propose {
-            Some(value) => value,
-            None => self.start_data_hash,
-        };
+        // prepare justification, we want to propose that value. Else, just the justified value
+        let value_to_propose = value_to_propose.unwrap_or(hash);
 
         // Construct a unsigned proposal
         let unsigned_msg = self.new_unsigned_message(


### PR DESCRIPTION
## Issue Addressed

Before if we did not have a justified value to propose, we would just propose the start data. While im not sure if this is really wrong, we should instead be proposing the hash passed into the function. Most of the time, this should be `value_to_propose` anyways. 

Sidenote: it looks like there is some duplicate work between [justify_round_change_quorum](https://github.com/sigp/anchor/blob/0e23a1d226db1cc099ebf746563560150d021d86/anchor/common/qbft/src/lib.rs#L350) which finds us the value [to propose](https://github.com/sigp/anchor/blob/0e23a1d226db1cc099ebf746563560150d021d86/anchor/common/qbft/src/lib.rs#L418) and [get_prepare_justifications](https://github.com/sigp/anchor/blob/0e23a1d226db1cc099ebf746563560150d021d86/anchor/common/qbft/src/lib.rs#L1203) which essentially does the same thing by getting the highest prepared value. We should take a look at this and see if we can clean it up a bit.