### PR TITLE
feat: Add logging flags for dependencies

### DIFF
--- a/anchor/logging/src/logging.rs
+++ b/anchor/logging/src/logging.rs
@@ -63,7 +63,7 @@ pub struct FileLoggingFlags {
     #[arg(
         long,
         global = true,
-        default_value_t = Level::WARN,
+        default_value_t = Level::DEBUG,
         value_parser = Level::from_str,
         help = "Specifies the verbosity level used for the discv5 dependency log file")]
     pub discv5_debug_level: Level,
@@ -71,7 +71,7 @@ pub struct FileLoggingFlags {
     #[arg(
         long,
         global = true,
-        default_value_t = Level::WARN,
+        default_value_t = Level::DEBUG,
         value_parser = Level::from_str,
         help = "Specifies the verbosity level used for the libp2p dependency log file. \
                 Certain score penalty information is logged regardless of this setting.")]

--- a/anchor/logging/src/logging.rs
+++ b/anchor/logging/src/logging.rs
@@ -59,6 +59,23 @@ pub struct FileLoggingFlags {
 
     #[arg(long, global = true, help = "Enables colors in logfile.")]
     pub logfile_color: bool,
+
+    #[arg(
+        long,
+        global = true,
+        default_value_t = Level::WARN,
+        value_parser = Level::from_str,
+        help = "Specifies the verbosity level used for the discv5 dependency log file")]
+    pub discv5_debug_level: Level,
+
+    #[arg(
+        long,
+        global = true,
+        default_value_t = Level::WARN,
+        value_parser = Level::from_str,
+        help = "Specifies the verbosity level used for the libp2p dependency log file. \
+                Certain score penalty information is logged regardless of this setting.")]
+    pub libp2p_debug_level: Level,
 }
 
 impl FileLoggingFlags {

--- a/anchor/logging/src/logging.rs
+++ b/anchor/logging/src/logging.rs
@@ -66,7 +66,7 @@ pub struct FileLoggingFlags {
         default_value_t = Level::DEBUG,
         value_parser = Level::from_str,
         help = "Specifies the verbosity level used for the discv5 dependency log file")]
-    pub discv5_debug_level: Level,
+    pub discv5_log_level: Level,
 
     #[arg(
         long,
@@ -75,7 +75,7 @@ pub struct FileLoggingFlags {
         value_parser = Level::from_str,
         help = "Specifies the verbosity level used for the libp2p dependency log file. \
                 Certain score penalty information is logged regardless of this setting.")]
-    pub libp2p_debug_level: Level,
+    pub libp2p_log_level: Level,
 }
 
 impl FileLoggingFlags {

--- a/anchor/src/main.rs
+++ b/anchor/src/main.rs
@@ -210,7 +210,7 @@ pub fn enable_logging(
 
             let default = format!(
                 "discv5={},libp2p_gossipsub={}",
-                file_logging_flags.discv5_debug_level, file_logging_flags.libp2p_debug_level
+                file_logging_flags.discv5_log_level, file_logging_flags.libp2p_log_level
             );
 
             logging_layers.push(

--- a/anchor/src/main.rs
+++ b/anchor/src/main.rs
@@ -209,7 +209,7 @@ pub fn enable_logging(
             // while preserving the configured file log level for Anchor crates
 
             let default = format!(
-                "discv5={},libp2p_gossipsub={},libp2p_gossipsub::peer_score=debug,libp2p_gossipsub::gossip_promises=debug",
+                "discv5={},libp2p_gossipsub={}",
                 file_logging_flags.discv5_debug_level, file_logging_flags.libp2p_debug_level
             );
 

--- a/anchor/src/main.rs
+++ b/anchor/src/main.rs
@@ -205,14 +205,19 @@ pub fn enable_logging(
         let file_logging_layer = init_file_logging(&logs_dir, file_logging_flags.clone());
 
         if let Some(libp2p_discv5_layer) = libp2p_discv5_layer {
-            // Create filter that reduces external library noise to WARN level while preserving
-            // the configured file log level for Anchor crates
+            // Create filter that reduces external library noise to separately configured levels
+            // while preserving the configured file log level for Anchor crates
+
+            let default = format!(
+                "discv5={},libp2p_gossipsub={},libp2p_gossipsub::peer_score=debug,libp2p_gossipsub::gossip_promises=debug",
+                file_logging_flags.discv5_debug_level, file_logging_flags.libp2p_debug_level
+            );
 
             logging_layers.push(
                 libp2p_discv5_layer
                     .with_filter(
-                        EnvFilter::try_new("warn,libp2p_gossipsub::peer_score=debug,libp2p_gossipsub::gossip_promises=debug")
-                            .unwrap_or_else(|_| EnvFilter::new("debug")),
+                        EnvFilter::try_from_default_env()
+                            .unwrap_or_else(|_| EnvFilter::new(default)),
                     )
                     .boxed(),
             );


### PR DESCRIPTION
## Proposed Changes

To allow debugging issues relating to `discv5` and `libp2p_gossipsub`, allow configuring the log level for these dependencies on the command line.

Also, add the possibility to let `RUST_LOG` replace this behaviour.

## Additional Info

I kept the enforced logging of penalty information, but i am not sure about that.
