### PR TITLE
fix: prevent Round arithmetic overflow in consensus validation

### DIFF
--- a/anchor/common/qbft/src/msg_container.rs
+++ b/anchor/common/qbft/src/msg_container.rs
@@ -84,7 +84,9 @@ impl MessageContainer {
         let mut all_operators = HashSet::new();
         let mut min_future_round = None;
 
-        for (&r, operators) in self.senders_by_round.range((round + 1)..) {
+        let start_round = round.next()?; // No future rounds possible if overflow
+
+        for (&r, operators) in self.senders_by_round.range(start_round..) {
             // Track minimum round
             if min_future_round.is_none() {
                 min_future_round = Some(r);

--- a/anchor/common/ssv_types/src/round.rs
+++ b/anchor/common/ssv_types/src/round.rs
@@ -24,10 +24,23 @@ impl From<Round> for u64 {
 }
 
 impl Add<u64> for Round {
-    type Output = Round;
+    type Output = Option<Round>;
 
-    fn add(self, rhs: u64) -> Round {
-        Round(NonZeroUsize::new(self.0.get() + rhs as usize).expect("round == 0"))
+    /// Adds a u64 to a Round using checked arithmetic to prevent overflow.
+    ///
+    /// Returns None if:
+    /// - The addition would overflow (self + rhs > usize::MAX)
+    /// - The result would be zero (handled by NonZeroUsize::new)
+    ///
+    /// This prevents security vulnerabilities where overflow could cause:
+    /// - Message validation to accept messages from any round
+    /// - Message container iteration to process all rounds instead of just future ones
+    fn add(self, rhs: u64) -> Option<Round> {
+        self.0
+            .get()
+            .checked_add(rhs as usize)
+            .and_then(NonZeroUsize::new)
+            .map(Round)
     }
 }
 

--- a/anchor/message_validator/src/consensus_message.rs
+++ b/anchor/message_validator/src/consensus_message.rs
@@ -299,10 +299,8 @@ fn validate_round_in_allowed_spread(
     };
 
     let lowest_allowed = FIRST_ROUND;
-    let highest_allowed = match estimated_round + MAX_ALLOWED_ROUNDS_FUTURE {
-        Some(round) => round,
-        None => return Err(ValidationFailure::RoundOverflow),
-    };
+    let highest_allowed =
+        (estimated_round + MAX_ALLOWED_ROUNDS_FUTURE).ok_or(ValidationFailure::RoundOverflow)?;
 
     // Check if the round is within allowed spread
     if consensus_message.round < lowest_allowed || consensus_message.round > highest_allowed.into()

--- a/anchor/message_validator/src/consensus_message.rs
+++ b/anchor/message_validator/src/consensus_message.rs
@@ -299,7 +299,10 @@ fn validate_round_in_allowed_spread(
     };
 
     let lowest_allowed = FIRST_ROUND;
-    let highest_allowed = estimated_round + MAX_ALLOWED_ROUNDS_FUTURE;
+    let highest_allowed = match estimated_round + MAX_ALLOWED_ROUNDS_FUTURE {
+        Some(round) => round,
+        None => return Err(ValidationFailure::RoundOverflow),
+    };
 
     // Check if the round is within allowed spread
     if consensus_message.round < lowest_allowed || consensus_message.round > highest_allowed.into()

--- a/anchor/message_validator/src/lib.rs
+++ b/anchor/message_validator/src/lib.rs
@@ -168,6 +168,7 @@ pub enum ValidationFailure {
     FullDataNotInConsensusMessage,
     TripleValidatorIndexInPartialSignatures,
     ZeroRound,
+    RoundOverflow,
     DuplicatedMessage {
         got: String,
     }, // Updated to include context
@@ -214,6 +215,7 @@ impl From<&ValidationFailure> for MessageAcceptance {
             | ValidationFailure::IncorrectTopic
             | ValidationFailure::NonExistentCommitteeID
             | ValidationFailure::RoundTooHigh
+            | ValidationFailure::RoundOverflow
             | ValidationFailure::ValidatorIndexMismatch
             | ValidationFailure::TooManyDutiesPerEpoch
             | ValidationFailure::NoDuty


### PR DESCRIPTION
## Issue Addressed

Critical overflow vulnerability in Round arithmetic that could bypass consensus validation.

## Proposed Changes

- **Round + u64 operator**: Changed to checked arithmetic returning `Option<Round>`
- **Message validation**: Handle overflow with new `ValidationFailure::RoundOverflow` error
- **Message container**: Use safe `Round::next()?` for iteration
- **Error handling**: Added overflow error variant that ignores (not rejects) messages

## Additional Info

**Security Impact:**
Prevents attackers from using rounds near `u64::MAX` to:
- Bypass round validation via overflow wrap-around
- Cause DoS through consensus disruption
- Make message container iterate incorrectly

**Backward Compatibility:** No breaking API changes, internal sites handle new Option return type.