### PR TITLE
fix: Check all quorums more rigorously

### DIFF
--- a/anchor/common/qbft/src/lib.rs
+++ b/anchor/common/qbft/src/lib.rs
@@ -233,7 +233,7 @@ where
     }
 
     /// Checks if we have a quorum of unique committee operators from these messages.
-    fn check_quorum<'a, T: Into<&'a SignedSSVMessage>>(
+    fn has_quorum<'a, T: Into<&'a SignedSSVMessage>>(
         &self,
         msgs: impl IntoIterator<Item = T>,
     ) -> bool {
@@ -273,7 +273,7 @@ where
                 }
                 QbftMessageType::Commit => {
                     // Only decided messages (with quorum) are allowed from future rounds
-                    if !self.check_quorum([wrapped_msg]) {
+                    if !self.has_quorum([wrapped_msg]) {
                         return None;
                     }
                 }
@@ -359,7 +359,7 @@ where
             .get_messages_for_round(self.current_round);
 
         // Need quorum to proceed
-        if !self.check_quorum(round_change_messages) {
+        if !self.has_quorum(round_change_messages) {
             return None;
         }
 
@@ -551,7 +551,7 @@ where
         let mut max_prepared_msg = None;
 
         // Make sure we have a quorum of round change messages
-        if !self.check_quorum(&msg.qbft_message.round_change_justification) {
+        if !self.has_quorum(&msg.qbft_message.round_change_justification) {
             warn!("Did not receive a quorum of round change messages");
             return false;
         }
@@ -624,7 +624,7 @@ where
                     return false;
                 }
 
-                if !self.check_quorum(&round_change.round_change_justification) {
+                if !self.has_quorum(&round_change.round_change_justification) {
                     warn!(
                         num_justifications = round_change.round_change_justification.len(),
                         "Not enough prepare messages for quorum"
@@ -649,7 +649,7 @@ where
         // prepare justifications
         if let Some(max_prepared_msg) = max_prepared_msg {
             // Make sure we have a quorum of prepare messages
-            if !self.check_quorum(&msg.qbft_message.prepare_justification) {
+            if !self.has_quorum(&msg.qbft_message.prepare_justification) {
                 warn!(
                     num_justifications = msg.qbft_message.prepare_justification.len(),
                     "Not enough prepare messages for quorum"
@@ -948,7 +948,7 @@ where
         let qbft_msg = &wrapped_msg.qbft_message;
         // If this is a "prepared" round change, we have to check the justifications.
         if qbft_msg.data_round > 0 {
-            if !self.check_quorum(&qbft_msg.round_change_justification) {
+            if !self.has_quorum(&qbft_msg.round_change_justification) {
                 debug!(
                     from = *operator_id,
                     justifications = qbft_msg.round_change_justification.len(),
@@ -1038,7 +1038,7 @@ where
     // We have received a decided message
     fn received_decided(&mut self, wrapped_msg: WrappedQbftMessage) {
         // Make sure we have a quorum of signatures
-        if !self.check_quorum([&wrapped_msg.signed_message]) {
+        if !self.has_quorum([&wrapped_msg.signed_message]) {
             return;
         }
 
@@ -1185,7 +1185,7 @@ where
                 .get_messages_for_round(self.current_round);
 
             // We need at least a quorum of round changes to justify the proposal
-            if self.check_quorum(round_changes) {
+            if self.has_quorum(round_changes) {
                 return round_changes
                     .iter()
                     .map(|msg| msg.signed_message.clone())
@@ -1213,7 +1213,7 @@ where
                 .filter(|msg| msg.qbft_message.root == last_prepared_value);
 
             // We need a quorum of prepares to justify the prepared value
-            if self.check_quorum(filtered_prepares.clone()) {
+            if self.has_quorum(filtered_prepares.clone()) {
                 let result: Vec<SignedSSVMessage> = filtered_prepares
                     .into_iter()
                     .map(|msg| msg.signed_message.clone())
@@ -1257,7 +1257,7 @@ where
             .round_change_container
             .get_messages_for_round(self.current_round);
 
-        if !self.check_quorum(round_changes) {
+        if !self.has_quorum(round_changes) {
             return (vec![], None);
         }
 
@@ -1283,7 +1283,7 @@ where
             let prepares = &highest_rc.qbft_message.round_change_justification;
 
             // Verify we have quorum of prepares
-            if self.check_quorum(prepares) {
+            if self.has_quorum(prepares) {
                 return (prepares.clone(), Some(prepared_value));
             }
         }

--- a/anchor/common/qbft/src/lib.rs
+++ b/anchor/common/qbft/src/lib.rs
@@ -233,10 +233,13 @@ where
     }
 
     /// Checks if we have a quorum of unique committee operators from these messages.
-    fn check_quorum<'a>(&self, msgs: impl IntoIterator<Item = &'a SignedSSVMessage>) -> bool {
+    fn check_quorum<'a, T: Into<&'a SignedSSVMessage>>(
+        &self,
+        msgs: impl IntoIterator<Item = T>,
+    ) -> bool {
         let unique_operators = msgs
             .into_iter()
-            .flat_map(|justification| justification.operator_ids())
+            .flat_map(|msg| msg.into().operator_ids())
             .filter(|operator_id| self.check_committee(operator_id))
             .collect::<HashSet<_>>();
         unique_operators.len() >= self.config.quorum_size()
@@ -270,7 +273,7 @@ where
                 }
                 QbftMessageType::Commit => {
                     // Only decided messages (with quorum) are allowed from future rounds
-                    if wrapped_msg.signed_message.operator_ids().len() < self.config.quorum_size() {
+                    if !self.check_quorum([wrapped_msg]) {
                         return None;
                     }
                 }
@@ -356,7 +359,7 @@ where
             .get_messages_for_round(self.current_round);
 
         // Need quorum to proceed
-        if round_change_messages.len() < self.config.quorum_size() {
+        if !self.check_quorum(round_change_messages) {
             return None;
         }
 
@@ -1035,7 +1038,7 @@ where
     // We have received a decided message
     fn received_decided(&mut self, wrapped_msg: WrappedQbftMessage) {
         // Make sure we have a quorum of signatures
-        if wrapped_msg.signed_message.operator_ids().len() < self.config().quorum_size() {
+        if !self.check_quorum([&wrapped_msg.signed_message]) {
             return;
         }
 
@@ -1182,9 +1185,9 @@ where
                 .get_messages_for_round(self.current_round);
 
             // We need at least a quorum of round changes to justify the proposal
-            if round_changes.len() >= self.config.quorum_size() {
+            if self.check_quorum(round_changes) {
                 return round_changes
-                    .into_iter()
+                    .iter()
                     .map(|msg| msg.signed_message.clone())
                     .collect();
             }
@@ -1205,13 +1208,12 @@ where
                 .get_messages_for_round(last_prepared_round);
 
             // Only include prepares that match our prepared value
-            let filtered_prepares: Vec<_> = prepares
+            let filtered_prepares = prepares
                 .iter()
-                .filter(|msg| msg.qbft_message.root == last_prepared_value)
-                .collect();
+                .filter(|msg| msg.qbft_message.root == last_prepared_value);
 
             // We need a quorum of prepares to justify the prepared value
-            if filtered_prepares.len() >= self.config.quorum_size() {
+            if self.check_quorum(filtered_prepares.clone()) {
                 let result: Vec<SignedSSVMessage> = filtered_prepares
                     .into_iter()
                     .map(|msg| msg.signed_message.clone())
@@ -1255,14 +1257,14 @@ where
             .round_change_container
             .get_messages_for_round(self.current_round);
 
-        if round_changes.len() < self.config.quorum_size() {
+        if !self.check_quorum(round_changes) {
             return (vec![], None);
         }
 
         // Find the highest prepared round among all round changes
         let mut highest_prepared: Option<(Round, Hash256, &WrappedQbftMessage)> = None;
 
-        for rc_msg in &round_changes {
+        for rc_msg in round_changes {
             // Check if this round change has a prepared value
             if rc_msg.qbft_message.data_round > 0 {
                 let prepared_round = Round::from(rc_msg.qbft_message.data_round);
@@ -1281,7 +1283,7 @@ where
             let prepares = &highest_rc.qbft_message.round_change_justification;
 
             // Verify we have quorum of prepares
-            if prepares.len() >= self.config.quorum_size() {
+            if self.check_quorum(prepares) {
                 return (prepares.clone(), Some(prepared_value));
             }
         }

--- a/anchor/common/qbft/src/msg_container.rs
+++ b/anchor/common/qbft/src/msg_container.rs
@@ -123,10 +123,10 @@ impl MessageContainer {
     }
 
     /// Gets all messages for a specific round
-    pub fn get_messages_for_round(&self, round: Round) -> Vec<&WrappedQbftMessage> {
+    pub fn get_messages_for_round(&self, round: Round) -> &[WrappedQbftMessage] {
         self.messages
             .get(&round)
-            .map(|round_messages| round_messages.iter().collect())
+            .map(|msgs| msgs.as_slice())
             .unwrap_or_default()
     }
 }

--- a/anchor/common/qbft/src/qbft_types.rs
+++ b/anchor/common/qbft/src/qbft_types.rs
@@ -67,6 +67,12 @@ impl Display for WrappedQbftMessage {
     }
 }
 
+impl<'a> From<&'a WrappedQbftMessage> for &'a SignedSSVMessage {
+    fn from(value: &WrappedQbftMessage) -> &SignedSSVMessage {
+        &value.signed_message
+    }
+}
+
 // Wrapped qbft message is a wrapper around both an unsigned ssv message, and the underlying qbft
 // message.
 #[derive(Debug, Clone)]


### PR DESCRIPTION
## Issue Addressed

We have a lot of `>= quorum_size` floating around. These make me nervous, as we do not actually check for duplicated operator ids and proper committee membership (at least is that not immediately obvious at call site). 

## Proposed Changes

Use the existing `check_quorum` function to check quorums, making sure we have enough **unique** operators that are **members of our committee**.

## Additional Info

Uses some trait bounds for convenient and easy-to-read calling. For that I needed to change surrounding code a bit for it to work, but always improvements anyway.
