### PR TITLE
chore: Enable mainnet

### DIFF
--- a/anchor/client/src/lib.rs
+++ b/anchor/client/src/lib.rs
@@ -77,8 +77,6 @@ const HTTP_GET_DEPOSIT_SNAPSHOT_QUOTIENT: u32 = 4;
 const HTTP_GET_VALIDATOR_BLOCK_TIMEOUT_QUOTIENT: u32 = 4;
 const HTTP_DEFAULT_TIMEOUT_QUOTIENT: u32 = 4;
 
-const MAINNET_GENESIS_FORK_VERSION: [u8; 4] = [0, 0, 0, 0];
-
 pub struct Client {}
 
 impl Client {
@@ -117,12 +115,6 @@ impl Client {
                 .eth2_network
                 .chain_spec::<E>()?,
         );
-
-        if spec.genesis_fork_version == MAINNET_GENESIS_FORK_VERSION {
-            return Err(
-                "Mainnet is not supported. Please use a testnet configuration.".to_string(),
-            );
-        }
 
         let key = read_or_generate_private_key(
             &config.global_config.data_dir,

--- a/anchor/common/global_config/src/lib.rs
+++ b/anchor/common/global_config/src/lib.rs
@@ -9,7 +9,7 @@ use tracing::Level;
 use crate::data_dir::DataDir;
 
 /// Default network, used to partition the data storage
-pub const DEFAULT_HARDCODED_NETWORK: &str = "hoodi";
+pub const DEFAULT_HARDCODED_NETWORK: &str = "mainnet";
 
 /// Config that applies to all subcommands: The resolved network and datadir. This avoids repeated
 /// logic matching the datadir from the actual CLI definition.
@@ -49,9 +49,9 @@ pub struct GlobalFlags {
         long,
         global = true,
         value_name = "NETWORK",
-        value_parser = vec!["holesky", "hoodi"],
+        value_parser = vec!["mainnet", "holesky", "hoodi"],
         conflicts_with = "testnet_dir",
-        help = "Name of the chain Anchor will validate. Mainnet is not supported.",
+        help = "Name of the chain Anchor will validate.",
         display_order = 0,
         default_value = DEFAULT_HARDCODED_NETWORK,
     )]

--- a/anchor/eth/README.md
+++ b/anchor/eth/README.md
@@ -1,5 +1,5 @@
 ## Execution Layer
-This crate implements the execution layer component of the SSV node, responsible for monitoring and processing SSV network events on Ethereum L1 networks (Mainnet and Holesky).
+This crate implements the execution layer component of the SSV node, responsible for monitoring and processing SSV network events on Ethereum L1 networks.
 
 ## Overview
 The execution layer client maintains synchronization with the SSV network contract by:

--- a/anchor/eth/README.md
+++ b/anchor/eth/README.md
@@ -1,5 +1,5 @@
 ## Execution Layer
-This crate implements the execution layer component of the SSV node, responsible for monitoring and processing SSV network events on Ethereum L1 testnet networks.
+This crate implements the execution layer component of the SSV node, responsible for monitoring and processing SSV network events on Ethereum L1 networks (Mainnet and Holesky).
 
 ## Overview
 The execution layer client maintains synchronization with the SSV network contract by:
@@ -32,6 +32,5 @@ event ValidatorExited(address indexed owner, uint64[] operatorIds, bytes publicK
 ```
 
 ## Contract Addresses
+* Mainnet: `0xDD9BC35aE942eF0cFa76930954a156B3fF30a4E1`
 * Holesky: `0x38A4794cCEd47d3baf7370CcC43B560D3a1beEFA`
-
-Note: Mainnet is not supported in this version of Anchor.

--- a/anchor/keysplit/README.md
+++ b/anchor/keysplit/README.md
@@ -44,8 +44,8 @@ anchor keysplit onchain \
   --owner 0x123... \
   --operators 1,2,3,4 \
   --output-path /path/to/output.json \
-  --rpc https://eth-hoodi.provider.com \
-  --network Hoodi
+  --rpc https://eth-mainnet.provider.com \
+  --network mainnet
 ```
 
 # Command Options
@@ -61,7 +61,7 @@ anchor keysplit onchain \
 - `--public-keys KEYS`: Comma-separated list of RSA public keys for the operators
 ## Onchain Mode Options
 - `--rpc ENDPOINT`: RPC endpoint to access L1 data
-- `--network NETWORK`: Ethereum network (Holesky or Hoodi - Mainnet is not supported)
+- `--network NETWORK`: Ethereum network (Mainnet or Holesky)
 
 # Output
 The tool generates a JSON file compatible with the SSV validator registration webapp.

--- a/anchor/keysplit/README.md
+++ b/anchor/keysplit/README.md
@@ -61,7 +61,7 @@ anchor keysplit onchain \
 - `--public-keys KEYS`: Comma-separated list of RSA public keys for the operators
 ## Onchain Mode Options
 - `--rpc ENDPOINT`: RPC endpoint to access L1 data
-- `--network NETWORK`: Ethereum network (Mainnet or Holesky)
+- `--network NETWORK`: Ethereum network (Mainnet, Holesky, Hoodi)
 
 # Output
 The tool generates a JSON file compatible with the SSV validator registration webapp.

--- a/docs/docs/pages/cli.mdx
+++ b/docs/docs/pages/cli.mdx
@@ -22,6 +22,6 @@ Where `<COMMAND>` is one of:
 | --- | --- |-----------------------|
 | `--data-dir <DIR>` | Data directory for node files | `~/.anchor/{network}` |
 | `--testnet-dir <DIR>` | Directory containing testnet specs | None                  |
-| `--network <NETWORK>` | Network to use (Holesky, Hoodi) | `hoodi`               |
+| `--network <NETWORK>` | Network to use (Mainnet, Holesky, Hoodi) | `mainnet`               |
 | `--help` | Display help information | Unset                 |
 

--- a/docs/docs/pages/running_an_operator.mdx
+++ b/docs/docs/pages/running_an_operator.mdx
@@ -33,7 +33,7 @@ To register an operator, follow the instructions for the official
 **Step 3: Configure and run your Anchor node**
 
 Create a directory for Anchor-related data and move the generated private key into the directory. By default, Anchor
-uses `~/.anchor/<network>`, where `<network>` is `hoodi` or `holesky`. We use `hoodi` below:
+uses `~/.anchor/<network>`, where `<network>` is `mainnet`, `hoodi` or `holesky`. We use `hoodi` below:
 
 ```bash
 mkdir -p ~/.anchor/hoodi


### PR DESCRIPTION
## Proposed Changes

- Allow passing `mainnet` to `network`.
- Remove `mainnet` safeguard from client startup function.
- Adjust comments and docs.
- Make `mainnet` the default network.