### PR TITLE
fix: verify signatures of justifications

### DIFF
--- a/anchor/message_validator/src/consensus_message.rs
+++ b/anchor/message_validator/src/consensus_message.rs
@@ -1,6 +1,7 @@
 use std::{convert::Into, sync::Arc, time::Duration};
 
 use duties_tracker::DutiesProvider;
+use openssl::{pkey::Public, rsa::Rsa};
 use slot_clock::SlotClock;
 use ssv_types::{
     CommitteeInfo, IndexSet, OperatorId, Round, Slot, VariableList,
@@ -34,6 +35,7 @@ pub(crate) fn validate_consensus_message(
         validation_context.signed_ssv_message,
         &consensus_message,
         validation_context.committee_info,
+        Some(validation_context.operators_pk),
     )?;
 
     validate_qbft_logic(&validation_context, &consensus_message, duty_state)?;
@@ -64,6 +66,7 @@ pub(crate) fn validate_consensus_message_semantics(
     signed_ssv_message: &SignedSSVMessage,
     consensus_message: &QbftMessage,
     committee_info: &CommitteeInfo,
+    operators_pks: Option<&[Rsa<Public>]>,
 ) -> Result<(), ValidationFailure> {
     let signers = signed_ssv_message.operator_ids().len();
 
@@ -139,13 +142,14 @@ pub(crate) fn validate_consensus_message_semantics(
         });
     }
 
-    validate_justifications(consensus_message)?;
+    validate_justifications(consensus_message, operators_pks)?;
 
     Ok(())
 }
 
 pub(crate) fn validate_justifications(
     consensus_message: &QbftMessage,
+    operators_pks: Option<&[Rsa<Public>]>,
 ) -> Result<(), ValidationFailure> {
     // Rule: Can only exist for Proposal messages
     let prepare_justifications = &consensus_message.prepare_justification;
@@ -163,6 +167,13 @@ pub(crate) fn validate_justifications(
     {
         return Err(ValidationFailure::UnexpectedRoundChangeJustifications);
     }
+
+    prepare_justifications
+        .iter()
+        .chain(round_change_justifications.iter())
+        .try_for_each(|signed_message| {
+            verify_message_signatures(signed_message, operators_pks.unwrap())
+        })?;
 
     Ok(())
 }
@@ -696,7 +707,7 @@ mod tests {
         );
 
         let result =
-            validate_consensus_message_semantics(&signed_msg, &qbft_message, &committee_info);
+            validate_consensus_message_semantics(&signed_msg, &qbft_message, &committee_info, None);
 
         assert!(
             result.is_ok(),
@@ -716,7 +727,7 @@ mod tests {
             create_signed_consensus_message(qbft_message.clone(), signers.clone(), vec![], vec![]);
 
         let result =
-            validate_consensus_message_semantics(&signed_msg, &qbft_message, &committee_info);
+            validate_consensus_message_semantics(&signed_msg, &qbft_message, &committee_info, None);
 
         assert_validation_error(
             result,
@@ -737,7 +748,7 @@ mod tests {
             create_signed_consensus_message(qbft_message.clone(), signers.clone(), vec![], vec![]);
 
         let result =
-            validate_consensus_message_semantics(&signed_msg, &qbft_message, &committee_info);
+            validate_consensus_message_semantics(&signed_msg, &qbft_message, &committee_info, None);
 
         assert_validation_error(
             result,
@@ -761,7 +772,7 @@ mod tests {
         );
 
         let result =
-            validate_consensus_message_semantics(&signed_msg, &qbft_message, &committee_info);
+            validate_consensus_message_semantics(&signed_msg, &qbft_message, &committee_info, None);
 
         assert_validation_error(
             result,
@@ -785,7 +796,7 @@ mod tests {
         );
 
         let result =
-            validate_consensus_message_semantics(&signed_msg, &qbft_message, &committee_info);
+            validate_consensus_message_semantics(&signed_msg, &qbft_message, &committee_info, None);
 
         assert_validation_error(
             result,
@@ -809,7 +820,7 @@ mod tests {
         );
 
         let result =
-            validate_consensus_message_semantics(&signed_msg, &qbft_message, &committee_info);
+            validate_consensus_message_semantics(&signed_msg, &qbft_message, &committee_info, None);
 
         assert_validation_error(
             result,
@@ -848,7 +859,8 @@ mod tests {
         )
         .expect("SignedSSVMessage should be created");
 
-        let result = validate_consensus_message_semantics(&signed_msg, &qbft_msg, &committee_info);
+        let result =
+            validate_consensus_message_semantics(&signed_msg, &qbft_msg, &committee_info, None);
 
         assert_validation_error(
             result,
@@ -885,7 +897,7 @@ mod tests {
         .expect("SignedSSVMessage should be created");
 
         let result =
-            validate_consensus_message_semantics(&signed_msg, &qbft_message, &committee_info);
+            validate_consensus_message_semantics(&signed_msg, &qbft_message, &committee_info, None);
 
         assert_validation_error(
             result,
@@ -916,7 +928,7 @@ mod tests {
         );
 
         let result =
-            validate_consensus_message_semantics(&signed_msg, &qbft_message, &committee_info);
+            validate_consensus_message_semantics(&signed_msg, &qbft_message, &committee_info, None);
 
         assert_validation_error(
             result,
@@ -947,7 +959,7 @@ mod tests {
         );
 
         let result =
-            validate_consensus_message_semantics(&signed_msg, &qbft_message, &committee_info);
+            validate_consensus_message_semantics(&signed_msg, &qbft_message, &committee_info, None);
 
         assert_validation_error(
             result,
@@ -980,7 +992,7 @@ mod tests {
         );
 
         let result =
-            validate_consensus_message_semantics(&signed_msg, &qbft_message, &committee_info);
+            validate_consensus_message_semantics(&signed_msg, &qbft_message, &committee_info, None);
 
         assert_validation_error(
             result,
@@ -1011,7 +1023,7 @@ mod tests {
             create_signed_consensus_message(qbft_message.clone(), signers, full_data, vec![]);
 
         let result =
-            validate_consensus_message_semantics(&signed_msg, &qbft_message, &committee_info);
+            validate_consensus_message_semantics(&signed_msg, &qbft_message, &committee_info, None);
 
         assert!(
             result.is_ok(),

--- a/anchor/message_validator/src/consensus_message.rs
+++ b/anchor/message_validator/src/consensus_message.rs
@@ -168,12 +168,12 @@ pub(crate) fn validate_justifications(
         return Err(ValidationFailure::UnexpectedRoundChangeJustifications);
     }
 
-    prepare_justifications
-        .iter()
-        .chain(round_change_justifications.iter())
-        .try_for_each(|signed_message| {
-            verify_message_signatures(signed_message, operators_pks.unwrap())
-        })?;
+    if let Some(pks) = operators_pks {
+        prepare_justifications
+            .iter()
+            .chain(round_change_justifications.iter())
+            .try_for_each(|signed_message| verify_message_signatures(signed_message, pks))?;
+    }
 
     Ok(())
 }

--- a/anchor/message_validator/src/consensus_message.rs
+++ b/anchor/message_validator/src/consensus_message.rs
@@ -35,7 +35,7 @@ pub(crate) fn validate_consensus_message(
         validation_context.signed_ssv_message,
         &consensus_message,
         validation_context.committee_info,
-        validation_context.operator_public_keys,
+        validation_context.operator_pub_keys,
     )?;
 
     validate_qbft_logic(&validation_context, &consensus_message, duty_state)?;
@@ -49,7 +49,7 @@ pub(crate) fn validate_consensus_message(
 
     verify_message_signatures(
         validation_context.signed_ssv_message,
-        validation_context.operator_public_keys,
+        validation_context.operator_pub_keys,
     )?;
 
     duty_state.update_for_consensus_message(
@@ -66,7 +66,7 @@ pub(crate) fn validate_consensus_message_semantics(
     signed_ssv_message: &SignedSSVMessage,
     consensus_message: &QbftMessage,
     committee_info: &CommitteeInfo,
-    operator_public_keys: &HashMap<OperatorId, Rsa<Public>>,
+    operator_pub_keys: &HashMap<OperatorId, Rsa<Public>>,
 ) -> Result<(), ValidationFailure> {
     let signers = signed_ssv_message.operator_ids().len();
 
@@ -142,14 +142,14 @@ pub(crate) fn validate_consensus_message_semantics(
         });
     }
 
-    validate_justifications(consensus_message, operator_public_keys)?;
+    validate_justifications(consensus_message, operator_pub_keys)?;
 
     Ok(())
 }
 
 pub(crate) fn validate_justifications(
     consensus_message: &QbftMessage,
-    operator_public_keys: &HashMap<OperatorId, Rsa<Public>>,
+    operator_pub_keys: &HashMap<OperatorId, Rsa<Public>>,
 ) -> Result<(), ValidationFailure> {
     // Rule: Can only exist for Proposal messages
     let prepare_justifications = &consensus_message.prepare_justification;
@@ -172,7 +172,7 @@ pub(crate) fn validate_justifications(
         .iter()
         .chain(round_change_justifications.iter())
         .try_for_each(|signed_message| {
-            verify_message_signatures(signed_message, operator_public_keys)
+            verify_message_signatures(signed_message, operator_pub_keys)
         })?;
 
     Ok(())
@@ -437,7 +437,7 @@ mod tests {
         LATE_MESSAGE_MARGIN, LATE_SLOT_ALLOWANCE, ValidatedSSVMessage, duty_limit,
         tests::{
             FOUR_NODE_COMMITTEE, SINGLE_NODE_COMMITTEE, create_committee_info,
-            create_hashmap_for_test, generate_random_rsa_public_keys,
+            create_operator_pub_keys, generate_random_rsa_public_keys,
         },
         validate_ssv_message,
     };
@@ -482,7 +482,7 @@ mod tests {
         let (_private_key, public_key) = generate_test_key_pair();
         let (private_key2, public_key2) = generate_test_key_pair();
         let committee_info = create_committee_info(FOUR_NODE_COMMITTEE);
-        let map = create_hashmap_for_test(
+        let map = create_operator_pub_keys(
             committee_info.committee_members.clone(),
             vec![public_key, public_key2],
         );
@@ -515,7 +515,7 @@ mod tests {
             epochs_per_sync_committee_period: 256,
             sync_committee_size: 512,
             slot_clock,
-            operator_public_keys: &map,
+            operator_pub_keys: &map,
         };
 
         let expected_duty_count = 5;
@@ -574,7 +574,7 @@ mod tests {
             epochs_per_sync_committee_period: 256,
             sync_committee_size: 512,
             slot_clock,
-            operator_public_keys: &HashMap::new(),
+            operator_pub_keys: &HashMap::new(),
         };
 
         let result = validate_ssv_message(
@@ -628,7 +628,7 @@ mod tests {
             epochs_per_sync_committee_period: 256,
             sync_committee_size: 512,
             slot_clock,
-            operator_public_keys: &HashMap::new(),
+            operator_pub_keys: &HashMap::new(),
         };
 
         let result = validate_ssv_message(
@@ -664,7 +664,7 @@ mod tests {
         .expect("SignedSSVMessage should be created");
 
         let public_keys = generate_random_rsa_public_keys(signed_msg.operator_ids().len());
-        let map = create_hashmap_for_test(committee_info.committee_members.clone(), public_keys);
+        let map = create_operator_pub_keys(committee_info.committee_members.clone(), public_keys);
 
         let validation_context = ValidationContext {
             signed_ssv_message: &signed_msg,
@@ -679,7 +679,7 @@ mod tests {
                 SystemTime::now().duration_since(UNIX_EPOCH).unwrap(),
                 Duration::from_secs(1),
             ),
-            operator_public_keys: &map,
+            operator_pub_keys: &map,
         };
 
         let result = validate_ssv_message(
@@ -714,7 +714,7 @@ mod tests {
             vec![],
         );
 
-        let map = create_hashmap_for_test(committee_info.committee_members.clone(), vec![]);
+        let map = create_operator_pub_keys(committee_info.committee_members.clone(), vec![]);
 
         let result =
             validate_consensus_message_semantics(&signed_msg, &qbft_message, &committee_info, &map);
@@ -736,7 +736,7 @@ mod tests {
         let signed_msg =
             create_signed_consensus_message(qbft_message.clone(), signers.clone(), vec![], vec![]);
 
-        let map = create_hashmap_for_test(committee_info.committee_members.clone(), vec![]);
+        let map = create_operator_pub_keys(committee_info.committee_members.clone(), vec![]);
 
         let result =
             validate_consensus_message_semantics(&signed_msg, &qbft_message, &committee_info, &map);
@@ -759,7 +759,7 @@ mod tests {
         let signed_msg =
             create_signed_consensus_message(qbft_message.clone(), signers.clone(), vec![], vec![]);
 
-        let map = create_hashmap_for_test(committee_info.committee_members.clone(), vec![]);
+        let map = create_operator_pub_keys(committee_info.committee_members.clone(), vec![]);
 
         let result =
             validate_consensus_message_semantics(&signed_msg, &qbft_message, &committee_info, &map);
@@ -785,7 +785,7 @@ mod tests {
             vec![],
         );
 
-        let map = create_hashmap_for_test(committee_info.committee_members.clone(), vec![]);
+        let map = create_operator_pub_keys(committee_info.committee_members.clone(), vec![]);
 
         let result =
             validate_consensus_message_semantics(&signed_msg, &qbft_message, &committee_info, &map);
@@ -811,7 +811,7 @@ mod tests {
             vec![],
         );
 
-        let map = create_hashmap_for_test(committee_info.committee_members.clone(), vec![]);
+        let map = create_operator_pub_keys(committee_info.committee_members.clone(), vec![]);
 
         let result =
             validate_consensus_message_semantics(&signed_msg, &qbft_message, &committee_info, &map);
@@ -837,7 +837,7 @@ mod tests {
             vec![],
         );
 
-        let map = create_hashmap_for_test(committee_info.committee_members.clone(), vec![]);
+        let map = create_operator_pub_keys(committee_info.committee_members.clone(), vec![]);
 
         let result =
             validate_consensus_message_semantics(&signed_msg, &qbft_message, &committee_info, &map);
@@ -879,7 +879,7 @@ mod tests {
         )
         .expect("SignedSSVMessage should be created");
 
-        let map = create_hashmap_for_test(committee_info.committee_members.clone(), vec![]);
+        let map = create_operator_pub_keys(committee_info.committee_members.clone(), vec![]);
 
         let result =
             validate_consensus_message_semantics(&signed_msg, &qbft_msg, &committee_info, &map);
@@ -918,7 +918,7 @@ mod tests {
         )
         .expect("SignedSSVMessage should be created");
 
-        let map = create_hashmap_for_test(committee_info.committee_members.clone(), vec![]);
+        let map = create_operator_pub_keys(committee_info.committee_members.clone(), vec![]);
 
         let result =
             validate_consensus_message_semantics(&signed_msg, &qbft_message, &committee_info, &map);
@@ -951,7 +951,7 @@ mod tests {
             vec![],
         );
 
-        let map = create_hashmap_for_test(committee_info.committee_members.clone(), vec![]);
+        let map = create_operator_pub_keys(committee_info.committee_members.clone(), vec![]);
 
         let result =
             validate_consensus_message_semantics(&signed_msg, &qbft_message, &committee_info, &map);
@@ -984,7 +984,7 @@ mod tests {
             vec![],
         );
 
-        let map = create_hashmap_for_test(committee_info.committee_members.clone(), vec![]);
+        let map = create_operator_pub_keys(committee_info.committee_members.clone(), vec![]);
 
         let result =
             validate_consensus_message_semantics(&signed_msg, &qbft_message, &committee_info, &map);
@@ -1019,7 +1019,7 @@ mod tests {
             vec![],
         );
 
-        let map = create_hashmap_for_test(committee_info.committee_members.clone(), vec![]);
+        let map = create_operator_pub_keys(committee_info.committee_members.clone(), vec![]);
 
         let result =
             validate_consensus_message_semantics(&signed_msg, &qbft_message, &committee_info, &map);
@@ -1052,7 +1052,7 @@ mod tests {
         let signed_msg =
             create_signed_consensus_message(qbft_message.clone(), signers, full_data, vec![]);
 
-        let map = create_hashmap_for_test(committee_info.committee_members.clone(), vec![]);
+        let map = create_operator_pub_keys(committee_info.committee_members.clone(), vec![]);
 
         let result =
             validate_consensus_message_semantics(&signed_msg, &qbft_message, &committee_info, &map);
@@ -1194,7 +1194,7 @@ mod tests {
 
         let mut committee = IndexSet::new();
         committee.insert(OperatorId(1));
-        let map = create_hashmap_for_test(committee, vec![public_key]);
+        let map = create_operator_pub_keys(committee, vec![public_key]);
 
         // Verify signatures
         let result = verify_message_signatures(&signed_msg, &map);
@@ -1218,7 +1218,7 @@ mod tests {
         let mut committee = IndexSet::new();
         committee.insert(OperatorId(1));
         committee.insert(OperatorId(2));
-        let map = create_hashmap_for_test(committee, rsa_keys);
+        let map = create_operator_pub_keys(committee, rsa_keys);
 
         let result = verify_message_signatures(&signed_msg, &map);
 
@@ -1262,7 +1262,7 @@ mod tests {
 
         let mut committee = IndexSet::new();
         committee.insert(OperatorId(1));
-        let map = create_hashmap_for_test(committee, vec![public_key]);
+        let map = create_operator_pub_keys(committee, vec![public_key]);
 
         // Verify should fail
         let result = verify_message_signatures(&signed_msg, &map);
@@ -1299,7 +1299,7 @@ mod tests {
 
         let mut committee = IndexSet::new();
         committee.insert(OperatorId(1));
-        let map = create_hashmap_for_test(committee, vec![invalid_key]);
+        let map = create_operator_pub_keys(committee, vec![invalid_key]);
 
         let result = verify_message_signatures(&signed_msg, &map);
 
@@ -1348,7 +1348,7 @@ mod tests {
             voluntary_exit_duty_count: expected_duty_count,
         });
 
-        let map = create_hashmap_for_test(committee_info.committee_members.clone(), vec![]);
+        let map = create_operator_pub_keys(committee_info.committee_members.clone(), vec![]);
 
         // Create the validation context with voluntary exit role
         let validation_context = ValidationContext {
@@ -1360,7 +1360,7 @@ mod tests {
             epochs_per_sync_committee_period: 256,
             sync_committee_size: 512,
             slot_clock: slot_clock.clone(),
-            operator_public_keys: &map,
+            operator_pub_keys: &map,
         };
 
         let slot = slot_clock.now().unwrap();

--- a/anchor/message_validator/src/consensus_message.rs
+++ b/anchor/message_validator/src/consensus_message.rs
@@ -1,4 +1,4 @@
-use std::{convert::Into, sync::Arc, time::Duration};
+use std::{collections::HashMap, convert::Into, sync::Arc, time::Duration};
 
 use duties_tracker::DutiesProvider;
 use openssl::{pkey::Public, rsa::Rsa};
@@ -35,7 +35,7 @@ pub(crate) fn validate_consensus_message(
         validation_context.signed_ssv_message,
         &consensus_message,
         validation_context.committee_info,
-        Some(validation_context.operators_pk),
+        validation_context.operator_public_keys,
     )?;
 
     validate_qbft_logic(&validation_context, &consensus_message, duty_state)?;
@@ -49,7 +49,7 @@ pub(crate) fn validate_consensus_message(
 
     verify_message_signatures(
         validation_context.signed_ssv_message,
-        validation_context.operators_pk,
+        validation_context.operator_public_keys,
     )?;
 
     duty_state.update_for_consensus_message(
@@ -66,7 +66,7 @@ pub(crate) fn validate_consensus_message_semantics(
     signed_ssv_message: &SignedSSVMessage,
     consensus_message: &QbftMessage,
     committee_info: &CommitteeInfo,
-    operators_pks: Option<&[Rsa<Public>]>,
+    operator_public_keys: &HashMap<OperatorId, Rsa<Public>>,
 ) -> Result<(), ValidationFailure> {
     let signers = signed_ssv_message.operator_ids().len();
 
@@ -142,14 +142,14 @@ pub(crate) fn validate_consensus_message_semantics(
         });
     }
 
-    validate_justifications(consensus_message, operators_pks)?;
+    validate_justifications(consensus_message, operator_public_keys)?;
 
     Ok(())
 }
 
 pub(crate) fn validate_justifications(
     consensus_message: &QbftMessage,
-    operators_pks: Option<&[Rsa<Public>]>,
+    operator_public_keys: &HashMap<OperatorId, Rsa<Public>>,
 ) -> Result<(), ValidationFailure> {
     // Rule: Can only exist for Proposal messages
     let prepare_justifications = &consensus_message.prepare_justification;
@@ -168,12 +168,12 @@ pub(crate) fn validate_justifications(
         return Err(ValidationFailure::UnexpectedRoundChangeJustifications);
     }
 
-    if let Some(pks) = operators_pks {
-        prepare_justifications
-            .iter()
-            .chain(round_change_justifications.iter())
-            .try_for_each(|signed_message| verify_message_signatures(signed_message, pks))?;
-    }
+    prepare_justifications
+        .iter()
+        .chain(round_change_justifications.iter())
+        .try_for_each(|signed_message| {
+            verify_message_signatures(signed_message, operator_public_keys)
+        })?;
 
     Ok(())
 }
@@ -437,7 +437,7 @@ mod tests {
         LATE_MESSAGE_MARGIN, LATE_SLOT_ALLOWANCE, ValidatedSSVMessage, duty_limit,
         tests::{
             FOUR_NODE_COMMITTEE, SINGLE_NODE_COMMITTEE, create_committee_info,
-            generate_random_rsa_public_keys,
+            create_hashmap_for_test, generate_random_rsa_public_keys,
         },
         validate_ssv_message,
     };
@@ -479,8 +479,13 @@ mod tests {
     #[test]
     fn test_validate_ssv_message_consensus_success() {
         // Generate a key pair
-        let (private_key, public_key) = generate_test_key_pair();
+        let (_private_key, public_key) = generate_test_key_pair();
+        let (private_key2, public_key2) = generate_test_key_pair();
         let committee_info = create_committee_info(FOUR_NODE_COMMITTEE);
+        let map = create_hashmap_for_test(
+            committee_info.committee_members.clone(),
+            vec![public_key, public_key2],
+        );
 
         let qbft_message =
             QbftMessageBuilder::new(Role::Committee, QbftMessageType::Proposal).build();
@@ -488,7 +493,7 @@ mod tests {
             qbft_message,
             vec![OperatorId(2)],
             vec![],
-            vec![private_key],
+            vec![private_key2],
         );
 
         let now = SystemTime::now();
@@ -506,11 +511,11 @@ mod tests {
             committee_info: &committee_info,
             role: Role::Committee,
             received_at: now + slot_duration,
-            operators_pk: &[public_key],
             slots_per_epoch: 32,
             epochs_per_sync_committee_period: 256,
             sync_committee_size: 512,
             slot_clock,
+            operator_public_keys: &map,
         };
 
         let expected_duty_count = 5;
@@ -565,11 +570,11 @@ mod tests {
             committee_info: &committee_info,
             role: Role::Committee,
             received_at: now,
-            operators_pk: &[],
             slots_per_epoch: 32,
             epochs_per_sync_committee_period: 256,
             sync_committee_size: 512,
             slot_clock,
+            operator_public_keys: &HashMap::new(),
         };
 
         let result = validate_ssv_message(
@@ -619,11 +624,11 @@ mod tests {
                 .unwrap()
                 .checked_add(LATE_MESSAGE_MARGIN)
                 .unwrap(),
-            operators_pk: &[],
             slots_per_epoch: 32,
             epochs_per_sync_committee_period: 256,
             sync_committee_size: 512,
             slot_clock,
+            operator_public_keys: &HashMap::new(),
         };
 
         let result = validate_ssv_message(
@@ -658,12 +663,14 @@ mod tests {
         )
         .expect("SignedSSVMessage should be created");
 
+        let public_keys = generate_random_rsa_public_keys(signed_msg.operator_ids().len());
+        let map = create_hashmap_for_test(committee_info.committee_members.clone(), public_keys);
+
         let validation_context = ValidationContext {
             signed_ssv_message: &signed_msg,
             committee_info: &committee_info,
             role: Role::Committee,
             received_at: SystemTime::now(),
-            operators_pk: &generate_random_rsa_public_keys(signed_msg.operator_ids().len()),
             slots_per_epoch: 32,
             epochs_per_sync_committee_period: 256,
             sync_committee_size: 512,
@@ -672,6 +679,7 @@ mod tests {
                 SystemTime::now().duration_since(UNIX_EPOCH).unwrap(),
                 Duration::from_secs(1),
             ),
+            operator_public_keys: &map,
         };
 
         let result = validate_ssv_message(
@@ -706,8 +714,10 @@ mod tests {
             vec![],
         );
 
+        let map = create_hashmap_for_test(committee_info.committee_members.clone(), vec![]);
+
         let result =
-            validate_consensus_message_semantics(&signed_msg, &qbft_message, &committee_info, None);
+            validate_consensus_message_semantics(&signed_msg, &qbft_message, &committee_info, &map);
 
         assert!(
             result.is_ok(),
@@ -726,8 +736,10 @@ mod tests {
         let signed_msg =
             create_signed_consensus_message(qbft_message.clone(), signers.clone(), vec![], vec![]);
 
+        let map = create_hashmap_for_test(committee_info.committee_members.clone(), vec![]);
+
         let result =
-            validate_consensus_message_semantics(&signed_msg, &qbft_message, &committee_info, None);
+            validate_consensus_message_semantics(&signed_msg, &qbft_message, &committee_info, &map);
 
         assert_validation_error(
             result,
@@ -747,8 +759,10 @@ mod tests {
         let signed_msg =
             create_signed_consensus_message(qbft_message.clone(), signers.clone(), vec![], vec![]);
 
+        let map = create_hashmap_for_test(committee_info.committee_members.clone(), vec![]);
+
         let result =
-            validate_consensus_message_semantics(&signed_msg, &qbft_message, &committee_info, None);
+            validate_consensus_message_semantics(&signed_msg, &qbft_message, &committee_info, &map);
 
         assert_validation_error(
             result,
@@ -771,8 +785,10 @@ mod tests {
             vec![],
         );
 
+        let map = create_hashmap_for_test(committee_info.committee_members.clone(), vec![]);
+
         let result =
-            validate_consensus_message_semantics(&signed_msg, &qbft_message, &committee_info, None);
+            validate_consensus_message_semantics(&signed_msg, &qbft_message, &committee_info, &map);
 
         assert_validation_error(
             result,
@@ -795,8 +811,10 @@ mod tests {
             vec![],
         );
 
+        let map = create_hashmap_for_test(committee_info.committee_members.clone(), vec![]);
+
         let result =
-            validate_consensus_message_semantics(&signed_msg, &qbft_message, &committee_info, None);
+            validate_consensus_message_semantics(&signed_msg, &qbft_message, &committee_info, &map);
 
         assert_validation_error(
             result,
@@ -819,8 +837,10 @@ mod tests {
             vec![],
         );
 
+        let map = create_hashmap_for_test(committee_info.committee_members.clone(), vec![]);
+
         let result =
-            validate_consensus_message_semantics(&signed_msg, &qbft_message, &committee_info, None);
+            validate_consensus_message_semantics(&signed_msg, &qbft_message, &committee_info, &map);
 
         assert_validation_error(
             result,
@@ -859,8 +879,10 @@ mod tests {
         )
         .expect("SignedSSVMessage should be created");
 
+        let map = create_hashmap_for_test(committee_info.committee_members.clone(), vec![]);
+
         let result =
-            validate_consensus_message_semantics(&signed_msg, &qbft_msg, &committee_info, None);
+            validate_consensus_message_semantics(&signed_msg, &qbft_msg, &committee_info, &map);
 
         assert_validation_error(
             result,
@@ -896,8 +918,10 @@ mod tests {
         )
         .expect("SignedSSVMessage should be created");
 
+        let map = create_hashmap_for_test(committee_info.committee_members.clone(), vec![]);
+
         let result =
-            validate_consensus_message_semantics(&signed_msg, &qbft_message, &committee_info, None);
+            validate_consensus_message_semantics(&signed_msg, &qbft_message, &committee_info, &map);
 
         assert_validation_error(
             result,
@@ -927,8 +951,10 @@ mod tests {
             vec![],
         );
 
+        let map = create_hashmap_for_test(committee_info.committee_members.clone(), vec![]);
+
         let result =
-            validate_consensus_message_semantics(&signed_msg, &qbft_message, &committee_info, None);
+            validate_consensus_message_semantics(&signed_msg, &qbft_message, &committee_info, &map);
 
         assert_validation_error(
             result,
@@ -958,8 +984,10 @@ mod tests {
             vec![],
         );
 
+        let map = create_hashmap_for_test(committee_info.committee_members.clone(), vec![]);
+
         let result =
-            validate_consensus_message_semantics(&signed_msg, &qbft_message, &committee_info, None);
+            validate_consensus_message_semantics(&signed_msg, &qbft_message, &committee_info, &map);
 
         assert_validation_error(
             result,
@@ -991,8 +1019,10 @@ mod tests {
             vec![],
         );
 
+        let map = create_hashmap_for_test(committee_info.committee_members.clone(), vec![]);
+
         let result =
-            validate_consensus_message_semantics(&signed_msg, &qbft_message, &committee_info, None);
+            validate_consensus_message_semantics(&signed_msg, &qbft_message, &committee_info, &map);
 
         assert_validation_error(
             result,
@@ -1022,8 +1052,10 @@ mod tests {
         let signed_msg =
             create_signed_consensus_message(qbft_message.clone(), signers, full_data, vec![]);
 
+        let map = create_hashmap_for_test(committee_info.committee_members.clone(), vec![]);
+
         let result =
-            validate_consensus_message_semantics(&signed_msg, &qbft_message, &committee_info, None);
+            validate_consensus_message_semantics(&signed_msg, &qbft_message, &committee_info, &map);
 
         assert!(
             result.is_ok(),
@@ -1160,8 +1192,12 @@ mod tests {
             SignedSSVMessage::new(vec![padded_signature], vec![OperatorId(1)], ssv_msg, vec![])
                 .expect("SignedSSVMessage should be created");
 
+        let mut committee = IndexSet::new();
+        committee.insert(OperatorId(1));
+        let map = create_hashmap_for_test(committee, vec![public_key]);
+
         // Verify signatures
-        let result = verify_message_signatures(&signed_msg, &[public_key]);
+        let result = verify_message_signatures(&signed_msg, &map);
         assert!(result.is_ok(), "Expected successful signature verification");
     }
 
@@ -1179,7 +1215,12 @@ mod tests {
         // Provide only one key when we have two signatures
         let rsa_keys = generate_random_rsa_public_keys(1);
 
-        let result = verify_message_signatures(&signed_msg, &rsa_keys);
+        let mut committee = IndexSet::new();
+        committee.insert(OperatorId(1));
+        committee.insert(OperatorId(2));
+        let map = create_hashmap_for_test(committee, rsa_keys);
+
+        let result = verify_message_signatures(&signed_msg, &map);
 
         assert_validation_error(
             result,
@@ -1219,8 +1260,12 @@ mod tests {
         )
         .expect("SignedSSVMessage should be created");
 
+        let mut committee = IndexSet::new();
+        committee.insert(OperatorId(1));
+        let map = create_hashmap_for_test(committee, vec![public_key]);
+
         // Verify should fail
-        let result = verify_message_signatures(&signed_msg, &[public_key]);
+        let result = verify_message_signatures(&signed_msg, &map);
 
         assert!(result.is_err(), "Expected signature verification to fail");
         assert_validation_error(
@@ -1252,7 +1297,11 @@ mod tests {
         )
         .expect("Failed to create invalid key");
 
-        let result = verify_message_signatures(&signed_msg, &[invalid_key]);
+        let mut committee = IndexSet::new();
+        committee.insert(OperatorId(1));
+        let map = create_hashmap_for_test(committee, vec![invalid_key]);
+
+        let result = verify_message_signatures(&signed_msg, &map);
 
         assert!(result.is_err(), "Expected PKey creation to fail");
     }
@@ -1299,17 +1348,19 @@ mod tests {
             voluntary_exit_duty_count: expected_duty_count,
         });
 
+        let map = create_hashmap_for_test(committee_info.committee_members.clone(), vec![]);
+
         // Create the validation context with voluntary exit role
         let validation_context = ValidationContext {
             signed_ssv_message: &signed_msg,
             committee_info: &committee_info,
             role: Role::VoluntaryExit,
             received_at: now,
-            operators_pk: &[],
             slots_per_epoch: 32,
             epochs_per_sync_committee_period: 256,
             sync_committee_size: 512,
             slot_clock: slot_clock.clone(),
+            operator_public_keys: &map,
         };
 
         let slot = slot_clock.now().unwrap();

--- a/anchor/message_validator/src/lib.rs
+++ b/anchor/message_validator/src/lib.rs
@@ -264,7 +264,7 @@ struct ValidationContext<'a, S> {
     pub epochs_per_sync_committee_period: u64,
     pub sync_committee_size: usize,
     pub slot_clock: S,
-    pub operator_public_keys: &'a HashMap<OperatorId, Rsa<Public>>,
+    pub operator_pub_keys: &'a HashMap<OperatorId, Rsa<Public>>,
 }
 
 pub struct Validator<S: SlotClock, D: DutiesProvider> {
@@ -353,8 +353,8 @@ impl<S: SlotClock + 'static, D: DutiesProvider> Validator<S, D> {
                     .ok_or(ValidationFailure::UnknownValidator)?
             }
         };
-        let operator_public_keys =
-            &get_operator_public_keys_map(&network_state, &committee_info.committee_members)?;
+        let operator_pub_keys =
+            &get_operator_pub_keys(&network_state, &committee_info.committee_members)?;
 
         drop(network_state);
 
@@ -369,7 +369,7 @@ impl<S: SlotClock + 'static, D: DutiesProvider> Validator<S, D> {
             epochs_per_sync_committee_period: self.epochs_per_sync_committee_period,
             sync_committee_size: self.sync_committee_size,
             slot_clock: self.slot_clock.clone(),
-            operator_public_keys,
+            operator_pub_keys,
         };
 
         validate_ssv_message(
@@ -484,14 +484,14 @@ fn verify_message_signature(
 /// Verifies all signatures in a signed SSV message
 fn verify_message_signatures(
     signed_message: &SignedSSVMessage,
-    operator_public_keys: &HashMap<OperatorId, Rsa<Public>>,
+    operator_pub_keys: &HashMap<OperatorId, Rsa<Public>>,
 ) -> Result<(), ValidationFailure> {
     let signatures = signed_message.signatures();
 
     let operators_pks = signed_message
         .operator_ids()
         .iter()
-        .filter_map(|operator_id| operator_public_keys.get(operator_id))
+        .filter_map(|operator_id| operator_pub_keys.get(operator_id))
         .collect::<Vec<&Rsa<Public>>>();
 
     // Basic validation for signature/operator count matching
@@ -764,7 +764,7 @@ pub(crate) fn compute_quorum_size(committee_size: usize) -> usize {
     f * 2 + 1
 }
 
-fn get_operator_public_keys_map(
+fn get_operator_pub_keys(
     network_state: &NetworkState,
     operator_ids: &IndexSet<OperatorId>,
 ) -> Result<HashMap<OperatorId, Rsa<Public>>, ValidationFailure> {
@@ -969,7 +969,7 @@ mod tests {
     }
 
     // Helper to create a HashMap of CommitteeId -> PublicKey for tests
-    pub(crate) fn create_hashmap_for_test(
+    pub(crate) fn create_operator_pub_keys(
         committee_members: IndexSet<OperatorId>,
         public_keys: Vec<Rsa<Public>>,
     ) -> HashMap<OperatorId, Rsa<Public>> {

--- a/anchor/message_validator/src/lib.rs
+++ b/anchor/message_validator/src/lib.rs
@@ -4,6 +4,7 @@ mod message_counts;
 mod partial_signature;
 
 use std::{
+    collections::HashMap,
     sync::Arc,
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
@@ -22,7 +23,7 @@ use safe_arith::SafeArith;
 use sha2::{Digest, Sha256};
 use slot_clock::SlotClock;
 use ssv_types::{
-    CommitteeInfo, OperatorId, ValidatorIndex,
+    CommitteeInfo, IndexSet, OperatorId, ValidatorIndex,
     consensus::QbftMessage,
     message::{MsgType, SignedSSVMessage},
     msgid::{DutyExecutor, MessageId, Role},
@@ -259,11 +260,11 @@ struct ValidationContext<'a, S> {
     pub role: Role, // Small value type can remain owned
     pub committee_info: &'a CommitteeInfo,
     pub received_at: SystemTime, // Small value type
-    pub operators_pk: &'a [Rsa<Public>],
     pub slots_per_epoch: u64,
     pub epochs_per_sync_committee_period: u64,
     pub sync_committee_size: usize,
     pub slot_clock: S,
+    pub operator_public_keys: &'a HashMap<OperatorId, Rsa<Public>>,
 }
 
 pub struct Validator<S: SlotClock, D: DutiesProvider> {
@@ -352,7 +353,9 @@ impl<S: SlotClock + 'static, D: DutiesProvider> Validator<S, D> {
                     .ok_or(ValidationFailure::UnknownValidator)?
             }
         };
-        let operators_pks = get_operator_pks(&network_state, signed_ssv_message.operator_ids())?;
+        let operator_public_keys =
+            &get_operator_public_keys_map(&network_state, &committee_info.committee_members)?;
+
         drop(network_state);
 
         let mut duty_state = self.get_duty_state(ssv_message.msg_id(), self.slots_per_epoch);
@@ -362,11 +365,11 @@ impl<S: SlotClock + 'static, D: DutiesProvider> Validator<S, D> {
             role,
             committee_info: &committee_info,
             received_at: SystemTime::now(),
-            operators_pk: &operators_pks,
             slots_per_epoch: self.slots_per_epoch,
             epochs_per_sync_committee_period: self.epochs_per_sync_committee_period,
             sync_committee_size: self.sync_committee_size,
             slot_clock: self.slot_clock.clone(),
+            operator_public_keys,
         };
 
         validate_ssv_message(
@@ -481,9 +484,15 @@ fn verify_message_signature(
 /// Verifies all signatures in a signed SSV message
 fn verify_message_signatures(
     signed_message: &SignedSSVMessage,
-    operators_pks: &[Rsa<Public>],
+    operator_public_keys: &HashMap<OperatorId, Rsa<Public>>,
 ) -> Result<(), ValidationFailure> {
     let signatures = signed_message.signatures();
+
+    let operators_pks = signed_message
+        .operator_ids()
+        .iter()
+        .filter_map(|operator_id| operator_public_keys.get(operator_id))
+        .collect::<Vec<&Rsa<Public>>>();
 
     // Basic validation for signature/operator count matching
     if signatures.len() != operators_pks.len() {
@@ -755,19 +764,20 @@ pub(crate) fn compute_quorum_size(committee_size: usize) -> usize {
     f * 2 + 1
 }
 
-fn get_operator_pks(
+fn get_operator_public_keys_map(
     network_state: &NetworkState,
-    operator_ids: &[OperatorId],
-) -> Result<Vec<Rsa<Public>>, ValidationFailure> {
+    operator_ids: &IndexSet<OperatorId>,
+) -> Result<HashMap<OperatorId, Rsa<Public>>, ValidationFailure> {
     operator_ids
         .iter()
-        .map(|o_id| {
-            network_state
-                .get_operator(o_id)
-                .ok_or(ValidationFailure::OperatorNotFound { operator_id: *o_id })
-                .map(|operator| operator.rsa_pubkey)
+        .map(|id| {
+            let operator = network_state
+                .get_operator(id)
+                .ok_or(ValidationFailure::OperatorNotFound { operator_id: *id })
+                .map(|operator| operator.rsa_pubkey)?;
+            Ok((*id, operator))
         })
-        .collect() // This will combine all the Results into a single Result<Vec<>>
+        .collect()
 }
 
 // # TODO centralize this and the one in the qbft crate
@@ -784,6 +794,8 @@ pub(crate) fn hash_data(full_data: &[u8]) -> [u8; 32] {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
+
     use bls::{Hash256, PublicKeyBytes};
     use duties_tracker::DutiesProvider;
     use openssl::{
@@ -954,6 +966,14 @@ mod tests {
             _ => DutyExecutor::Validator(PublicKeyBytes::empty()),
         };
         MessageId::new(&domain, role, &duty_executor)
+    }
+
+    // Helper to create a HashMap of CommitteeId -> PublicKey for tests
+    pub(crate) fn create_hashmap_for_test(
+        committee_members: IndexSet<OperatorId>,
+        public_keys: Vec<Rsa<Public>>,
+    ) -> HashMap<OperatorId, Rsa<Public>> {
+        committee_members.into_iter().zip(public_keys).collect()
     }
 
     // Assert helpers for common validation patterns

--- a/anchor/message_validator/src/partial_signature.rs
+++ b/anchor/message_validator/src/partial_signature.rs
@@ -3,6 +3,7 @@ use std::{collections::HashMap, sync::Arc};
 use duties_tracker::DutiesProvider;
 use slot_clock::SlotClock;
 use ssv_types::{
+    OperatorId,
     msgid::Role,
     partial_sig::{PartialSignatureKind, PartialSignatureMessages},
 };
@@ -30,7 +31,7 @@ pub(crate) fn validate_partial_signature_message(
     };
 
     // Validate basic semantics
-    validate_partial_signature_message_semantics(&validation_context, &messages)?;
+    let signer = validate_partial_signature_message_semantics(&validation_context, &messages)?;
 
     // Validate duty-specific logic
     validate_partial_sig_messages_by_duty_logic(
@@ -40,10 +41,9 @@ pub(crate) fn validate_partial_signature_message(
         duty_provider,
     )?;
 
-    let operator_pk = validation_context
+    let operator_public_key = validation_context
         .operator_public_keys
-        .values()
-        .next()
+        .get(&signer)
         .ok_or(ValidationFailure::NoSigners)?;
 
     let signature = validation_context
@@ -54,7 +54,7 @@ pub(crate) fn validate_partial_signature_message(
 
     verify_message_signature(
         validation_context.signed_ssv_message,
-        operator_pk,
+        operator_public_key,
         signature,
     )?;
 
@@ -77,7 +77,7 @@ pub(crate) fn validate_partial_signature_message(
 fn validate_partial_signature_message_semantics(
     validation_context: &ValidationContext<impl SlotClock>,
     partial_signature_messages: &PartialSignatureMessages,
-) -> Result<(), ValidationFailure> {
+) -> Result<OperatorId, ValidationFailure> {
     // Rule: Partial Signature message must have 1 signer
     let signers = validation_context.signed_ssv_message.operator_ids();
     if signers.len() != 1 {
@@ -127,7 +127,7 @@ fn validate_partial_signature_message_semantics(
         }
     }
 
-    Ok(())
+    Ok(signer)
 }
 
 fn partial_signature_type_matches_role(kind: PartialSignatureKind, role: Role) -> bool {

--- a/anchor/message_validator/src/partial_signature.rs
+++ b/anchor/message_validator/src/partial_signature.rs
@@ -41,8 +41,9 @@ pub(crate) fn validate_partial_signature_message(
     )?;
 
     let operator_pk = validation_context
-        .operators_pk
-        .first()
+        .operator_public_keys
+        .values()
+        .next()
         .ok_or(ValidationFailure::NoSigners)?;
 
     let signature = validation_context
@@ -289,7 +290,7 @@ mod tests {
     use super::*;
     use crate::tests::{
         FOUR_NODE_COMMITTEE, MockDutiesProvider, assert_validation_error, create_committee_info,
-        create_message_id_for_test, generate_random_rsa_public_keys,
+        create_hashmap_for_test, create_message_id_for_test, generate_random_rsa_public_keys,
     };
 
     // Options for creating test partial signature messages
@@ -370,14 +371,13 @@ mod tests {
         signed_msg: &'a SignedSSVMessage,
         committee_info: &'a crate::CommitteeInfo,
         role: Role,
-        operators_pk: &'a [Rsa<Public>],
+        operator_public_keys: &'a HashMap<OperatorId, Rsa<Public>>,
     ) -> ValidationContext<'a, ManualSlotClock> {
         ValidationContext {
             signed_ssv_message: signed_msg,
             committee_info,
             role,
             received_at: SystemTime::now(),
-            operators_pk,
             slots_per_epoch: 32,
             epochs_per_sync_committee_period: 256,
             sync_committee_size: 512,
@@ -386,6 +386,7 @@ mod tests {
                 SystemTime::now().duration_since(UNIX_EPOCH).unwrap(),
                 Duration::from_secs(1),
             ),
+            operator_public_keys,
         }
     }
 
@@ -402,8 +403,10 @@ mod tests {
         );
 
         let binding = generate_random_rsa_public_keys(signed_msg.operator_ids().len());
+        let map = create_hashmap_for_test(committee_info.committee_members.clone(), binding);
+
         let validation_context =
-            create_test_validation_context(&signed_msg, &committee_info, Role::Committee, &binding);
+            create_test_validation_context(&signed_msg, &committee_info, Role::Committee, &map);
 
         let result = validate_partial_signature_message(
             validation_context,
@@ -449,8 +452,10 @@ mod tests {
             .expect("SignedSSVMessage should be created");
 
         let binding = generate_random_rsa_public_keys(signed_msg.operator_ids().len());
+        let map = create_hashmap_for_test(committee_info.committee_members.clone(), binding);
+
         let validation_context =
-            create_test_validation_context(&signed_msg, &committee_info, Role::Proposer, &binding);
+            create_test_validation_context(&signed_msg, &committee_info, Role::Proposer, &map);
 
         let result = validate_partial_signature_message(
             validation_context,
@@ -483,8 +488,10 @@ mod tests {
         );
 
         let binding = generate_random_rsa_public_keys(signed_msg.operator_ids().len());
+        let map = create_hashmap_for_test(committee_info.committee_members.clone(), binding);
+
         let validation_context =
-            create_test_validation_context(&signed_msg, &committee_info, Role::Proposer, &binding);
+            create_test_validation_context(&signed_msg, &committee_info, Role::Proposer, &map);
 
         let result = validate_partial_signature_message(
             validation_context,
@@ -517,8 +524,10 @@ mod tests {
         );
 
         let binding = generate_random_rsa_public_keys(signed_msg.operator_ids().len());
+        let map = create_hashmap_for_test(committee_info.committee_members.clone(), binding);
+
         let validation_context =
-            create_test_validation_context(&signed_msg, &committee_info, Role::Proposer, &binding);
+            create_test_validation_context(&signed_msg, &committee_info, Role::Proposer, &map);
 
         let result = validate_partial_signature_message(
             validation_context,
@@ -551,8 +560,10 @@ mod tests {
         );
 
         let binding = generate_random_rsa_public_keys(signed_msg.operator_ids().len());
+        let map = create_hashmap_for_test(committee_info.committee_members.clone(), binding);
+
         let validation_context =
-            create_test_validation_context(&signed_msg, &committee_info, Role::Proposer, &binding);
+            create_test_validation_context(&signed_msg, &committee_info, Role::Proposer, &map);
 
         let result = validate_partial_signature_message(
             validation_context,
@@ -583,8 +594,11 @@ mod tests {
         );
 
         let binding = [public_key];
+        let map =
+            create_hashmap_for_test(committee_info.committee_members.clone(), binding.to_vec());
+
         let validation_context =
-            create_test_validation_context(&signed_msg, &committee_info, Role::Proposer, &binding);
+            create_test_validation_context(&signed_msg, &committee_info, Role::Proposer, &map);
 
         let result = validate_partial_signature_message(
             validation_context,
@@ -627,11 +641,13 @@ mod tests {
         );
 
         let binding = generate_random_rsa_public_keys(signed_msg.operator_ids().len());
+        let map = create_hashmap_for_test(committee_info.committee_members.clone(), binding);
+
         let validation_context = create_test_validation_context(
             &signed_msg,
             &committee_info,
             Role::Proposer, // Not a committee role, so validator index is checked
-            &binding,
+            &map,
         );
 
         let result = validate_partial_signature_message(
@@ -670,11 +686,14 @@ mod tests {
         );
 
         let binding = [public_key];
+        let map =
+            create_hashmap_for_test(committee_info.committee_members.clone(), binding.to_vec());
+
         let validation_context = create_test_validation_context(
             &signed_msg,
             &committee_info,
             Role::Committee, // Committee role, so validator index is not checked
-            &binding,
+            &map,
         );
 
         let result = validate_partial_signature_message(
@@ -732,8 +751,10 @@ mod tests {
         .expect("SignedSSVMessage should be created");
 
         let binding = generate_random_rsa_public_keys(signed_msg.operator_ids().len());
+        let map = create_hashmap_for_test(committee_info.committee_members.clone(), binding);
+
         let validation_context =
-            create_test_validation_context(&signed_msg, &committee_info, Role::Proposer, &binding);
+            create_test_validation_context(&signed_msg, &committee_info, Role::Proposer, &map);
 
         let result = validate_partial_signature_message(
             validation_context,
@@ -782,8 +803,10 @@ mod tests {
         .expect("SignedSSVMessage should be created");
 
         let binding = generate_random_rsa_public_keys(signed_msg.operator_ids().len());
+        let map = create_hashmap_for_test(committee_info.committee_members.clone(), binding);
+
         let validation_context =
-            create_test_validation_context(&signed_msg, &committee_info, Role::Committee, &binding);
+            create_test_validation_context(&signed_msg, &committee_info, Role::Committee, &map);
 
         let result = validate_partial_signature_message(
             validation_context,

--- a/anchor/message_validator/src/partial_signature.rs
+++ b/anchor/message_validator/src/partial_signature.rs
@@ -41,8 +41,8 @@ pub(crate) fn validate_partial_signature_message(
         duty_provider,
     )?;
 
-    let operator_public_key = validation_context
-        .operator_public_keys
+    let operator_pub_keys = validation_context
+        .operator_pub_keys
         .get(&signer)
         .ok_or(ValidationFailure::NoSigners)?;
 
@@ -54,7 +54,7 @@ pub(crate) fn validate_partial_signature_message(
 
     verify_message_signature(
         validation_context.signed_ssv_message,
-        operator_public_key,
+        operator_pub_keys,
         signature,
     )?;
 
@@ -290,7 +290,7 @@ mod tests {
     use super::*;
     use crate::tests::{
         FOUR_NODE_COMMITTEE, MockDutiesProvider, assert_validation_error, create_committee_info,
-        create_hashmap_for_test, create_message_id_for_test, generate_random_rsa_public_keys,
+        create_message_id_for_test, create_operator_pub_keys, generate_random_rsa_public_keys,
     };
 
     // Options for creating test partial signature messages
@@ -371,7 +371,7 @@ mod tests {
         signed_msg: &'a SignedSSVMessage,
         committee_info: &'a crate::CommitteeInfo,
         role: Role,
-        operator_public_keys: &'a HashMap<OperatorId, Rsa<Public>>,
+        operator_pub_keys: &'a HashMap<OperatorId, Rsa<Public>>,
     ) -> ValidationContext<'a, ManualSlotClock> {
         ValidationContext {
             signed_ssv_message: signed_msg,
@@ -386,7 +386,7 @@ mod tests {
                 SystemTime::now().duration_since(UNIX_EPOCH).unwrap(),
                 Duration::from_secs(1),
             ),
-            operator_public_keys,
+            operator_pub_keys,
         }
     }
 
@@ -403,7 +403,7 @@ mod tests {
         );
 
         let binding = generate_random_rsa_public_keys(signed_msg.operator_ids().len());
-        let map = create_hashmap_for_test(committee_info.committee_members.clone(), binding);
+        let map = create_operator_pub_keys(committee_info.committee_members.clone(), binding);
 
         let validation_context =
             create_test_validation_context(&signed_msg, &committee_info, Role::Committee, &map);
@@ -452,7 +452,7 @@ mod tests {
             .expect("SignedSSVMessage should be created");
 
         let binding = generate_random_rsa_public_keys(signed_msg.operator_ids().len());
-        let map = create_hashmap_for_test(committee_info.committee_members.clone(), binding);
+        let map = create_operator_pub_keys(committee_info.committee_members.clone(), binding);
 
         let validation_context =
             create_test_validation_context(&signed_msg, &committee_info, Role::Proposer, &map);
@@ -488,7 +488,7 @@ mod tests {
         );
 
         let binding = generate_random_rsa_public_keys(signed_msg.operator_ids().len());
-        let map = create_hashmap_for_test(committee_info.committee_members.clone(), binding);
+        let map = create_operator_pub_keys(committee_info.committee_members.clone(), binding);
 
         let validation_context =
             create_test_validation_context(&signed_msg, &committee_info, Role::Proposer, &map);
@@ -524,7 +524,7 @@ mod tests {
         );
 
         let binding = generate_random_rsa_public_keys(signed_msg.operator_ids().len());
-        let map = create_hashmap_for_test(committee_info.committee_members.clone(), binding);
+        let map = create_operator_pub_keys(committee_info.committee_members.clone(), binding);
 
         let validation_context =
             create_test_validation_context(&signed_msg, &committee_info, Role::Proposer, &map);
@@ -560,7 +560,7 @@ mod tests {
         );
 
         let binding = generate_random_rsa_public_keys(signed_msg.operator_ids().len());
-        let map = create_hashmap_for_test(committee_info.committee_members.clone(), binding);
+        let map = create_operator_pub_keys(committee_info.committee_members.clone(), binding);
 
         let validation_context =
             create_test_validation_context(&signed_msg, &committee_info, Role::Proposer, &map);
@@ -595,7 +595,7 @@ mod tests {
 
         let binding = [public_key];
         let map =
-            create_hashmap_for_test(committee_info.committee_members.clone(), binding.to_vec());
+            create_operator_pub_keys(committee_info.committee_members.clone(), binding.to_vec());
 
         let validation_context =
             create_test_validation_context(&signed_msg, &committee_info, Role::Proposer, &map);
@@ -641,7 +641,7 @@ mod tests {
         );
 
         let binding = generate_random_rsa_public_keys(signed_msg.operator_ids().len());
-        let map = create_hashmap_for_test(committee_info.committee_members.clone(), binding);
+        let map = create_operator_pub_keys(committee_info.committee_members.clone(), binding);
 
         let validation_context = create_test_validation_context(
             &signed_msg,
@@ -687,7 +687,7 @@ mod tests {
 
         let binding = [public_key];
         let map =
-            create_hashmap_for_test(committee_info.committee_members.clone(), binding.to_vec());
+            create_operator_pub_keys(committee_info.committee_members.clone(), binding.to_vec());
 
         let validation_context = create_test_validation_context(
             &signed_msg,
@@ -751,7 +751,7 @@ mod tests {
         .expect("SignedSSVMessage should be created");
 
         let binding = generate_random_rsa_public_keys(signed_msg.operator_ids().len());
-        let map = create_hashmap_for_test(committee_info.committee_members.clone(), binding);
+        let map = create_operator_pub_keys(committee_info.committee_members.clone(), binding);
 
         let validation_context =
             create_test_validation_context(&signed_msg, &committee_info, Role::Proposer, &map);
@@ -803,7 +803,7 @@ mod tests {
         .expect("SignedSSVMessage should be created");
 
         let binding = generate_random_rsa_public_keys(signed_msg.operator_ids().len());
-        let map = create_hashmap_for_test(committee_info.committee_members.clone(), binding);
+        let map = create_operator_pub_keys(committee_info.committee_members.clone(), binding);
 
         let validation_context =
             create_test_validation_context(&signed_msg, &committee_info, Role::Committee, &map);


### PR DESCRIPTION
## Issue Addressed

Addresses issue #559

## Proposed Changes

Go through all of the justifications chained together and verify their signatures.

## Additional Info

Added operators public keys to the `validate_justifications()` function because they are needed for justification verification.
