### PR TITLE
fix: reduce external library logging noise

### DIFF
--- a/anchor/logging/src/tracing_libp2p_discv5_layer.rs
+++ b/anchor/logging/src/tracing_libp2p_discv5_layer.rs
@@ -38,7 +38,13 @@ where
         };
 
         event.record(&mut visitor);
-        let message = format!("{} {} {}\n", timestamp, log_level, visitor.message);
+        let message = format!(
+            "{} {} [{}] {}\n",
+            timestamp,
+            log_level,
+            meta.target(),
+            visitor.message
+        );
 
         if let Err(e) = writer.write_all(message.as_bytes()) {
             eprintln!("Failed to write log: {e}");

--- a/anchor/src/main.rs
+++ b/anchor/src/main.rs
@@ -207,11 +207,13 @@ pub fn enable_logging(
         if let Some(libp2p_discv5_layer) = libp2p_discv5_layer {
             // Create filter that reduces external library noise to WARN level while preserving
             // the configured file log level for Anchor crates
-            let external_libs_filter = "libp2p_gossipsub=warn,discv5=warn";
 
             logging_layers.push(
                 libp2p_discv5_layer
-                    .with_filter(EnvFilter::new(&external_libs_filter))
+                    .with_filter(
+                        EnvFilter::try_new("warn,libp2p_gossipsub::peer_score=debug,libp2p_gossipsub::gossip_promises=debug")
+                            .unwrap_or_else(|_| EnvFilter::new("debug")),
+                    )
                     .boxed(),
             );
         }

--- a/anchor/src/main.rs
+++ b/anchor/src/main.rs
@@ -205,13 +205,13 @@ pub fn enable_logging(
         let file_logging_layer = init_file_logging(&logs_dir, file_logging_flags.clone());
 
         if let Some(libp2p_discv5_layer) = libp2p_discv5_layer {
+            // Create filter that reduces external library noise to WARN level while preserving
+            // the configured file log level for Anchor crates
+            let external_libs_filter = format!("libp2p_gossipsub=warn,discv5=warn");
+            
             logging_layers.push(
                 libp2p_discv5_layer
-                    .with_filter(
-                        EnvFilter::builder()
-                            .with_default_directive(Level::DEBUG.into())
-                            .from_env_lossy(),
-                    )
+                    .with_filter(EnvFilter::new(&external_libs_filter))
                     .boxed(),
             );
         }

--- a/anchor/src/main.rs
+++ b/anchor/src/main.rs
@@ -207,8 +207,8 @@ pub fn enable_logging(
         if let Some(libp2p_discv5_layer) = libp2p_discv5_layer {
             // Create filter that reduces external library noise to WARN level while preserving
             // the configured file log level for Anchor crates
-            let external_libs_filter = format!("libp2p_gossipsub=warn,discv5=warn");
-            
+            let external_libs_filter = "libp2p_gossipsub=warn,discv5=warn";
+
             logging_layers.push(
                 libp2p_discv5_layer
                     .with_filter(EnvFilter::new(&external_libs_filter))


### PR DESCRIPTION
## Issue Addressed

Excessive logging noise from external libraries libp2p_gossipsub and discv5 affecting log readability and storage.

## Proposed Changes

- Set external library log levels to WARN in libp2p_discv5_layer filter
- Changed from DEBUG to `EnvFilter::new("libp2p_gossipsub=warn,discv5=warn")`
- Added documentation explaining the noise reduction strategy

## Additional Info

Preserves Anchor's debug logging while filtering external library noise. Targeted change affecting only the specialized logging layer.