### PR TITLE
fix: check for rc quorum before and after

### DIFF
--- a/anchor/common/qbft/src/lib.rs
+++ b/anchor/common/qbft/src/lib.rs
@@ -975,12 +975,12 @@ where
 
         debug!(from = ?operator_id, state = ?self.state, "ROUNDCHANGE received");
 
-        // 1. If we have received a quorum of round change messages, we need to start a new round
+        // Check if we already have a quorum
         let had_quorum_before = self
             .round_change_container
             .has_quorum_disregarding_root(round);
 
-        // Store the round changed message
+        // Store the round changed message regardless
         if !self
             .round_change_container
             .add_message(round, operator_id, &wrapped_msg)
@@ -988,7 +988,7 @@ where
             warn!(from = ?operator_id, "ROUNDCHANGE message is a duplicate")
         }
 
-        // If we already had quorum, don't trigger again
+        // If we already had quorum, just return
         if had_quorum_before {
             debug!(from = ?operator_id, "Already had round change quorum, ignoring");
             return;

--- a/anchor/common/qbft/src/lib.rs
+++ b/anchor/common/qbft/src/lib.rs
@@ -975,12 +975,23 @@ where
 
         debug!(from = ?operator_id, state = ?self.state, "ROUNDCHANGE received");
 
+        // 1. If we have received a quorum of round change messages, we need to start a new round
+        let had_quorum_before = self
+            .round_change_container
+            .has_quorum_disregarding_root(round);
+
         // Store the round changed message
         if !self
             .round_change_container
             .add_message(round, operator_id, &wrapped_msg)
         {
             warn!(from = ?operator_id, "ROUNDCHANGE message is a duplicate")
+        }
+
+        // If we already had quorum, don't trigger again
+        if had_quorum_before {
+            debug!(from = ?operator_id, "Already had round change quorum, ignoring");
+            return;
         }
 
         // There are two cases to check here


### PR DESCRIPTION
## Proposed Changes

Follow the [go logic here](https://github.com/ssvlabs/ssv-spec/blob/d4c734909677b5fd3304e1d9220963cc9d794f09/qbft/round_change.go#L19-L31). Make sure to check if we have a quorum before adding a rc message to ensure we dont double trigger a proposal. 