### PR TITLE
fix: fix name and docs of `lowest_partial_quorum_above_round`

### DIFF
--- a/anchor/common/qbft/src/lib.rs
+++ b/anchor/common/qbft/src/lib.rs
@@ -996,7 +996,7 @@ where
             //    message
             let round = self
                 .round_change_container
-                .highest_partial_quorum_above_round(self.current_round, self.config.get_f() + 1);
+                .lowest_partial_quorum_above_round(self.current_round, self.config.get_f() + 1);
             if let Some(round) = round
                 && round > self.current_round
             {

--- a/anchor/common/qbft/src/msg_container.rs
+++ b/anchor/common/qbft/src/msg_container.rs
@@ -78,12 +78,8 @@ impl MessageContainer {
             .is_some_and(|msgs| msgs.len() >= self.quorum_size)
     }
 
-    /// Count the number of messages we have received for this round
-    pub fn highest_partial_quorum_above_round(
-        &self,
-        round: Round,
-        partial: usize,
-    ) -> Option<Round> {
+    /// Return the lowest round above a certain round that has at least `partial` amount of msgs.
+    pub fn lowest_partial_quorum_above_round(&self, round: Round, partial: usize) -> Option<Round> {
         // Collect all operators from rounds > round
         let mut all_operators = HashSet::new();
         let mut min_future_round = None;

--- a/anchor/common/qbft/src/msg_container.rs
+++ b/anchor/common/qbft/src/msg_container.rs
@@ -70,12 +70,8 @@ impl MessageContainer {
             .map(|(value, _)| value)
     }
 
-    /// Count the number of messages we have received for this round
-    pub fn highest_partial_quorum_above_round(
-        &self,
-        round: Round,
-        partial: usize,
-    ) -> Option<Round> {
+    /// Return the lowest round above a certain round that has at least `partial` amount of msgs.
+    pub fn lowest_partial_quorum_above_round(&self, round: Round, partial: usize) -> Option<Round> {
         // Collect all operators from rounds > round
         let mut all_operators = HashSet::new();
         let mut min_future_round = None;


### PR DESCRIPTION
## Issue Addressed
During a late change in a previous pr, the behaviour of `highest_partial_quorum_above_round` was adjusted, but the name was not. The copy-pasted docs were also inaccurate

## Proposed Changes

Rename to `lowest_partial_quorum_above_round` and change docs.