### PR TITLE
chore: Add coauthor info to merge commits

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -115,6 +115,10 @@ pull_request_rules:
     
     
             {{ body | get_section("## Proposed Changes", "") }}
+          
+          {% for commit in commits | unique(attribute='email_author') %}
+          Co-Authored-By: {{ commit.author }} <{{ commit.email_author }}>
+          {% endfor %}
 
 queue_rules:
   - name: default
@@ -129,6 +133,10 @@ queue_rules:
 
 
         {{ body | get_section("## Proposed Changes", "") }}
+      
+      {% for commit in commits | unique(attribute='email_author') %}
+      Co-Authored-By: {{ commit.author }} <{{ commit.email_author }}>
+      {% endfor %}
     queue_conditions:
       - "#approved-reviews-by >= 1"
       - "check-success=license/cla"


### PR DESCRIPTION
## Issue Addressed

After we introduced mergify, co-authors stopped showing up in merge commits.

## Proposed Changes

To make sure everyone is credited for their work, add the `Co-Authored-By:` footer(s) to the commits generated by mergify. This is based on the author info of the individual commits in the PR.

## Additional Info

Stolen from @jimmygchen: https://github.com/sigp/lighthouse/pull/7993

Intentionally targets stable. Pls no touch, I'll take care of merging after approval.
