### PR TITLE
feat: Allow RUST_LOG to override specific logging targets while preserving defaults

### DIFF
--- a/anchor/src/main.rs
+++ b/anchor/src/main.rs
@@ -208,14 +208,20 @@ pub fn enable_logging(
             // Create filter that reduces external library noise to WARN level while preserving
             // the configured file log level for Anchor crates
 
-            logging_layers.push(
-                libp2p_discv5_layer
-                    .with_filter(
-                        EnvFilter::try_new("warn,libp2p_gossipsub::peer_score=debug,libp2p_gossipsub::gossip_promises=debug")
-                            .unwrap_or_else(|_| EnvFilter::new("debug")),
-                    )
-                    .boxed(),
-            );
+            let base = "discv5=warn,libp2p_gossipsub::peer_score=debug,libp2p_gossipsub::gossip_promises=debug";
+            let env = std::env::var(EnvFilter::DEFAULT_ENV).unwrap_or_default();
+
+            // Defaults first, env last (env overrides only what it mentions)
+            let combined = if env.is_empty() {
+                base.to_string()
+            } else {
+                format!("{base},{env}")
+            };
+
+            // Use parse_lossy so a bad RUST_LOG doesn't crash; it falls back to the base part.
+            let layer_filter = EnvFilter::builder().parse_lossy(combined);
+
+            logging_layers.push(libp2p_discv5_layer.with_filter(layer_filter).boxed());
         }
 
         if let Some(file_logging_layer) = file_logging_layer {


### PR DESCRIPTION
## Issue Addressed

Improve RUST_LOG environment variable support for debugging discv5 and libp2p_gossipsub components.

## Proposed Changes

Replace hardcoded `EnvFilter::try_new()` with combined filter approach that supports selective RUST_LOG overrides while preserving defaults:

- Build filter from defaults + RUST_LOG using tracing-subscriber's directive precedence
- Use `EnvFilter::builder().parse_lossy()` for graceful error handling
- RUST_LOG overrides only specified components, others keep defaults

**Examples:**
- `RUST_LOG=discv5=trace` → only discv5 becomes trace; libp2p stays at default debug
- `RUST_LOG=libp2p_gossipsub::gossip_promises=info` → only that component changes; others remain default
- `RUST_LOG=debug` → sets base level for unmatched targets while preserving explicit settings

## Additional Info

Tested with network runs confirming selective overrides work correctly and unspecified components maintain their hardcoded defaults.