### PR TITLE
fix: safe arithmetic in timeout calculation

### DIFF
--- a/anchor/common/qbft/src/lib.rs
+++ b/anchor/common/qbft/src/lib.rs
@@ -206,6 +206,16 @@ where
         self.current_round
     }
 
+    /// Get the current instance identifier
+    pub fn get_identifier(&self) -> &MessageId {
+        &self.identifier
+    }
+
+    /// Get the current instance height
+    pub fn get_instance_height(&self) -> InstanceHeight {
+        self.instance_height
+    }
+
     // Shifts this instance into a new round>
     fn set_round(&mut self, new_round: Round) {
         self.current_round.set(new_round);

--- a/anchor/qbft_manager/src/instance.rs
+++ b/anchor/qbft_manager/src/instance.rs
@@ -176,10 +176,10 @@ impl<D: QbftData<Hash = Hash256>> Initialized<D> {
         // round to advance
         let round_end = calculate_round_timeout(self.qbft.get_round().into(), &self.start_time);
 
-        let timeout_instant = round_end.unwrap_or_else(|| {
-            error!("Round timeout calculation overflowed, defaulting to maximum");
-            tokio::time::Instant::now() + tokio::time::Duration::MAX
-        });
+        let Some(timeout_instant) = round_end else {
+            error!("Round timeout calculation overflowed, stopping the instance");
+            return RecvResult::Closed;
+        };
 
         let round_timeout_sleep = tokio::time::sleep_until(timeout_instant);
         tokio::pin!(round_timeout_sleep);

--- a/anchor/qbft_manager/src/instance.rs
+++ b/anchor/qbft_manager/src/instance.rs
@@ -175,7 +175,13 @@ impl<D: QbftData<Hash = Hash256>> Initialized<D> {
         // We calculate the sleep dynamically, as both messages and the local timer might cause the
         // round to advance
         let round_end = calculate_round_timeout(self.qbft.get_round().into(), &self.start_time);
-        let round_timeout_sleep = tokio::time::sleep_until(round_end);
+
+        let timeout_instant = round_end.unwrap_or_else(|| {
+            error!("Round timeout calculation overflowed, defaulting to maximum");
+            tokio::time::Instant::now() + tokio::time::Duration::MAX
+        });
+
+        let round_timeout_sleep = tokio::time::sleep_until(timeout_instant);
         tokio::pin!(round_timeout_sleep);
 
         select! {

--- a/anchor/qbft_manager/src/instance.rs
+++ b/anchor/qbft_manager/src/instance.rs
@@ -177,7 +177,13 @@ impl<D: QbftData<Hash = Hash256>> Initialized<D> {
         let round_end = calculate_round_timeout(self.qbft.get_round().into(), &self.start_time);
 
         let Some(timeout_instant) = round_end else {
-            error!("Round timeout calculation overflowed, stopping the instance");
+            error!(
+                "Round timeout calculation overflowed for round {}, stopping the instance. \
+            QBFT identifier: {:?}, instance height: {:?}",
+                self.qbft.get_round(),
+                self.qbft.get_identifier(),
+                self.qbft.get_instance_height()
+            );
             return RecvResult::Closed;
         };
 

--- a/anchor/qbft_manager/src/timeout.rs
+++ b/anchor/qbft_manager/src/timeout.rs
@@ -10,7 +10,7 @@ pub fn calculate_round_timeout(round: u64, start_time: &Instant) -> Option<Insta
     let additional_timeout = if round <= QUICK_TIMEOUT_THRESHOLD {
         // If we are below the quick timeout threshold the additonal timeout is round *
         // QUICK_TIMEOUT
-        Duration::from_secs(round * QUICK_TIMEOUT)
+        Duration::from_secs(round.checked_mul(QUICK_TIMEOUT)?)
     } else {
         // For higher rounds, use a combination of quick and slow timeouts
 
@@ -18,7 +18,9 @@ pub fn calculate_round_timeout(round: u64, start_time: &Instant) -> Option<Insta
         let quick_portion = Duration::from_secs(QUICK_TIMEOUT_THRESHOLD * QUICK_TIMEOUT);
 
         // The slow poritin is (round - threshold) * SLOW_TIMEOUT
-        let slow_portion = Duration::from_secs((round - QUICK_TIMEOUT_THRESHOLD) * SLOW_TIMEOUT);
+        let slow_portion = Duration::from_secs(
+            (round.checked_sub(QUICK_TIMEOUT_THRESHOLD))?.checked_mul(SLOW_TIMEOUT)?,
+        );
 
         quick_portion.checked_add(slow_portion)?
     };

--- a/anchor/qbft_manager/src/timeout.rs
+++ b/anchor/qbft_manager/src/timeout.rs
@@ -6,7 +6,7 @@ const QUICK_TIMEOUT_THRESHOLD: u64 = 8; // Round 8
 const QUICK_TIMEOUT: u64 = 2; // 2 Seconds
 const SLOW_TIMEOUT: u64 = 120; // 2 Minutes
 
-pub fn calculate_round_timeout(round: u64, start_time: &Instant) -> Instant {
+pub fn calculate_round_timeout(round: u64, start_time: &Instant) -> Option<Instant> {
     let additional_timeout = if round <= QUICK_TIMEOUT_THRESHOLD {
         // If we are below the quick timeout threshold the additonal timeout is round *
         // QUICK_TIMEOUT
@@ -22,5 +22,5 @@ pub fn calculate_round_timeout(round: u64, start_time: &Instant) -> Instant {
         quick_portion + slow_portion
     };
 
-    *start_time + additional_timeout
+    start_time.checked_add(additional_timeout)
 }

--- a/anchor/qbft_manager/src/timeout.rs
+++ b/anchor/qbft_manager/src/timeout.rs
@@ -20,10 +20,7 @@ pub fn calculate_round_timeout(round: u64, start_time: &Instant) -> Option<Insta
         // The slow poritin is (round - threshold) * SLOW_TIMEOUT
         let slow_portion = Duration::from_secs((round - QUICK_TIMEOUT_THRESHOLD) * SLOW_TIMEOUT);
 
-        let Some(additional_timeout) = quick_portion.checked_add(slow_portion) else {
-            return None;
-        };
-        additional_timeout
+        quick_portion.checked_add(slow_portion)?
     };
 
     start_time.checked_add(additional_timeout)

--- a/anchor/qbft_manager/src/timeout.rs
+++ b/anchor/qbft_manager/src/timeout.rs
@@ -19,7 +19,11 @@ pub fn calculate_round_timeout(round: u64, start_time: &Instant) -> Option<Insta
 
         // The slow poritin is (round - threshold) * SLOW_TIMEOUT
         let slow_portion = Duration::from_secs((round - QUICK_TIMEOUT_THRESHOLD) * SLOW_TIMEOUT);
-        quick_portion + slow_portion
+
+        let Some(additional_timeout) = quick_portion.checked_add(slow_portion) else {
+            return None;
+        };
+        additional_timeout
     };
 
     start_time.checked_add(additional_timeout)


### PR DESCRIPTION
## Issue Addressed

Addresses issue #560 

## Proposed Changes

Makes sure the round can't be bumped to high for the addition to overflow in `calculate_round_timeout`, returning `None` if the round is too high for the timeout to be properly calculated.
