### PR TITLE
fix: Read keystore password from disk or stdin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4307,12 +4307,14 @@ dependencies = [
  "hex",
  "openssl",
  "operator_key",
+ "rpassword",
  "serde",
  "serde_json",
  "ssv_types",
  "tokio",
  "tracing",
  "types",
+ "zeroize",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4311,6 +4311,7 @@ dependencies = [
  "serde",
  "serde_json",
  "ssv_types",
+ "tempfile",
  "tokio",
  "tracing",
  "types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -128,6 +128,7 @@ r2d2 = "0.8.10"
 r2d2_sqlite = "0.21.0"
 rand = "0.9"
 reqwest = "0.12.12"
+rpassword = "7.4.0"
 rusqlite = "0.28.0"
 serde = { version = "1.0.208", features = ["derive"] }
 serde_json = "1.0.140"

--- a/anchor/keygen/Cargo.toml
+++ b/anchor/keygen/Cargo.toml
@@ -10,7 +10,7 @@ clap = { workspace = true }
 global_config = { workspace = true }
 openssl = { workspace = true }
 operator_key = { workspace = true }
-rpassword = "7.4.0"
+rpassword = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/anchor/keysplit/Cargo.toml
+++ b/anchor/keysplit/Cargo.toml
@@ -25,3 +25,6 @@ tokio = { workspace = true }
 tracing = { workspace = true }
 types = { workspace = true }
 zeroize = { workspace = true }
+
+[dev-dependencies]
+tempfile = "3.14.0"

--- a/anchor/keysplit/Cargo.toml
+++ b/anchor/keysplit/Cargo.toml
@@ -17,9 +17,11 @@ global_config = { workspace = true }
 hex = { workspace = true }
 openssl = { workspace = true }
 operator_key = { workspace = true }
+rpassword = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 ssv_types = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
 types = { workspace = true }
+zeroize = { workspace = true }

--- a/anchor/keysplit/src/cli.rs
+++ b/anchor/keysplit/src/cli.rs
@@ -1,4 +1,4 @@
-use std::str::FromStr;
+use std::{path::PathBuf, str::FromStr};
 
 use clap::Parser;
 use openssl::{pkey::Public, rsa::Rsa};
@@ -72,10 +72,11 @@ pub struct SharedKeygenOptions {
 
     #[clap(
         long,
-        help = "Password for the validator keystore",
-        value_name = "PASSWORD"
+        help = "Path to a file containing the password for the validator keystore. If ommitted, \
+                the password will be prompted for.",
+        value_name = "PATH"
     )]
-    pub password: String,
+    pub password_file: Option<PathBuf>,
 
     #[clap(
         long,

--- a/anchor/keysplit/src/cli.rs
+++ b/anchor/keysplit/src/cli.rs
@@ -72,7 +72,7 @@ pub struct SharedKeygenOptions {
 
     #[clap(
         long,
-        help = "Path to a file containing the password for the validator keystore. If ommitted, \
+        help = "Path to a file containing the password for the validator keystore. If omitted, \
                 the password will be prompted for.",
         value_name = "PATH"
     )]

--- a/anchor/keysplit/src/lib.rs
+++ b/anchor/keysplit/src/lib.rs
@@ -57,7 +57,7 @@ pub fn run_keysplitter(
     let keys = keystore
         .decrypt_keypair(
             read_password(shared.password_file.as_deref())
-                .map_err(KeysplitError::Keystore)?
+                .map_err(|e| KeysplitError::Keystore(format!("Unable to get password: {e}")))?
                 .as_bytes(),
         )
         .map_err(|e| KeysplitError::Keystore(format!("Failed to decrypt keystore file: {e:?}")))?;

--- a/anchor/keysplit/src/lib.rs
+++ b/anchor/keysplit/src/lib.rs
@@ -11,6 +11,7 @@ use crate::{
     crypto::{encrypt_keyshares, split_keys},
     output::OutputData,
     split::{manual_split, onchain_split},
+    util::read_password,
 };
 
 mod cli;
@@ -54,7 +55,11 @@ pub fn run_keysplitter(
     // 2) Extract the validator keys from the keystore file
     info!("Extracting keys from keystore file...");
     let keys = keystore
-        .decrypt_keypair(shared.password.as_bytes())
+        .decrypt_keypair(
+            read_password(shared.password_file.as_deref())
+                .map_err(KeysplitError::Keystore)?
+                .as_bytes(),
+        )
         .map_err(|e| KeysplitError::Keystore(format!("Failed to decrypt keystore file: {e:?}")))?;
     info!("Successfully extracted keys from keystore file");
 

--- a/anchor/keysplit/src/util.rs
+++ b/anchor/keysplit/src/util.rs
@@ -1,4 +1,4 @@
-use std::{fs, path::Path, str::FromStr};
+use std::{fs, io::BufRead, path::Path, str::FromStr};
 
 use base64::prelude::*;
 use openssl::{pkey::Public, rsa::Rsa};
@@ -32,15 +32,220 @@ where
     s.serialize_str(&encoded)
 }
 
+/// Reads a password from either a file or stdin.
+///
+/// If `file` is `Some`, reads the password from the file at the given path,
+/// trimming trailing newlines and carriage returns.
+///
+/// If `file` is `None`, prompts the user interactively for a password via stdin.
+///
+/// Returns an error if the file cannot be read, the password is empty, or stdin read fails.
 pub(crate) fn read_password(file: Option<&Path>) -> Result<Zeroizing<String>, String> {
     if let Some(path) = file {
-        let full = Zeroizing::new(
-            fs::read_to_string(path).map_err(|e| format!("Unable to read password file: {e}"))?,
-        );
-        Ok(Zeroizing::new(full.trim_matches(['\n', '\r']).to_string()))
+        read_password_from_file(path)
     } else {
-        let password = rpassword::prompt_password("Enter keystore password: ")
-            .map_err(|e| format!("Unable to read password from stdin: {e}"))?;
-        Ok(Zeroizing::new(password))
+        read_password_from_stdin(&mut std::io::stdin().lock())
+    }
+}
+
+fn read_password_from_file(path: &Path) -> Result<Zeroizing<String>, String> {
+    let raw = fs::read_to_string(path).map_err(|e| format!("Unable to read password file: {e}"))?;
+    process_password(raw)
+}
+
+fn read_password_from_stdin<R: BufRead>(stdin: &mut R) -> Result<Zeroizing<String>, String> {
+    let raw = rpassword::read_password_from_bufread(stdin)
+        .map_err(|e| format!("Unable to read password from stdin: {e}"))?;
+    process_password(raw)
+}
+
+fn process_password(raw: String) -> Result<Zeroizing<String>, String> {
+    let trimmed = raw.trim_matches(['\n', '\r']);
+    if trimmed.is_empty() {
+        return Err("Password cannot be empty".to_string());
+    }
+    Ok(Zeroizing::new(trimmed.to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        io::{Cursor, Write},
+        path::PathBuf,
+    };
+
+    use tempfile::NamedTempFile;
+
+    use super::*;
+
+    // Helper function for stdin tests
+    fn test_read_password_from_stdin(input: &[u8]) -> Result<Zeroizing<String>, String> {
+        let mut cursor = Cursor::new(input);
+        read_password_from_stdin(&mut cursor)
+    }
+
+    // Helper function to create a temp file with content
+    fn create_password_file(content: &str) -> NamedTempFile {
+        let mut file = NamedTempFile::new().expect("Failed to create temp file");
+        file.write_all(content.as_bytes())
+            .expect("Failed to write to temp file");
+        file
+    }
+
+    // === File Path Tests ===
+
+    #[test]
+    fn test_read_password_from_file_success() {
+        let file = create_password_file("hunter2");
+        let result = read_password(Some(file.path()));
+
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().as_str(), "hunter2");
+    }
+
+    #[test]
+    fn test_read_password_from_file_with_trailing_newline() {
+        let file = create_password_file("hunter2\n");
+        let result = read_password(Some(file.path()));
+
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().as_str(), "hunter2");
+    }
+
+    #[test]
+    fn test_read_password_from_file_with_trailing_crlf() {
+        let file = create_password_file("hunter2\r\n");
+        let result = read_password(Some(file.path()));
+
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().as_str(), "hunter2");
+    }
+
+    #[test]
+    fn test_read_password_from_file_with_multiple_trailing_newlines() {
+        let file = create_password_file("hunter2\n\n\n");
+        let result = read_password(Some(file.path()));
+
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().as_str(), "hunter2");
+    }
+
+    #[test]
+    fn test_read_password_from_file_missing_file() {
+        let missing_path = PathBuf::from("/tmp/nonexistent_password_file_12345.txt");
+        let result = read_password(Some(&missing_path));
+
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("Unable to read password file"));
+    }
+
+    #[test]
+    fn test_read_password_from_file_empty_password() {
+        let file = create_password_file("");
+        let result = read_password(Some(file.path()));
+
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err(), "Password cannot be empty");
+    }
+
+    #[test]
+    fn test_read_password_from_file_only_whitespace() {
+        let file = create_password_file("\n\n\r\n");
+        let result = read_password(Some(file.path()));
+
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err(), "Password cannot be empty");
+    }
+
+    #[test]
+    fn test_read_password_from_file_with_spaces() {
+        let file = create_password_file("pass word\n");
+        let result = read_password(Some(file.path()));
+
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().as_str(), "pass word");
+    }
+
+    // === Stdin Tests ===
+
+    #[test]
+    fn test_read_password_from_stdin_success() {
+        let result = test_read_password_from_stdin(b"hunter2\n");
+
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().as_str(), "hunter2");
+    }
+
+    #[test]
+    fn test_read_password_from_stdin_no_newline() {
+        // rpassword reads until newline, so without one it reaches EOF
+        let result = test_read_password_from_stdin(b"hunter2");
+
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .contains("Unable to read password from stdin")
+        );
+    }
+
+    #[test]
+    fn test_read_password_from_stdin_with_crlf() {
+        let result = test_read_password_from_stdin(b"hunter2\r\n");
+
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().as_str(), "hunter2");
+    }
+
+    #[test]
+    fn test_read_password_from_stdin_empty_input() {
+        let result = test_read_password_from_stdin(b"");
+
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .contains("Unable to read password from stdin")
+        );
+    }
+
+    #[test]
+    fn test_read_password_from_stdin_only_newline() {
+        let result = test_read_password_from_stdin(b"\n");
+
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err(), "Password cannot be empty");
+    }
+
+    #[test]
+    fn test_read_password_from_stdin_only_whitespace() {
+        let result = test_read_password_from_stdin(b"\r\n");
+
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err(), "Password cannot be empty");
+    }
+
+    #[test]
+    fn test_read_password_from_stdin_with_spaces() {
+        let result = test_read_password_from_stdin(b"pass word\n");
+
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().as_str(), "pass word");
+    }
+
+    #[test]
+    fn test_read_password_from_stdin_special_characters() {
+        let result = test_read_password_from_stdin(b"p@ssw0rd!#$%\n");
+
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().as_str(), "p@ssw0rd!#$%");
+    }
+
+    #[test]
+    fn test_read_password_from_stdin_unicode() {
+        let result = test_read_password_from_stdin("パスワード\n".as_bytes());
+
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().as_str(), "パスワード");
     }
 }

--- a/anchor/keysplit/src/util.rs
+++ b/anchor/keysplit/src/util.rs
@@ -1,9 +1,10 @@
-use std::str::FromStr;
+use std::{fs, path::Path, str::FromStr};
 
 use base64::prelude::*;
 use openssl::{pkey::Public, rsa::Rsa};
 use serde::Serializer;
 use types::Address;
+use zeroize::Zeroizing;
 
 // Serde deserialization and serialization helper functions
 pub(crate) fn parse_address(s: &str) -> Result<Address, String> {
@@ -29,4 +30,17 @@ where
 
     let encoded = BASE64_STANDARD.encode(pem_string.clone());
     s.serialize_str(&encoded)
+}
+
+pub(crate) fn read_password(file: Option<&Path>) -> Result<Zeroizing<String>, String> {
+    if let Some(path) = file {
+        let full = Zeroizing::new(
+            fs::read_to_string(path).map_err(|e| format!("Unable to read password file: {e}"))?,
+        );
+        Ok(Zeroizing::new(full.trim_matches(['\n', '\r']).to_string()))
+    } else {
+        let password = rpassword::prompt_password("Enter keystore password: ")
+            .map_err(|e| format!("Unable to read password from stdin: {e}"))?;
+        Ok(Zeroizing::new(password))
+    }
 }


### PR DESCRIPTION
## Issue Addressed

- #632

## Proposed Changes

Change `--password` to `--password-file` and make it optional. If it is provided, the password is read from the provided path, else it is read from stdin.
