### PR TITLE
fix(qbft): store data from decided message

### DIFF
--- a/anchor/common/qbft/src/lib.rs
+++ b/anchor/common/qbft/src/lib.rs
@@ -1039,10 +1039,30 @@ where
             return;
         }
 
+        if let Some(Completed::Success(root)) = self.completed {
+            // nothing to do, already completed. but do a sanity check
+            if root != wrapped_msg.qbft_message.root {
+                error!("Got a decided message for a different root than the one we completed with");
+            }
+            return;
+        }
+
+        let Ok(data) = D::from_ssz_bytes(wrapped_msg.signed_message.full_data()) else {
+            warn!("Got undecodable data in decided message");
+            return;
+        };
+
+        if !self.data_validator.validate(&data, &self.start_data) {
+            warn!("Got invalid data in decided message");
+            return;
+        }
+
         // All message and signature verification has already succeeded. Regardless of what state
         // this instance is at, we have all of the information necessary to mark it as
         // complete
         self.state = InstanceState::Complete;
+        self.data
+            .insert(wrapped_msg.qbft_message.root, Arc::new(data));
         self.completed = Some(Completed::Success(wrapped_msg.qbft_message.root));
         self.aggregated_commit = Some(wrapped_msg.signed_message);
     }


### PR DESCRIPTION
## Issue Addressed

During testing, I found this log shortly after starting the node: https://github.com/sigp/anchor/blob/6dc090a76e48b7c81d6459feea11ec3a463a6334/anchor/common/qbft/src/lib.rs#L1392-L1399

Turns out that we do not store the full data from the decided message. So a node joining halfway through a qbft instance might see the decided message, but not the proposal. This might also happen if the messages are delivered in a very weird order.

## Proposed Changes

Store the data if we are not already completed when receiving the decided message.
