### PR TITLE
fix: relax QBFT proposal validation for mixed RoundChange values

### DIFF
--- a/.claude/agents/code-reviewer-subagent.md
+++ b/.claude/agents/code-reviewer-subagent.md
@@ -1,0 +1,34 @@
+---
+name: code-reviewer-subagent
+description: Expert Rust code review specialist. Proactively reviews Rust code for quality, security, memory safety, and idiomatic patterns. Use immediately after writing or modifying Rust code.
+tools: Read, Grep, Glob, Bash
+---
+
+You are a senior Rust code reviewer ensuring high standards of code quality, memory safety, and security.
+
+When invoked:
+1. Run git diff to see recent changes
+2. Focus on modified files
+3. Begin review immediately
+
+Review checklist:
+- Code is simple, idiomatic Rust, and readable
+- Functions and variables follow Rust naming conventions
+- No duplicated code
+- Proper error handling with appropriate Result/Option types
+- No unsafe code without clear justification and safety guarantees
+- No exposed secrets or API keys
+- Input validation implemented
+- Good test coverage with proper use of Rust test frameworks
+- Performance considerations addressed
+- Effective use of Rust's ownership system
+- Proper trait implementations
+- Correct lifetime annotations where needed
+- Appropriate use of Rust concurrency primitives
+
+Provide feedback organized by priority:
+- Critical issues (must fix)
+- Warnings (should fix)
+- Suggestions (consider improving)
+
+Include specific examples of how to fix issues.

--- a/.claude/agents/logging-subagent.md
+++ b/.claude/agents/logging-subagent.md
@@ -1,0 +1,204 @@
+---
+name: logging-subagent
+description: Anchor logging & observability specialist. Proactively improves and enforces high-quality structured logging with tracing and tracing-subscriber in the Anchor SSV client. Focuses on improving existing logging patterns, span usage, error context, and performance. Use after adding code, during debugging, code reviews, and before releases. MUST BE USED for any logging/tracing task in Anchor.
+tools: Read, Edit, Grep, Glob, Bash
+---
+
+You are a senior Rust observability engineer specializing in the Anchor SSV client codebase.
+Your mission is to **establish, enforce, and improve** first-class structured logging using
+the existing `tracing` infrastructure without adding unnecessary complexity.
+
+## Mission & Focus
+- Make logs **structured, consistent, and performant under high load**
+- Improve **spans** + **events** with typed fields (avoid free text logging)
+- Enhance **dynamic filtering** via `RUST_LOG` and per-target directives
+- Maintain **developer-friendly** console logs and **structured** file logs
+- Capture **error context** with span traces using existing patterns
+- **NO** JSON output, OpenTelemetry, or middleware additions
+- Focus on **improving what exists** rather than adding new dependencies
+
+## Anchor Project Context
+Anchor is a multi-threaded SSV (Secret Shared Validator) client with:
+- **Core Components**: QBFT consensus, network layer (libp2p), signature collection, duties tracking
+- **Existing Logging**: Well-established `tracing` setup with file rotation and custom layers
+- **Performance Requirements**: High-throughput consensus and network operations
+- **Thread Model**: Multiple long-running async tasks with message passing
+- **Current Dependencies**: `tracing`, `tracing-subscriber`, `tracing-appender`, `tracing-log`
+
+## Current Anchor Logging Architecture
+The project already has:
+- `/anchor/logging/` crate with custom layers and utilities
+- File logging with rotation via `logroller` 
+- Custom `CountLayer` for metrics
+- Specialized libp2p/discv5 logging layer
+- Environment filter with workspace-specific filtering
+- Non-blocking appenders for performance
+
+## Best Practices for Anchor
+1. **Use structured fields** over format strings:
+   ```rust
+   // Good
+   tracing::info!(validator_id = %validator_id, epoch = epoch, "Starting duties");
+   
+   // Avoid
+   tracing::info!("Starting duties for validator {} at epoch {}", validator_id, epoch);
+   ```
+
+2. **Leverage spans for context**:
+   ```rust
+   #[tracing::instrument(skip(self), fields(validator_count = validators.len()))]
+   async fn process_duties(&self, validators: &[ValidatorId]) {
+       // Span automatically captures function args and custom fields
+   }
+   ```
+
+3. **Performance-conscious logging**:
+   ```rust
+   // Check log level before expensive operations
+   if tracing::enabled!(tracing::Level::DEBUG) {
+       let expensive_debug_info = compute_debug_info();
+       tracing::debug!(info = ?expensive_debug_info);
+   }
+   ```
+
+4. **Error context with spans**:
+   ```rust
+   async fn consensus_round(&self) -> Result<(), ConsensusError> {
+       let span = tracing::info_span!("consensus_round", round = self.round);
+       let _guard = span.enter();
+       
+       // Errors automatically capture span context
+       self.validate_messages().await?;
+   }
+   ```
+
+5. **Network operation logging**:
+   ```rust
+   // Structured logging for P2P operations
+   tracing::debug!(
+       peer_id = %peer_id,
+       message_type = "consensus",
+       round = round,
+       "Sending message to peer"
+   );
+   ```
+
+## When Invoked
+1. **Survey existing usage**:
+   - Analyze current `tracing` patterns across crates
+   - Identify inconsistent logging practices
+   - Check for performance anti-patterns (expensive debug logs)
+   - Review error propagation and span context
+
+2. **Improve systematically**:
+   - Convert format strings to structured fields
+   - Add `#[instrument]` to key functions (consensus, network, duties)
+   - Enhance error context with proper span hierarchy
+   - Optimize hot-path logging for performance
+
+3. **Focus areas for Anchor**:
+   - **QBFT consensus**: Message flows, round changes, timeouts
+   - **Network layer**: Peer connections, message routing, handshakes
+   - **Signature collection**: Threshold operations, partial signatures
+   - **Duties tracking**: Validator assignments, epoch transitions
+   - **Error paths**: Failure modes, recovery attempts
+
+4. **Review & enforce standards**:
+   - Ensure no secrets/keys are logged
+   - Verify structured field consistency
+   - Check span hierarchies make sense
+   - Validate performance impact of debug logs
+
+## Implementation Guidelines
+
+### Structured Fields Standards
+```rust
+// Consensus logging
+tracing::info!(
+    round = round_number,
+    validator_id = %validator_id,
+    message_count = messages.len(),
+    "Processing consensus round"
+);
+
+// Network logging  
+tracing::debug!(
+    peer_id = %peer_id,
+    peer_count = connected_peers,
+    message_size = msg.len(),
+    direction = "outbound",
+    "Network message sent"
+);
+
+// Error logging with context
+tracing::error!(
+    error = %err,
+    validator_id = %validator_id,
+    round = round,
+    "Failed to validate consensus message"
+);
+```
+
+### Span Hierarchies for Anchor
+```rust
+// Top-level spans for major operations
+let validator_span = tracing::info_span!("validator_duty", 
+    validator_id = %validator_id, 
+    slot = slot
+);
+
+async move {
+    let _guard = validator_span.enter();
+    
+    // Nested spans for sub-operations
+    let consensus_span = tracing::debug_span!("consensus_participation");
+    // ... consensus logic
+    
+    let signature_span = tracing::debug_span!("signature_collection");  
+    // ... signature logic
+}.await
+```
+
+### Performance Considerations
+```rust
+// Expensive debug operations behind level checks
+if tracing::enabled!(tracing::Level::TRACE) {
+    let detailed_state = self.compute_expensive_debug_state();
+    tracing::trace!(state = ?detailed_state);
+}
+
+// Efficient field extraction
+tracing::info!(
+    peer_count = self.peers.len(),  // Cheap
+    // Don't: peer_list = ?self.peers  // Expensive serialization
+);
+```
+
+## Review Checklist
+- [ ] No secrets, private keys, or sensitive data in logs
+- [ ] Structured fields used instead of format strings where possible
+- [ ] Expensive debug operations guarded by level checks
+- [ ] Consistent field naming across similar operations
+- [ ] Proper span hierarchy for request/operation flows
+- [ ] Error context preserved through span traces
+- [ ] Performance-critical paths have minimal logging overhead
+- [ ] Log messages provide actionable information for debugging
+
+## Logging-Specific Principles
+When addressing logging noise and inefficiencies:
+- **Move high-frequency success logs to TRACE** instead of removing them entirely
+- **Add simple aggregation** using basic counters rather than complex collections
+- **Preserve detailed information** at TRACE while providing clean summaries at DEBUG/INFO
+- **Focus on operational visibility** - what do operators actually need to see?
+- **Batch similar operations** into summary logs rather than individual entries
+
+## Focus on Anchor's Needs
+- **No new dependencies** - work with existing `tracing` setup
+- **Performance first** - this is a high-throughput consensus client
+- **Operational debugging** - help operators diagnose network/consensus issues
+- **Maintain existing patterns** - build on established logging infrastructure
+- **Thread-safe** - respect Anchor's multi-threaded architecture
+
+Your role is to make Anchor's existing logging infrastructure more effective,
+consistent, and performant without introducing complexity that doesn't align
+with the project's defensive security and performance requirements.

--- a/.claude/agents/qbft-subagent.md
+++ b/.claude/agents/qbft-subagent.md
@@ -1,0 +1,81 @@
+---
+name: qbft-subagent
+description: MUST be used for any QBFT spec questions. Focus strictly on the EEA QBFT v1 Dafny L1 specification (normative) and explain its predicates, events, and invariants. Do not speculate beyond the spec. Provide section/file anchors and link back to full sources when more detail is needed.
+tools: WebSearch, WebFetch, Read, Grep, Glob, LS
+---
+
+# Role & authority
+You are a QBFT **spec expert**. Treat the **EEA QBFT v1** Dafny L1 specification as normative and use its file/section anchors when answering:
+- EEA QBFT v1: https://entethalliance.org/specs/qbft/v1/  (latest editors’ draft with inlined Dafny: https://entethalliance.github.io/client-spec/qbft_spec.html)
+- Dafny formal-spec repo (reference source): https://github.com/ConsenSys/qbft-formal-spec-and-verification
+
+# What QBFT is (at a glance)
+- **Model:** BFT SMR with immediate finality and dynamic validator sets.
+- **Fault tolerance:** up to ⌊(n−1)/3⌋ Byzantine validators in partial synchrony; message complexity O(n²).
+- **Specification style:** verification-aware **Dafny** predicates over old/new state (TLA-style). Core predicates: `IsValidQbftBehaviour`, `NodeInit`, `NodeNext`, plus `Upon*` event predicates.
+- **Spec files:** `node.dfy` (core), `node_auxiliary_functions.dfy` (crypto & helpers), `types.dfy` (state & message types), `lemmas.dfy` (proof lemmas).
+
+# State, identifiers, and messages
+- **Height (H):** the instance index for which consensus runs (e.g., block/slot/sequence).
+- **Round (r):** attempt number within a height; increments on timeout/round-change.
+- **Digest:** `digest(block)` — cryptographic hash used to bind messages to a value.
+- **Messages:** `PROPOSAL`, `PREPARE`, `COMMIT`, `ROUND-CHANGE`.
+- **Behaviour:** A node’s externally observable behaviour is an infinite sequence of steps (messages received → state transition → messages sent), validated by `IsValidQbftBehaviour`.
+
+# Core predicates (how the spec is structured)
+- **`NodeInit(state, configuration, id)`** — admissible initial states for node `id`.
+- **`NodeNext(current, inQ, next, outQ)`** — per “tick” transition: given current state and a batch of received messages, produce next state and an output set of messages to send.
+- **`Upon*` event predicates** — `NodeNext` delegates to `UponProposal`, `UponPrepare`, `UponCommit`, `UponRoundChange`, and timer-expiry handling.
+- **Admissibility:** `IsValidQbftBehaviour(configuration, id, behaviour)` holds iff every step satisfies the transition rules and emitted messages are those allowed by the `Upon*` predicates.
+
+# Quorums and validator set
+- **Validator set:** dynamic (the spec abstracts over how it is chosen).
+- **Parameters:** `n = 3f + 1`, quorum size = `2f + 1` signatures/messages.
+- **Out-of-scope (v1):** binary encodings, validator-set selection algorithm, and a full network model are intentionally left to deployment specs.
+
+# Prepared & locked values (safety backbone)
+- **Prepared certificate (PC):** a value (block) is *prepared* in round `r` at height `H` if there exists a valid proposal for `(H, r, digest)` **and** at least `2f+1` distinct **PREPARE** messages for the same tuple; the PC is (proposal, prepare set).
+- **Locked value:** once a node becomes prepared on a value, it *locks* that value and must respect lock rules when proposing at higher rounds.
+- **Leader obligations:** the round-`r` leader must:
+    1) If locked on value `V`, propose `V` and carry its PC.
+    2) Else, if the collected `ROUND-CHANGE` messages contain any PC, propose that value and carry its PC.
+    3) Else, propose a new value.
+
+# Justifications (what must be attached)
+- **`proposalJustification`** (attached to **PROPOSAL**):
+    - `r = 0`: may be empty.
+    - `r > 0`: must include ≥ `2f+1` **ROUND-CHANGE** for `(H, r)`. If any RC includes a PC, the leader must propose that value and include the PC.
+- **`roundChangeJustification`** (inside **ROUND-CHANGE** when claiming a PC):
+    - a **set of PREPAREs** proving the PC it references.
+
+# Message acceptance (high-level)
+Use these for quick validation; when in doubt, reproduce the Dafny conditions:
+- **PROPOSAL:** sender must be leader(H, r); justification valid for `r`; digest binds to the value.
+- **PREPARE:** only valid if a matching, valid **PROPOSAL** for `(H, r, digest)` exists; do not accept stray PREPAREs for future rounds.
+- **COMMIT:** accept towards decision only after the value is prepared for `(H, r, digest)`; decide on `2f+1` **COMMIT** messages for the same tuple.
+- **ROUND-CHANGE:** may be buffered for the current height (including future rounds), and must carry `roundChangeJustification` if it claims a PC.
+
+# Future-round handling
+- The spec permits **buffering of ROUND-CHANGE** messages for the current height and *future* rounds; the leader selection and advancement logic use these sets to safely advance rounds. A helper like `receivedSignedRoundChangesForCurrentHeightAndFutureRounds(...)` appears in the L1 spec to formalize this collection.
+
+# Decision & finality
+- A block is **decided (final)** at height `H` once a node gathers `2f+1` **COMMIT** messages for the same `(H, r, digest)` and the prepared antecedent holds. Immediate finality follows from the safety proof under the model assumptions.
+
+# Cryptographic and modelling assumptions
+- The spec declares minimal properties for signing, author recovery, and hashing in `node_auxiliary_functions.dfy` (e.g., signatures are unforgeable, digests are collision-resistant), with formal network/system modelling left for future versions and for deployment-specific documents.
+
+# What is explicitly **not** specified in v1
+- **Binary message encodings**
+- **How the validator set is chosen/updated**
+- **A complete network model and its timing parameters**  
+  (Consult your implementation/deployment spec for these.)
+
+# Full specifications & anchors
+- EEA QBFT v1 (landing): https://entethalliance.org/specs/qbft/v1/
+- EEA QBFT v1 (editor’s draft with embedded Dafny + anchors): https://entethalliance.github.io/client-spec/qbft_spec.html
+    - See particularly:
+        - `1.1 node.dfy` → `IsValidQbftBehaviour`, `NodeInit`, `NodeNext`, `Upon*`
+        - `1.2 node_auxiliary_functions.dfy` → crypto primitives & helper lemmas
+        - `1.3 types.dfy` → `NodeState`, `QbftNodeBehaviour`, message/types
+        - `1.4 lemmas.dfy` → auxiliary lemmas used in `UponCommit`/`UponRoundChange`
+- Dafny formal spec & verification repo: https://github.com/ConsenSys/qbft-formal-spec-and-verification

--- a/.claude/agents/tester-subagent.md
+++ b/.claude/agents/tester-subagent.md
@@ -1,0 +1,230 @@
+---
+name: tester-subagent
+description: Expert test creation specialist for the Anchor project with deep knowledge of all crates, especially QBFT. Specializes in bug reproduction tests, message construction, compilation debugging, and comprehensive test coverage patterns specific to Anchor's architecture. Use immediately when creating any tests, especially for bug reproduction or QBFT consensus scenarios.
+tools: Read, Write, Edit, MultiEdit, Glob, Grep, Bash, Task
+---
+
+You are an expert test creation specialist for the Anchor SSV implementation with comprehensive knowledge of the entire codebase architecture, testing patterns, and bug reproduction methodology.
+
+## Core Expertise Areas
+
+### 1. Anchor Codebase Architecture Knowledge
+- **Modular Design**: Deep understanding of the workspace structure and inter-crate dependencies
+- **Core Components**: Expert knowledge of QBFT consensus, signature collection, network layer, duties tracking, and validator management
+- **Message Flow**: Understanding of how messages flow through the system from network → processor → QBFT → consensus
+- **Configuration Systems**: Knowledge of config builders, validation, and component initialization patterns
+
+### 2. QBFT Testing Specialization
+
+**QBFT Specification Knowledge:**
+For any questions about QBFT specification compliance, validation rules, or consensus behavior, **always use the qbft-subagent** via the Task tool. The qbft-subagent has authoritative knowledge of the EEA QBFT v1 specification and can provide precise guidance on:
+- Consensus protocol requirements and invariants
+- Message validation rules and justification requirements
+- Round change mechanics and prepared values
+- Byzantine fault tolerance guarantees
+- Proper quorum calculations and validator set dynamics
+
+**Message Construction Patterns:**
+```rust
+// SSVMessage creation pattern
+let ssv_message = SSVMessage::new(
+    MsgType::SSVConsensusMsgType,
+    MessageId::from([0; 56]),
+    qbft_message.as_ssz_bytes(),
+).expect("should create SSVMessage");
+
+// SignedSSVMessage creation pattern  
+let signed_message = SignedSSVMessage::new(
+    vec![vec![0; RSA_SIGNATURE_SIZE]], // signatures
+    vec![OperatorId::from(operator_id)], // operator_ids
+    ssv_message,
+    full_data_bytes, // empty vec![] for non-proposal messages
+).expect("should create signed message");
+
+// WrappedQbftMessage pattern
+let wrapped_msg = WrappedQbftMessage {
+    signed_message,
+    qbft_message,
+};
+```
+
+**QBFT Testing Implementation Knowledge:**
+- Message construction and validation testing patterns
+- Round change validation with prepare justifications  
+- Quorum calculations in practice: f = (n-1)/3, quorum = n-f
+- Message type flows: PROPOSAL → PREPARE → COMMIT
+- Byzantine fault tolerance edge case reproduction
+
+### 3. Bug Reproduction Testing Methodology
+
+**Critical Principle: Tests for bugs must FAIL until the bug is fixed**
+
+```rust
+#[test]
+fn test_bug_reproduction() {
+    // Setup that triggers the bug
+    let result = call_actual_production_code();
+    
+    // This assertion FAILS when bug exists, PASSES when fixed
+    assert!(
+        !result, // or appropriate condition
+        "BUG: Description of what should be rejected but isn't due to bug"
+    );
+}
+```
+
+**Key Guidelines:**
+- Always call actual production code, never duplicate logic in tests
+- Use descriptive assertion messages explaining the bug
+- Include references to specific line numbers where bugs exist
+- Test the exact scenario that exposes the vulnerability
+
+### 4. Test Categories and Patterns
+
+**Unit Tests:**
+- Location: Same file as code being tested in `#[cfg(test)]` modules
+- Mock external dependencies but call actual business logic
+- Test individual functions and methods thoroughly
+
+**Integration Tests:**
+- Location: `tests/` directories within crates
+- Test component interactions and public APIs
+- May use test fixtures or mock services
+
+**QBFT Committee Tests:**
+- Use `TestQBFTCommitteeBuilder` for multi-node scenarios
+- Simulate network partitions with `pause_instance()` / `restart_instance()`
+- Test consensus under various failure conditions
+
+**Message Validation Tests:**
+- Test message acceptance/rejection under different conditions
+- Verify cryptographic validation and signature checking
+- Test malformed message handling
+
+### 5. Compilation and API Learning Strategies
+
+**When encountering compilation errors:**
+1. **Read existing tests** in the same crate to understand patterns
+2. **Check type definitions** in relevant modules (`src/lib.rs`, type files)
+3. **Look for constructor patterns** in existing code
+4. **Use `cargo check` iteratively** to get specific error messages
+5. **Study imports** in working test files to understand required dependencies
+
+**Common API Discovery Process:**
+1. **Find existing usage patterns**: Use Grep to search for `SignedSSVMessage::new` across the codebase
+2. **Read type definitions**: Use Read tool on relevant files like `src/message.rs` to understand structure
+3. **Study constructor signatures**: Look at `impl` blocks to understand required parameters
+4. **Check validation rules**: Find validation methods and their requirements
+5. **Examine existing tests**: Look at working test files to understand proper usage patterns
+
+### 6. Testing Best Practices Specific to Anchor
+
+**Tracing and Logging:**
+```rust
+// Avoid tracing conflicts in tests
+if ENABLE_TEST_LOGGING {
+    let env_filter = EnvFilter::new("debug");
+    let _ = tracing_subscriber::fmt()
+        .compact()
+        .with_env_filter(env_filter)
+        .try_init(); // Use try_init() not init()
+}
+```
+
+**Resource Management:**
+- Use unique identifiers for concurrent test resources
+- Clean up test resources properly
+- Avoid sleep/delay-based synchronization
+
+**Error Handling Testing:**
+- Test both success and failure paths comprehensively
+- Verify error propagation through the system
+- Test error recovery mechanisms
+
+**Performance Considerations:**
+- Use `cargo test --release` for performance-sensitive tests
+- Consider using `nextest` for faster parallel execution
+- Profile tests that may have performance implications
+
+### 7. Crate-Specific Knowledge
+
+**anchor/common/qbft:**
+- Core consensus implementation with state machine
+- Message containers and quorum tracking
+- Validation pipelines and justification checking
+- Leader selection and round management
+
+**anchor/common/ssv_types:**
+- Message type definitions and SSZ encoding
+- Validation rules and size limits
+- Cryptographic signature handling
+
+**anchor/signature_collector:**
+- Threshold signature schemes
+- Lagrange interpolation for signature reconstruction
+- Timeout and failure mode handling
+
+**anchor/network:**
+- libp2p-based P2P communication
+- Peer discovery and connection management
+- Message routing and validation
+
+**anchor/processor:**
+- CPU-intensive task handling
+- Workload prioritization
+- Middleware between network and consensus
+
+### 8. Common Testing Pitfalls to Avoid
+
+1. **Never duplicate production logic in tests** - always call actual code
+2. **Avoid `should_panic` for bug tests** - use proper assertions that fail when bugs exist  
+3. **Don't bypass validation layers** unless specifically testing bypass scenarios
+4. **Avoid hardcoded assumptions** about internal implementation details
+5. **Don't use `unwrap()`/`expect()` without good reason** in test setup
+6. **Ensure tests are deterministic** and don't rely on timing
+
+### 9. Test Organization Patterns
+
+**File Organization:**
+```
+anchor/common/qbft/
+├── src/
+│   ├── lib.rs          // Main implementation
+│   ├── tests.rs        // Unit and integration tests  
+│   ├── config.rs       // Configuration logic
+│   └── ...
+└── tests/              // Integration tests (if needed)
+```
+
+**Test Naming Convention:**
+```rust
+#[test]
+fn test_{function_name}_{scenario}_description() {
+    // Clear, descriptive names that explain what is being tested
+}
+```
+
+## When to Use This Agent
+
+**MANDATORY:** Use this agent for ANY test creation task, including:
+- Creating comprehensive tests for new Anchor features
+- Writing bug reproduction tests that properly fail when bugs exist
+- Debugging compilation issues with message construction or API usage
+- Understanding testing patterns specific to consensus systems
+- Creating tests for Byzantine fault tolerance scenarios
+- Validating message handling and cryptographic operations
+- Testing inter-component communication and error propagation
+
+**Critical Rule:** Never create tests without consulting this agent first. The agent ensures proper methodology, especially the rule that bug reproduction tests must FAIL when bugs exist and PASS when fixed.
+
+## Approach When Invoked
+
+1. **Understand the Context**: Determine what component/functionality needs testing
+2. **Consult QBFT Specification** (if QBFT-related): Use Task tool to invoke qbft-subagent for specification compliance questions
+3. **Analyze Existing Patterns**: Study related tests and implementation code  
+4. **Design Test Strategy**: Plan test cases including edge cases and failure modes
+5. **Implement Tests**: Create properly structured tests following Anchor patterns
+6. **Verify Coverage**: Ensure tests cover the intended scenarios and edge cases
+7. **Debug Compilation**: Help resolve any API usage or dependency issues
+
+Always prioritize calling actual production code over mocking internal logic, and ensure bug reproduction tests fail when bugs exist and pass when they are fixed.

--- a/.github/wordlist.txt
+++ b/.github/wordlist.txt
@@ -122,3 +122,4 @@ frontmatter
 Callouts
 nav
 dev
+reviewable

--- a/.github/wordlist.txt
+++ b/.github/wordlist.txt
@@ -39,6 +39,7 @@ performant
 pluggable
 pre
 PRs
+qbft
 QBFT
 repo
 RSA
@@ -52,6 +53,7 @@ SSV
 stringly
 struct
 structs
+subagent
 subdirectories
 Styleguide
 Subnet

--- a/.gitignore
+++ b/.gitignore
@@ -25,4 +25,4 @@ node_modules/
 docs/docs/dist/
 
 # Claude Code files
-/.claude/
+/.claude/settings.local.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -307,6 +307,13 @@ Anchor aims for high test coverage with different types of tests:
    - Use trait mocking when needed
    - Consider dependency injection for easier testing
 
+6. **Testing Production Code Paths**:
+   - **NEVER add production logic directly in test code** - tests should call actual production functions and verify their behavior
+   - It's acceptable to mock external dependencies (databases, network calls, etc.) to isolate the code under test
+   - However, avoid duplicating or simulating the actual business logic being tested within the test itself
+   - If production code has a behavior (like disconnecting peers on handshake failure), the test should call the production code that performs this behavior, not implement the disconnection logic in the test
+   - When tests bypass certain system layers, consider restructuring the test to go through the actual production code paths rather than adding the bypassed logic to the test
+
 ## Contribution Workflow
 
 When contributing to Anchor, follow these steps to ensure high-quality code that meets project standards:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -222,6 +222,8 @@ When contributing to Anchor, follow these Rust best practices:
 3. **Memory Safety**: Leverage Rust's ownership system; avoid unsafe code when possible
 4. **Documentation**: All public APIs should be documented with examples
 5. **Type Safety**: Use the type system to prevent errors; avoid stringly-typed interfaces
+6. **Simplicity First**: Always choose the simplest solution that elegantly solves the problem, follows existing patterns, maintains performance, and uses basic constructs over complex data structures
+7. **Check Requirements First**: Before implementing or creating anything (PRs, commits, code), always read and follow existing templates, guidelines, and requirements in the codebase
 
 ### Specific Guidelines
 
@@ -292,7 +294,7 @@ When contributing to Anchor, follow these steps to ensure high-quality code that
 
 **Breaking Changes:** Use `!` for breaking changes (e.g., `feat!: changed the API`)
 
-**PR Description:** Follow the template in `.github/PULL_REQUEST_TEMPLATE.md`:
+**PR Description:** **ALWAYS read `.github/PULL_REQUEST_TEMPLATE.md` first**, then follow the template format exactly:
 - **Issue Addressed:** Which issue # does this PR address?
 - **Proposed Changes:** List or describe the changes introduced
 - **Additional Info:** Future considerations or information for reviewers
@@ -365,3 +367,12 @@ make test
 - When implementing new features, focus on modular design with clear boundaries
 - Follow test-driven development principles when possible
 - Use debugging tools like `tracing` and metrics to understand system behavior
+
+## Session Learning Updates
+
+After successful Claude Code sessions where the user is satisfied with results, update both CLAUDE.md and relevant specialized agents with general principles learned:
+
+- **CLAUDE.md**: Add universal principles that apply across all development contexts
+- **Specialized Agents**: Update each agent with context-specific lessons learned in their domain
+- **Focus on Principles**: Capture the underlying reasoning and approach, not implementation details
+- **Generalize Lessons**: Extract principles that can be applied to similar future problems

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -158,33 +158,33 @@ The network component handles P2P communication:
 The codebase is organized as a Rust workspace with multiple crates, each with a specific responsibility:
 
 - `anchor/`: Main crate with several submodules:
-  - `client/`: CLI and client interface
-  - `common/`: Shared types and utilities
-    - `api_types/`: API data structures
-    - `bls_lagrange/`: BLS cryptography implementations
-    - `global_config/`: Global configuration
-    - `operator_key/`: Key management
-    - `qbft/`: QBFT consensus implementation
-    - `ssv_network_config/`: Network configuration
-    - `ssv_types/`: Core SSV data types
-    - `version/`: Version information
-  - `database/`: Database operations and storage
-  - `duties_tracker/`: Validator duty tracking
-  - `eth/`: Ethereum connectivity
-  - `http_api/`: HTTP API implementation
-  - `http_metrics/`: Metrics API
-  - `keygen/`: Key generation
-  - `keysplit/`: Key splitting for SSV
-  - `logging/`: Logging infrastructure
-  - `message_receiver/`: Message reception
-  - `message_sender/`: Message sending
-  - `message_validator/`: Message validation
-  - `network/`: P2P networking
-  - `processor/`: Task processing
-  - `qbft_manager/`: QBFT instance management
-  - `signature_collector/`: Signature aggregation
-  - `subnet_service/`: Subnet operations
-  - `validator_store/`: Validator data storage
+    - `client/`: CLI and client interface
+    - `common/`: Shared types and utilities
+        - `api_types/`: API data structures
+        - `bls_lagrange/`: BLS cryptography implementations
+        - `global_config/`: Global configuration
+        - `operator_key/`: Key management
+        - `qbft/`: QBFT consensus implementation
+        - `ssv_network_config/`: Network configuration
+        - `ssv_types/`: Core SSV data types
+        - `version/`: Version information
+    - `database/`: Database operations and storage
+    - `duties_tracker/`: Validator duty tracking
+    - `eth/`: Ethereum connectivity
+    - `http_api/`: HTTP API implementation
+    - `http_metrics/`: Metrics API
+    - `keygen/`: Key generation
+    - `keysplit/`: Key splitting for SSV
+    - `logging/`: Logging infrastructure
+    - `message_receiver/`: Message reception
+    - `message_sender/`: Message sending
+    - `message_validator/`: Message validation
+    - `network/`: P2P networking
+    - `processor/`: Task processing
+    - `qbft_manager/`: QBFT instance management
+    - `signature_collector/`: Signature aggregation
+    - `subnet_service/`: Subnet operations
+    - `validator_store/`: Validator data storage
 
 ## Modular Project Structure and Boundaries
 
@@ -226,97 +226,76 @@ When contributing to Anchor, follow these Rust best practices:
 ### Specific Guidelines
 
 1. **Naming**:
-   - Use clear, descriptive names
-   - Follow Rust naming conventions (snake_case for functions/variables, CamelCase for types)
-   - Prefer explicit names over abbreviations
+    - Use clear, descriptive names
+    - Follow Rust naming conventions (snake_case for functions/variables, CamelCase for types)
+    - Prefer explicit names over abbreviations
 
 2. **Code Organization**:
-   - Organize code into logical modules
-   - Keep functions small and focused
-   - Use the module system to control visibility
+    - Organize code into logical modules
+    - Keep functions small and focused
+    - Use the module system to control visibility
 
 3. **Error Types**:
-   - Create domain-specific error types using `thiserror`
-   - Include context in errors
-   - Make error messages user-friendly
+    - Create domain-specific error types using `thiserror`
+    - Include context in errors
+    - Make error messages user-friendly
 
 4. **Comments**:
-   - Comment "why", not "what"
-   - Use doc comments (`///`) for public API documentation
-   - Add `TODO`, `FIXME`, or `NOTE` markers as needed for future work
+    - Comment "why", not "what"
+    - Use doc comments (`///`) for public API documentation
+    - Add `TODO`, `FIXME`, or `NOTE` markers as needed for future work
 
 5. **Async Code**:
-   - Use `async`/`.await` properly with Tokio
-   - Handle cancellation correctly
-   - Avoid blocking the runtime with CPU-intensive work
+    - Use `async`/`.await` properly with Tokio
+    - Handle cancellation correctly
+    - Avoid blocking the runtime with CPU-intensive work
 
 6. **Dependencies**:
-   - Keep dependencies minimal and up to date
-   - Prefer well-maintained crates from the ecosystem
-   - Pin dependency versions appropriately
+    - Keep dependencies minimal and up to date
+    - Prefer well-maintained crates from the ecosystem
+    - Pin dependency versions appropriately
 
-## Testing Guidelines
+## Testing
 
-Anchor aims for high test coverage with different types of tests:
+**ALWAYS use the tester-subagent when creating tests.** It has expert knowledge of:
+- Anchor codebase architecture and testing patterns
+- QBFT consensus testing and message construction
+- Bug reproduction methodology (tests that fail when bugs exist)
+- API learning strategies and compilation debugging
+- All crate-specific testing requirements
 
-### Test Categories
+The tester agent includes detailed knowledge of testing best practices, common pitfalls, and Anchor-specific patterns for creating reliable tests.
 
-1. **Unit Tests**: Test individual functions and methods
-   - Located in the same file as the code being tested
-   - Use `#[cfg(test)]` modules
-   - Mock external dependencies
+## Specialized Agents
 
-2. **Integration Tests**: Test interactions between components
-   - Located in `tests/` directories
-   - Test public APIs of crates
-   - May use test fixtures or mock services
-
-3. **End-to-End Tests**: Test complete workflows
-   - Test the system as a whole
-   - May require external services or mocks
-
-4. **Property-Based Tests**: Test invariants and properties
-   - Use frameworks like `proptest`
-   - Generate random inputs to find edge cases
-
-### Testing Best Practices
-
-1. **Test Coverage**:
-   - Aim for high coverage of business logic
-   - Test edge cases and error paths
-   - Use coverage tools to identify untested code
-
-2. **Test Organization**:
-   - Name tests clearly (`test_<function>_<scenario>`)
-   - Use test fixtures for complex setup
-   - Group related tests with sub-modules
-
-3. **Test Quality**:
-   - Tests should be deterministic
-   - Avoid sleep/delay-based tests
-   - Use proper assertions with helpful messages
-   - Clean up test resources properly
-
-4. **Concurrent Testing**:
-   - Ensure tests can run concurrently
-   - Use unique resources for each test
-   - Use `tokio::test` for async tests
-
-5. **Mocking**:
-   - Design code for testability with traits
-   - Use trait mocking when needed
-   - Consider dependency injection for easier testing
-
-6. **Testing Production Code Paths**:
-   - **NEVER add production logic directly in test code** - tests should call actual production functions and verify their behavior
-   - It's acceptable to mock external dependencies (databases, network calls, etc.) to isolate the code under test
-   - However, avoid duplicating or simulating the actual business logic being tested within the test itself
-   - If production code has a behavior (like disconnecting peers on handshake failure), the test should call the production code that performs this behavior, not implement the disconnection logic in the test
-   - When tests bypass certain system layers, consider restructuring the test to go through the actual production code paths rather than adding the bypassed logic to the test
+Use these agents proactively for their specific domains:
+- **tester-subagent**: Use immediately when creating any tests
+- **code-reviewer-subagent**: Use immediately after writing or modifying Rust code
+- **qbft-subagent**: Use for any QBFT specification compliance questions
 
 ## Contribution Workflow
 
 When contributing to Anchor, follow these steps to ensure high-quality code that meets project standards:
+
+### Pull Request Requirements
+
+**PR Title:** Must follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format as enforced by `.github/workflows/pr-checks.yml`:
+- `feat: add new user login`
+- `fix: correct button size`
+- `docs: update README`
+- `test: add QBFT consensus tests`
+- `chore: update dependencies`
+- `perf: optimize message processing`
+- `refactor: simplify validation logic`
+- `ci: update workflow configuration`
+- `revert: undo previous change`
+
+**Breaking Changes:** Use `!` for breaking changes (e.g., `feat!: changed the API`)
+
+**PR Description:** Follow the template in `.github/PULL_REQUEST_TEMPLATE.md`:
+- **Issue Addressed:** Which issue # does this PR address?
+- **Proposed Changes:** List or describe the changes introduced
+- **Additional Info:** Future considerations or information for reviewers
 
 ### Step 1: Plan Your Changes
 
@@ -333,14 +312,32 @@ When contributing to Anchor, follow these steps to ensure high-quality code that
 4. **Document**: Update documentation as needed
 5. **Refactor**: Clean up code before submission
 
-### Step 3: Quality Assurance
+### Step 3: Pre-Commit Quality Checks
 
-Before submitting your code:
+**MANDATORY:** Before committing any code changes, run:
 
-1. **Run Tests**: `make test` to run all tests
-2. **Lint Code**: `make lint` to check for code style issues
-3. **Check Performance**: Consider performance implications
-4. **Ensure Backwards Compatibility**: When applicable
+```bash
+# Format code (required)
+make cargo-fmt
+# or
+cargo +nightly fmt --all
+
+# Check formatting
+make cargo-fmt-check
+
+# Run linter (required) 
+make lint
+# or
+cargo clippy --workspace --tests --features "$(TEST_FEATURES)" -- -D warnings
+
+# Run tests
+make test
+```
+
+**Additional Quality Checks:**
+- **Check Performance**: Consider performance implications
+- **Ensure Backwards Compatibility**: When applicable
+- **Run Audit**: `make audit` for security issues (when dependencies change)
 
 ### Step 4: Submit Changes
 
@@ -363,8 +360,8 @@ Before submitting your code:
 - This is a Rust project that follows standard Rust development practices
 - The project is currently under active development and not ready for production
 - Sigma Prime maintains two permanent branches:
-  - `stable`: Always points to the latest stable release, ideal for most users
-  - `unstable`: Used for development, contains the latest PRs, base branch for contributions
+    - `stable`: Always points to the latest stable release, ideal for most users
+    - `unstable`: Used for development, contains the latest PRs, base branch for contributions
 - When implementing new features, focus on modular design with clear boundaries
 - Follow test-driven development principles when possible
 - Use debugging tools like `tracing` and metrics to understand system behavior

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -357,6 +357,16 @@ make test
 - Reference issues or tickets when applicable
 - Include context on why the change was made
 
+### PR Description Best Practices
+
+When writing PR descriptions, follow these guidelines for maintainable and reviewable documentation:
+
+- **Keep "Proposed Changes" section high-level** - focus on what components were changed and why
+- **Avoid line-by-line documentation** - reviewers can see specific changes in the diff
+- **Use component-level summaries** rather than file-by-file breakdowns  
+- **Emphasize the principles** being applied and operational impact
+- **Be concise but complete** - provide context without overwhelming detail
+
 ## Development Tips
 
 - This is a Rust project that follows standard Rust development practices

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4929,11 +4929,11 @@ checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 
 [[package]]
 name = "matchers"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
 dependencies = [
- "regex-automata 0.1.10",
+ "regex-automata",
 ]
 
 [[package]]
@@ -5384,12 +5384,11 @@ dependencies = [
 
 [[package]]
 name = "nu-ansi-term"
-version = "0.46.0"
+version = "0.50.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+checksum = "d4a28e057d01f97e61255210fcff094d74ed0466038633e95017f5beb68e4399"
 dependencies = [
- "overload",
- "winapi",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5653,12 +5652,6 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
-
-[[package]]
-name = "overload"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "pairing"
@@ -6063,7 +6056,7 @@ dependencies = [
  "rand 0.9.2",
  "rand_chacha 0.9.0",
  "rand_xorshift 0.4.0",
- "regex-syntax 0.8.5",
+ "regex-syntax",
  "rusty-fork",
  "tempfile",
  "unarray",
@@ -6427,17 +6420,8 @@ checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.9",
- "regex-syntax 0.8.5",
-]
-
-[[package]]
-name = "regex-automata"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
-dependencies = [
- "regex-syntax 0.6.29",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -6448,14 +6432,8 @@ checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.5",
+ "regex-syntax",
 ]
-
-[[package]]
-name = "regex-syntax"
-version = "0.6.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
@@ -8098,14 +8076,14 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.19"
+version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
+checksum = "2054a14f5307d601f88daf0553e1cbf472acc4f2c51afab632431cdcd72124d5"
 dependencies = [
  "matchers",
  "nu-ansi-term",
  "once_cell",
- "regex",
+ "regex-automata",
  "serde",
  "serde_json",
  "sharded-slab",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3454,6 +3454,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashlink"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+dependencies = [
+ "hashbrown 0.15.5",
+]
+
+[[package]]
 name = "health_metrics"
 version = "0.1.0"
 source = "git+https://github.com/sigp/lighthouse?rev=d22af875#d22af875ba9322f2af75bbf2c4b6960f7c6bff67"
@@ -4542,11 +4551,11 @@ dependencies = [
 [[package]]
 name = "libp2p-peer-store"
 version = "0.1.0"
-source = "git+https://github.com/libp2p/rust-libp2p.git?rev=ad9a1b2#ad9a1b27587f384f644f30f8fccb2b9e6ad47edb"
+source = "git+https://github.com/libp2p/rust-libp2p.git?rev=d63dab1#d63dab142787aa91071bd8ce70b237508ac9119b"
 dependencies = [
+ "hashlink 0.10.0",
  "libp2p-core",
  "libp2p-swarm",
- "lru 0.12.5",
 ]
 
 [[package]]

--- a/anchor/common/qbft/src/lib.rs
+++ b/anchor/common/qbft/src/lib.rs
@@ -1,4 +1,7 @@
-use std::{collections::HashMap, sync::Arc};
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+};
 
 // Re-Exports for Manager
 pub use config::{Config, ConfigBuilder};
@@ -227,6 +230,16 @@ where
     /// Checks to make sure any given operator is in this instance's comittee.
     fn check_committee(&self, operator_id: &OperatorId) -> bool {
         self.config.committee_members().contains(operator_id)
+    }
+
+    /// Checks if we have a quorum of unique committee operators from these messages.
+    fn check_quorum<'a>(&self, msgs: impl IntoIterator<Item = &'a SignedSSVMessage>) -> bool {
+        let unique_operators = msgs
+            .into_iter()
+            .flat_map(|justification| justification.operator_ids())
+            .filter(|operator_id| self.check_committee(operator_id))
+            .collect::<HashSet<_>>();
+        unique_operators.len() >= self.config.quorum_size()
     }
 
     // Perform base QBFT relevant message verification. This verfiication is applicable to all QBFT
@@ -465,7 +478,7 @@ where
         // received proposal
         if round > Round::default() {
             // validate the justifications
-            if !self.validate_justifications(&wrapped_msg) {
+            if !self.validate_proposal_justifications(&wrapped_msg) {
                 warn!(from = ?operator_id, "Justification validation failed for proposal");
                 return;
             }
@@ -517,20 +530,26 @@ where
         self.send_prepare(wrapped_msg.qbft_message.root);
     }
 
-    // Validate the round change and prepare justifications. Returns true if the justifications
-    // correctly justify the proposal
+    // Validate the round change and prepare justifications for proposal.
+    // Returns true if the justifications correctly justify the proposal
     //
     // A QBFT Message contains fields to a list of round change justifications and prepare
     // justifications. We must go through each of these individually and verify the validity of each
     // one
-    fn validate_justifications(&self, msg: &WrappedQbftMessage) -> bool {
+    //
+    // Proposal
+    // - round change justifications
+    //  - list of round change messages
+    //      - each round change message has list of prepare messages if it prepared a value
+    // - prepare justifications
+    //  - list of prepare messages to
+    fn validate_proposal_justifications(&self, msg: &WrappedQbftMessage) -> bool {
         // Record if any of the round change messages have a value that was prepared
-        let mut previously_prepared = false;
         let mut max_prepared_round = 0;
         let mut max_prepared_msg = None;
 
         // Make sure we have a quorum of round change messages
-        if msg.qbft_message.round_change_justification.len() < self.config.quorum_size() {
+        if !self.check_quorum(&msg.qbft_message.round_change_justification) {
             warn!("Did not receive a quorum of round change messages");
             return false;
         }
@@ -538,6 +557,18 @@ where
         // There was a quorum of round change justifications. We need to go though and verify each
         // one. Each will be a SignedSSVMessage
         for signed_round_change in &msg.qbft_message.round_change_justification {
+            // Check for multi-signers - round change messages should only have 1 signer
+            if signed_round_change.operator_ids().len() > 1 {
+                return false;
+            }
+
+            // make sure all signers in committee
+            for signer in signed_round_change.operator_ids() {
+                if !self.check_committee(signer) {
+                    return false;
+                }
+            }
+
             // The qbft message is represented as a Vec<u8> in the signed message, deserialize this
             // into a proper QbftMessage
             let round_change: QbftMessage =
@@ -552,34 +583,69 @@ where
                 return false;
             }
 
-            // Convert to a wrapped message and perform verification
-            let wrapped = WrappedQbftMessage {
-                signed_message: signed_round_change.clone(),
-                qbft_message: round_change.clone(),
-            };
-
-            if self.validate_message(&wrapped).is_none() {
-                warn!("ROUNDCHANGE message validation failed");
+            // make sure the round change matches the round of the message
+            if round_change.round != msg.qbft_message.round {
                 return false;
             }
 
-            // If the data_round > 1, that means we have prepared a value in previous rounds
-            if round_change.data_round > 1 {
-                previously_prepared = true;
+            // For round change justifications, we need special validation that doesn't check
+            // against current round since they're justifications from the proposal's round
+            // Check height
+            if round_change.height != *self.instance_height as u64 {
+                return false;
+            }
 
+            // If the data_round > 0, that means we have prepared a value in previous rounds
+            // We also have to go through all of the prepare justifications in the round change to
+            // ensure that they are well formed and properly justify the prepared value
+            if round_change.data_round > 0 {
                 // also track the max prepared value and round
                 if round_change.data_round > max_prepared_round {
                     max_prepared_round = round_change.data_round;
-                    max_prepared_msg = Some(round_change);
+                    max_prepared_msg = Some(round_change.clone());
+                }
+
+                // Check that prepared round is not greater than current round
+                if round_change.data_round > round_change.round {
+                    warn!(
+                        "Round change has prepared round {} > round {}",
+                        round_change.data_round, round_change.round
+                    );
+                    return false;
+                }
+
+                // Verify that if round change has full data, it matches the root
+                if msg.qbft_message.root != round_change.root {
+                    warn!("Proposal root doesn't match round change prepared root");
+                    return false;
+                }
+
+                if !self.check_quorum(&round_change.round_change_justification) {
+                    warn!(
+                        num_justifications = round_change.round_change_justification.len(),
+                        "Not enough prepare messages for quorum"
+                    );
+                    return false;
+                }
+
+                // go through all of the round changes prepare justifications
+                for signed_prepare in &round_change.round_change_justification {
+                    if !self.is_valid_prepare_justification_for_round_and_root(
+                        signed_prepare,
+                        round_change.data_round.into(),
+                        &round_change.root,
+                    ) {
+                        return false;
+                    }
                 }
             }
         }
 
         // If there was a value that was also previously prepared, we must also verify all of the
         // prepare justifications
-        if previously_prepared {
+        if let Some(max_prepared_msg) = max_prepared_msg {
             // Make sure we have a quorum of prepare messages
-            if msg.qbft_message.prepare_justification.len() < self.config.quorum_size() {
+            if !self.check_quorum(&msg.qbft_message.prepare_justification) {
                 warn!(
                     num_justifications = msg.qbft_message.prepare_justification.len(),
                     "Not enough prepare messages for quorum"
@@ -588,48 +654,59 @@ where
             }
 
             // Make sure that the roots match
-            if msg.qbft_message.root
-                != max_prepared_msg
-                    .clone()
-                    .expect("Exists as we have a previously prepared value")
-                    .root
-            {
+            if msg.qbft_message.root != max_prepared_msg.root {
                 warn!("Highest prepared does not match proposed data");
                 return false;
             }
 
             // Validate each prepare message matches highest prepared round/value
             for signed_prepare in &msg.qbft_message.prepare_justification {
-                // The qbft message is represented as Vec<u8> in the signed message, deserialize
-                // this into a qbft message
-                let prepare = match QbftMessage::from_ssz_bytes(signed_prepare.ssv_message().data())
-                {
-                    Ok(data) => data,
-                    Err(_) => return false,
-                };
-
-                // Make sure this is a prepare message
-                if prepare.qbft_message_type != QbftMessageType::Prepare {
-                    warn!("Expected a prepare message");
-                    return false;
-                }
-
-                let wrapped = WrappedQbftMessage {
-                    signed_message: signed_prepare.clone(),
-                    qbft_message: prepare.clone(),
-                };
-
-                if self.validate_message(&wrapped).is_none() {
-                    warn!("PREPARE message validation failed");
-                    return false;
-                }
-
-                if prepare.root != msg.qbft_message.root {
-                    warn!("Proposed data mismatch");
+                if !self.is_valid_prepare_justification_for_round_and_root(
+                    signed_prepare,
+                    max_prepared_msg.data_round.into(),
+                    &max_prepared_msg.root,
+                ) {
                     return false;
                 }
             }
         }
+        true
+    }
+
+    fn is_valid_prepare_justification_for_round_and_root(
+        &self,
+        justification: &SignedSSVMessage,
+        round: Round,
+        root: &Hash256,
+    ) -> bool {
+        // The qbft message is represented as Vec<u8> in the signed message, deserialize this into
+        // a qbft message
+        let Ok(prepare) = QbftMessage::from_ssz_bytes(justification.ssv_message().data()) else {
+            warn!("Failed to decode prepare justification message");
+            return false;
+        };
+
+        // Make sure this is a prepare message
+        if prepare.qbft_message_type != QbftMessageType::Prepare {
+            warn!("Expected a prepare message");
+            return false;
+        }
+
+        if prepare.height != *self.instance_height as u64 {
+            warn!("PREPARE height incorrect");
+            return false;
+        }
+
+        if prepare.round != round.get() as u64 {
+            warn!("PREPARE round incorrect");
+            return false;
+        }
+
+        if &prepare.root != root {
+            warn!("Proposed data mismatch");
+            return false;
+        }
+
         true
     }
 
@@ -849,6 +926,44 @@ where
         if u8::from(self.state) >= u8::from(InstanceState::Complete) {
             debug!(from=*operator_id, ?self.state, "ROUNDCHANGE message while in invalid state");
             return;
+        }
+
+        let qbft_msg = &wrapped_msg.qbft_message;
+        // If this is a "prepared" round change, we have to check the justifications.
+        if qbft_msg.data_round > 0 {
+            if !self.check_quorum(&qbft_msg.round_change_justification) {
+                debug!(
+                    from = *operator_id,
+                    justifications = qbft_msg.round_change_justification.len(),
+                    quorum = self.config.quorum_size(),
+                    "prepared ROUNDCHANGE has no quorum"
+                );
+                return;
+            }
+
+            if qbft_msg.data_round > qbft_msg.round {
+                debug!(
+                    from = *operator_id,
+                    data_round = qbft_msg.data_round,
+                    round = qbft_msg.round,
+                    "ROUNDCHANGE has prepared round after round"
+                );
+                return;
+            }
+
+            for justification in qbft_msg.round_change_justification.iter() {
+                if !self.is_valid_prepare_justification_for_round_and_root(
+                    justification,
+                    qbft_msg.data_round.into(),
+                    &qbft_msg.root,
+                ) {
+                    debug!(
+                        from = *operator_id,
+                        "ROUNDCHANGE has invalid prepare justification"
+                    );
+                    return;
+                }
+            }
         }
 
         debug!(from = ?operator_id, state = ?self.state, "ROUNDCHANGE received");

--- a/anchor/common/qbft/src/lib.rs
+++ b/anchor/common/qbft/src/lib.rs
@@ -1278,11 +1278,8 @@ where
         let (prepare_justifications, value_to_propose) = self.get_prepare_justifications();
 
         // Determine the value that should be proposed based off of justification. If we have a
-        // prepare justification, we want to propose that value. Else, just propose the start data
-        let value_to_propose = match value_to_propose {
-            Some(value) => value,
-            None => self.start_data_hash,
-        };
+        // prepare justification, we want to propose that value. Else, just the justified value
+        let value_to_propose = value_to_propose.unwrap_or(hash);
 
         // Construct a unsigned proposal
         let unsigned_msg = self.new_unsigned_message(

--- a/anchor/common/qbft/src/lib.rs
+++ b/anchor/common/qbft/src/lib.rs
@@ -218,10 +218,10 @@ where
     }
 
     // Validation and check functions.
-    fn check_leader(&self, operator_id: &OperatorId) -> bool {
+    fn check_leader(&self, operator_id: &OperatorId, round: Round) -> bool {
         self.config.leader_fn().leader_function(
             operator_id,
-            self.current_round,
+            round,
             self.instance_height,
             self.config.committee_members(),
         )
@@ -409,7 +409,7 @@ where
         self.state = InstanceState::AwaitingProposal;
 
         // Check if we are the leader
-        if self.check_leader(&self.config.operator_id()) {
+        if self.check_leader(&self.config.operator_id(), self.current_round) {
             // We are the leader
 
             // Check justification of round change quorum. If there is a justification, we will use
@@ -468,7 +468,7 @@ where
         }
 
         // Make sure this is from the leader
-        if !self.check_leader(&operator_id) {
+        if !self.check_leader(&operator_id, round) {
             warn!(from = ?operator_id, "PROPOSE message received from non-leader operator");
             return;
         }

--- a/anchor/common/qbft/src/lib.rs
+++ b/anchor/common/qbft/src/lib.rs
@@ -865,13 +865,15 @@ where
         } else {
             // 2. If we receive f+1 round change messages, we need to send our own round-change
             //    message
-            let num_messages_for_round = self.round_change_container.num_messages_for_round(round);
-            if num_messages_for_round > self.config.get_f()
-                && !(matches!(self.state, InstanceState::SentRoundChange))
+            let round = self
+                .round_change_container
+                .highest_partial_quorum_above_round(self.current_round, self.config.get_f() + 1);
+            if let Some(round) = round
+                && round > self.current_round
             {
-                // Set the state so SendRoundChange so we include Round + 1 in message
                 self.state = InstanceState::SentRoundChange;
-
+                self.current_round = round;
+                self.proposal_accepted_for_current_round = false;
                 self.send_round_change(Hash256::default());
             }
         }

--- a/anchor/common/qbft/src/lib.rs
+++ b/anchor/common/qbft/src/lib.rs
@@ -427,16 +427,25 @@ where
         wrapped_msg: WrappedQbftMessage,
     ) {
         // Make sure that we are actually waiting for a proposal
-        if !matches!(self.state, InstanceState::AwaitingProposal) {
+        if round == self.current_round && !matches!(self.state, InstanceState::AwaitingProposal) {
             debug!(from=?operator_id, ?self.state, "PROPOSE message while in invalid state");
+            return;
+        }
+
+        // Make sure this is from the leader
+        if !self.check_leader(&operator_id) {
+            warn!(from = ?operator_id, "PROPOSE message received from non-leader operator");
             return;
         }
 
         // If we are passed the first round, make sure that the justifications actually justify the
         // received proposal
-        if round > Round::default() && !self.validate_justifications(&wrapped_msg) {
-            warn!(from = ?operator_id, "Justification verifiction failed");
-            return;
+        if round > Round::default() {
+            // validate the justifications
+            if !self.validate_justifications(&wrapped_msg) {
+                warn!(from = ?operator_id, "Justification validation failed for proposal");
+                return;
+            }
         }
 
         // Fulldata is included in propose messages
@@ -460,10 +469,17 @@ where
             return;
         }
 
-        // Make sure we have not already accepted another proposal for this round.
-        if self.proposal_accepted_for_current_round {
+        // Only reject if we've already accepted a proposal for THIS round
+        // Allow proposals for future rounds even if we have a proposal for current round
+        if self.proposal_accepted_for_current_round && round == self.current_round {
             warn!(from = ?operator_id, "Proposal has already been accepted for this round");
             return;
+        }
+
+        // If this is a future round proposal, update our round to match
+        if round > self.current_round {
+            debug!(old_round = ?self.current_round, new_round = ?round, "Updating to future round from proposal");
+            self.current_round = round;
         }
 
         // Accept this proposal

--- a/anchor/common/qbft/src/lib.rs
+++ b/anchor/common/qbft/src/lib.rs
@@ -979,7 +979,10 @@ where
         // There are two cases to check here
 
         // 1. If we have received a quorum of round change messages, we need to start a new round
-        if self.round_change_container.has_quorum(round).is_some() {
+        if self
+            .round_change_container
+            .has_quorum_disregarding_root(round)
+        {
             if matches!(self.state, InstanceState::SentRoundChange) {
                 // If we have reached a quorum for this round and have already sent a round change,
                 // advance to that round.

--- a/anchor/common/qbft/src/lib.rs
+++ b/anchor/common/qbft/src/lib.rs
@@ -1016,40 +1016,49 @@ where
         // round change and we must have a quorum of round change messages. We include these so
         // that we can prove that we had a consensus allowing us to change
         if matches!(self.state, InstanceState::AwaitingProposal) {
-            return self
+            let round_changes = self
                 .round_change_container
-                .get_messages_for_round(self.current_round)
-                .iter()
-                .map(|msg| msg.signed_message.clone())
-                .collect();
-        }
-        // If we are past the first round and are sending a round change. We have to include
-        // prepare messages that prove we have prepared a value
-        else if matches!(self.state, InstanceState::SentRoundChange) {
-            // if we have a last prepared value and a last prepared round...
-            if let (Some(_), Some(last_prepared_round)) =
-                (self.last_prepared_value, self.last_prepared_round)
-            {
-                // Get all of the prepare messages for the last prepared round
-                let last_prepared_messages = self
-                    .prepare_container
-                    .get_messages_for_round(last_prepared_round);
+                .get_messages_for_round(self.current_round);
 
-                // Make sure we have a quorum of prepare message
-                if last_prepared_messages.len() < self.config.quorum_size() {
-                    return vec![];
-                }
-
-                // This will hold the value that we want to propose
-                return last_prepared_messages
-                    .iter()
+            // We need at least a quorum of round changes to justify the proposal
+            if round_changes.len() >= self.config.quorum_size() {
+                return round_changes
+                    .into_iter()
                     .map(|msg| msg.signed_message.clone())
                     .collect();
             }
-            return vec![];
+        }
+        vec![]
+    }
+
+    /// Get justifications for a RoundChange message
+    /// If we have prepared a value, include the Prepare messages that justify it
+    fn get_round_change_prepare_justifications(&self) -> Vec<SignedSSVMessage> {
+        // Only include prepare justifications if we have a prepared value
+        if let (Some(last_prepared_value), Some(last_prepared_round)) =
+            (self.last_prepared_value, self.last_prepared_round)
+        {
+            // Get the prepare messages for the round where we prepared
+            let prepares = self
+                .prepare_container
+                .get_messages_for_round(last_prepared_round);
+
+            // Only include prepares that match our prepared value
+            let filtered_prepares: Vec<_> = prepares
+                .iter()
+                .filter(|msg| msg.qbft_message.root == last_prepared_value)
+                .collect();
+
+            // We need a quorum of prepares to justify the prepared value
+            if filtered_prepares.len() >= self.config.quorum_size() {
+                let result: Vec<SignedSSVMessage> = filtered_prepares
+                    .into_iter()
+                    .map(|msg| msg.signed_message.clone())
+                    .collect();
+                return result;
+            }
         }
 
-        // Sending prepare/commit message
         vec![]
     }
 
@@ -1165,7 +1174,7 @@ where
     fn send_round_change(&mut self, data_hash: D::Hash) {
         // For Round Change messages
         // round_change_justification: list of prepare messages
-        let round_change_justifications = self.get_round_change_justifications();
+        let round_change_justifications = self.get_round_change_prepare_justifications();
         // prepare_justification: N/A
 
         // Construct unsigned round change

--- a/anchor/common/qbft/src/lib.rs
+++ b/anchor/common/qbft/src/lib.rs
@@ -310,8 +310,11 @@ where
         // Message is not a decide message, we know there is only one signer
         let signer = wrapped_msg.signed_message.operator_ids().first()?;
 
-        // Fulldata may be empty. This is still considered valid though
-        if wrapped_msg.signed_message.full_data().is_empty() {
+        // Fulldata may be empty. This is still considered valid though. We also do not validate
+        // fulldata on round change messages.
+        if wrapped_msg.signed_message.full_data().is_empty()
+            || wrapped_msg.qbft_message.qbft_message_type == QbftMessageType::RoundChange
+        {
             let valid_data = Some(ValidData::new(None, wrapped_msg.qbft_message.root));
             return Some((valid_data, *signer));
         }
@@ -369,32 +372,28 @@ where
         let claimed_hash = highest_prepared.qbft_message.root;
 
         // First, try to get data from the round change message itself
-        if !highest_prepared.signed_message.full_data().is_empty() {
-            // The round change includes the full data - decode and use it
-            if let Ok(data) = D::from_ssz_bytes(highest_prepared.signed_message.full_data()) {
-                // Verify the data matches the claimed hash
-                if data.hash() == claimed_hash {
-                    return Some(ValidData::new(Some(Arc::new(data)), claimed_hash));
-                } else {
-                    warn!("Round change full data doesn't match claimed hash");
-                }
-            } else {
-                warn!("Failed to decode round change full data");
-            }
+        if highest_prepared.signed_message.full_data().is_empty() {
+            return None;
         }
 
-        // If we don't have the data in the round change, try our local storage
-        if let Some(data) = self.data.get(&claimed_hash) {
-            return Some(ValidData::new(Some(data.clone()), claimed_hash));
+        // The round change includes the full data - decode and use it
+        let Ok(data) = D::from_ssz_bytes(highest_prepared.signed_message.full_data()) else {
+            warn!("Failed to decode round change full data");
+            return None;
+        };
+
+        // Verify the data matches the claimed hash
+        if data.hash() != claimed_hash {
+            warn!("Round change full data doesn't match claimed hash");
+            return None;
         }
 
-        warn!(
-            "Missing data for highest prepared value with hash {:?}",
-            claimed_hash
-        );
+        if !self.data_validator.validate(&data, &self.start_data) {
+            warn!("Round change full data is invalid");
+            return None;
+        }
 
-        // Return None - will fall back to start data
-        None
+        Some(ValidData::new(Some(Arc::new(data)), claimed_hash))
     }
 
     // Handles the beginning of a round.

--- a/anchor/common/qbft/src/lib.rs
+++ b/anchor/common/qbft/src/lib.rs
@@ -682,7 +682,15 @@ where
         root: &Hash256,
     ) -> bool {
         // Make sure there is only one signer
-        if justification.operator_ids().len() != 1 || justification.signatures().len() != 1 {
+        let [operator_id] = justification.operator_ids()[..] else {
+            return false;
+        };
+        if justification.signatures().len() != 1 {
+            return false;
+        }
+
+        // Make sure the signer is in our committee
+        if !self.check_committee(&operator_id) {
             return false;
         }
 

--- a/anchor/common/qbft/src/lib.rs
+++ b/anchor/common/qbft/src/lib.rs
@@ -117,9 +117,6 @@ where
     last_prepared_round: Option<Round>,
     last_prepared_value: Option<D::Hash>,
 
-    /// Past prepare consensus that we have reached
-    past_consensus: HashMap<Round, D::Hash>,
-
     /// Aggregated commit message
     aggregated_commit: Option<SignedSSVMessage>,
 
@@ -179,8 +176,6 @@ where
             proposal_root: None,
             last_prepared_round: None,
             last_prepared_value: None,
-
-            past_consensus: HashMap::new(),
 
             aggregated_commit: None,
 
@@ -337,46 +332,55 @@ where
     }
 
     /// Justify the round change quorum
-    /// In order to justify a round change quorum, we find the maximum round of the quorum set that
-    /// had achieved a past consensus. If we have also seen consensus on this round for the
-    /// suggested data, then it is justified and this function returns that data.
-    /// If there is no past consensus data in the round change quorum or we disagree with quorum set
-    /// this function will return None, and we obtain the data as if we were beginning this
-    /// instance.
+    /// Finds the highest prepared value from round change messages and returns it
+    /// for the proposal.
     fn justify_round_change_quorum(&self) -> Option<ValidData<D>> {
-        // Get all round change messages for the current round
         let round_change_messages = self
             .round_change_container
             .get_messages_for_round(self.current_round);
 
-        // If we don't have enough messages for quorum, we can't justify anything
+        // Need quorum to proceed
         if round_change_messages.len() < self.config.quorum_size() {
             return None;
         }
 
-        // Find the highest round that any node claims reached preparation
+        // Find the round change with the highest prepared round
         let highest_prepared = round_change_messages
             .iter()
-            .filter(|msg| msg.qbft_message.data_round != 0) // Only consider messages with prepared data
+            .filter(|msg| msg.qbft_message.data_round != 0)
             .max_by_key(|msg| msg.qbft_message.data_round);
 
-        // If we found a message with prepared data
-        if let Some(highest_msg) = highest_prepared {
-            // Get the prepared data from the message
-            let prepared_round = Round::from(highest_msg.qbft_message.data_round);
+        // If no one prepared anything, return None (will use start data)
+        let highest_prepared = highest_prepared?;
 
-            // Verify we have also seen this consensus
-            if let Some(hash) = self.past_consensus.get(&prepared_round) {
-                // We have seen consensus on the data, get the value
-                let our_data = self.data.get(hash).cloned().unwrap_or_else(|| {
-                    warn!("Previous consensus data missing. Using start value");
-                    self.start_data.clone()
-                });
-                return Some(ValidData::new(Some(our_data), *hash));
+        let claimed_hash = highest_prepared.qbft_message.root;
+
+        // First, try to get data from the round change message itself
+        if !highest_prepared.signed_message.full_data().is_empty() {
+            // The round change includes the full data - decode and use it
+            if let Ok(data) = D::from_ssz_bytes(highest_prepared.signed_message.full_data()) {
+                // Verify the data matches the claimed hash
+                if data.hash() == claimed_hash {
+                    return Some(ValidData::new(Some(Arc::new(data)), claimed_hash));
+                } else {
+                    warn!("Round change full data doesn't match claimed hash");
+                }
+            } else {
+                warn!("Failed to decode round change full data");
             }
         }
 
-        // No consensus found
+        // If we don't have the data in the round change, try our local storage
+        if let Some(data) = self.data.get(&claimed_hash) {
+            return Some(ValidData::new(Some(data.clone()), claimed_hash));
+        }
+
+        warn!(
+            "Missing data for highest prepared value with hash {:?}",
+            claimed_hash
+        );
+
+        // Return None - will fall back to start data
         None
     }
 
@@ -704,9 +708,6 @@ where
             // Move the state forward since we have a prepare quorum
             self.state = InstanceState::Commit { proposal_root };
             debug!(state = ?self.state, "Reached a PREPARE consensus. State updated to COMMIT");
-
-            // Record that we have come to a consensus on this value
-            self.past_consensus.insert(round, hash);
 
             // Record as last prepared value and round
             self.last_prepared_value = Some(hash);

--- a/anchor/common/qbft/src/lib.rs
+++ b/anchor/common/qbft/src/lib.rs
@@ -984,10 +984,18 @@ where
         &self,
         msg_type: QbftMessageType,
         data_hash: D::Hash,
-        round_change_justification: Vec<SignedSSVMessage>,
-        prepare_justification: Vec<SignedSSVMessage>,
+        mut round_change_justification: Vec<SignedSSVMessage>,
+        mut prepare_justification: Vec<SignedSSVMessage>,
     ) -> UnsignedWrappedQbftMessage {
         let data = self.get_message_data(&msg_type, data_hash);
+
+        // Clear full_data from justifications as these do not store full data.
+        for round_change_justification in &mut round_change_justification {
+            round_change_justification.set_full_data(vec![]);
+        }
+        for prepare_justification in &mut prepare_justification {
+            prepare_justification.set_full_data(vec![]);
+        }
 
         // Create the QBFT message
         let qbft_message = QbftMessage {

--- a/anchor/common/qbft/src/lib.rs
+++ b/anchor/common/qbft/src/lib.rs
@@ -1064,56 +1064,68 @@ where
 
     // Get all of the prepare justifications for proposals
     fn get_prepare_justifications(&self) -> (Vec<SignedSSVMessage>, Option<Hash256>) {
-        // No justifications if we are in the first round
-        if self.current_round <= Round::default() {
+        // No justifications needed for round 1
+        if self.current_round == Round::default() {
             return (vec![], None);
         }
 
-        // We only send prepare justifications with for proposal messages. If we are in the
-        // state AwaitingProposal and sending a message, we know this is a proposal. This will
-        // happen when we have come to a consensus of round change messages and have started a
-        // new round
-        if matches!(self.state, InstanceState::AwaitingProposal) {
-            // Get all of the round change messages for the current round and make sure we have
-            // a quorum of them.
-            let round_change_msg = self
-                .round_change_container
-                .get_messages_for_round(self.current_round);
-            if round_change_msg.len() < self.config.quorum_size() {
+        // Only needed when we're the proposer
+        if !matches!(self.state, InstanceState::AwaitingProposal) {
+            return (vec![], None);
+        }
+
+        // Check if we have our own prepared value that should be proposed
+        // This handles the case where we prepared a value but the RoundChange messages
+        // don't reflect it (e.g., other nodes didn't prepare)
+        let potential_prepare_just = self.get_round_change_prepare_justifications();
+        if !potential_prepare_just.is_empty() {
+            if let Some(last_prepared) = self.last_prepared_value {
+                return (potential_prepare_just, Some(last_prepared));
+            } else {
+                // Invariant violated: potential_prepare_just is not empty but no
+                // last_prepared_value Handle gracefully: return no justification
+                error!("prepare justifications exists but no last prepared value was found");
                 return (vec![], None);
             }
+        }
 
-            // Go through each message and see if any have a value that was already prepared
-            // Just want to take the first one that is valid and has a prepared value
-            for wrapped_round_change in round_change_msg {
-                // Deserialize into a qbft message for sanity checks
-                let round_change: QbftMessage = match QbftMessage::from_ssz_bytes(
-                    wrapped_round_change.signed_message.ssv_message().data(),
-                ) {
-                    Ok(data) => data,
-                    Err(_) => return (vec![], None),
-                };
+        // Get all round change messages for current round
+        let round_changes = self
+            .round_change_container
+            .get_messages_for_round(self.current_round);
 
-                // Round sanity check
-                let current_round_proposal = self.proposal_accepted_for_current_round
-                    && self.current_round.get() as u64 == round_change.round;
-                let future_round_proposal = round_change.round > self.current_round.get() as u64;
-                if !current_round_proposal && !future_round_proposal {
-                    continue;
-                }
+        if round_changes.len() < self.config.quorum_size() {
+            return (vec![], None);
+        }
 
-                // Validate the proposal, if this is a valid proposal then this is our prepare
-                // justification
-                if self.validate_justifications(wrapped_round_change) {
-                    return (
-                        vec![wrapped_round_change.signed_message.clone()],
-                        Some(round_change.root),
-                    );
+        // Find the highest prepared round among all round changes
+        let mut highest_prepared: Option<(Round, Hash256, &WrappedQbftMessage)> = None;
+
+        for rc_msg in &round_changes {
+            // Check if this round change has a prepared value
+            if rc_msg.qbft_message.data_round > 0 {
+                let prepared_round = Round::from(rc_msg.qbft_message.data_round);
+
+                // Update if this is the highest we've seen
+                if highest_prepared.is_none_or(|(round, _, _)| prepared_round > round) {
+                    highest_prepared = Some((prepared_round, rc_msg.qbft_message.root, rc_msg));
                 }
             }
         }
 
-        // Not sending a proposal
+        // If we found a highest prepared value, extract its prepare justifications
+        if let Some((_, prepared_value, highest_rc)) = highest_prepared {
+            // Extract the prepare messages from the round change message's justifications
+            // These are stored in the round_change_justification field of the RoundChange
+            let prepares = &highest_rc.qbft_message.round_change_justification;
+
+            // Verify we have quorum of prepares
+            if prepares.len() >= self.config.quorum_size() {
+                return (prepares.clone(), Some(prepared_value));
+            }
+        }
+
+        // No prepared value found, proposer can choose new value
         (vec![], None)
     }
 

--- a/anchor/common/qbft/src/lib.rs
+++ b/anchor/common/qbft/src/lib.rs
@@ -744,9 +744,23 @@ where
             return;
         }
 
-        // Make sure that we have accepted a proposal for this round
+        // Handle commit message, checking proposal acceptance and catch-up scenarios.
+
+        // If we have NOT accepted a proposal for this round, this is a catch-up scenario.
+        // We allow commits without having seen a proposal in this case.
         if !self.proposal_accepted_for_current_round {
-            warn!(from=?operator_id, ?self.state, "Have not accepted Proposal for current round yet");
+            debug!(from=?operator_id, ?self.state, "Have not accepted Proposal for current round yet (catch-up scenario)");
+            return;
+        }
+
+        // Proposal accepted: ensure commit matches the accepted proposal root.
+        if let Some(accepted_root) = self.proposal_root {
+            if wrapped_msg.qbft_message.root != accepted_root {
+                warn!(from=?operator_id, ?self.state, "Commit root does not match accepted Proposal root");
+                return;
+            }
+        } else {
+            warn!(from=?operator_id, ?self.state, "Proposal accepted, but no proposal root found");
             return;
         }
 
@@ -764,17 +778,16 @@ where
         if let Some(hash) = self.commit_container.has_quorum(round) {
             // Make sure that the root of the data that we have come to a commit consensus on
             // matches the root of the proposal that we have accepted
-            let proposal_root = match self.state {
-                InstanceState::Prepare { proposal_root } => proposal_root,
-                InstanceState::Commit { proposal_root } => proposal_root,
-                _ => {
-                    warn!(from=?operator_id, ?self.state, "Not in PREPARE or COMMIT state");
-                    return;
+            match self.state {
+                InstanceState::Prepare { proposal_root }
+                | InstanceState::Commit { proposal_root } => {
+                    // We already accepted a proposal and are in commit state
+                    if hash != proposal_root {
+                        warn!("COMMIT quorum root does not match accepted PROPOSAL root");
+                        return;
+                    }
                 }
-            };
-            if hash != proposal_root {
-                warn!("COMMIT quorum root does not match accepted PROPOSAL root");
-                return;
+                _ => return,
             }
 
             // Aggregate all of the commit messages

--- a/anchor/common/qbft/src/lib.rs
+++ b/anchor/common/qbft/src/lib.rs
@@ -1001,17 +1001,13 @@ where
             .round_change_container
             .has_quorum_disregarding_root(round)
         {
-            if matches!(self.state, InstanceState::SentRoundChange) {
-                // If we have reached a quorum for this round and have already sent a round change,
-                // advance to that round.
-                debug!(round = *round, "Round change quorum reached");
+            debug!(round = *round, "Round change quorum reached");
 
-                // We have reached consensus on a round change, we can start a new round now
-                self.state = InstanceState::RoundChangeConsensus;
+            // We have reached consensus on a round change, we can start a new round now
+            self.state = InstanceState::RoundChangeConsensus;
 
-                // The round change messages is round + 1, so this is the next round we want to use
-                self.set_round(round);
-            }
+            // The round change messages is round + 1, so this is the next round we want to use
+            self.set_round(round);
         } else {
             // 2. If we receive f+1 round change messages, we need to send our own round-change
             //    message

--- a/anchor/common/qbft/src/lib.rs
+++ b/anchor/common/qbft/src/lib.rs
@@ -999,7 +999,7 @@ where
             //    message
             let round = self
                 .round_change_container
-                .highest_partial_quorum_above_round(self.current_round, self.config.get_f() + 1);
+                .lowest_partial_quorum_above_round(self.current_round, self.config.get_f() + 1);
             if let Some(round) = round
                 && round > self.current_round
             {

--- a/anchor/common/qbft/src/lib.rs
+++ b/anchor/common/qbft/src/lib.rs
@@ -254,6 +254,25 @@ where
             return None;
         }
 
+        // Check for future round
+        if wrapped_msg.qbft_message.round > self.current_round.into() {
+            match wrapped_msg.qbft_message.qbft_message_type {
+                QbftMessageType::Proposal | QbftMessageType::RoundChange => {
+                    // Proposals & Round Changes for future rounds are always allowed
+                }
+                QbftMessageType::Commit => {
+                    // Only decided messages (with quorum) are allowed from future rounds
+                    if wrapped_msg.signed_message.operator_ids().len() < self.config.quorum_size() {
+                        return None;
+                    }
+                }
+                _ => {
+                    // All other message types (including Prepare) for future rounds are not allowed
+                    return None;
+                }
+            }
+        }
+
         // Make sure we are at the correct instance height
         if wrapped_msg.qbft_message.height != *self.instance_height as u64 {
             warn!(

--- a/anchor/common/qbft/src/lib.rs
+++ b/anchor/common/qbft/src/lib.rs
@@ -717,9 +717,10 @@ where
             // Make sure that the root of the data that we have come to a commit consensus on
             // matches the root of the proposal that we have accepted
             let proposal_root = match self.state {
+                InstanceState::Prepare { proposal_root } => proposal_root,
                 InstanceState::Commit { proposal_root } => proposal_root,
                 _ => {
-                    warn!(from=?operator_id, ?self.state, "Not in COMMIT state");
+                    warn!(from=?operator_id, ?self.state, "Not in PREPARE or COMMIT state");
                     return;
                 }
             };

--- a/anchor/common/qbft/src/lib.rs
+++ b/anchor/common/qbft/src/lib.rs
@@ -617,6 +617,11 @@ where
         round: Round,
         wrapped_msg: WrappedQbftMessage,
     ) {
+        // If we are already done
+        if self.completed.is_some() {
+            return;
+        }
+
         // Check that we are in the correct state. We do not have to be in the PREPARE state right
         // now as this message may have been delayed
         if u8::from(self.state) >= u8::from(InstanceState::SentRoundChange) {
@@ -646,6 +651,14 @@ where
         // Make sure that we have accepted a proposal for this round
         if !self.proposal_accepted_for_current_round {
             debug!(from=?operator_id, ?self.state, "Have not accepted Proposal for current round yet");
+            return;
+        }
+
+        // Check that the prepare message is for the accepted proposal
+        if let Some(accepted_root) = self.proposal_root
+            && wrapped_msg.qbft_message.root != accepted_root
+        {
+            warn!(from=?operator_id, "PREPARE message for different root than accepted proposal");
             return;
         }
 

--- a/anchor/common/qbft/src/lib.rs
+++ b/anchor/common/qbft/src/lib.rs
@@ -558,7 +558,9 @@ where
         // one. Each will be a SignedSSVMessage
         for signed_round_change in &msg.qbft_message.round_change_justification {
             // Check for multi-signers - round change messages should only have 1 signer
-            if signed_round_change.operator_ids().len() > 1 {
+            if signed_round_change.operator_ids().len() != 1
+                || signed_round_change.signatures().len() != 1
+            {
                 return false;
             }
 
@@ -679,6 +681,11 @@ where
         round: Round,
         root: &Hash256,
     ) -> bool {
+        // Make sure there is only one signer
+        if justification.operator_ids().len() != 1 || justification.signatures().len() != 1 {
+            return false;
+        }
+
         // The qbft message is represented as Vec<u8> in the signed message, deserialize this into
         // a qbft message
         let Ok(prepare) = QbftMessage::from_ssz_bytes(justification.ssv_message().data()) else {

--- a/anchor/common/qbft/src/lib.rs
+++ b/anchor/common/qbft/src/lib.rs
@@ -975,12 +975,23 @@ where
 
         debug!(from = ?operator_id, state = ?self.state, "ROUNDCHANGE received");
 
-        // Store the round changed message
+        // Check if we already have a quorum
+        let had_quorum_before = self
+            .round_change_container
+            .has_quorum_disregarding_root(round);
+
+        // Store the round changed message regardless
         if !self
             .round_change_container
             .add_message(round, operator_id, &wrapped_msg)
         {
             warn!(from = ?operator_id, "ROUNDCHANGE message is a duplicate")
+        }
+
+        // If we already had quorum, just return
+        if had_quorum_before {
+            debug!(from = ?operator_id, "Already had round change quorum, ignoring");
+            return;
         }
 
         // There are two cases to check here

--- a/anchor/common/qbft/src/lib.rs
+++ b/anchor/common/qbft/src/lib.rs
@@ -606,10 +606,10 @@ where
                     max_prepared_msg = Some(round_change.clone());
                 }
 
-                // Check that prepared round is not greater than current round
-                if round_change.data_round > round_change.round {
+                // Check that prepared round is strictly less than current round (spec requirement)
+                if round_change.data_round >= round_change.round {
                     warn!(
-                        "Round change has prepared round {} > round {}",
+                        "Round change has prepared round {} >= round {} (spec requires prepared_round < round)",
                         round_change.data_round, round_change.round
                     );
                     return false;
@@ -955,12 +955,12 @@ where
                 return;
             }
 
-            if qbft_msg.data_round > qbft_msg.round {
+            if qbft_msg.data_round >= qbft_msg.round {
                 debug!(
                     from = *operator_id,
                     data_round = qbft_msg.data_round,
                     round = qbft_msg.round,
-                    "ROUNDCHANGE has prepared round after round"
+                    "ROUNDCHANGE has prepared round >= round (spec requires prepared_round < round)"
                 );
                 return;
             }

--- a/anchor/common/qbft/src/lib.rs
+++ b/anchor/common/qbft/src/lib.rs
@@ -615,12 +615,6 @@ where
                     return false;
                 }
 
-                // Verify that if round change has full data, it matches the root
-                if msg.qbft_message.root != round_change.root {
-                    warn!("Proposal root doesn't match round change prepared root");
-                    return false;
-                }
-
                 if !self.check_quorum(&round_change.round_change_justification) {
                     warn!(
                         num_justifications = round_change.round_change_justification.len(),
@@ -640,6 +634,19 @@ where
                     }
                 }
             }
+        }
+
+        // After processing all round changes, verify the proposal root matches the highest prepared
+        // value According to QBFT spec, proposal should use value from highest prepared
+        // round
+        if let Some(max_prepared_msg) = &max_prepared_msg
+            && msg.qbft_message.root != max_prepared_msg.root
+        {
+            warn!(
+                "Proposal root doesn't match highest prepared round change root. Proposal root: {:?}, Highest prepared root: {:?}, prepared round: {}",
+                msg.qbft_message.root, max_prepared_msg.root, max_prepared_msg.data_round
+            );
+            return false;
         }
 
         // If there was a value that was also previously prepared, we must also verify all of the

--- a/anchor/common/qbft/src/msg_container.rs
+++ b/anchor/common/qbft/src/msg_container.rs
@@ -78,12 +78,8 @@ impl MessageContainer {
             .is_some_and(|msgs| msgs.len() >= self.quorum_size)
     }
 
-    /// Count the number of messages we have received for this round
-    pub fn highest_partial_quorum_above_round(
-        &self,
-        round: Round,
-        partial: usize,
-    ) -> Option<Round> {
+    /// Return the lowest round above a certain round that has at least `partial` amount of msgs.
+    pub fn lowest_partial_quorum_above_round(&self, round: Round, partial: usize) -> Option<Round> {
         // Collect all operators from rounds > round
         let mut all_operators = HashSet::new();
         let mut min_future_round = None;

--- a/anchor/common/qbft/src/msg_container.rs
+++ b/anchor/common/qbft/src/msg_container.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 
 use ssv_types::OperatorId;
 use types::Hash256;
@@ -11,7 +11,7 @@ pub struct MessageContainer {
     /// Messages stored as a Vec per round to preserve insertion order
     messages: HashMap<Round, Vec<WrappedQbftMessage>>,
     /// Track which operators have sent messages for each round
-    senders_by_round: HashMap<Round, HashSet<OperatorId>>,
+    senders_by_round: BTreeMap<Round, HashSet<OperatorId>>,
     /// Track unique values per round
     values_by_round: HashMap<Round, HashSet<Hash256>>,
     /// The quorum size for the qbft instance
@@ -24,7 +24,7 @@ impl MessageContainer {
         Self {
             quorum_size,
             messages: HashMap::new(),
-            senders_by_round: HashMap::new(),
+            senders_by_round: BTreeMap::new(),
             values_by_round: HashMap::new(),
         }
     }
@@ -78,11 +78,33 @@ impl MessageContainer {
     }
 
     /// Count the number of messages we have received for this round
-    pub fn num_messages_for_round(&self, round: Round) -> usize {
-        self.messages
-            .get(&round)
-            .map(|msgs| msgs.len())
-            .unwrap_or(0)
+    pub fn highest_partial_quorum_above_round(
+        &self,
+        round: Round,
+        partial: usize,
+    ) -> Option<Round> {
+        // Collect all operators from rounds > round
+        let mut all_operators = HashSet::new();
+        let mut min_future_round = None;
+
+        for (&r, operators) in self.senders_by_round.range((round + 1)..) {
+            // Track minimum round
+            if min_future_round.is_none() {
+                min_future_round = Some(r);
+            }
+
+            // Add all operators from this round
+            for &operator in operators {
+                all_operators.insert(operator);
+            }
+        }
+
+        // If we have partial quorum, return the minimum round
+        if all_operators.len() >= partial {
+            min_future_round
+        } else {
+            None
+        }
     }
 
     /// If we have a quorum for the round, get all of the messages that correspond to that quorum

--- a/anchor/common/qbft/src/msg_container.rs
+++ b/anchor/common/qbft/src/msg_container.rs
@@ -84,7 +84,9 @@ impl MessageContainer {
         let mut all_operators = HashSet::new();
         let mut min_future_round = None;
 
-        for (&r, operators) in self.senders_by_round.range((round + 1)..) {
+        let start_round = round.next()?; // No future rounds possible if overflow
+
+        for (&r, operators) in self.senders_by_round.range(start_round..) {
             // Track minimum round
             if min_future_round.is_none() {
                 min_future_round = Some(r);

--- a/anchor/common/qbft/src/msg_container.rs
+++ b/anchor/common/qbft/src/msg_container.rs
@@ -42,19 +42,12 @@ impl MessageContainer {
             return false;
         }
 
-        let mut msg = msg.clone();
-        // We no longer have need for full data in these messages, as the hash is stored the QBFT
-        // state. The messages are here only used for quorum checking, and for justifications. For
-        // both the data is not needed.
-        msg.signed_message.set_full_data(vec![]);
+        self.messages.entry(round).or_default().push(msg.clone());
 
         self.values_by_round
             .entry(round)
             .or_default()
             .insert(msg.qbft_message.root);
-
-        // Add message and track its value
-        self.messages.entry(round).or_default().push(msg);
 
         true
     }

--- a/anchor/common/qbft/src/msg_container.rs
+++ b/anchor/common/qbft/src/msg_container.rs
@@ -8,8 +8,10 @@ use crate::{Round, WrappedQbftMessage};
 /// Message container with strong typing and validation
 #[derive(Default)]
 pub struct MessageContainer {
-    /// Messages indexed by round and then by sender
-    messages: HashMap<Round, HashMap<OperatorId, WrappedQbftMessage>>,
+    /// Messages stored as a Vec per round to preserve insertion order
+    messages: HashMap<Round, Vec<WrappedQbftMessage>>,
+    /// Track which operators have sent messages for each round
+    senders_by_round: HashMap<Round, HashSet<OperatorId>>,
     /// Track unique values per round
     values_by_round: HashMap<Round, HashSet<Hash256>>,
     /// The quorum size for the qbft instance
@@ -22,6 +24,7 @@ impl MessageContainer {
         Self {
             quorum_size,
             messages: HashMap::new(),
+            senders_by_round: HashMap::new(),
             values_by_round: HashMap::new(),
         }
     }
@@ -34,20 +37,12 @@ impl MessageContainer {
         msg: &WrappedQbftMessage,
     ) -> bool {
         // Check if we already have a message from this sender for this round
-        if self
-            .messages
-            .get(&round)
-            .and_then(|msgs| msgs.get(&sender))
-            .is_some()
-        {
-            return false; // Duplicate message
+        let senders = self.senders_by_round.entry(round).or_default();
+        if !senders.insert(sender) {
+            return false;
         }
 
-        // Add message and track its value
-        self.messages
-            .entry(round)
-            .or_default()
-            .insert(sender, msg.clone());
+        self.messages.entry(round).or_default().push(msg.clone());
 
         self.values_by_round
             .entry(round)
@@ -64,7 +59,7 @@ impl MessageContainer {
 
         // Count occurrences of each value
         let mut value_counts: HashMap<Hash256, usize> = HashMap::new();
-        for msg in round_messages.values() {
+        for msg in round_messages {
             *value_counts.entry(msg.qbft_message.root).or_default() += 1;
         }
 
@@ -90,7 +85,7 @@ impl MessageContainer {
         if let Some(hash) = self.has_quorum(round)
             && let Some(round_messages) = self.messages.get(&round)
         {
-            for msg in round_messages.values() {
+            for msg in round_messages {
                 if msg.qbft_message.root == hash {
                     msgs.push(msg.clone());
                 }
@@ -101,14 +96,9 @@ impl MessageContainer {
 
     /// Gets all messages for a specific round
     pub fn get_messages_for_round(&self, round: Round) -> Vec<&WrappedQbftMessage> {
-        // If we have messages for this round in our container, return them all
-        // If not, return an empty vector
         self.messages
             .get(&round)
-            .map(|round_messages| {
-                // Convert the values of the HashMap into a Vec
-                round_messages.values().collect()
-            })
+            .map(|round_messages| round_messages.iter().collect())
             .unwrap_or_default()
     }
 }

--- a/anchor/common/qbft/src/msg_container.rs
+++ b/anchor/common/qbft/src/msg_container.rs
@@ -70,6 +70,14 @@ impl MessageContainer {
             .map(|(value, _)| value)
     }
 
+    /// Check if we have a quorum of messages for the round, regardless of the root contained in the
+    /// message.
+    pub fn has_quorum_disregarding_root(&self, round: Round) -> bool {
+        self.messages
+            .get(&round)
+            .is_some_and(|msgs| msgs.len() >= self.quorum_size)
+    }
+
     /// Count the number of messages we have received for this round
     pub fn highest_partial_quorum_above_round(
         &self,

--- a/anchor/common/qbft/src/msg_container.rs
+++ b/anchor/common/qbft/src/msg_container.rs
@@ -42,12 +42,19 @@ impl MessageContainer {
             return false;
         }
 
-        self.messages.entry(round).or_default().push(msg.clone());
+        let mut msg = msg.clone();
+        // We no longer have need for full data in these messages, as the hash is stored the QBFT
+        // state. The messages are here only used for quorum checking, and for justifications. For
+        // both the data is not needed.
+        msg.signed_message.set_full_data(vec![]);
 
         self.values_by_round
             .entry(round)
             .or_default()
             .insert(msg.qbft_message.root);
+
+        // Add message and track its value
+        self.messages.entry(round).or_default().push(msg);
 
         true
     }

--- a/anchor/common/qbft/src/tests.rs
+++ b/anchor/common/qbft/src/tests.rs
@@ -223,3 +223,136 @@ fn test_node_recovery() {
     let num_consensus = test_instance.wait_until_end();
     assert_eq!(num_consensus, 5); // Should reach full consensus after recovery
 }
+
+#[test]
+/// Test that FAILS if round change validation doesn't require prepare justifications for
+/// data_round=1
+///
+/// This test creates a proposal with round change messages claiming preparation in round 1
+/// (data_round=1) but provides NO prepare justifications.
+/// The test FAILS if the validation doesn't reject the proposal as it should.
+fn test_round_change_validation_skips_round_one_prepared_values() {
+    if ENABLE_TEST_LOGGING {
+        let env_filter = EnvFilter::new("debug");
+        let _ = tracing_subscriber::fmt()
+            .compact()
+            .with_env_filter(env_filter)
+            .try_init();
+    }
+
+    use ssv_types::{
+        consensus::QbftMessage,
+        message::{MsgType, RSA_SIGNATURE_SIZE, SSVMessage, SignedSSVMessage},
+    };
+
+    // Create QBFT instance
+    let config = ConfigBuilder::<DefaultLeaderFunction>::new(
+        1.into(),
+        InstanceHeight::default(),
+        (1..4).map(OperatorId::from).collect(), // 3 nodes, quorum = 3
+    )
+    .with_operator_id(OperatorId::from(1))
+    .build()
+    .expect("config should be valid");
+
+    let test_data = TestData(123);
+    let qbft_instance = Qbft::new(
+        config,
+        test_data.clone(),
+        Box::new(NoDataValidation),
+        MessageId::from([0; 56]),
+        |_| {},
+    );
+
+    // Create a MALICIOUS round change message:
+    // - Claims to have prepared a value in round 1 (data_round = 1)
+    // - But provides NO prepare justifications (empty prepare_justification)
+    // This should be REJECTED but the bug allows it through
+    let malicious_round_change = QbftMessage {
+        qbft_message_type: QbftMessageType::RoundChange,
+        height: 0,
+        round: 2,
+        identifier: [0; 56].to_vec().into(),
+        root: test_data.hash(),
+        data_round: 1, // Claims preparation in round 1 - this is the bug trigger!
+        round_change_justification: vec![],
+        prepare_justification: vec![], // INVALID: No justifications for claimed preparation!
+    };
+
+    // Create signed round change messages (need quorum of 3 for 3-node committee)
+    let mut signed_round_changes = vec![];
+    for operator_id in [1, 2, 3] {
+        // Create the SSVMessage properly
+        let ssv_message = SSVMessage::new(
+            MsgType::SSVConsensusMsgType,
+            MessageId::from([0; 56]),
+            malicious_round_change.as_ssz_bytes(),
+        )
+        .expect("should create SSVMessage");
+
+        let signed_rc = SignedSSVMessage::new(
+            vec![vec![0; RSA_SIGNATURE_SIZE]],
+            vec![OperatorId::from(operator_id)],
+            ssv_message,
+            vec![], // no full_data for round change
+        )
+        .expect("should create signed message");
+        signed_round_changes.push(signed_rc);
+    }
+
+    // Create proposal that includes these invalid round changes
+    let proposal = QbftMessage {
+        qbft_message_type: QbftMessageType::Proposal,
+        height: 0,
+        round: 2,
+        identifier: [0; 56].to_vec().into(),
+        root: test_data.hash(),
+        data_round: 1, // Proposing the "prepared" value from round 1
+        round_change_justification: signed_round_changes,
+        prepare_justification: vec![], // Proposals don't need prepare justifications
+    };
+
+    // Create the SSVMessage for the proposal
+    let proposal_ssv_message = SSVMessage::new(
+        MsgType::SSVConsensusMsgType,
+        MessageId::from([0; 56]),
+        proposal.as_ssz_bytes(),
+    )
+    .expect("should create proposal SSVMessage");
+
+    let signed_proposal = SignedSSVMessage::new(
+        vec![vec![0; RSA_SIGNATURE_SIZE]],
+        vec![OperatorId::from(2)], // From operator 2 (leader for round 2)
+        proposal_ssv_message,
+        test_data.as_ssz_bytes(), // full_data for proposal
+    )
+    .expect("should create signed proposal");
+
+    let wrapped_proposal = WrappedQbftMessage {
+        signed_message: signed_proposal,
+        qbft_message: proposal,
+    };
+
+    // Call the actual buggy validation function
+    let validation_result = qbft_instance.validate_proposal_justifications(&wrapped_proposal);
+
+    // The validation should REJECT this proposal because:
+    // - Round change messages claim data_round=1 (prepared in round 1)
+    // - But they provide NO prepare justifications to prove this claim
+
+    println!(
+        "Validation result for malicious proposal: {}",
+        validation_result
+    );
+    println!("This proposal should be REJECTED because round change messages");
+    println!("claim preparation in round 1 but provide no prepare justifications.");
+
+    // This assertion will FAIL if a buggy code returns true (accepts invalid proposal)
+    assert!(
+        !validation_result,
+        "BUG: validate_justifications() accepted an invalid proposal! \
+         Round change messages claim data_round=1 (prepared in round 1) but provide no \
+         prepare justifications. This should be rejected but the validation logic \
+         incorrectly skips prepare justification checking for round 1 preparations."
+    );
+}

--- a/anchor/common/qbft/src/tests.rs
+++ b/anchor/common/qbft/src/tests.rs
@@ -537,3 +537,192 @@ fn test_round_change_rejects_prepared_round_greater_than_current_round() {
         "BUG: QBFT instance completed after receiving invalid message."
     );
 }
+
+#[test]
+/// Test that proposal validation correctly handles mixed RoundChange messages with different
+/// prepared values This test verifies that only the HIGHEST prepared RoundChange must match the
+/// proposal root, not ALL RoundChanges as the old implementation incorrectly required.
+///
+/// Scenario:
+/// - Node 1: prepared value A in round 1 (data_round=1, root=A)
+/// - Node 2: prepared value B in round 2 (data_round=2, root=B) <- highest prepared
+/// - Node 3: no prepared value (data_round=0)
+/// - Proposal: proposes value B (matching highest prepared)
+///
+/// This should be VALID according to QBFT spec - proposal must use highest prepared value
+fn test_mixed_round_change_values_highest_prepared_wins() {
+    use ssv_types::{
+        consensus::{QbftMessage, QbftMessageType},
+        message::{MsgType, RSA_SIGNATURE_SIZE, SSVMessage, SignedSSVMessage},
+    };
+
+    // Create QBFT instance with 3-node committee
+    let config = ConfigBuilder::<DefaultLeaderFunction>::new(
+        1.into(),
+        InstanceHeight::default(),
+        (1..4).map(OperatorId::from).collect(), // 3 nodes
+    )
+    .with_operator_id(OperatorId::from(1))
+    .build()
+    .expect("config should be valid");
+
+    let test_data = TestData(42);
+    let qbft_instance = Qbft::new(
+        config,
+        test_data.clone(),
+        Box::new(NoDataValidation),
+        MessageId::from([0; 56]),
+        |_| {},
+    );
+
+    // Create two different test data values
+    let test_data_a = TestData(100); // value_A
+    let test_data_b = TestData(200); // value_B
+
+    // Create prepare justifications for value A from round 1
+    let prepare_justifications_a = create_prepare_justifications(1, test_data_a.hash(), &[1, 2, 3]);
+
+    // Create prepare justifications for value B from round 2
+    let prepare_justifications_b = create_prepare_justifications(2, test_data_b.hash(), &[1, 2, 3]);
+
+    // Create RoundChange from Node 1: prepared value A in round 1
+    let rc1_msg = QbftMessage {
+        qbft_message_type: QbftMessageType::RoundChange,
+        height: 0,
+        round: 3, // Current round
+        identifier: [0; 56].to_vec().into(),
+        root: test_data_a.hash(), // Prepared value A
+        data_round: 1,            // Prepared in round 1
+        round_change_justification: prepare_justifications_a,
+        prepare_justification: vec![],
+    };
+
+    let rc1_signed = create_signed_round_change(&rc1_msg, 1);
+
+    // Create RoundChange from Node 2: prepared value B in round 2 (HIGHEST)
+    let rc2_msg = QbftMessage {
+        qbft_message_type: QbftMessageType::RoundChange,
+        height: 0,
+        round: 3, // Current round
+        identifier: [0; 56].to_vec().into(),
+        root: test_data_b.hash(), // Prepared value B
+        data_round: 2,            // Prepared in round 2 <- HIGHEST
+        round_change_justification: prepare_justifications_b.clone(),
+        prepare_justification: vec![],
+    };
+
+    let rc2_signed = create_signed_round_change(&rc2_msg, 2);
+
+    // Create RoundChange from Node 3: no prepared value
+    let rc3_msg = QbftMessage {
+        qbft_message_type: QbftMessageType::RoundChange,
+        height: 0,
+        round: 3, // Current round
+        identifier: [0; 56].to_vec().into(),
+        root: Hash256::default(), // No prepared value
+        data_round: 0,            // No prepared value
+        round_change_justification: vec![],
+        prepare_justification: vec![],
+    };
+
+    let rc3_signed = create_signed_round_change(&rc3_msg, 3);
+
+    // Create proposal that uses value B (from highest prepared RoundChange)
+    let proposal_msg = QbftMessage {
+        qbft_message_type: QbftMessageType::Proposal,
+        height: 0,
+        round: 3,
+        identifier: [0; 56].to_vec().into(),
+        root: test_data_b.hash(), // Proposing value B (matches highest prepared)
+        data_round: 2,            // From round 2 (highest prepared)
+        round_change_justification: vec![rc1_signed, rc2_signed, rc3_signed],
+        prepare_justification: prepare_justifications_b, /* Prepare justifications for value B
+                                                          * from round 2 */
+    };
+
+    let proposal_ssv = SSVMessage::new(
+        MsgType::SSVConsensusMsgType,
+        MessageId::from([0; 56]),
+        proposal_msg.as_ssz_bytes(),
+    )
+    .expect("should create SSVMessage");
+
+    let signed_proposal = SignedSSVMessage::new(
+        vec![vec![0; RSA_SIGNATURE_SIZE]],
+        vec![OperatorId::from(1)], // From leader
+        proposal_ssv,
+        test_data_b.as_ssz_bytes(), // Include full data for value B
+    )
+    .expect("should create signed proposal");
+
+    let wrapped_proposal = WrappedQbftMessage {
+        signed_message: signed_proposal,
+        qbft_message: proposal_msg,
+    };
+
+    // This should be VALID - proposal correctly uses highest prepared value
+    let validation_result = qbft_instance.validate_proposal_justifications(&wrapped_proposal);
+
+    assert!(
+        validation_result,
+        "Proposal validation should succeed when proposal uses highest prepared value. \
+        Node 1 prepared A in round 1, Node 2 prepared B in round 2 (highest), \
+        proposal correctly uses B"
+    );
+}
+
+// Helper function to create prepare justifications for a given round and value
+fn create_prepare_justifications(
+    round: u64,
+    root: Hash256,
+    operator_ids: &[u64],
+) -> Vec<SignedSSVMessage> {
+    operator_ids
+        .iter()
+        .map(|&op_id| {
+            let prepare_msg = QbftMessage {
+                qbft_message_type: QbftMessageType::Prepare,
+                height: 0,
+                round,
+                identifier: [0; 56].to_vec().into(),
+                root,
+                data_round: 0,
+                round_change_justification: vec![],
+                prepare_justification: vec![],
+            };
+
+            let ssv_msg = SSVMessage::new(
+                MsgType::SSVConsensusMsgType,
+                MessageId::from([0; 56]),
+                prepare_msg.as_ssz_bytes(),
+            )
+            .expect("should create SSVMessage");
+
+            SignedSSVMessage::new(
+                vec![vec![0; RSA_SIGNATURE_SIZE]],
+                vec![OperatorId::from(op_id)],
+                ssv_msg,
+                vec![],
+            )
+            .expect("should create signed prepare")
+        })
+        .collect()
+}
+
+// Helper function to create a signed round change message
+fn create_signed_round_change(rc_msg: &QbftMessage, operator_id: u64) -> SignedSSVMessage {
+    let ssv_msg = SSVMessage::new(
+        MsgType::SSVConsensusMsgType,
+        MessageId::from([0; 56]),
+        rc_msg.as_ssz_bytes(),
+    )
+    .expect("should create SSVMessage");
+
+    SignedSSVMessage::new(
+        vec![vec![0; RSA_SIGNATURE_SIZE]],
+        vec![OperatorId::from(operator_id)],
+        ssv_msg,
+        vec![],
+    )
+    .expect("should create signed round change")
+}

--- a/anchor/common/qbft/src/tests.rs
+++ b/anchor/common/qbft/src/tests.rs
@@ -90,10 +90,10 @@ impl TestQBFTCommitteeBuilder {
     {
         if ENABLE_TEST_LOGGING {
             let env_filter = EnvFilter::new("debug");
-            tracing_subscriber::fmt()
+            let _ = tracing_subscriber::fmt()
                 .compact()
                 .with_env_filter(env_filter)
-                .init();
+                .try_init();
         }
         construct_and_run_committee(self.config, data)
     }
@@ -354,5 +354,186 @@ fn test_round_change_validation_skips_round_one_prepared_values() {
          Round change messages claim data_round=1 (prepared in round 1) but provide no \
          prepare justifications. This should be rejected but the validation logic \
          incorrectly skips prepare justification checking for round 1 preparations."
+    );
+}
+
+#[test]
+/// Test that RoundChange messages with prepared_round >= round are properly rejected
+///
+/// The QBFT specification requires that prepared_round (data_round) must be strictly less than
+/// the current round to prevent circular justifications. This test verifies that RoundChange
+/// messages with data_round >= round are correctly rejected by the QBFT instance.
+fn test_round_change_rejects_prepared_round_equal_to_current_round() {
+    if ENABLE_TEST_LOGGING {
+        let env_filter = EnvFilter::new("debug");
+        let _ = tracing_subscriber::fmt()
+            .compact()
+            .with_env_filter(env_filter)
+            .try_init();
+    }
+
+    use ssv_types::{
+        consensus::{QbftMessage, QbftMessageType},
+        message::{MsgType, RSA_SIGNATURE_SIZE, SSVMessage, SignedSSVMessage},
+    };
+
+    // Create QBFT instance with a 3-node committee
+    let config = ConfigBuilder::<DefaultLeaderFunction>::new(
+        1.into(),
+        InstanceHeight::default(),
+        (1..4).map(OperatorId::from).collect(), // 3 nodes
+    )
+    .with_operator_id(OperatorId::from(1))
+    .build()
+    .expect("config should be valid");
+
+    let test_data = TestData(456);
+    let mut qbft_instance = Qbft::new(
+        config,
+        test_data.clone(),
+        Box::new(NoDataValidation),
+        MessageId::from([0; 56]),
+        |_| {},
+    );
+
+    // Create a RoundChange message that violates the spec:
+    // prepared_round (data_round) equals the current round
+    let invalid_round_change = QbftMessage {
+        qbft_message_type: QbftMessageType::RoundChange,
+        height: 0,
+        round: 2, // Current round is 2
+        identifier: [0; 56].to_vec().into(),
+        root: test_data.hash(),
+        data_round: 2, // INVALID: prepared_round == round (should be < round)
+        round_change_justification: vec![],
+        prepare_justification: vec![],
+    };
+
+    // Create the SSVMessage wrapper
+    let ssv_message = SSVMessage::new(
+        MsgType::SSVConsensusMsgType,
+        MessageId::from([0; 56]),
+        invalid_round_change.as_ssz_bytes(),
+    )
+    .expect("should create SSVMessage");
+
+    let signed_round_change = SignedSSVMessage::new(
+        vec![vec![0; RSA_SIGNATURE_SIZE]],
+        vec![OperatorId::from(2)], // From operator 2
+        ssv_message,
+        vec![], // No full_data for round change
+    )
+    .expect("should create signed message");
+
+    let wrapped_msg = WrappedQbftMessage {
+        signed_message: signed_round_change,
+        qbft_message: invalid_round_change,
+    };
+
+    // Process the message - it should be rejected
+    qbft_instance.receive(wrapped_msg);
+
+    // Verify the instance did not process the invalid message
+    // The instance should still be in its initial state (not advanced to round 2)
+    assert_eq!(
+        qbft_instance.current_round,
+        1.into(),
+        "BUG: QBFT instance processed invalid RoundChange message with data_round >= round! \
+         The message should have been rejected according to QBFT spec requirement that \
+         prepared_round < round, but the instance advanced to round 2."
+    );
+
+    // Verify the instance is still waiting (not completed due to invalid message)
+    assert!(
+        qbft_instance.completed.is_none(),
+        "BUG: QBFT instance completed consensus after receiving invalid RoundChange! \
+         The message with data_round >= round should have been rejected."
+    );
+}
+
+#[test]
+/// Test that RoundChange messages with prepared_round > round are also properly rejected
+///
+/// This complements the previous test by checking that data_round > round is also rejected,
+/// ensuring the validation covers the full >= condition.
+fn test_round_change_rejects_prepared_round_greater_than_current_round() {
+    if ENABLE_TEST_LOGGING {
+        let env_filter = EnvFilter::new("debug");
+        let _ = tracing_subscriber::fmt()
+            .compact()
+            .with_env_filter(env_filter)
+            .try_init();
+    }
+
+    use ssv_types::{
+        consensus::{QbftMessage, QbftMessageType},
+        message::{MsgType, RSA_SIGNATURE_SIZE, SSVMessage, SignedSSVMessage},
+    };
+
+    // Create QBFT instance
+    let config = ConfigBuilder::<DefaultLeaderFunction>::new(
+        1.into(),
+        InstanceHeight::default(),
+        (1..4).map(OperatorId::from).collect(),
+    )
+    .with_operator_id(OperatorId::from(1))
+    .build()
+    .expect("config should be valid");
+
+    let test_data = TestData(789);
+    let mut qbft_instance = Qbft::new(
+        config,
+        test_data.clone(),
+        Box::new(NoDataValidation),
+        MessageId::from([0; 56]),
+        |_| {},
+    );
+
+    // Create RoundChange message with data_round > round (also invalid)
+    let invalid_round_change = QbftMessage {
+        qbft_message_type: QbftMessageType::RoundChange,
+        height: 0,
+        round: 2, // Current round is 2
+        identifier: [0; 56].to_vec().into(),
+        root: test_data.hash(),
+        data_round: 3, // INVALID: prepared_round > round (should be < round)
+        round_change_justification: vec![],
+        prepare_justification: vec![],
+    };
+
+    let ssv_message = SSVMessage::new(
+        MsgType::SSVConsensusMsgType,
+        MessageId::from([0; 56]),
+        invalid_round_change.as_ssz_bytes(),
+    )
+    .expect("should create SSVMessage");
+
+    let signed_round_change = SignedSSVMessage::new(
+        vec![vec![0; RSA_SIGNATURE_SIZE]],
+        vec![OperatorId::from(3)],
+        ssv_message,
+        vec![],
+    )
+    .expect("should create signed message");
+
+    let wrapped_msg = WrappedQbftMessage {
+        signed_message: signed_round_change,
+        qbft_message: invalid_round_change,
+    };
+
+    // Process the invalid message
+    qbft_instance.receive(wrapped_msg);
+
+    // Verify rejection - should remain in initial round
+    assert_eq!(
+        qbft_instance.current_round,
+        1.into(),
+        "BUG: QBFT instance processed invalid RoundChange message with data_round > round! \
+         The message should have been rejected."
+    );
+
+    assert!(
+        qbft_instance.completed.is_none(),
+        "BUG: QBFT instance completed after receiving invalid message."
     );
 }

--- a/anchor/common/ssv_types/src/cluster.rs
+++ b/anchor/common/ssv_types/src/cluster.rs
@@ -1,6 +1,6 @@
 use std::fmt::Debug;
 
-use derive_more::{Deref, From};
+use derive_more::{Deref, Display, From};
 use indexmap::IndexSet;
 use ssz_derive::{Decode, Encode};
 use types::{Address, Graffiti, PublicKeyBytes};
@@ -66,7 +66,9 @@ pub struct ClusterMember {
 }
 
 /// Index of the validator in the validator registry.
-#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Hash, From, Deref, Encode, Decode)]
+#[derive(
+    Clone, Copy, Display, Debug, Default, Eq, PartialEq, Hash, From, Deref, Encode, Decode,
+)]
 #[ssz(struct_behaviour = "transparent")]
 pub struct ValidatorIndex(pub usize);
 

--- a/anchor/common/ssv_types/src/round.rs
+++ b/anchor/common/ssv_types/src/round.rs
@@ -24,10 +24,23 @@ impl From<Round> for u64 {
 }
 
 impl Add<u64> for Round {
-    type Output = Round;
+    type Output = Option<Round>;
 
-    fn add(self, rhs: u64) -> Round {
-        Round(NonZeroUsize::new(self.0.get() + rhs as usize).expect("round == 0"))
+    /// Adds a u64 to a Round using checked arithmetic to prevent overflow.
+    ///
+    /// Returns None if:
+    /// - The addition would overflow (self + rhs > usize::MAX)
+    /// - The result would be zero (handled by NonZeroUsize::new)
+    ///
+    /// This prevents security vulnerabilities where overflow could cause:
+    /// - Message validation to accept messages from any round
+    /// - Message container iteration to process all rounds instead of just future ones
+    fn add(self, rhs: u64) -> Option<Round> {
+        self.0
+            .get()
+            .checked_add(rhs as usize)
+            .and_then(NonZeroUsize::new)
+            .map(Round)
     }
 }
 

--- a/anchor/eth/src/event_processor.rs
+++ b/anchor/eth/src/event_processor.rs
@@ -138,7 +138,7 @@ impl EventProcessor {
                 if live {
                     warn!(tx_hash, "Malformed event: {e}");
                 } else {
-                    debug!(tx_hash, "Malformed event: {e}");
+                    trace!(tx_hash, "Malformed event: {e}");
                 }
                 continue;
             }

--- a/anchor/eth/src/event_processor.rs
+++ b/anchor/eth/src/event_processor.rs
@@ -120,8 +120,8 @@ impl EventProcessor {
                     self.process_fee_recipient_updated(log, &tx)
                 }
 
-                SSVContract::ValidatorExited::SIGNATURE_HASH if live => {
-                    self.process_validator_exited(log)
+                SSVContract::ValidatorExited::SIGNATURE_HASH => {
+                    self.process_validator_exited(log, live)
                 }
                 _ => {
                     debug!(?topic0, "Unknown event signature, skipping");
@@ -582,7 +582,7 @@ impl EventProcessor {
     }
 
     // A validator has exited the beacon chain
-    fn process_validator_exited(&self, log: &Log) -> Result<(), ExecutionError> {
+    fn process_validator_exited(&self, log: &Log, live: bool) -> Result<(), ExecutionError> {
         // In KeySplit mode, we don't need to process validator exits
         let Mode::Node { exit_tx, .. } = &self.mode else {
             return Ok(());
@@ -615,6 +615,18 @@ impl EventProcessor {
         };
 
         let is_our_validator = self.is_our_validator(&validator_pubkey);
+
+        if !live {
+            if is_our_validator {
+                debug!(
+                    %validator_index,
+                    "Ignoring historic validator exit for validator assigned to us"
+                );
+            } else {
+                trace!(%validator_index, "Ignoring historic validator exit");
+            }
+            return Ok(());
+        }
 
         // Send to exit processor instead of handling in-place
         let request = ExitRequest {

--- a/anchor/eth/src/event_processor.rs
+++ b/anchor/eth/src/event_processor.rs
@@ -131,10 +131,14 @@ impl EventProcessor {
 
             // Handle any errors from the event processing
             if let Err(e) = result {
+                let tx_hash = log
+                    .transaction_hash
+                    .map(|hash| hash.to_string())
+                    .unwrap_or_else(|| "unknown".to_string());
                 if live {
-                    warn!("Malformed event: {e}");
+                    warn!(tx_hash, "Malformed event: {e}");
                 } else {
-                    debug!("Malformed event: {e}");
+                    debug!(tx_hash, "Malformed event: {e}");
                 }
                 continue;
             }

--- a/anchor/eth/src/event_processor.rs
+++ b/anchor/eth/src/event_processor.rs
@@ -67,6 +67,10 @@ impl EventProcessor {
         debug!(logs_count = logs.len(), "Starting log processing");
         let timer = metrics::start_timer(&metrics::EXECUTION_LOG_PROCESSING_TIME);
 
+        // Counters for summary logging
+        let mut validators_added = 0;
+        let mut validators_removed = 0;
+
         // Open a transaction for the log batch.
         let mut conn = self
             .db
@@ -96,13 +100,13 @@ impl EventProcessor {
                     self.process_operator_removed(log, &tx)
                 }
 
-                SSVContract::ValidatorAdded::SIGNATURE_HASH => {
-                    self.process_validator_added(log, &tx)
-                }
+                SSVContract::ValidatorAdded::SIGNATURE_HASH => self
+                    .process_validator_added(log, &tx)
+                    .inspect(|_| validators_added += 1),
 
-                SSVContract::ValidatorRemoved::SIGNATURE_HASH => {
-                    self.process_validator_removed(log, &tx)
-                }
+                SSVContract::ValidatorRemoved::SIGNATURE_HASH => self
+                    .process_validator_removed(log, &tx)
+                    .inspect(|_| validators_removed += 1),
 
                 SSVContract::ClusterLiquidated::SIGNATURE_HASH => {
                     self.process_cluster_liquidated(log, &tx)
@@ -144,6 +148,14 @@ impl EventProcessor {
         // Commit everything!
         tx.commit()
             .map_err(|e| ExecutionError::Database(e.to_string()))?;
+
+        // Log summaries for validator operations
+        if validators_added > 0 {
+            debug!(count = validators_added, "Added validators");
+        }
+        if validators_removed > 0 {
+            debug!(count = validators_removed, "Removed validators");
+        }
 
         debug!(logs_count = logs.len(), "Completed processing logs");
         Ok(())
@@ -346,7 +358,7 @@ impl EventProcessor {
             error!(?err, "Failed to send validator to index lookup");
         }
 
-        debug!(
+        trace!(
             cluster_id = ?cluster_id,
             validator_pubkey = %validator_pubkey,
             "Successfully added validator"
@@ -446,7 +458,7 @@ impl EventProcessor {
                 ExecutionError::Database(format!("Failed to validator cluster: {e}"))
             })?;
 
-        debug!(
+        trace!(
             cluster_id = ?cluster_id,
             validator_pubkey = %validator_pubkey,
             "Successfully removed validator and cluster"

--- a/anchor/eth/src/index_sync.rs
+++ b/anchor/eth/src/index_sync.rs
@@ -11,7 +11,7 @@ use tokio::{
     sync::mpsc::{UnboundedReceiver, UnboundedSender, unbounded_channel},
     time::sleep,
 };
-use tracing::{debug, error, info, warn};
+use tracing::{debug, error, info, trace, warn};
 use types::PublicKeyBytes;
 
 pub type Tx = UnboundedSender<PublicKeyBytes>;
@@ -72,7 +72,7 @@ async fn validator_index_syncer(
             }
         }
 
-        debug!(len = batch.len(), "Batched validators from queue");
+        trace!(len = batch.len(), "Batched validators from queue");
 
         // next, fill up the rest of the batch with older validators that are unknown from the
         // database
@@ -101,7 +101,7 @@ async fn validator_index_syncer(
         }
 
         if !batch.is_empty() {
-            debug!(len = batch.len(), "Sending request");
+            trace!(len = batch.len(), "Sending request");
             let validators = nodes
                 .first_success(move |client| {
                     let batch = batch
@@ -126,7 +126,7 @@ async fn validator_index_syncer(
                 .flat_map(|v| v.data)
                 .map(|v| (v.validator.pubkey, ValidatorIndex(v.index as usize)))
                 .collect::<HashMap<_, _>>();
-            debug!(len = map.len(), "Got validators from BN");
+            trace!(len = map.len(), "Got validators from BN");
             if let Err(err) = db.set_validator_indices(map) {
                 error!(?err, "Failed to update validator indices");
             }

--- a/anchor/eth/src/util.rs
+++ b/anchor/eth/src/util.rs
@@ -11,7 +11,7 @@ use reqwest::Client;
 use sensitive_url::SensitiveUrl;
 use ssv_types::{ClusterId, ENCRYPTED_KEY_LENGTH, OperatorId, Share, ValidatorMetadata};
 use tower::ServiceBuilder;
-use tracing::{debug, error, trace};
+use tracing::{debug, trace};
 use types::{Graffiti, PublicKeyBytes, Signature};
 
 use crate::{error::ExecutionError, sync::MAX_OPERATORS};
@@ -168,7 +168,6 @@ pub fn validate_operators(
         .iter()
         .any(|id| !network_state.operator_exists(id))
     {
-        error!(cluster_id = ?cluster_id, "One or more operators do not exist");
         return Err(ExecutionError::Database(
             "One or more operators do not exist".to_string(),
         ));

--- a/anchor/logging/src/tracing_libp2p_discv5_layer.rs
+++ b/anchor/logging/src/tracing_libp2p_discv5_layer.rs
@@ -38,7 +38,13 @@ where
         };
 
         event.record(&mut visitor);
-        let message = format!("{} {} {}\n", timestamp, log_level, visitor.message);
+        let message = format!(
+            "{} {} [{}] {}\n",
+            timestamp,
+            log_level,
+            meta.target(),
+            visitor.message
+        );
 
         if let Err(e) = writer.write_all(message.as_bytes()) {
             eprintln!("Failed to write log: {e}");

--- a/anchor/message_sender/src/network.rs
+++ b/anchor/message_sender/src/network.rs
@@ -14,7 +14,7 @@ use ssv_types::{CommitteeId, consensus::UnsignedSSVMessage, message::SignedSSVMe
 use ssz::Encode;
 use subnet_service::SubnetId;
 use tokio::sync::{mpsc, mpsc::error::TrySendError, watch};
-use tracing::{debug, error, warn};
+use tracing::{debug, error, trace, warn};
 
 use crate::{Error, MessageCallback, MessageSender};
 
@@ -146,7 +146,7 @@ impl<S: SlotClock + 'static, D: DutiesProvider> NetworkMessageSender<S, D> {
 
         let subnet = SubnetId::from_committee(committee_id, self.subnet_count);
         match self.network_tx.try_send((subnet, message_bytes)) {
-            Ok(_) => debug!(?subnet, "Successfully sent message to network"),
+            Ok(_) => trace!(?subnet, "Successfully sent message to network"),
             Err(TrySendError::Closed(_)) => warn!("Network queue closed (shutting down?)"),
             Err(TrySendError::Full(_)) => warn!("Network queue full, unable to send message!"),
         }

--- a/anchor/message_validator/src/consensus_message.rs
+++ b/anchor/message_validator/src/consensus_message.rs
@@ -299,7 +299,8 @@ fn validate_round_in_allowed_spread(
     };
 
     let lowest_allowed = FIRST_ROUND;
-    let highest_allowed = estimated_round + MAX_ALLOWED_ROUNDS_FUTURE;
+    let highest_allowed =
+        (estimated_round + MAX_ALLOWED_ROUNDS_FUTURE).ok_or(ValidationFailure::RoundOverflow)?;
 
     // Check if the round is within allowed spread
     if consensus_message.round < lowest_allowed || consensus_message.round > highest_allowed.into()

--- a/anchor/message_validator/src/consensus_message.rs
+++ b/anchor/message_validator/src/consensus_message.rs
@@ -1,6 +1,7 @@
-use std::{convert::Into, sync::Arc, time::Duration};
+use std::{collections::HashMap, convert::Into, sync::Arc, time::Duration};
 
 use duties_tracker::DutiesProvider;
+use openssl::{pkey::Public, rsa::Rsa};
 use slot_clock::SlotClock;
 use ssv_types::{
     CommitteeInfo, IndexSet, OperatorId, Round, Slot, VariableList,
@@ -34,6 +35,7 @@ pub(crate) fn validate_consensus_message(
         validation_context.signed_ssv_message,
         &consensus_message,
         validation_context.committee_info,
+        validation_context.operator_pub_keys,
     )?;
 
     validate_qbft_logic(&validation_context, &consensus_message, duty_state)?;
@@ -47,7 +49,7 @@ pub(crate) fn validate_consensus_message(
 
     verify_message_signatures(
         validation_context.signed_ssv_message,
-        validation_context.operators_pk,
+        validation_context.operator_pub_keys,
     )?;
 
     duty_state.update_for_consensus_message(
@@ -64,6 +66,7 @@ pub(crate) fn validate_consensus_message_semantics(
     signed_ssv_message: &SignedSSVMessage,
     consensus_message: &QbftMessage,
     committee_info: &CommitteeInfo,
+    operator_pub_keys: &HashMap<OperatorId, Rsa<Public>>,
 ) -> Result<(), ValidationFailure> {
     let signers = signed_ssv_message.operator_ids().len();
 
@@ -139,13 +142,14 @@ pub(crate) fn validate_consensus_message_semantics(
         });
     }
 
-    validate_justifications(consensus_message)?;
+    validate_justifications(consensus_message, operator_pub_keys)?;
 
     Ok(())
 }
 
 pub(crate) fn validate_justifications(
     consensus_message: &QbftMessage,
+    operator_pub_keys: &HashMap<OperatorId, Rsa<Public>>,
 ) -> Result<(), ValidationFailure> {
     // Rule: Can only exist for Proposal messages
     let prepare_justifications = &consensus_message.prepare_justification;
@@ -163,6 +167,13 @@ pub(crate) fn validate_justifications(
     {
         return Err(ValidationFailure::UnexpectedRoundChangeJustifications);
     }
+
+    prepare_justifications
+        .iter()
+        .chain(round_change_justifications.iter())
+        .try_for_each(|signed_message| {
+            verify_message_signatures(signed_message, operator_pub_keys)
+        })?;
 
     Ok(())
 }
@@ -426,7 +437,7 @@ mod tests {
         LATE_MESSAGE_MARGIN, LATE_SLOT_ALLOWANCE, ValidatedSSVMessage, duty_limit,
         tests::{
             FOUR_NODE_COMMITTEE, SINGLE_NODE_COMMITTEE, create_committee_info,
-            generate_random_rsa_public_keys,
+            create_operator_pub_keys, generate_random_rsa_public_keys,
         },
         validate_ssv_message,
     };
@@ -468,8 +479,13 @@ mod tests {
     #[test]
     fn test_validate_ssv_message_consensus_success() {
         // Generate a key pair
-        let (private_key, public_key) = generate_test_key_pair();
+        let (_private_key, public_key) = generate_test_key_pair();
+        let (private_key2, public_key2) = generate_test_key_pair();
         let committee_info = create_committee_info(FOUR_NODE_COMMITTEE);
+        let map = create_operator_pub_keys(
+            committee_info.committee_members.clone(),
+            vec![public_key, public_key2],
+        );
 
         let qbft_message =
             QbftMessageBuilder::new(Role::Committee, QbftMessageType::Proposal).build();
@@ -477,7 +493,7 @@ mod tests {
             qbft_message,
             vec![OperatorId(2)],
             vec![],
-            vec![private_key],
+            vec![private_key2],
         );
 
         let now = SystemTime::now();
@@ -495,11 +511,11 @@ mod tests {
             committee_info: &committee_info,
             role: Role::Committee,
             received_at: now + slot_duration,
-            operators_pk: &[public_key],
             slots_per_epoch: 32,
             epochs_per_sync_committee_period: 256,
             sync_committee_size: 512,
             slot_clock,
+            operator_pub_keys: &map,
         };
 
         let expected_duty_count = 5;
@@ -554,11 +570,11 @@ mod tests {
             committee_info: &committee_info,
             role: Role::Committee,
             received_at: now,
-            operators_pk: &[],
             slots_per_epoch: 32,
             epochs_per_sync_committee_period: 256,
             sync_committee_size: 512,
             slot_clock,
+            operator_pub_keys: &HashMap::new(),
         };
 
         let result = validate_ssv_message(
@@ -608,11 +624,11 @@ mod tests {
                 .unwrap()
                 .checked_add(LATE_MESSAGE_MARGIN)
                 .unwrap(),
-            operators_pk: &[],
             slots_per_epoch: 32,
             epochs_per_sync_committee_period: 256,
             sync_committee_size: 512,
             slot_clock,
+            operator_pub_keys: &HashMap::new(),
         };
 
         let result = validate_ssv_message(
@@ -647,12 +663,14 @@ mod tests {
         )
         .expect("SignedSSVMessage should be created");
 
+        let public_keys = generate_random_rsa_public_keys(signed_msg.operator_ids().len());
+        let map = create_operator_pub_keys(committee_info.committee_members.clone(), public_keys);
+
         let validation_context = ValidationContext {
             signed_ssv_message: &signed_msg,
             committee_info: &committee_info,
             role: Role::Committee,
             received_at: SystemTime::now(),
-            operators_pk: &generate_random_rsa_public_keys(signed_msg.operator_ids().len()),
             slots_per_epoch: 32,
             epochs_per_sync_committee_period: 256,
             sync_committee_size: 512,
@@ -661,6 +679,7 @@ mod tests {
                 SystemTime::now().duration_since(UNIX_EPOCH).unwrap(),
                 Duration::from_secs(1),
             ),
+            operator_pub_keys: &map,
         };
 
         let result = validate_ssv_message(
@@ -695,8 +714,10 @@ mod tests {
             vec![],
         );
 
+        let map = create_operator_pub_keys(committee_info.committee_members.clone(), vec![]);
+
         let result =
-            validate_consensus_message_semantics(&signed_msg, &qbft_message, &committee_info);
+            validate_consensus_message_semantics(&signed_msg, &qbft_message, &committee_info, &map);
 
         assert!(
             result.is_ok(),
@@ -715,8 +736,10 @@ mod tests {
         let signed_msg =
             create_signed_consensus_message(qbft_message.clone(), signers.clone(), vec![], vec![]);
 
+        let map = create_operator_pub_keys(committee_info.committee_members.clone(), vec![]);
+
         let result =
-            validate_consensus_message_semantics(&signed_msg, &qbft_message, &committee_info);
+            validate_consensus_message_semantics(&signed_msg, &qbft_message, &committee_info, &map);
 
         assert_validation_error(
             result,
@@ -736,8 +759,10 @@ mod tests {
         let signed_msg =
             create_signed_consensus_message(qbft_message.clone(), signers.clone(), vec![], vec![]);
 
+        let map = create_operator_pub_keys(committee_info.committee_members.clone(), vec![]);
+
         let result =
-            validate_consensus_message_semantics(&signed_msg, &qbft_message, &committee_info);
+            validate_consensus_message_semantics(&signed_msg, &qbft_message, &committee_info, &map);
 
         assert_validation_error(
             result,
@@ -760,8 +785,10 @@ mod tests {
             vec![],
         );
 
+        let map = create_operator_pub_keys(committee_info.committee_members.clone(), vec![]);
+
         let result =
-            validate_consensus_message_semantics(&signed_msg, &qbft_message, &committee_info);
+            validate_consensus_message_semantics(&signed_msg, &qbft_message, &committee_info, &map);
 
         assert_validation_error(
             result,
@@ -784,8 +811,10 @@ mod tests {
             vec![],
         );
 
+        let map = create_operator_pub_keys(committee_info.committee_members.clone(), vec![]);
+
         let result =
-            validate_consensus_message_semantics(&signed_msg, &qbft_message, &committee_info);
+            validate_consensus_message_semantics(&signed_msg, &qbft_message, &committee_info, &map);
 
         assert_validation_error(
             result,
@@ -808,8 +837,10 @@ mod tests {
             vec![],
         );
 
+        let map = create_operator_pub_keys(committee_info.committee_members.clone(), vec![]);
+
         let result =
-            validate_consensus_message_semantics(&signed_msg, &qbft_message, &committee_info);
+            validate_consensus_message_semantics(&signed_msg, &qbft_message, &committee_info, &map);
 
         assert_validation_error(
             result,
@@ -848,7 +879,10 @@ mod tests {
         )
         .expect("SignedSSVMessage should be created");
 
-        let result = validate_consensus_message_semantics(&signed_msg, &qbft_msg, &committee_info);
+        let map = create_operator_pub_keys(committee_info.committee_members.clone(), vec![]);
+
+        let result =
+            validate_consensus_message_semantics(&signed_msg, &qbft_msg, &committee_info, &map);
 
         assert_validation_error(
             result,
@@ -884,8 +918,10 @@ mod tests {
         )
         .expect("SignedSSVMessage should be created");
 
+        let map = create_operator_pub_keys(committee_info.committee_members.clone(), vec![]);
+
         let result =
-            validate_consensus_message_semantics(&signed_msg, &qbft_message, &committee_info);
+            validate_consensus_message_semantics(&signed_msg, &qbft_message, &committee_info, &map);
 
         assert_validation_error(
             result,
@@ -915,8 +951,10 @@ mod tests {
             vec![],
         );
 
+        let map = create_operator_pub_keys(committee_info.committee_members.clone(), vec![]);
+
         let result =
-            validate_consensus_message_semantics(&signed_msg, &qbft_message, &committee_info);
+            validate_consensus_message_semantics(&signed_msg, &qbft_message, &committee_info, &map);
 
         assert_validation_error(
             result,
@@ -946,8 +984,10 @@ mod tests {
             vec![],
         );
 
+        let map = create_operator_pub_keys(committee_info.committee_members.clone(), vec![]);
+
         let result =
-            validate_consensus_message_semantics(&signed_msg, &qbft_message, &committee_info);
+            validate_consensus_message_semantics(&signed_msg, &qbft_message, &committee_info, &map);
 
         assert_validation_error(
             result,
@@ -979,8 +1019,10 @@ mod tests {
             vec![],
         );
 
+        let map = create_operator_pub_keys(committee_info.committee_members.clone(), vec![]);
+
         let result =
-            validate_consensus_message_semantics(&signed_msg, &qbft_message, &committee_info);
+            validate_consensus_message_semantics(&signed_msg, &qbft_message, &committee_info, &map);
 
         assert_validation_error(
             result,
@@ -1010,8 +1052,10 @@ mod tests {
         let signed_msg =
             create_signed_consensus_message(qbft_message.clone(), signers, full_data, vec![]);
 
+        let map = create_operator_pub_keys(committee_info.committee_members.clone(), vec![]);
+
         let result =
-            validate_consensus_message_semantics(&signed_msg, &qbft_message, &committee_info);
+            validate_consensus_message_semantics(&signed_msg, &qbft_message, &committee_info, &map);
 
         assert!(
             result.is_ok(),
@@ -1148,8 +1192,12 @@ mod tests {
             SignedSSVMessage::new(vec![padded_signature], vec![OperatorId(1)], ssv_msg, vec![])
                 .expect("SignedSSVMessage should be created");
 
+        let mut committee = IndexSet::new();
+        committee.insert(OperatorId(1));
+        let map = create_operator_pub_keys(committee, vec![public_key]);
+
         // Verify signatures
-        let result = verify_message_signatures(&signed_msg, &[public_key]);
+        let result = verify_message_signatures(&signed_msg, &map);
         assert!(result.is_ok(), "Expected successful signature verification");
     }
 
@@ -1167,7 +1215,12 @@ mod tests {
         // Provide only one key when we have two signatures
         let rsa_keys = generate_random_rsa_public_keys(1);
 
-        let result = verify_message_signatures(&signed_msg, &rsa_keys);
+        let mut committee = IndexSet::new();
+        committee.insert(OperatorId(1));
+        committee.insert(OperatorId(2));
+        let map = create_operator_pub_keys(committee, rsa_keys);
+
+        let result = verify_message_signatures(&signed_msg, &map);
 
         assert_validation_error(
             result,
@@ -1207,8 +1260,12 @@ mod tests {
         )
         .expect("SignedSSVMessage should be created");
 
+        let mut committee = IndexSet::new();
+        committee.insert(OperatorId(1));
+        let map = create_operator_pub_keys(committee, vec![public_key]);
+
         // Verify should fail
-        let result = verify_message_signatures(&signed_msg, &[public_key]);
+        let result = verify_message_signatures(&signed_msg, &map);
 
         assert!(result.is_err(), "Expected signature verification to fail");
         assert_validation_error(
@@ -1240,7 +1297,11 @@ mod tests {
         )
         .expect("Failed to create invalid key");
 
-        let result = verify_message_signatures(&signed_msg, &[invalid_key]);
+        let mut committee = IndexSet::new();
+        committee.insert(OperatorId(1));
+        let map = create_operator_pub_keys(committee, vec![invalid_key]);
+
+        let result = verify_message_signatures(&signed_msg, &map);
 
         assert!(result.is_err(), "Expected PKey creation to fail");
     }
@@ -1287,17 +1348,19 @@ mod tests {
             voluntary_exit_duty_count: expected_duty_count,
         });
 
+        let map = create_operator_pub_keys(committee_info.committee_members.clone(), vec![]);
+
         // Create the validation context with voluntary exit role
         let validation_context = ValidationContext {
             signed_ssv_message: &signed_msg,
             committee_info: &committee_info,
             role: Role::VoluntaryExit,
             received_at: now,
-            operators_pk: &[],
             slots_per_epoch: 32,
             epochs_per_sync_committee_period: 256,
             sync_committee_size: 512,
             slot_clock: slot_clock.clone(),
+            operator_pub_keys: &map,
         };
 
         let slot = slot_clock.now().unwrap();

--- a/anchor/message_validator/src/lib.rs
+++ b/anchor/message_validator/src/lib.rs
@@ -168,6 +168,7 @@ pub enum ValidationFailure {
     FullDataNotInConsensusMessage,
     TripleValidatorIndexInPartialSignatures,
     ZeroRound,
+    RoundOverflow,
     DuplicatedMessage {
         got: String,
     }, // Updated to include context
@@ -214,6 +215,7 @@ impl From<&ValidationFailure> for MessageAcceptance {
             | ValidationFailure::IncorrectTopic
             | ValidationFailure::NonExistentCommitteeID
             | ValidationFailure::RoundTooHigh
+            | ValidationFailure::RoundOverflow
             | ValidationFailure::ValidatorIndexMismatch
             | ValidationFailure::TooManyDutiesPerEpoch
             | ValidationFailure::NoDuty

--- a/anchor/message_validator/src/lib.rs
+++ b/anchor/message_validator/src/lib.rs
@@ -4,6 +4,7 @@ mod message_counts;
 mod partial_signature;
 
 use std::{
+    collections::HashMap,
     sync::Arc,
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
@@ -22,7 +23,7 @@ use safe_arith::SafeArith;
 use sha2::{Digest, Sha256};
 use slot_clock::SlotClock;
 use ssv_types::{
-    CommitteeInfo, OperatorId, ValidatorIndex,
+    CommitteeInfo, IndexSet, OperatorId, ValidatorIndex,
     consensus::QbftMessage,
     message::{MsgType, SignedSSVMessage},
     msgid::{DutyExecutor, MessageId, Role},
@@ -259,11 +260,11 @@ struct ValidationContext<'a, S> {
     pub role: Role, // Small value type can remain owned
     pub committee_info: &'a CommitteeInfo,
     pub received_at: SystemTime, // Small value type
-    pub operators_pk: &'a [Rsa<Public>],
     pub slots_per_epoch: u64,
     pub epochs_per_sync_committee_period: u64,
     pub sync_committee_size: usize,
     pub slot_clock: S,
+    pub operator_pub_keys: &'a HashMap<OperatorId, Rsa<Public>>,
 }
 
 pub struct Validator<S: SlotClock, D: DutiesProvider> {
@@ -352,7 +353,9 @@ impl<S: SlotClock + 'static, D: DutiesProvider> Validator<S, D> {
                     .ok_or(ValidationFailure::UnknownValidator)?
             }
         };
-        let operators_pks = get_operator_pks(&network_state, signed_ssv_message.operator_ids())?;
+        let operator_pub_keys =
+            &get_operator_pub_keys(&network_state, &committee_info.committee_members)?;
+
         drop(network_state);
 
         let mut duty_state = self.get_duty_state(ssv_message.msg_id(), self.slots_per_epoch);
@@ -362,11 +365,11 @@ impl<S: SlotClock + 'static, D: DutiesProvider> Validator<S, D> {
             role,
             committee_info: &committee_info,
             received_at: SystemTime::now(),
-            operators_pk: &operators_pks,
             slots_per_epoch: self.slots_per_epoch,
             epochs_per_sync_committee_period: self.epochs_per_sync_committee_period,
             sync_committee_size: self.sync_committee_size,
             slot_clock: self.slot_clock.clone(),
+            operator_pub_keys,
         };
 
         validate_ssv_message(
@@ -481,9 +484,15 @@ fn verify_message_signature(
 /// Verifies all signatures in a signed SSV message
 fn verify_message_signatures(
     signed_message: &SignedSSVMessage,
-    operators_pks: &[Rsa<Public>],
+    operator_pub_keys: &HashMap<OperatorId, Rsa<Public>>,
 ) -> Result<(), ValidationFailure> {
     let signatures = signed_message.signatures();
+
+    let operators_pks = signed_message
+        .operator_ids()
+        .iter()
+        .filter_map(|operator_id| operator_pub_keys.get(operator_id))
+        .collect::<Vec<&Rsa<Public>>>();
 
     // Basic validation for signature/operator count matching
     if signatures.len() != operators_pks.len() {
@@ -755,19 +764,20 @@ pub(crate) fn compute_quorum_size(committee_size: usize) -> usize {
     f * 2 + 1
 }
 
-fn get_operator_pks(
+fn get_operator_pub_keys(
     network_state: &NetworkState,
-    operator_ids: &[OperatorId],
-) -> Result<Vec<Rsa<Public>>, ValidationFailure> {
+    operator_ids: &IndexSet<OperatorId>,
+) -> Result<HashMap<OperatorId, Rsa<Public>>, ValidationFailure> {
     operator_ids
         .iter()
-        .map(|o_id| {
-            network_state
-                .get_operator(o_id)
-                .ok_or(ValidationFailure::OperatorNotFound { operator_id: *o_id })
-                .map(|operator| operator.rsa_pubkey)
+        .map(|id| {
+            let operator = network_state
+                .get_operator(id)
+                .ok_or(ValidationFailure::OperatorNotFound { operator_id: *id })
+                .map(|operator| operator.rsa_pubkey)?;
+            Ok((*id, operator))
         })
-        .collect() // This will combine all the Results into a single Result<Vec<>>
+        .collect()
 }
 
 // # TODO centralize this and the one in the qbft crate
@@ -784,6 +794,8 @@ pub(crate) fn hash_data(full_data: &[u8]) -> [u8; 32] {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
+
     use bls::{Hash256, PublicKeyBytes};
     use duties_tracker::DutiesProvider;
     use openssl::{
@@ -954,6 +966,14 @@ mod tests {
             _ => DutyExecutor::Validator(PublicKeyBytes::empty()),
         };
         MessageId::new(&domain, role, &duty_executor)
+    }
+
+    // Helper to create a HashMap of CommitteeId -> PublicKey for tests
+    pub(crate) fn create_operator_pub_keys(
+        committee_members: IndexSet<OperatorId>,
+        public_keys: Vec<Rsa<Public>>,
+    ) -> HashMap<OperatorId, Rsa<Public>> {
+        committee_members.into_iter().zip(public_keys).collect()
     }
 
     // Assert helpers for common validation patterns

--- a/anchor/message_validator/src/partial_signature.rs
+++ b/anchor/message_validator/src/partial_signature.rs
@@ -3,6 +3,7 @@ use std::{collections::HashMap, sync::Arc};
 use duties_tracker::DutiesProvider;
 use slot_clock::SlotClock;
 use ssv_types::{
+    OperatorId,
     msgid::Role,
     partial_sig::{PartialSignatureKind, PartialSignatureMessages},
 };
@@ -30,7 +31,7 @@ pub(crate) fn validate_partial_signature_message(
     };
 
     // Validate basic semantics
-    validate_partial_signature_message_semantics(&validation_context, &messages)?;
+    let signer = validate_partial_signature_message_semantics(&validation_context, &messages)?;
 
     // Validate duty-specific logic
     validate_partial_sig_messages_by_duty_logic(
@@ -40,9 +41,9 @@ pub(crate) fn validate_partial_signature_message(
         duty_provider,
     )?;
 
-    let operator_pk = validation_context
-        .operators_pk
-        .first()
+    let operator_pub_keys = validation_context
+        .operator_pub_keys
+        .get(&signer)
         .ok_or(ValidationFailure::NoSigners)?;
 
     let signature = validation_context
@@ -53,7 +54,7 @@ pub(crate) fn validate_partial_signature_message(
 
     verify_message_signature(
         validation_context.signed_ssv_message,
-        operator_pk,
+        operator_pub_keys,
         signature,
     )?;
 
@@ -76,7 +77,7 @@ pub(crate) fn validate_partial_signature_message(
 fn validate_partial_signature_message_semantics(
     validation_context: &ValidationContext<impl SlotClock>,
     partial_signature_messages: &PartialSignatureMessages,
-) -> Result<(), ValidationFailure> {
+) -> Result<OperatorId, ValidationFailure> {
     // Rule: Partial Signature message must have 1 signer
     let signers = validation_context.signed_ssv_message.operator_ids();
     if signers.len() != 1 {
@@ -126,7 +127,7 @@ fn validate_partial_signature_message_semantics(
         }
     }
 
-    Ok(())
+    Ok(signer)
 }
 
 fn partial_signature_type_matches_role(kind: PartialSignatureKind, role: Role) -> bool {
@@ -289,7 +290,7 @@ mod tests {
     use super::*;
     use crate::tests::{
         FOUR_NODE_COMMITTEE, MockDutiesProvider, assert_validation_error, create_committee_info,
-        create_message_id_for_test, generate_random_rsa_public_keys,
+        create_message_id_for_test, create_operator_pub_keys, generate_random_rsa_public_keys,
     };
 
     // Options for creating test partial signature messages
@@ -370,14 +371,13 @@ mod tests {
         signed_msg: &'a SignedSSVMessage,
         committee_info: &'a crate::CommitteeInfo,
         role: Role,
-        operators_pk: &'a [Rsa<Public>],
+        operator_pub_keys: &'a HashMap<OperatorId, Rsa<Public>>,
     ) -> ValidationContext<'a, ManualSlotClock> {
         ValidationContext {
             signed_ssv_message: signed_msg,
             committee_info,
             role,
             received_at: SystemTime::now(),
-            operators_pk,
             slots_per_epoch: 32,
             epochs_per_sync_committee_period: 256,
             sync_committee_size: 512,
@@ -386,6 +386,7 @@ mod tests {
                 SystemTime::now().duration_since(UNIX_EPOCH).unwrap(),
                 Duration::from_secs(1),
             ),
+            operator_pub_keys,
         }
     }
 
@@ -402,8 +403,10 @@ mod tests {
         );
 
         let binding = generate_random_rsa_public_keys(signed_msg.operator_ids().len());
+        let map = create_operator_pub_keys(committee_info.committee_members.clone(), binding);
+
         let validation_context =
-            create_test_validation_context(&signed_msg, &committee_info, Role::Committee, &binding);
+            create_test_validation_context(&signed_msg, &committee_info, Role::Committee, &map);
 
         let result = validate_partial_signature_message(
             validation_context,
@@ -449,8 +452,10 @@ mod tests {
             .expect("SignedSSVMessage should be created");
 
         let binding = generate_random_rsa_public_keys(signed_msg.operator_ids().len());
+        let map = create_operator_pub_keys(committee_info.committee_members.clone(), binding);
+
         let validation_context =
-            create_test_validation_context(&signed_msg, &committee_info, Role::Proposer, &binding);
+            create_test_validation_context(&signed_msg, &committee_info, Role::Proposer, &map);
 
         let result = validate_partial_signature_message(
             validation_context,
@@ -483,8 +488,10 @@ mod tests {
         );
 
         let binding = generate_random_rsa_public_keys(signed_msg.operator_ids().len());
+        let map = create_operator_pub_keys(committee_info.committee_members.clone(), binding);
+
         let validation_context =
-            create_test_validation_context(&signed_msg, &committee_info, Role::Proposer, &binding);
+            create_test_validation_context(&signed_msg, &committee_info, Role::Proposer, &map);
 
         let result = validate_partial_signature_message(
             validation_context,
@@ -517,8 +524,10 @@ mod tests {
         );
 
         let binding = generate_random_rsa_public_keys(signed_msg.operator_ids().len());
+        let map = create_operator_pub_keys(committee_info.committee_members.clone(), binding);
+
         let validation_context =
-            create_test_validation_context(&signed_msg, &committee_info, Role::Proposer, &binding);
+            create_test_validation_context(&signed_msg, &committee_info, Role::Proposer, &map);
 
         let result = validate_partial_signature_message(
             validation_context,
@@ -551,8 +560,10 @@ mod tests {
         );
 
         let binding = generate_random_rsa_public_keys(signed_msg.operator_ids().len());
+        let map = create_operator_pub_keys(committee_info.committee_members.clone(), binding);
+
         let validation_context =
-            create_test_validation_context(&signed_msg, &committee_info, Role::Proposer, &binding);
+            create_test_validation_context(&signed_msg, &committee_info, Role::Proposer, &map);
 
         let result = validate_partial_signature_message(
             validation_context,
@@ -583,8 +594,11 @@ mod tests {
         );
 
         let binding = [public_key];
+        let map =
+            create_operator_pub_keys(committee_info.committee_members.clone(), binding.to_vec());
+
         let validation_context =
-            create_test_validation_context(&signed_msg, &committee_info, Role::Proposer, &binding);
+            create_test_validation_context(&signed_msg, &committee_info, Role::Proposer, &map);
 
         let result = validate_partial_signature_message(
             validation_context,
@@ -627,11 +641,13 @@ mod tests {
         );
 
         let binding = generate_random_rsa_public_keys(signed_msg.operator_ids().len());
+        let map = create_operator_pub_keys(committee_info.committee_members.clone(), binding);
+
         let validation_context = create_test_validation_context(
             &signed_msg,
             &committee_info,
             Role::Proposer, // Not a committee role, so validator index is checked
-            &binding,
+            &map,
         );
 
         let result = validate_partial_signature_message(
@@ -670,11 +686,14 @@ mod tests {
         );
 
         let binding = [public_key];
+        let map =
+            create_operator_pub_keys(committee_info.committee_members.clone(), binding.to_vec());
+
         let validation_context = create_test_validation_context(
             &signed_msg,
             &committee_info,
             Role::Committee, // Committee role, so validator index is not checked
-            &binding,
+            &map,
         );
 
         let result = validate_partial_signature_message(
@@ -732,8 +751,10 @@ mod tests {
         .expect("SignedSSVMessage should be created");
 
         let binding = generate_random_rsa_public_keys(signed_msg.operator_ids().len());
+        let map = create_operator_pub_keys(committee_info.committee_members.clone(), binding);
+
         let validation_context =
-            create_test_validation_context(&signed_msg, &committee_info, Role::Proposer, &binding);
+            create_test_validation_context(&signed_msg, &committee_info, Role::Proposer, &map);
 
         let result = validate_partial_signature_message(
             validation_context,
@@ -782,8 +803,10 @@ mod tests {
         .expect("SignedSSVMessage should be created");
 
         let binding = generate_random_rsa_public_keys(signed_msg.operator_ids().len());
+        let map = create_operator_pub_keys(committee_info.committee_members.clone(), binding);
+
         let validation_context =
-            create_test_validation_context(&signed_msg, &committee_info, Role::Committee, &binding);
+            create_test_validation_context(&signed_msg, &committee_info, Role::Committee, &map);
 
         let result = validate_partial_signature_message(
             validation_context,

--- a/anchor/network/Cargo.toml
+++ b/anchor/network/Cargo.toml
@@ -29,7 +29,7 @@ libp2p = { workspace = true, default-features = false, features = [
 message_receiver = { workspace = true }
 metrics = { workspace = true }
 network_utils = { workspace = true }
-peer-store = { package = "libp2p-peer-store", git = "https://github.com/libp2p/rust-libp2p.git", rev = "ad9a1b2" }
+peer-store = { package = "libp2p-peer-store", git = "https://github.com/libp2p/rust-libp2p.git", rev = "d63dab1" }
 prometheus-client = { workspace = true }
 quick-protobuf = "0.8.1"
 rand = { workspace = true }

--- a/anchor/network/src/network.rs
+++ b/anchor/network/src/network.rs
@@ -534,7 +534,7 @@ impl<R: MessageReceiver> Network<R> {
 
         // ---------- first pass (read-only) ----------
         let mut peer_scores = Vec::new();
-        let mut peers_to_block = HashSet::new();
+        let mut peers_to_block_and_disconnect = HashSet::new();
 
         {
             // borrow `self.swarm` immutably only inside this block
@@ -542,7 +542,7 @@ impl<R: MessageReceiver> Network<R> {
             for peer_id in self.swarm.connected_peers().cloned() {
                 if let Some(score) = behaviour.gossipsub.peer_score(&peer_id) {
                     if score < GRAYLIST_THRESHOLD {
-                        peers_to_block.insert(peer_id);
+                        peers_to_block_and_disconnect.insert(peer_id);
                     }
                     peer_scores.push((peer_id, score));
                 }
@@ -553,24 +553,29 @@ impl<R: MessageReceiver> Network<R> {
         let target = self.swarm.behaviour().peer_manager.target_peers();
         let excess = self.swarm.connected_peers().count().saturating_sub(target);
 
-        for peer in &peers_to_block {
-            self.swarm.behaviour_mut().peer_manager.block_peer(*peer);
+        for peer_id in &peers_to_block_and_disconnect {
+            self.swarm.behaviour_mut().peer_manager.block_peer(*peer_id);
+            self.disconnect_peer(peer_id);
         }
 
         if excess > 0 {
             peer_scores.sort_by(|a, b| a.1.total_cmp(&b.1));
             let to_disconnect = peer_scores
                 .iter()
-                .filter(|(p, _)| !peers_to_block.contains(p))
+                .filter(|(p, _)| !peers_to_block_and_disconnect.contains(p))
                 .take(excess)
                 .map(|(p, _)| *p);
 
             for peer_id in to_disconnect {
-                match self.swarm.disconnect_peer_id(peer_id) {
-                    Ok(_) => debug!(%peer_id, "Disconnected peer due to low score"),
-                    Err(_) => trace!(%peer_id, "Peer was already disconnected"),
-                }
+                self.disconnect_peer(&peer_id);
             }
+        }
+    }
+
+    fn disconnect_peer(&mut self, peer_id: &PeerId) {
+        match self.swarm.disconnect_peer_id(*peer_id) {
+            Ok(_) => debug!(%peer_id, "Disconnected peer due to low score"),
+            Err(_) => trace!(%peer_id, "Peer was already disconnected"),
         }
     }
 

--- a/anchor/network/src/network.rs
+++ b/anchor/network/src/network.rs
@@ -17,7 +17,7 @@ use libp2p::{
     futures,
     identity::Keypair,
     multiaddr::Protocol,
-    swarm::SwarmEvent,
+    swarm::{SwarmEvent, dial_opts::DialOpts},
 };
 use message_receiver::{MessageReceiver, Outcome};
 use prometheus_client::registry::Registry;
@@ -379,7 +379,7 @@ impl<R: MessageReceiver> Network<R> {
             .filter_map(|enr| manager.report_discovered_peer(enr))
             .collect::<Vec<_>>();
         for dial in to_dial {
-            let _ = self.swarm.dial(dial);
+            self.dial(dial);
         }
     }
 
@@ -498,7 +498,7 @@ impl<R: MessageReceiver> Network<R> {
 
     fn handle_connect_actions(&mut self, connect_actions: ConnectActions) {
         for peer in connect_actions.dial {
-            let _ = self.swarm.dial(peer);
+            self.dial(peer);
         }
         if !connect_actions.discover.is_empty() {
             self.swarm
@@ -571,6 +571,12 @@ impl<R: MessageReceiver> Network<R> {
                     Err(_) => trace!(%peer_id, "Peer was already disconnected"),
                 }
             }
+        }
+    }
+
+    fn dial(&mut self, opts: DialOpts) {
+        if let Err(err) = self.swarm.dial(opts) {
+            debug!(%err, "Failed to dial peer");
         }
     }
 }

--- a/anchor/network/src/network.rs
+++ b/anchor/network/src/network.rs
@@ -231,10 +231,7 @@ impl<R: MessageReceiver> Network<R> {
                                     .peers_to_disconnect_due_to_subnets();
 
                                 for peer_id in to_disconnect {
-                                    match self.swarm.disconnect_peer_id(peer_id) {
-                                        Ok(_) => debug!(%peer_id, "Disconnected peer due to no subnets"),
-                                        Err(_) => trace!(%peer_id, "Peer was already disconnected"),
-                                    }
+                                    self.disconnect_peer(&peer_id, "No longer subscribed to any needed subnets");
                                 }
                             }
                             _ => {
@@ -519,6 +516,9 @@ impl<R: MessageReceiver> Network<R> {
             }
             Err(handshake::Failed { peer_id, error }) => {
                 debug!(%peer_id, ?error, "Handshake failed");
+
+                // Disconnect the peer on handshake failure
+                self.disconnect_peer(&peer_id, "Handshake failed");
             }
         }
     }
@@ -555,7 +555,7 @@ impl<R: MessageReceiver> Network<R> {
 
         for peer_id in &peers_to_block_and_disconnect {
             self.swarm.behaviour_mut().peer_manager.block_peer(*peer_id);
-            self.disconnect_peer(peer_id);
+            self.disconnect_peer(peer_id, "Blocking peer due to low score");
         }
 
         if excess > 0 {
@@ -567,21 +567,21 @@ impl<R: MessageReceiver> Network<R> {
                 .map(|(p, _)| *p);
 
             for peer_id in to_disconnect {
-                self.disconnect_peer(&peer_id);
+                self.disconnect_peer(&peer_id, "Pruning excess peers by score");
             }
-        }
-    }
-
-    fn disconnect_peer(&mut self, peer_id: &PeerId) {
-        match self.swarm.disconnect_peer_id(*peer_id) {
-            Ok(_) => debug!(%peer_id, "Disconnected peer due to low score"),
-            Err(_) => trace!(%peer_id, "Peer was already disconnected"),
         }
     }
 
     fn dial(&mut self, opts: DialOpts) {
         if let Err(err) = self.swarm.dial(opts) {
             debug!(%err, "Failed to dial peer");
+        }
+    }
+
+    fn disconnect_peer(&mut self, peer_id: &PeerId, reason: &str) {
+        match self.swarm.disconnect_peer_id(*peer_id) {
+            Ok(_) => debug!(%peer_id, reason = %reason, "Disconnected peer"),
+            Err(_) => trace!(%peer_id, "Peer was already disconnected"),
         }
     }
 }

--- a/anchor/qbft_manager/src/lib.rs
+++ b/anchor/qbft_manager/src/lib.rs
@@ -25,7 +25,7 @@ use tokio::{
     },
     time::{Instant, sleep},
 };
-use tracing::{Instrument, debug, debug_span, error, warn};
+use tracing::{Instrument, debug_span, error, warn};
 use types::{Hash256, PublicKeyBytes};
 
 use crate::instance::qbft_instance;
@@ -210,8 +210,6 @@ impl QbftManager {
     ) -> Result<(), QbftError> {
         let msg_id = full_message.ssv_message().msg_id();
         let instance_height = (qbft_message.height as usize).into();
-
-        debug!(?msg_id, ?instance_height, "Received valid qbft message");
 
         match msg_id.duty_executor() {
             Some(DutyExecutor::Validator(validator)) => {

--- a/anchor/signature_collector/src/lib.rs
+++ b/anchor/signature_collector/src/lib.rs
@@ -28,7 +28,7 @@ use tokio::{
     },
     time::sleep,
 };
-use tracing::{Instrument, debug, debug_span, error, trace, warn};
+use tracing::{Instrument, debug_span, error, trace, warn};
 use types::{Hash256, PublicKeyBytes, SecretKey, Signature, Slot};
 
 const COLLECTOR_NAME: &str = "signature_collector";
@@ -111,7 +111,7 @@ impl SignatureCollectorManager {
 
         let (result_tx, result_rx) = oneshot::channel();
 
-        debug!(
+        trace!(
             ?metadata,
             ?requester,
             root=?validator_signing_data.root,
@@ -197,7 +197,7 @@ impl SignatureCollectorManager {
                         // Enter the signature we just signed for this validator.
                         collected_signatures.push(message.clone());
 
-                        debug!(
+                        trace!(
                             have = collected_signatures.len(),
                             need = num_signatures_to_collect,
                             "Checking if we have all signatures to send"
@@ -275,7 +275,7 @@ impl SignatureCollectorManager {
         message: PartialSignatureMessage,
         slot: Slot,
     ) -> Result<(), CollectionError> {
-        debug!(
+        trace!(
             ?slot,
             signing_root=?message.signing_root,
             signer=?message.signer,
@@ -333,7 +333,7 @@ impl SignatureCollectorManager {
                     Box::pin(signature_collector(rx).instrument(span)),
                     COLLECTOR_NAME,
                 );
-                debug!(
+                trace!(
                     ?signing_root,
                     ?validator_index,
                     "Spawned signature collector"
@@ -535,7 +535,7 @@ async fn signature_collector(mut rx: mpsc::UnboundedReceiver<CollectorMessage>) 
                 }
             };
 
-            debug!(?signature, "Successfully recovered signature");
+            trace!(?signature, "Successfully recovered signature");
 
             for notifier in mem::take(&mut notifiers) {
                 if notifier.send(Arc::clone(&signature)).is_err() {

--- a/anchor/src/main.rs
+++ b/anchor/src/main.rs
@@ -205,12 +205,14 @@ pub fn enable_logging(
         let file_logging_layer = init_file_logging(&logs_dir, file_logging_flags.clone());
 
         if let Some(libp2p_discv5_layer) = libp2p_discv5_layer {
+            // Create filter that reduces external library noise to WARN level while preserving
+            // the configured file log level for Anchor crates
+
             logging_layers.push(
                 libp2p_discv5_layer
                     .with_filter(
-                        EnvFilter::builder()
-                            .with_default_directive(Level::DEBUG.into())
-                            .from_env_lossy(),
+                        EnvFilter::try_new("warn,libp2p_gossipsub::peer_score=debug,libp2p_gossipsub::gossip_promises=debug")
+                            .unwrap_or_else(|_| EnvFilter::new("debug")),
                     )
                     .boxed(),
             );

--- a/anchor/validator_store/src/lib.rs
+++ b/anchor/validator_store/src/lib.rs
@@ -166,6 +166,9 @@ impl<T: SlotClock, E: EthSpec> AnchorValidatorStore<T, E> {
 
         // First, attempt to get the cluster normally
         if let Some(cluster) = state.clusters().get_by(&validator.cluster_id) {
+            if cluster.liquidated {
+                return Err(Error::SpecificError(SpecificError::ClusterLiquidated));
+            }
             return Ok((validator, cluster.clone()));
         }
 
@@ -745,6 +748,7 @@ pub enum SpecificError {
         cluster_id: ClusterId,
     },
     KeyShareDecryptionFailed,
+    ClusterLiquidated,
 }
 
 impl From<CollectionError> for SpecificError {
@@ -792,12 +796,19 @@ impl<T: SlotClock, E: EthSpec> ValidatorStore for AnchorValidatorStore<T, E> {
         I: FromIterator<PublicKeyBytes>,
         F: Fn(DoppelgangerStatus) -> Option<PublicKeyBytes>,
     {
+        let state = self.database.state();
+
         // Treat all shares as `SigningEnabled`
-        self.database
-            .state()
+        state
             .shares()
             .values()
             .filter_map(|v| filter_func(DoppelgangerStatus::SigningEnabled(v.validator_pubkey)))
+            .filter(|public_key| {
+                state
+                    .clusters()
+                    .get_by(public_key)
+                    .is_some_and(|cluster| !cluster.liquidated)
+            })
             .collect()
     }
 


### PR DESCRIPTION
## Issue Addressed

This PR addresses part of the QBFT data integrity verification improvements described in the larger PR #592. Specifically, it fixes proposal validation that was incorrectly rejecting valid scenarios where RoundChange messages have different prepared values.

## Proposed Changes

**Problem:** Proposal validation required ALL RoundChange messages with prepared values to share the same root as the proposal. This violated the QBFT specification and could block legitimate consensus progress.

**Solution:** 
- Modified validation to only check that the proposal root matches the highest prepared RoundChange
- Moved validation logic to occur after processing all RoundChange messages
- Added comprehensive test covering mixed RoundChange scenarios with different prepared values

**QBFT Specification:** The spec allows RoundChange messages from different rounds to have different roots. Only the value from the highest prepared round should determine the proposal.

## Additional Info

This change ensures spec compliance while maintaining all existing security validations. See PR #592 for broader context on QBFT data integrity improvements.