### PR TITLE
feat: Add CLI flag to disable Enr auto update

### DIFF
--- a/anchor/client/src/cli.rs
+++ b/anchor/client/src/cli.rs
@@ -427,6 +427,16 @@ pub struct Node {
 
     #[clap(
         long,
+        global = true,
+        help = "Discovery can automatically discover external addresses if the node has correctly set up port forwards.\
+                It will automatically update this nodes ENR with values it finds. This can have undesired effects for complicated networks.\
+                Setting this flag will disable discovery from updating the ENR from CLI set values.",
+        display_order = 0
+    )]
+    pub disable_enr_auto_update: bool,
+
+    #[clap(
+        long,
         help = "Subscribe to all subnets, regardless of committee membership.",
         display_order = 0,
         help_heading = FLAG_HEADER,

--- a/anchor/client/src/config.rs
+++ b/anchor/client/src/config.rs
@@ -173,6 +173,7 @@ pub fn from_cli(cli_args: &Node, global_config: GlobalConfig) -> Result<Config, 
     }
 
     config.network.enr_address = (cli_args.enr_address, cli_args.enr_address6);
+    config.network.disable_enr_auto_update = cli_args.disable_enr_auto_update;
     config.network.enr_tcp4_port = cli_args.enr_tcp_port;
     config.network.enr_udp4_port = cli_args.enr_udp_port;
     config.network.enr_quic4_port = cli_args.enr_quic_port;

--- a/anchor/network/src/config.rs
+++ b/anchor/network/src/config.rs
@@ -30,6 +30,10 @@ pub struct Config {
     /// that no discovery address has been set in the CLI args.
     pub enr_address: (Option<Ipv4Addr>, Option<Ipv6Addr>),
 
+    /// If the user wishes to set the ENR via CLI args, they may wish to disable discovery from
+    /// updating the ENR at a later time. If this is set to true, the ENR will be fixed to the CLI parameters.
+    pub disable_enr_auto_update: bool,
+
     /// The udp ipv4 port to broadcast to peers in order to reach back for discovery.
     pub enr_udp4_port: Option<NonZeroU16>,
 
@@ -88,6 +92,7 @@ impl Config {
             network_dir,
             listen_addresses,
             enr_address: (None, None),
+            disable_enr_auto_update: false,
             enr_udp4_port: None,
             enr_quic4_port: None,
             enr_tcp4_port: None,

--- a/anchor/network/src/config.rs
+++ b/anchor/network/src/config.rs
@@ -31,7 +31,8 @@ pub struct Config {
     pub enr_address: (Option<Ipv4Addr>, Option<Ipv6Addr>),
 
     /// If the user wishes to set the ENR via CLI args, they may wish to disable discovery from
-    /// updating the ENR at a later time. If this is set to true, the ENR will be fixed to the CLI parameters.
+    /// updating the ENR at a later time. If this is set to true, the ENR will be fixed to the CLI
+    /// parameters.
     pub disable_enr_auto_update: bool,
 
     /// The udp ipv4 port to broadcast to peers in order to reach back for discovery.

--- a/anchor/network/src/discovery.rs
+++ b/anchor/network/src/discovery.rs
@@ -182,7 +182,14 @@ impl Discovery {
         );
 
         // discv5 configuration
-        let discv5_config = discv5::ConfigBuilder::new(discv5_listen_config).build();
+        let mut discv5_config_builder = discv5::ConfigBuilder::new(discv5_listen_config);
+
+        // Apply discovery options
+        if network_config.disable_enr_auto_update {
+            discv5_config_builder.disable_enr_update();
+        }
+
+        let discv5_config = discv5_config_builder.build();
 
         // convert the keypair into an ENR key
         let enr_key: CombinedKey =


### PR DESCRIPTION
## Description

Some complicated networks (and generally bootnodes) can be hindered by discovery's automatic external socket discovery mechanism. It's sometimes preferable to let the user specify the ENR fields and prevent discovery from modifying them. 

Currently Anchor allows users to set the ENR field, but has no option to prevent discovery from changing them as it runs if it decides there are better values for the ENR. 

This PR adds the CLI option to allow users to disable the discovery mechanism, in effect allowing them to keep the values of the ENR they set in the CLI. 
