### PR TITLE
fix(qbft): Check round change quorum disregarding root

### DIFF
--- a/anchor/common/qbft/src/lib.rs
+++ b/anchor/common/qbft/src/lib.rs
@@ -979,7 +979,10 @@ where
         // There are two cases to check here
 
         // 1. If we have received a quorum of round change messages, we need to start a new round
-        if self.round_change_container.has_quorum(round).is_some() {
+        if self
+            .round_change_container
+            .has_quorum_disregarding_root(round)
+        {
             if matches!(self.state, InstanceState::SentRoundChange) {
                 // If we have reached a quorum for this round and have already sent a round change,
                 // advance to that round.

--- a/anchor/common/qbft/src/msg_container.rs
+++ b/anchor/common/qbft/src/msg_container.rs
@@ -70,6 +70,14 @@ impl MessageContainer {
             .map(|(value, _)| value)
     }
 
+    /// Check if we have a quorum of messages for the round, regardless of the root contained in the
+    /// message.
+    pub fn has_quorum_disregarding_root(&self, round: Round) -> bool {
+        self.messages
+            .get(&round)
+            .is_some_and(|msgs| msgs.len() >= self.quorum_size)
+    }
+
     /// Count the number of messages we have received for this round
     pub fn highest_partial_quorum_above_round(
         &self,


### PR DESCRIPTION
## Issue Addressed

Round change messages may have a non-zero root (if we have previously prepared a value) or a zero root.

This causes us to not change round sometimes (where go-ssv does), as we check for quorum per round and root.

## Proposed Changes

Introduce a function to the message container just checking for a sufficient amount of messages in the container, without grouping by root.
