### PR TITLE
feat: specific qbft errors

### DIFF
--- a/anchor/common/qbft/src/error.rs
+++ b/anchor/common/qbft/src/error.rs
@@ -66,6 +66,7 @@ pub enum QbftError {
     // Proposal errors
     ProposalNotFromLeader,
     ProposalAlreadyReceived,
+    ProposalNotAccepted,
     ProposalMissingData,
     ProposalNotFound,
     ProposedDataMismatch,

--- a/anchor/common/qbft/src/error.rs
+++ b/anchor/common/qbft/src/error.rs
@@ -48,82 +48,53 @@ impl std::fmt::Display for ConfigBuilderError {
 }
 
 /// Errors that can occur during QBFT consensus
-/// todo!() check for unusued
 #[derive(Debug, Clone, PartialEq)]
 pub enum QbftError {
     // Message validation errors
-    InvalidSignature,
     SignerNotInCommittee,
     DuplicateSigners,
     WrongHeight,
     WrongRound,
     PastRound,
-    InvalidMessageType,
     InvalidFullData,
     DataValidationFailed,
     MissingOperators,
-    NoData,
     InvalidDataRound,
+    WrongMessageType,
+    NotEnoughSignatures,
 
     // Proposal errors
     ProposalNotFromLeader,
     ProposalAlreadyReceived,
     ProposalMissingData,
     ProposalNotFound,
-    DuplicateProposal,
+    ProposedDataMismatch,
 
+    // Duplicate Message Errors
+    DuplicateProposal,
     DuplicatePrepare,
     DuplicateCommit,
-
-    FailedToAggregate,
 
     // Justification errors
     RoundChangeJustificationNoQuorum,
     RoundChangeJustificationWrongRound,
     RoundChangeJustificationWrongHeight,
     RoundChangeJustificationInvalidMessage,
+    RoundChangeJustificationNotRoundChange,
     RoundChangeJustificationInvalidDataRound,
     RoundChangeJustificationDecodeFailed,
-    RoundChangeJustificationNotRoundChange,
-    RoundChangeJustificationValidationFailed,
-    RoundChangeJustificationInvalidSignature,
-    RoundChangeJustificationDuplicateMsg,
-    RoundChangeJustificationInvalidPrepares,
-    RoundChangeJustificationInvalidPrepareRound,
     RoundChangeJustificationInvalidPrepareRoot,
     RoundChangeJustificationNotInCommittee,
     RoundChangeJustificationNoPrepareQuorum,
-    StandaloneRoundChangeNoQuorum,
     RoundChangeJustificationMultiSigner,
     PrepareJustificationWrongRound,
     PrepareJustificationWrongHeight,
     PrepareJustificationNoQuorum,
-    PrepareJustificationNotEnough,
-    PrepareJustificationValueMismatch,
     PrepareJustificationDecodeFailed,
     PrepareJustificationNotPrepare,
-    PrepareJustificationValidationFailed,
     PrepareJustificationRootMismatch,
-    PrepareJustificationInvalidValue,
-    ProposalInvalidValue,
-    ProposalNotJustified,
 
-    // State errors
-    InstanceAlreadyDecided,
+    // Misc
+    FailedToAggregate,
     InvalidState,
-    NoProposalAccepted,
-    NotPreparedYet,
-    ProposedDataMismatch,
-
-    // Message format errors
-    NoSigners,
-    MultipleSignersNotAllowed,
-    WrongMessageType,
-    NotEnoughSignatures,
-    InvalidJustification,
-
-    // Other errors
-    ForceStopped,
-    RoundCutoff,
-    Unknown(String),
 }

--- a/anchor/common/qbft/src/error.rs
+++ b/anchor/common/qbft/src/error.rs
@@ -46,3 +46,84 @@ impl std::fmt::Display for ConfigBuilderError {
         }
     }
 }
+
+/// Errors that can occur during QBFT consensus
+/// todo!() check for unusued
+#[derive(Debug, Clone, PartialEq)]
+pub enum QbftError {
+    // Message validation errors
+    InvalidSignature,
+    SignerNotInCommittee,
+    DuplicateSigners,
+    WrongHeight,
+    WrongRound,
+    PastRound,
+    InvalidMessageType,
+    InvalidFullData,
+    DataValidationFailed,
+    MissingOperators,
+    NoData,
+    InvalidDataRound,
+
+    // Proposal errors
+    ProposalNotFromLeader,
+    ProposalAlreadyReceived,
+    ProposalMissingData,
+    ProposalNotFound,
+    DuplicateProposal,
+
+    DuplicatePrepare,
+    DuplicateCommit,
+
+    FailedToAggregate,
+
+    // Justification errors
+    RoundChangeJustificationNoQuorum,
+    RoundChangeJustificationWrongRound,
+    RoundChangeJustificationWrongHeight,
+    RoundChangeJustificationInvalidMessage,
+    RoundChangeJustificationInvalidDataRound,
+    RoundChangeJustificationDecodeFailed,
+    RoundChangeJustificationNotRoundChange,
+    RoundChangeJustificationValidationFailed,
+    RoundChangeJustificationInvalidSignature,
+    RoundChangeJustificationDuplicateMsg,
+    RoundChangeJustificationInvalidPrepares,
+    RoundChangeJustificationInvalidPrepareRound,
+    RoundChangeJustificationInvalidPrepareRoot,
+    RoundChangeJustificationNotInCommittee,
+    RoundChangeJustificationNoPrepareQuorum,
+    StandaloneRoundChangeNoQuorum,
+    RoundChangeJustificationMultiSigner,
+    PrepareJustificationWrongRound,
+    PrepareJustificationWrongHeight,
+    PrepareJustificationNoQuorum,
+    PrepareJustificationNotEnough,
+    PrepareJustificationValueMismatch,
+    PrepareJustificationDecodeFailed,
+    PrepareJustificationNotPrepare,
+    PrepareJustificationValidationFailed,
+    PrepareJustificationRootMismatch,
+    PrepareJustificationInvalidValue,
+    ProposalInvalidValue,
+    ProposalNotJustified,
+
+    // State errors
+    InstanceAlreadyDecided,
+    InvalidState,
+    NoProposalAccepted,
+    NotPreparedYet,
+    ProposedDataMismatch,
+
+    // Message format errors
+    NoSigners,
+    MultipleSignersNotAllowed,
+    WrongMessageType,
+    NotEnoughSignatures,
+    InvalidJustification,
+
+    // Other errors
+    ForceStopped,
+    RoundCutoff,
+    Unknown(String),
+}

--- a/anchor/common/qbft/src/error.rs
+++ b/anchor/common/qbft/src/error.rs
@@ -52,7 +52,6 @@ impl std::fmt::Display for ConfigBuilderError {
 pub enum QbftError {
     // Message validation errors
     SignerNotInCommittee,
-    DuplicateSigners,
     WrongHeight,
     WrongRound,
     PastRound,
@@ -73,10 +72,9 @@ pub enum QbftError {
 
     // Duplicate Message Errors
     DuplicateProposal,
-    DuplicatePrepare,
-    DuplicateCommit,
 
     // Justification errors
+    ProposalRoundChangeJustificationNoQuorum,
     RoundChangeJustificationNoQuorum,
     RoundChangeJustificationWrongRound,
     RoundChangeJustificationWrongHeight,
@@ -89,6 +87,7 @@ pub enum QbftError {
     RoundChangeJustificationNoPrepareQuorum,
     RoundChangeJustificationMultiSigner,
     PrepareJustificationWrongRound,
+    PrepareJustificationMultiSigner,
     PrepareJustificationWrongHeight,
     PrepareJustificationNoQuorum,
     PrepareJustificationDecodeFailed,

--- a/anchor/common/qbft/src/lib.rs
+++ b/anchor/common/qbft/src/lib.rs
@@ -558,7 +558,7 @@ where
         // Make sure we have a quorum of round change messages
         if !self.check_quorum(&msg.qbft_message.round_change_justification) {
             warn!("Did not receive a quorum of round change messages");
-            return Err(QbftError::RoundChangeJustificationNoQuorum);
+            return Err(QbftError::ProposalRoundChangeJustificationNoQuorum);
         }
 
         // There was a quorum of round change justifications. We need to go though and verify each
@@ -749,7 +749,7 @@ where
             .add_message(round, operator_id, &wrapped_msg)
         {
             warn!(from = ?operator_id, "PREPARE message is a duplicate");
-            return Err(QbftError::DuplicatePrepare);
+            return Ok(());
         }
 
         // Make sure that we have accepted a proposal for this round
@@ -855,7 +855,7 @@ where
             .add_message(round, operator_id, &wrapped_msg)
         {
             warn!(from = ?operator_id, "COMMIT message is a duplicate");
-            return Err(QbftError::DuplicateCommit);
+            return Ok(());
         }
 
         // Check if we have a commit quorum

--- a/anchor/common/qbft/src/lib.rs
+++ b/anchor/common/qbft/src/lib.rs
@@ -853,7 +853,7 @@ where
             .add_message(round, operator_id, &wrapped_msg)
         {
             warn!(from = ?operator_id, "COMMIT message is a duplicate");
-            return Err(QbftError::DuplicatePrepare);
+            return Err(QbftError::DuplicateCommit);
         }
 
         // Check if we have a commit quorum

--- a/anchor/common/qbft/src/lib.rs
+++ b/anchor/common/qbft/src/lib.rs
@@ -20,7 +20,7 @@ use ssz::{Decode, Encode};
 use tracing::{debug, error, warn};
 use types::Hash256;
 
-use crate::msg_container::MessageContainer;
+use crate::{error::QbftError, msg_container::MessageContainer};
 
 mod config;
 mod error;
@@ -251,7 +251,7 @@ where
     fn validate_message(
         &self,
         wrapped_msg: &WrappedQbftMessage,
-    ) -> Option<(Option<ValidData<D>>, OperatorId)> {
+    ) -> Result<(Option<ValidData<D>>, OperatorId), QbftError> {
         // Ensure that this message is for the correct round
         if wrapped_msg.qbft_message.round < self.current_round.into() {
             debug!(
@@ -259,7 +259,7 @@ where
                 current_round = *self.current_round,
                 "Message received for a previous round"
             );
-            return None;
+            return Err(QbftError::PastRound);
         }
 
         // Check for future round
@@ -271,12 +271,12 @@ where
                 QbftMessageType::Commit => {
                     // Only decided messages (with quorum) are allowed from future rounds
                     if wrapped_msg.signed_message.operator_ids().len() < self.config.quorum_size() {
-                        return None;
+                        return Err(QbftError::WrongRound);
                     }
                 }
                 _ => {
                     // All other message types (including Prepare) for future rounds are not allowed
-                    return None;
+                    return Err(QbftError::WrongRound);
                 }
             }
         }
@@ -287,14 +287,14 @@ where
                 expected_instance = *self.instance_height,
                 "Message received for the wrong instance"
             );
-            return None;
+            return Err(QbftError::WrongHeight);
         }
 
         // Make sure that all of the signers are in our committee
         for signer in wrapped_msg.signed_message.operator_ids() {
             if !self.check_committee(signer) {
                 warn!("Signer is not part of committee");
-                return None;
+                return Err(QbftError::SignerNotInCommittee);
             }
         }
 
@@ -304,16 +304,20 @@ where
             // with > 1 signers). Do not care about data here, just that we had a
             // success
             let valid_data = Some(ValidData::new(None, wrapped_msg.qbft_message.root));
-            return Some((valid_data, OperatorId::from(0)));
+            return Ok((valid_data, OperatorId::from(0)));
         }
 
         // Message is not a decide message, we know there is only one signer
-        let signer = wrapped_msg.signed_message.operator_ids().first()?;
+        let signer = wrapped_msg
+            .signed_message
+            .operator_ids()
+            .first()
+            .ok_or(QbftError::MissingOperators)?;
 
         // Fulldata may be empty. This is still considered valid though
         if wrapped_msg.signed_message.full_data().is_empty() {
             let valid_data = Some(ValidData::new(None, wrapped_msg.qbft_message.root));
-            return Some((valid_data, *signer));
+            return Ok((valid_data, *signer));
         }
 
         // Try to decode the data. If we can decode the data, then also validate it
@@ -328,12 +332,12 @@ where
                     full_data = hex::encode(wrapped_msg.signed_message.full_data()),
                     "Raw invalid full data",
                 );
-                return None;
+                return Err(QbftError::InvalidFullData);
             }
         };
 
         if !self.data_validator.validate(&data, &self.start_data) {
-            return None;
+            return Err(QbftError::DataValidationFailed);
         }
 
         // Success! Message is well formed
@@ -341,7 +345,7 @@ where
             Some(Arc::new(data)),
             wrapped_msg.qbft_message.root,
         ));
-        Some((valid_data, *signer))
+        Ok((valid_data, *signer))
     }
 
     /// Justify the round change quorum
@@ -427,10 +431,12 @@ where
     }
 
     /// Receive a new message from the network
-    pub fn receive(&mut self, wrapped_msg: WrappedQbftMessage) {
+    pub fn receive(&mut self, wrapped_msg: WrappedQbftMessage) -> Result<(), QbftError> {
         // Perform base qbft releveant verification on the message
-        let Some((Some(valid_data), signer)) = self.validate_message(&wrapped_msg) else {
-            return;
+        let (valid_data, signer) = match self.validate_message(&wrapped_msg) {
+            Ok((Some(data), signer)) => (data, signer),
+            Ok((None, _)) => return Ok(()),
+            Err(e) => return Err(e),
         };
 
         let msg_round: Round = wrapped_msg.qbft_message.round.into();
@@ -438,20 +444,21 @@ where
         // All basic verification successful! Dispatch to the correct handler
         match wrapped_msg.qbft_message.qbft_message_type {
             QbftMessageType::Proposal => {
-                self.received_propose(valid_data, signer, msg_round, wrapped_msg)
+                self.received_propose(valid_data, signer, msg_round, wrapped_msg)?
             }
-            QbftMessageType::Prepare => self.received_prepare(signer, msg_round, wrapped_msg),
+            QbftMessageType::Prepare => self.received_prepare(signer, msg_round, wrapped_msg)?,
             QbftMessageType::Commit => {
                 if wrapped_msg.signed_message.operator_ids().len() == 1 {
-                    self.received_commit(signer, msg_round, wrapped_msg)
+                    self.received_commit(signer, msg_round, wrapped_msg)?
                 } else {
-                    self.received_decided(wrapped_msg)
+                    self.received_decided(wrapped_msg)?
                 }
             }
             QbftMessageType::RoundChange => {
-                self.received_round_change(signer, msg_round, wrapped_msg)
+                self.received_round_change(signer, msg_round, wrapped_msg)?
             }
         }
+        Ok(())
     }
 
     // We have received a new Proposal messaage
@@ -461,27 +468,24 @@ where
         operator_id: OperatorId,
         round: Round,
         wrapped_msg: WrappedQbftMessage,
-    ) {
+    ) -> Result<(), QbftError> {
         // Make sure that we are actually waiting for a proposal
         if round == self.current_round && !matches!(self.state, InstanceState::AwaitingProposal) {
             debug!(from=?operator_id, ?self.state, "PROPOSE message while in invalid state");
-            return;
+            return Err(QbftError::InvalidState);
         }
 
         // Make sure this is from the leader
         if !self.check_leader(&operator_id) {
             warn!(from = ?operator_id, "PROPOSE message received from non-leader operator");
-            return;
+            return Err(QbftError::ProposalNotFromLeader);
         }
 
         // If we are passed the first round, make sure that the justifications actually justify the
         // received proposal
         if round > Round::default() {
             // validate the justifications
-            if !self.validate_proposal_justifications(&wrapped_msg) {
-                warn!(from = ?operator_id, "Justification validation failed for proposal");
-                return;
-            }
+            self.validate_proposal_justifications(&wrapped_msg)?;
         }
 
         // Fulldata is included in propose messages
@@ -489,7 +493,7 @@ where
             Some(data) => data,
             None => {
                 warn!(from = ?operator_id, "Proposal should contain data");
-                return;
+                return Err(QbftError::ProposalMissingData);
             }
         };
         self.data.insert(valid_data.hash, data);
@@ -502,14 +506,14 @@ where
             .add_message(round, operator_id, &wrapped_msg)
         {
             warn!(from = ?operator_id, "PROPOSE message is a duplicate");
-            return;
+            return Err(QbftError::DuplicateProposal);
         }
 
         // Only reject if we've already accepted a proposal for THIS round
         // Allow proposals for future rounds even if we have a proposal for current round
         if self.proposal_accepted_for_current_round && round == self.current_round {
             warn!(from = ?operator_id, "Proposal has already been accepted for this round");
-            return;
+            return Err(QbftError::ProposalAlreadyReceived);
         }
 
         // If this is a future round proposal, update our round to match
@@ -528,6 +532,7 @@ where
 
         // Create and send prepare message
         self.send_prepare(wrapped_msg.qbft_message.root);
+        Ok(())
     }
 
     // Validate the round change and prepare justifications for proposal.
@@ -543,7 +548,7 @@ where
     //      - each round change message has list of prepare messages if it prepared a value
     // - prepare justifications
     //  - list of prepare messages to
-    fn validate_proposal_justifications(&self, msg: &WrappedQbftMessage) -> bool {
+    fn validate_proposal_justifications(&self, msg: &WrappedQbftMessage) -> Result<(), QbftError> {
         // Record if any of the round change messages have a value that was prepared
         let mut max_prepared_round = 0;
         let mut max_prepared_msg = None;
@@ -551,7 +556,7 @@ where
         // Make sure we have a quorum of round change messages
         if !self.check_quorum(&msg.qbft_message.round_change_justification) {
             warn!("Did not receive a quorum of round change messages");
-            return false;
+            return Err(QbftError::RoundChangeJustificationNoQuorum);
         }
 
         // There was a quorum of round change justifications. We need to go though and verify each
@@ -559,13 +564,13 @@ where
         for signed_round_change in &msg.qbft_message.round_change_justification {
             // Check for multi-signers - round change messages should only have 1 signer
             if signed_round_change.operator_ids().len() > 1 {
-                return false;
+                return Err(QbftError::RoundChangeJustificationMultiSigner);
             }
 
             // make sure all signers in committee
             for signer in signed_round_change.operator_ids() {
                 if !self.check_committee(signer) {
-                    return false;
+                    return Err(QbftError::RoundChangeJustificationNotInCommittee);
                 }
             }
 
@@ -574,25 +579,25 @@ where
             let round_change: QbftMessage =
                 match QbftMessage::from_ssz_bytes(signed_round_change.ssv_message().data()) {
                     Ok(data) => data,
-                    Err(_) => return false,
+                    Err(_) => return Err(QbftError::RoundChangeJustificationDecodeFailed),
                 };
 
             // Make sure this is actually a round change message
             if !matches!(round_change.qbft_message_type, QbftMessageType::RoundChange) {
                 warn!(message_type = ?round_change.qbft_message_type, "Message is not a ROUNDCHANGE message");
-                return false;
+                return Err(QbftError::RoundChangeJustificationNotRoundChange);
             }
 
             // make sure the round change matches the round of the message
             if round_change.round != msg.qbft_message.round {
-                return false;
+                return Err(QbftError::RoundChangeJustificationWrongRound);
             }
 
             // For round change justifications, we need special validation that doesn't check
             // against current round since they're justifications from the proposal's round
             // Check height
             if round_change.height != *self.instance_height as u64 {
-                return false;
+                return Err(QbftError::RoundChangeJustificationWrongHeight);
             }
 
             // If the data_round > 0, that means we have prepared a value in previous rounds
@@ -611,13 +616,13 @@ where
                         "Round change has prepared round {} > round {}",
                         round_change.data_round, round_change.round
                     );
-                    return false;
+                    return Err(QbftError::RoundChangeJustificationInvalidDataRound);
                 }
 
                 // Verify that if round change has full data, it matches the root
                 if msg.qbft_message.root != round_change.root {
                     warn!("Proposal root doesn't match round change prepared root");
-                    return false;
+                    return Err(QbftError::RoundChangeJustificationInvalidPrepareRoot);
                 }
 
                 if !self.check_quorum(&round_change.round_change_justification) {
@@ -625,18 +630,16 @@ where
                         num_justifications = round_change.round_change_justification.len(),
                         "Not enough prepare messages for quorum"
                     );
-                    return false;
+                    return Err(QbftError::RoundChangeJustificationNoPrepareQuorum);
                 }
 
                 // go through all of the round changes prepare justifications
                 for signed_prepare in &round_change.round_change_justification {
-                    if !self.is_valid_prepare_justification_for_round_and_root(
+                    self.is_valid_prepare_justification_for_round_and_root(
                         signed_prepare,
                         round_change.data_round.into(),
                         &round_change.root,
-                    ) {
-                        return false;
-                    }
+                    )?
                 }
             }
         }
@@ -650,27 +653,25 @@ where
                     num_justifications = msg.qbft_message.prepare_justification.len(),
                     "Not enough prepare messages for quorum"
                 );
-                return false;
+                return Err(QbftError::PrepareJustificationNoQuorum);
             }
 
             // Make sure that the roots match
             if msg.qbft_message.root != max_prepared_msg.root {
                 warn!("Highest prepared does not match proposed data");
-                return false;
+                return Err(QbftError::PrepareJustificationRootMismatch);
             }
 
             // Validate each prepare message matches highest prepared round/value
             for signed_prepare in &msg.qbft_message.prepare_justification {
-                if !self.is_valid_prepare_justification_for_round_and_root(
+                self.is_valid_prepare_justification_for_round_and_root(
                     signed_prepare,
                     max_prepared_msg.data_round.into(),
                     &max_prepared_msg.root,
-                ) {
-                    return false;
-                }
+                )?
             }
         }
-        true
+        Ok(())
     }
 
     fn is_valid_prepare_justification_for_round_and_root(
@@ -678,36 +679,36 @@ where
         justification: &SignedSSVMessage,
         round: Round,
         root: &Hash256,
-    ) -> bool {
+    ) -> Result<(), QbftError> {
         // The qbft message is represented as Vec<u8> in the signed message, deserialize this into
         // a qbft message
         let Ok(prepare) = QbftMessage::from_ssz_bytes(justification.ssv_message().data()) else {
             warn!("Failed to decode prepare justification message");
-            return false;
+            return Err(QbftError::PrepareJustificationDecodeFailed);
         };
 
         // Make sure this is a prepare message
         if prepare.qbft_message_type != QbftMessageType::Prepare {
             warn!("Expected a prepare message");
-            return false;
+            return Err(QbftError::PrepareJustificationNotPrepare);
         }
 
         if prepare.height != *self.instance_height as u64 {
             warn!("PREPARE height incorrect");
-            return false;
+            return Err(QbftError::PrepareJustificationWrongHeight);
         }
 
         if prepare.round != round.get() as u64 {
             warn!("PREPARE round incorrect");
-            return false;
+            return Err(QbftError::PrepareJustificationWrongRound);
         }
 
         if &prepare.root != root {
             warn!("Proposed data mismatch");
-            return false;
+            return Err(QbftError::PrepareJustificationRootMismatch);
         }
 
-        true
+        Ok(())
     }
 
     /// We have received a prepare message
@@ -716,17 +717,17 @@ where
         operator_id: OperatorId,
         round: Round,
         wrapped_msg: WrappedQbftMessage,
-    ) {
+    ) -> Result<(), QbftError> {
         // If we are already done
         if self.completed.is_some() {
-            return;
+            return Ok(());
         }
 
         // Check that we are in the correct state. We do not have to be in the PREPARE state right
         // now as this message may have been delayed
         if u8::from(self.state) >= u8::from(InstanceState::SentRoundChange) {
             debug!(from=?operator_id, ?self.state, "PREPARE message while in invalid state");
-            return;
+            return Err(QbftError::InvalidState);
         }
 
         // Make sure this is actually a prepare message
@@ -735,7 +736,7 @@ where
             QbftMessageType::Prepare,
         )) {
             warn!(from=?operator_id, "Expected a PREPARE message");
-            return;
+            return Err(QbftError::WrongMessageType);
         }
 
         debug!(from = ?operator_id, state = ?self.state, "PREPARE received");
@@ -745,13 +746,14 @@ where
             .prepare_container
             .add_message(round, operator_id, &wrapped_msg)
         {
-            warn!(from = ?operator_id, "PREPARE message is a duplicate")
+            warn!(from = ?operator_id, "PREPARE message is a duplicate");
+            return Err(QbftError::DuplicatePrepare);
         }
 
         // Make sure that we have accepted a proposal for this round
         if !self.proposal_accepted_for_current_round {
             debug!(from=?operator_id, ?self.state, "Have not accepted Proposal for current round yet");
-            return;
+            return Err(QbftError::ProposalAlreadyReceived);
         }
 
         // Check that the prepare message is for the accepted proposal
@@ -759,7 +761,7 @@ where
             && wrapped_msg.qbft_message.root != accepted_root
         {
             warn!(from=?operator_id, "PREPARE message for different root than accepted proposal");
-            return;
+            return Err(QbftError::ProposedDataMismatch);
         }
 
         // Check if we have reached a prepare quorum for this round, if so send the commit message
@@ -769,7 +771,7 @@ where
                 InstanceState::Prepare { proposal_root } => proposal_root,
                 _ => {
                     debug!(from=?operator_id, ?self.state, "Not in PREPARE state");
-                    return;
+                    return Ok(());
                 }
             };
 
@@ -777,7 +779,7 @@ where
             // matches the root of the proposal that we have accepted
             if hash != proposal_root {
                 warn!("PREPARE quorum root does not match accepted PROPOSAL root");
-                return;
+                return Err(QbftError::ProposedDataMismatch);
             }
 
             // Success! We have come to a prepare consensus on a value
@@ -793,6 +795,7 @@ where
             // Send a commit message for the prepare quorum data
             self.send_commit(hash);
         }
+        Ok(())
     }
 
     /// We have received a commit message
@@ -801,16 +804,16 @@ where
         operator_id: OperatorId,
         round: Round,
         wrapped_msg: WrappedQbftMessage,
-    ) {
+    ) -> Result<(), QbftError> {
         // If we are already done, ignore
         if self.completed.is_some() {
-            return;
+            return Ok(());
         }
 
         // Make sure that we are in the correct state
         if u8::from(self.state) >= u8::from(InstanceState::SentRoundChange) {
             debug!(from=*operator_id, ?self.state, "COMMIT message while in invalid state");
-            return;
+            return Err(QbftError::InvalidState);
         }
 
         // Make sure this is actually a commit message
@@ -819,7 +822,7 @@ where
             QbftMessageType::Commit,
         )) {
             warn!(from=?operator_id, "Expected a COMMIT message");
-            return;
+            return Err(QbftError::WrongMessageType);
         }
 
         // Handle commit message, checking proposal acceptance and catch-up scenarios.
@@ -828,18 +831,18 @@ where
         // We allow commits without having seen a proposal in this case.
         if !self.proposal_accepted_for_current_round {
             debug!(from=?operator_id, ?self.state, "Have not accepted Proposal for current round yet (catch-up scenario)");
-            return;
+            return Err(QbftError::ProposalAlreadyReceived);
         }
 
         // Proposal accepted: ensure commit matches the accepted proposal root.
         if let Some(accepted_root) = self.proposal_root {
             if wrapped_msg.qbft_message.root != accepted_root {
                 warn!(from=?operator_id, ?self.state, "Commit root does not match accepted Proposal root");
-                return;
+                return Err(QbftError::ProposedDataMismatch);
             }
         } else {
             warn!(from=?operator_id, ?self.state, "Proposal accepted, but no proposal root found");
-            return;
+            return Err(QbftError::ProposalNotFound);
         }
 
         debug!(from = ?operator_id, state = ?self.state, "COMMIT received");
@@ -849,7 +852,8 @@ where
             .commit_container
             .add_message(round, operator_id, &wrapped_msg)
         {
-            warn!(from = ?operator_id, "COMMIT message is a duplicate")
+            warn!(from = ?operator_id, "COMMIT message is a duplicate");
+            return Err(QbftError::DuplicatePrepare);
         }
 
         // Check if we have a commit quorum
@@ -862,10 +866,10 @@ where
                     // We already accepted a proposal and are in commit state
                     if hash != proposal_root {
                         warn!("COMMIT quorum root does not match accepted PROPOSAL root");
-                        return;
+                        return Err(QbftError::ProposedDataMismatch);
                     }
                 }
-                _ => return,
+                _ => return Err(QbftError::InvalidState),
             }
 
             // Aggregate all of the commit messages
@@ -877,9 +881,11 @@ where
                 self.state = InstanceState::Complete;
                 self.completed = Some(Completed::Success(hash));
             } else {
-                error!("Failed to aggregate commit quorum")
+                error!("Failed to aggregate commit quorum");
+                return Err(QbftError::FailedToAggregate);
             }
         }
+        Ok(())
     }
 
     // Aggregate a quorum of commit messages into one signed message
@@ -921,11 +927,11 @@ where
         operator_id: OperatorId,
         round: Round,
         wrapped_msg: WrappedQbftMessage,
-    ) {
+    ) -> Result<(), QbftError> {
         // Make sure we are in the correct state
         if u8::from(self.state) >= u8::from(InstanceState::Complete) {
             debug!(from=*operator_id, ?self.state, "ROUNDCHANGE message while in invalid state");
-            return;
+            return Err(QbftError::InvalidState);
         }
 
         let qbft_msg = &wrapped_msg.qbft_message;
@@ -938,7 +944,7 @@ where
                     quorum = self.config.quorum_size(),
                     "prepared ROUNDCHANGE has no quorum"
                 );
-                return;
+                return Err(QbftError::RoundChangeJustificationNoQuorum);
             }
 
             if qbft_msg.data_round > qbft_msg.round {
@@ -948,21 +954,15 @@ where
                     round = qbft_msg.round,
                     "ROUNDCHANGE has prepared round after round"
                 );
-                return;
+                return Err(QbftError::InvalidDataRound);
             }
 
             for justification in qbft_msg.round_change_justification.iter() {
-                if !self.is_valid_prepare_justification_for_round_and_root(
+                self.is_valid_prepare_justification_for_round_and_root(
                     justification,
                     qbft_msg.data_round.into(),
                     &qbft_msg.root,
-                ) {
-                    debug!(
-                        from = *operator_id,
-                        "ROUNDCHANGE has invalid prepare justification"
-                    );
-                    return;
-                }
+                )?
             }
         }
 
@@ -1009,13 +1009,14 @@ where
                 self.send_round_change(Hash256::default());
             }
         }
+        Ok(())
     }
 
     // We have received a decided message
-    fn received_decided(&mut self, wrapped_msg: WrappedQbftMessage) {
+    fn received_decided(&mut self, wrapped_msg: WrappedQbftMessage) -> Result<(), QbftError> {
         // Make sure we have a quorum of signatures
         if wrapped_msg.signed_message.operator_ids().len() < self.config().quorum_size() {
-            return;
+            return Err(QbftError::NotEnoughSignatures);
         }
 
         // All message and signature verification has already succeeded. Regardless of what state
@@ -1024,6 +1025,8 @@ where
         self.state = InstanceState::Complete;
         self.completed = Some(Completed::Success(wrapped_msg.qbft_message.root));
         self.aggregated_commit = Some(wrapped_msg.signed_message);
+
+        Ok(())
     }
 
     // End the current round and move to the next one, if possible.

--- a/anchor/common/qbft/src/lib.rs
+++ b/anchor/common/qbft/src/lib.rs
@@ -242,6 +242,14 @@ where
         unique_operators.len() >= self.config.quorum_size()
     }
 
+    /// Checks if we have accepted a proposal
+    fn is_proposal_accepted(&self) -> Result<(), QbftError> {
+        if !self.proposal_accepted_for_current_round {
+            return Err(QbftError::ProposalNotAccepted);
+        }
+        Ok(())
+    }
+
     // Perform base QBFT relevant message verification. This verification is applicable to all QBFT
 
     // message types
@@ -252,7 +260,7 @@ where
     fn validate_message(
         &self,
         wrapped_msg: &WrappedQbftMessage,
-    ) -> Result<(Option<ValidData<D>>, OperatorId), QbftError> {
+    ) -> Result<(ValidData<D>, OperatorId), QbftError> {
         // Ensure that this message is for the correct round
         if wrapped_msg.qbft_message.round < self.current_round.into() {
             debug!(
@@ -304,7 +312,7 @@ where
             // The message validator already checked this is a decided message (a commit message
             // with > 1 signers). Do not care about data here, just that we had a
             // success
-            let valid_data = Some(ValidData::new(None, wrapped_msg.qbft_message.root));
+            let valid_data = ValidData::new(None, wrapped_msg.qbft_message.root);
             return Ok((valid_data, OperatorId::from(0)));
         }
 
@@ -317,7 +325,7 @@ where
 
         // Fulldata may be empty. This is still considered valid though
         if wrapped_msg.signed_message.full_data().is_empty() {
-            let valid_data = Some(ValidData::new(None, wrapped_msg.qbft_message.root));
+            let valid_data = ValidData::new(None, wrapped_msg.qbft_message.root);
             return Ok((valid_data, *signer));
         }
 
@@ -342,10 +350,7 @@ where
         }
 
         // Success! Message is well formed
-        let valid_data = Some(ValidData::new(
-            Some(Arc::new(data)),
-            wrapped_msg.qbft_message.root,
-        ));
+        let valid_data = ValidData::new(Some(Arc::new(data)), wrapped_msg.qbft_message.root);
         Ok((valid_data, *signer))
     }
 
@@ -433,12 +438,8 @@ where
 
     /// Receive a new message from the network
     pub fn receive(&mut self, wrapped_msg: WrappedQbftMessage) -> Result<(), QbftError> {
-        // Perform base qbft releveant verification on the message
-        let (valid_data, signer) = match self.validate_message(&wrapped_msg) {
-            Ok((Some(data), signer)) => (data, signer),
-            Ok((None, _)) => return Ok(()),
-            Err(e) => return Err(e),
-        };
+        // Perform base qbft relevant verification on the message
+        let (valid_data, signer) = self.validate_message(&wrapped_msg)?;
 
         let msg_round: Round = wrapped_msg.qbft_message.round.into();
 
@@ -752,9 +753,9 @@ where
         }
 
         // Make sure that we have accepted a proposal for this round
-        if !self.proposal_accepted_for_current_round {
+        if let Err(e) = self.is_proposal_accepted() {
             debug!(from=?operator_id, ?self.state, "Have not accepted Proposal for current round yet");
-            return Err(QbftError::ProposalAlreadyReceived);
+            return Err(e);
         }
 
         // Check that the prepare message is for the accepted proposal
@@ -830,9 +831,9 @@ where
 
         // If we have NOT accepted a proposal for this round, this is a catch-up scenario.
         // We allow commits without having seen a proposal in this case.
-        if !self.proposal_accepted_for_current_round {
+        if let Err(e) = self.is_proposal_accepted() {
             debug!(from=?operator_id, ?self.state, "Have not accepted Proposal for current round yet (catch-up scenario)");
-            return Err(QbftError::ProposalAlreadyReceived);
+            return Err(e);
         }
 
         // Proposal accepted: ensure commit matches the accepted proposal root.

--- a/anchor/common/qbft/src/tests.rs
+++ b/anchor/common/qbft/src/tests.rs
@@ -353,7 +353,7 @@ fn test_round_change_validation_skips_round_one_prepared_values() {
 
     // This assertion will FAIL if a buggy code returns true (accepts invalid proposal)
     assert!(
-        validation_result.is_ok(),
+        validation_result.is_err(),
         "BUG: validate_justifications() accepted an invalid proposal! \
          Round change messages claim data_round=1 (prepared in round 1) but provide no \
          prepare justifications. This should be rejected but the validation logic \

--- a/anchor/common/qbft/src/tests.rs
+++ b/anchor/common/qbft/src/tests.rs
@@ -174,7 +174,7 @@ impl<D: QbftData<Hash = Hash256>, S: FnMut(UnsignedWrappedQbftMessage)> TestQBFT
                 let wrapped = convert_unsigned_to_signed(msg.clone(), sender);
                 span.in_scope(|| {
                     if let Err(e) = instance.receive(wrapped) {
-                        error!("Qbft Error: {:?}", e);
+                        debug!("Qbft error: {:?}", e);
                     }
                 });
             }

--- a/anchor/common/qbft/src/tests.rs
+++ b/anchor/common/qbft/src/tests.rs
@@ -172,7 +172,11 @@ impl<D: QbftData<Hash = Hash256>, S: FnMut(UnsignedWrappedQbftMessage)> TestQBFT
                 let instance = self.instances.get_mut(id).expect("Instance exists");
 
                 let wrapped = convert_unsigned_to_signed(msg.clone(), sender);
-                span.in_scope(|| instance.receive(wrapped));
+                span.in_scope(|| {
+                    if let Err(e) = instance.receive(wrapped) {
+                        error!("Qbft Error: {:?}", e);
+                    }
+                });
             }
         }
     }
@@ -341,7 +345,7 @@ fn test_round_change_validation_skips_round_one_prepared_values() {
     // - But they provide NO prepare justifications to prove this claim
 
     println!(
-        "Validation result for malicious proposal: {}",
+        "Validation result for malicious proposal: {:?}",
         validation_result
     );
     println!("This proposal should be REJECTED because round change messages");
@@ -349,7 +353,7 @@ fn test_round_change_validation_skips_round_one_prepared_values() {
 
     // This assertion will FAIL if a buggy code returns true (accepts invalid proposal)
     assert!(
-        !validation_result,
+        validation_result.is_ok(),
         "BUG: validate_justifications() accepted an invalid proposal! \
          Round change messages claim data_round=1 (prepared in round 1) but provide no \
          prepare justifications. This should be rejected but the validation logic \

--- a/anchor/qbft_manager/src/instance.rs
+++ b/anchor/qbft_manager/src/instance.rs
@@ -88,7 +88,9 @@ impl<D: QbftData<Hash = Hash256>> QbftInstance<D> {
             QbftInstance::Initialized(initialized) => {
                 // If the instance is already initialized, receive it in the instance
                 // right away
-                initialized.qbft.receive(message);
+                if let Err(e) = initialized.qbft.receive(message) {
+                    error!("Qbft error: {:?}", e);
+                }
             }
             QbftInstance::Uninitialized(uninitialized) => {
                 // The instance has not been initialized yet, save it in the buffer to
@@ -142,7 +144,9 @@ impl Uninitialized {
                 "Replaying buffered messages"
             );
             for message in self.message_buffer {
-                instance.receive(message);
+                if let Err(e) = instance.receive(message) {
+                    error!("Qbft error: {:?}", e);
+                }
             }
         }
 

--- a/anchor/qbft_manager/src/instance.rs
+++ b/anchor/qbft_manager/src/instance.rs
@@ -89,7 +89,7 @@ impl<D: QbftData<Hash = Hash256>> QbftInstance<D> {
                 // If the instance is already initialized, receive it in the instance
                 // right away
                 if let Err(e) = initialized.qbft.receive(message) {
-                    error!("Qbft error: {:?}", e);
+                    debug!("Qbft error: {:?}", e);
                 }
             }
             QbftInstance::Uninitialized(uninitialized) => {
@@ -145,7 +145,7 @@ impl Uninitialized {
             );
             for message in self.message_buffer {
                 if let Err(e) = instance.receive(message) {
-                    error!("Qbft error: {:?}", e);
+                    debug!("Qbft error: {:?}", e);
                 }
             }
         }


### PR DESCRIPTION
## Issue Addressed

This PR adds in specific error variants for qbft. This is important for the spec tests as we have to map from qbft error -> error string for success validation. 
