### PR TITLE
fix: Make startup log nicer

### DIFF
--- a/anchor/client/src/lib.rs
+++ b/anchor/client/src/lib.rs
@@ -102,10 +102,11 @@ impl Client {
         };
 
         info!(
-            beacon_nodes = format!("{:?}", &config.beacon_nodes),
-            execution_nodes = format!("{:?}", &config.execution_nodes),
-            execution_nodes_websocket = format!("{:?}", &config.execution_nodes_websocket),
-            data_dir = format!("{:?}", config.global_config.data_dir),
+            beacon_nodes = ?config.beacon_nodes,
+            execution_nodes = ?config.execution_nodes,
+            execution_nodes_websocket = ?config.execution_nodes_websocket,
+            data_dir = %config.global_config.data_dir,
+            version = version::VERSION,
             "Starting the Anchor client"
         );
 

--- a/anchor/common/global_config/src/data_dir.rs
+++ b/anchor/common/global_config/src/data_dir.rs
@@ -1,4 +1,5 @@
 use std::{
+    fmt::Display,
     fs::{File, TryLockError, create_dir_all},
     path::PathBuf,
 };
@@ -87,6 +88,12 @@ impl DataDir {
 
     pub fn default_logs_dir(&self) -> PathBuf {
         self.path.join("logs")
+    }
+}
+
+impl Display for DataDir {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.path.display())
     }
 }
 


### PR DESCRIPTION
## Issue Addressed

Before: `2025-09-12T08:02:11.477337Z  INFO client: Starting the Anchor client beacon_nodes="[\"http://localhost:5052/\"]" execution_nodes="[\"http://localhost:8545/\"]" execution_nodes_websocket="\"ws://localhost:8546/\"" data_dir="DataDir { path: \"/tmp/hoodi2\", _lock_file: File { fd: 5, path: \"/tmp/hoodi2/.lock\", read: false, write: true } }"`

## Proposed Changes

After: `2025-09-12T08:31:21.595170Z  INFO client: Starting the Anchor client beacon_nodes=["http://localhost:5052/"] execution_nodes=["http://localhost:8545/"] execution_nodes_websocket="ws://localhost:8546/" data_dir=/tmp/hoodi2 version="Anchor/v0.3.1-fb79824+"`
