### PR TITLE
chore: Reduce number of log files

### DIFF
--- a/anchor/logging/src/logging.rs
+++ b/anchor/logging/src/logging.rs
@@ -10,7 +10,7 @@ use tracing::Level;
 use tracing_appender::non_blocking::{NonBlocking, WorkerGuard};
 
 pub use crate::tracing_libp2p_discv5_layer::{
-    create_libp2p_discv5_tracing_layer, Libp2pDiscv5TracingLayer,
+    Libp2pDiscv5TracingLayer, create_libp2p_discv5_tracing_layer,
 };
 
 #[derive(Parser, Debug, Clone)]

--- a/anchor/logging/src/logging.rs
+++ b/anchor/logging/src/logging.rs
@@ -10,7 +10,7 @@ use tracing::Level;
 use tracing_appender::non_blocking::{NonBlocking, WorkerGuard};
 
 pub use crate::tracing_libp2p_discv5_layer::{
-    Libp2pDiscv5TracingLayer, create_libp2p_discv5_tracing_layer,
+    create_libp2p_discv5_tracing_layer, Libp2pDiscv5TracingLayer,
 };
 
 #[derive(Parser, Debug, Clone)]
@@ -37,7 +37,7 @@ pub struct FileLoggingFlags {
         global = true,
         value_name = "NUMBER",
         help = "Maximum number of log files to keep. Set to 0 to disable file logging.",
-        default_value_t = 100
+        default_value_t = 10
     )]
     pub logfile_max_number: u64,
 


### PR DESCRIPTION
## Issue Addressed

I was looking through some logs on our servers and noticed a large number of compressed log files. 

I see that we have a default of 100 compressed log files. Each are default to 100MB. I think this is a bit excessive. I've reduced the default to 10 log files. 
