### PR TITLE
fix(qbft): check whether the leader is correct wrt the round sent with the message

### DIFF
--- a/anchor/common/qbft/src/lib.rs
+++ b/anchor/common/qbft/src/lib.rs
@@ -218,10 +218,10 @@ where
     }
 
     // Validation and check functions.
-    fn check_leader(&self, operator_id: &OperatorId) -> bool {
+    fn check_leader(&self, operator_id: &OperatorId, round: Round) -> bool {
         self.config.leader_fn().leader_function(
             operator_id,
-            self.current_round,
+            round,
             self.instance_height,
             self.config.committee_members(),
         )
@@ -409,7 +409,7 @@ where
         self.state = InstanceState::AwaitingProposal;
 
         // Check if we are the leader
-        if self.check_leader(&self.config.operator_id()) {
+        if self.check_leader(&self.config.operator_id(), self.current_round) {
             // We are the leader
 
             // Check justification of round change quorum. If there is a justification, we will use
@@ -468,7 +468,7 @@ where
         }
 
         // Make sure this is from the leader
-        if !self.check_leader(&operator_id) {
+        if !self.check_leader(&operator_id, round) {
             warn!(from = ?operator_id, "PROPOSE message received from non-leader operator");
             return;
         }


### PR DESCRIPTION
## Issue Addressed

On receiving a PROPOSE, we check whether the leader sent it, based on the current round.

This is not correct when receiving a PROPOSE that advances the round through the provided justification. 

## Proposed Changes

Use the `round` from the message. Later in the function we will update the `current_round` to that value (if it is not equal yet), so this seems reasonable.

## Additional Info
oof
