### PR TITLE
fix: Sign validator registration at the same time as Go-SSV

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -798,6 +798,7 @@ dependencies = [
  "database",
  "eth2",
  "ethereum_ssz",
+ "futures",
  "hex",
  "lru 0.16.0",
  "metrics",

--- a/anchor/client/src/lib.rs
+++ b/anchor/client/src/lib.rs
@@ -12,7 +12,10 @@ use std::{
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
-use anchor_validator_store::{AnchorValidatorStore, metadata_service::MetadataService};
+use anchor_validator_store::{
+    AnchorValidatorStore, metadata_service::MetadataService,
+    registration_service::RegistrationService,
+};
 use beacon_node_fallback::{
     ApiTopic, BeaconNodeFallback, CandidateBeaconNode, start_fallback_updater_service,
 };
@@ -604,6 +607,13 @@ impl Client {
             .validator_registration_batch_size(500)
             .build()?;
 
+        let registration_service = RegistrationService::new(
+            validator_store.clone(),
+            slot_clock.clone(),
+            beacon_nodes.clone(),
+            executor.clone(),
+        );
+
         let sync_committee_service = SyncCommitteeService::new(
             duties_service.clone(),
             validator_store.clone(),
@@ -646,8 +656,12 @@ impl Client {
             .map_err(|e| format!("Unable to start metadata service: {e}"))?;
 
         preparation_service
-            .start_update_service(&spec)
+            .start_proposer_prepare_service(&spec)
             .map_err(|e| format!("Unable to start preparation service: {e}"))?;
+
+        registration_service
+            .start_validator_registration_service(&spec)
+            .map_err(|e| format!("Unable to start validator registration service: {e}"))?;
 
         http_api_shared_state.write().database_state = Some(database.watch());
 

--- a/anchor/validator_store/Cargo.toml
+++ b/anchor/validator_store/Cargo.toml
@@ -9,6 +9,7 @@ beacon_node_fallback = { workspace = true }
 database = { workspace = true }
 eth2 = { workspace = true }
 ethereum_ssz = { workspace = true }
+futures = { workspace = true }
 hex = { workspace = true }
 lru = { workspace = true }
 metrics = { workspace = true }

--- a/anchor/validator_store/src/lib.rs
+++ b/anchor/validator_store/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod metadata_service;
 mod metrics;
+pub mod registration_service;
 
 use std::{
     collections::{HashMap, HashSet},
@@ -1081,7 +1082,6 @@ impl<T: SlotClock, E: EthSpec> ValidatorStore for AnchorValidatorStore<T, E> {
     ) -> Result<SignedValidatorRegistrationData, Error> {
         let future = async {
             let domain_hash = self.spec.get_builder_domain();
-            let signing_root = validator_registration_data.signing_root(domain_hash);
 
             let (validator, cluster) =
                 self.get_validator_and_cluster(validator_registration_data.pubkey)?;
@@ -1090,13 +1090,16 @@ impl<T: SlotClock, E: EthSpec> ValidatorStore for AnchorValidatorStore<T, E> {
             let epoch = self
                 .slot_clock
                 .slot_of(Duration::from_secs(validator_registration_data.timestamp))
-                .unwrap_or(self.spec.genesis_slot)
+                .ok_or(SpecificError::SlotClock)?
                 .epoch(E::slots_per_epoch());
-            let sign_slot = epoch.start_slot(E::slots_per_epoch());
-            let validity_slot = epoch.end_slot(E::slots_per_epoch());
-            if let Some(duration) = self.slot_clock.start_of(sign_slot) {
-                validator_registration_data.timestamp = duration.as_secs();
-            }
+            let slot = epoch.start_slot(E::slots_per_epoch());
+            let duration = self
+                .slot_clock
+                .start_of(slot)
+                .ok_or(SpecificError::SlotClock)?;
+            validator_registration_data.timestamp = duration.as_secs();
+
+            let signing_root = validator_registration_data.signing_root(domain_hash);
 
             let signature = self
                 .collect_signature(
@@ -1106,7 +1109,7 @@ impl<T: SlotClock, E: EthSpec> ValidatorStore for AnchorValidatorStore<T, E> {
                     &validator,
                     &cluster,
                     signing_root,
-                    validity_slot,
+                    slot,
                 )
                 .await?;
 

--- a/anchor/validator_store/src/lib.rs
+++ b/anchor/validator_store/src/lib.rs
@@ -1078,7 +1078,7 @@ impl<T: SlotClock, E: EthSpec> ValidatorStore for AnchorValidatorStore<T, E> {
 
     async fn sign_validator_registration_data(
         &self,
-        mut validator_registration_data: ValidatorRegistrationData,
+        validator_registration_data: ValidatorRegistrationData,
     ) -> Result<SignedValidatorRegistrationData, Error> {
         let future = async {
             let domain_hash = self.spec.get_builder_domain();
@@ -1097,7 +1097,10 @@ impl<T: SlotClock, E: EthSpec> ValidatorStore for AnchorValidatorStore<T, E> {
                 .slot_clock
                 .start_of(slot)
                 .ok_or(SpecificError::SlotClock)?;
-            validator_registration_data.timestamp = duration.as_secs();
+            let validator_registration_data = ValidatorRegistrationData {
+                timestamp: duration.as_secs(),
+                ..validator_registration_data
+            };
 
             let signing_root = validator_registration_data.signing_root(domain_hash);
 

--- a/anchor/validator_store/src/registration_service.rs
+++ b/anchor/validator_store/src/registration_service.rs
@@ -103,7 +103,7 @@ impl<S: ValidatorStore + 'static, T: SlotClock + 'static> Inner<S, T> {
     fn collect_validator_registration_data(
         &self,
         slot: Slot,
-        slots_between_registrations: u64,
+        number_of_slots_between_registrations: u64,
     ) -> Vec<ValidatorRegistrationData> {
         let all_pubkeys: Vec<_> = self
             .validator_store
@@ -125,7 +125,7 @@ impl<S: ValidatorStore + 'static, T: SlotClock + 'static> Inner<S, T> {
                     pubkey,
                     timestamp,
                     slot,
-                    slots_between_registrations,
+                    number_of_slots_between_registrations,
                 )
             })
             .collect()
@@ -136,17 +136,13 @@ impl<S: ValidatorStore + 'static, T: SlotClock + 'static> Inner<S, T> {
         pubkey: PublicKeyBytes,
         timestamp: u64,
         slot: Slot,
-        slots_between_registrations: u64,
+        number_of_slots_between_registrations: u64,
     ) -> Option<ValidatorRegistrationData> {
         let proposal_data = self.validator_store.proposal_data(&pubkey)?;
         // Ignore fee recipients for keys without indices, they are inactive.
         let index = proposal_data.validator_index?;
 
-        // To not sign for all validators at once, select based on the current slot.
-        // Note that it is important that this is the same across client implementations, as else
-        // the nodes broadcast partial signatures for their validators at varying times.
-        // The modulo is applied to both slot and index to balance the load.
-        if slot % slots_between_registrations != index % slots_between_registrations {
+        if is_scheduled_for_slot(slot, index, number_of_slots_between_registrations) {
             return None;
         }
 
@@ -213,12 +209,27 @@ impl<S: ValidatorStore + 'static, T: SlotClock + 'static> Inner<S, T> {
 
     /// Register validators with builders, used in the blinded block proposal flow.
     async fn register_validators(&self, slot: Slot) -> Result<(), String> {
-        let slots_per_registration =
+        let number_of_slots_between_registrations =
             EPOCHS_PER_VALIDATOR_REGISTRATION_SUBMISSION * S::E::slots_per_epoch();
         let registration_data =
-            self.collect_validator_registration_data(slot, slots_per_registration);
+            self.collect_validator_registration_data(slot, number_of_slots_between_registrations);
         let signed = self.sign_registration_data(registration_data).await;
         self.broadcast_registration_data(&signed).await;
         Ok(())
     }
+}
+
+/// To not sign for all validators at once, select based on the current slot.
+/// Note that it is important that this is the same across client implementations, as else
+/// the nodes broadcast partial signatures for their validators at varying times.
+/// Assigns each validator to one of `number_of_slots_between_registrations` slot buckets by `index`
+/// % `number_of_slots_between_registrations`. In slot s, we serve bucket s %
+/// `number_of_slots_between_registrations`. This ensures each validator refreshes once every
+/// `number_of_slots_between_registrations` slots.
+fn is_scheduled_for_slot(
+    slot: Slot,
+    index: u64,
+    number_of_slots_between_registrations: u64,
+) -> bool {
+    slot % number_of_slots_between_registrations != index % number_of_slots_between_registrations
 }

--- a/anchor/validator_store/src/registration_service.rs
+++ b/anchor/validator_store/src/registration_service.rs
@@ -6,7 +6,10 @@ use slot_clock::SlotClock;
 use task_executor::TaskExecutor;
 use tokio::time::{Duration, sleep};
 use tracing::{error, info, warn};
-use types::{ChainSpec, EthSpec, SignedValidatorRegistrationData, Slot, ValidatorRegistrationData};
+use types::{
+    ChainSpec, EthSpec, PublicKeyBytes, SignedValidatorRegistrationData, Slot,
+    ValidatorRegistrationData,
+};
 use validator_store::{DoppelgangerStatus, ValidatorStore};
 
 /// Number of epochs to wait before re-submitting validator registration.
@@ -84,7 +87,7 @@ impl<S: ValidatorStore + 'static, T: SlotClock + 'static> Inner<S, T> {
     fn collect_validator_registration_data(
         &self,
         slot: Slot,
-        slots_per_registration: u64,
+        slots_between_registrations: u64,
     ) -> Vec<ValidatorRegistrationData> {
         let all_pubkeys: Vec<_> = self
             .validator_store
@@ -102,29 +105,47 @@ impl<S: ValidatorStore + 'static, T: SlotClock + 'static> Inner<S, T> {
         all_pubkeys
             .into_iter()
             .filter_map(|pubkey| {
-                let proposal_data = self.validator_store.proposal_data(&pubkey)?;
-                // Ignore fee recipients for keys without indices, they are inactive.
-                let index = proposal_data.validator_index?;
-
-                // To not sign for all validators at once, select based on the current slot.
-                if slot % slots_per_registration != index % slots_per_registration {
-                    return None;
-                }
-
-                // We don't log for missing fee recipients here because this will be logged more
-                // frequently in `collect_preparation_data`.
-                proposal_data.fee_recipient.and_then(|fee_recipient| {
-                    proposal_data
-                        .builder_proposals
-                        .then_some(ValidatorRegistrationData {
-                            fee_recipient,
-                            gas_limit: proposal_data.gas_limit,
-                            pubkey,
-                            timestamp,
-                        })
-                })
+                self.get_registration_data_for_pubkey(
+                    pubkey,
+                    timestamp,
+                    slot,
+                    slots_between_registrations,
+                )
             })
             .collect()
+    }
+
+    fn get_registration_data_for_pubkey(
+        &self,
+        pubkey: PublicKeyBytes,
+        timestamp: u64,
+        slot: Slot,
+        slots_between_registrations: u64,
+    ) -> Option<ValidatorRegistrationData> {
+        let proposal_data = self.validator_store.proposal_data(&pubkey)?;
+        // Ignore fee recipients for keys without indices, they are inactive.
+        let index = proposal_data.validator_index?;
+
+        // To not sign for all validators at once, select based on the current slot.
+        // Note that it is important that this is the same across client implementations, as else
+        // the nodes broadcast partial signatures for their validators at varying times.
+        // The modulo is applied to both slot and index to balance the load.
+        if slot % slots_between_registrations != index % slots_between_registrations {
+            return None;
+        }
+
+        // We don't log for missing fee recipients here because this will be logged more
+        // frequently in `collect_preparation_data`.
+        proposal_data.fee_recipient.and_then(|fee_recipient| {
+            proposal_data
+                .builder_proposals
+                .then_some(ValidatorRegistrationData {
+                    fee_recipient,
+                    gas_limit: proposal_data.gas_limit,
+                    pubkey,
+                    timestamp,
+                })
+        })
     }
 
     async fn sign_registration_data(

--- a/anchor/validator_store/src/registration_service.rs
+++ b/anchor/validator_store/src/registration_service.rs
@@ -1,3 +1,17 @@
+//! Coordinates periodic MEV/Builder **validator registrations** for Anchor.
+//!
+//! Why this exists: in DVT the validator key is split, and the **registration payload includes
+//! a timestamp**; if different operators construct it at different moments they’ll sign different
+//! bytes. Anchor therefore **owns the timing** of registration (instead of Lighthouse’s
+//! `preparation_service`) so all operators sign the **same** message and submit it to relays via
+//! BN.
+//!
+//! This module:
+//! - derives a **slot-start** timestamp (deterministic) for each window,
+//! - builds `ValidatorRegistrationData` from proposer prefs (fee recipient, gas limit) and pubkey,
+//! - requests signatures from the `ValidatorStore`,
+//! - and submits `SignedValidatorRegistrationData` to connected beacon nodes (Builder API).
+
 use std::sync::Arc;
 
 use beacon_node_fallback::BeaconNodeFallback;

--- a/anchor/validator_store/src/registration_service.rs
+++ b/anchor/validator_store/src/registration_service.rs
@@ -1,0 +1,187 @@
+use std::sync::Arc;
+
+use beacon_node_fallback::BeaconNodeFallback;
+use futures::future::join_all;
+use slot_clock::SlotClock;
+use task_executor::TaskExecutor;
+use tokio::time::{Duration, sleep};
+use tracing::{error, info, warn};
+use types::{ChainSpec, EthSpec, SignedValidatorRegistrationData, Slot, ValidatorRegistrationData};
+use validator_store::{DoppelgangerStatus, ValidatorStore};
+
+/// Number of epochs to wait before re-submitting validator registration.
+const EPOCHS_PER_VALIDATOR_REGISTRATION_SUBMISSION: u64 = 10;
+
+pub struct RegistrationService<S, T> {
+    inner: Arc<Inner<S, T>>,
+}
+
+struct Inner<S, T> {
+    validator_store: Arc<S>,
+    slot_clock: T,
+    beacon_nodes: Arc<BeaconNodeFallback<T>>,
+    executor: TaskExecutor,
+}
+
+impl<S: ValidatorStore + 'static, T: SlotClock + 'static> RegistrationService<S, T> {
+    pub fn new(
+        validator_store: Arc<S>,
+        slot_clock: T,
+        beacon_nodes: Arc<BeaconNodeFallback<T>>,
+        executor: TaskExecutor,
+    ) -> Self {
+        Self {
+            inner: Arc::new(Inner {
+                validator_store,
+                slot_clock,
+                beacon_nodes,
+                executor,
+            }),
+        }
+    }
+
+    /// Starts the service which periodically sends connected beacon nodes validator registration
+    /// information.
+    pub fn start_validator_registration_service(self, spec: &ChainSpec) -> Result<(), String> {
+        info!("Validator registration service started");
+
+        let spec = spec.clone();
+        let slot_duration = Duration::from_secs(spec.seconds_per_slot);
+
+        let executor = self.inner.executor.clone();
+
+        let validator_registration_fut = async move {
+            loop {
+                if let Some(slot) = self.inner.slot_clock.now() {
+                    let inner = self.inner.clone();
+                    let executor = inner.executor.clone();
+                    let future = async move {
+                        // Poll the endpoint immediately to ensure fee recipients are received.
+                        if let Err(e) = inner.register_validators(slot).await {
+                            error!(error = ?e, "Error during validator registration");
+                        }
+                    };
+                    executor.spawn(future, "validator_registration");
+                }
+
+                // Wait one slot if the register validator request fails or if we should not publish
+                // at the current slot.
+                if let Some(duration_to_next_slot) = self.inner.slot_clock.duration_to_next_slot() {
+                    sleep(duration_to_next_slot).await;
+                } else {
+                    error!("Failed to read slot clock");
+                    // If we can't read the slot clock, just wait another slot.
+                    sleep(slot_duration).await;
+                }
+            }
+        };
+        executor.spawn(validator_registration_fut, "validator_registration_service");
+        Ok(())
+    }
+}
+
+impl<S: ValidatorStore + 'static, T: SlotClock + 'static> Inner<S, T> {
+    fn collect_validator_registration_data(
+        &self,
+        slot: Slot,
+        slots_per_registration: u64,
+    ) -> Vec<ValidatorRegistrationData> {
+        let all_pubkeys: Vec<_> = self
+            .validator_store
+            .voting_pubkeys(DoppelgangerStatus::ignored);
+
+        let Some(timestamp) = self
+            .slot_clock
+            .start_of(slot)
+            .map(|duration| duration.as_secs())
+        else {
+            // Try again later.
+            return vec![];
+        };
+
+        all_pubkeys
+            .into_iter()
+            .filter_map(|pubkey| {
+                let proposal_data = self.validator_store.proposal_data(&pubkey)?;
+                // Ignore fee recipients for keys without indices, they are inactive.
+                let index = proposal_data.validator_index?;
+
+                // To not sign for all validators at once, select based on the current slot.
+                if slot % slots_per_registration != index % slots_per_registration {
+                    return None;
+                }
+
+                // We don't log for missing fee recipients here because this will be logged more
+                // frequently in `collect_preparation_data`.
+                proposal_data.fee_recipient.and_then(|fee_recipient| {
+                    proposal_data
+                        .builder_proposals
+                        .then_some(ValidatorRegistrationData {
+                            fee_recipient,
+                            gas_limit: proposal_data.gas_limit,
+                            pubkey,
+                            timestamp,
+                        })
+                })
+            })
+            .collect()
+    }
+
+    async fn sign_registration_data(
+        &self,
+        registration_data: Vec<ValidatorRegistrationData>,
+    ) -> Vec<SignedValidatorRegistrationData> {
+        // Execute signing in parallel
+        let results = join_all(registration_data.into_iter().map(|data| async {
+            (
+                data.pubkey,
+                self.validator_store
+                    .sign_validator_registration_data(data)
+                    .await,
+            )
+        }))
+        .await;
+        results
+            .into_iter()
+            .filter_map(|(validator, result)| match result {
+                Ok(signed) => Some(signed),
+                Err(err) => {
+                    warn!(?err, %validator, "Failed to sign validator MEV registration");
+                    None
+                }
+            })
+            .collect()
+    }
+
+    async fn broadcast_registration_data(&self, signed: &[SignedValidatorRegistrationData]) {
+        if !signed.is_empty() {
+            match self
+                .beacon_nodes
+                .broadcast(|beacon_node| async move {
+                    beacon_node.post_validator_register_validator(signed).await
+                })
+                .await
+            {
+                Ok(()) => info!(
+                    count = signed.len(),
+                    "Published validator registrations to the builder network"
+                ),
+                Err(err) => warn!(
+                    %err,
+                    "Unable to publish validator registrations to the builder network"
+                ),
+            }
+        }
+    }
+
+    /// Register validators with builders, used in the blinded block proposal flow.
+    async fn register_validators(&self, slot: Slot) -> Result<(), String> {
+        let slots_per_registration =
+            EPOCHS_PER_VALIDATOR_REGISTRATION_SUBMISSION * S::E::slots_per_epoch();
+        let registration_data =
+            self.collect_validator_registration_data(slot, slots_per_registration);
+        let signed = self.sign_registration_data(registration_data).await;
+        self.broadcast_registration_data(&signed).await;
+        Ok(())
+    }
+}

--- a/anchor/validator_store/src/registration_service.rs
+++ b/anchor/validator_store/src/registration_service.rs
@@ -79,6 +79,8 @@ impl<S: ValidatorStore + 'static, T: SlotClock + 'static> RegistrationService<S,
                         }
                     };
                     executor.spawn(future, "validator_registration");
+                } else {
+                    error!("Slot clock can not return current slot");
                 }
 
                 // Wait one slot if the register validator request fails or if we should not publish


### PR DESCRIPTION
## Issue Addressed

We can not rely on Lighthouse's `preparation_service` to trigger signing the validator MEV registration, as we need to do it at the same time as Go-SSV.

## Proposed Changes

Implement our own `registration_service` and use the `preparation_service` only for proposal preparations.
