### PR TITLE
fix: implement periodic peer discovery without connection failure tracking

### DIFF
--- a/anchor/logging/src/tracing_libp2p_discv5_layer.rs
+++ b/anchor/logging/src/tracing_libp2p_discv5_layer.rs
@@ -81,12 +81,12 @@ pub fn create_libp2p_discv5_tracing_layer(
         let libp2p_writer =
             LogRollerBuilder::new(tracing_log_path.clone(), PathBuf::from("libp2p.log"))
                 .rotation(Rotation::SizeBased(RotationSize::MB(max_log_size)))
-                .max_keep_files(1);
+                .max_keep_files(5);
 
         let discv5_writer =
             LogRollerBuilder::new(tracing_log_path.clone(), PathBuf::from("discv5.log"))
                 .rotation(Rotation::SizeBased(RotationSize::MB(max_log_size)))
-                .max_keep_files(1);
+                .max_keep_files(5);
 
         let libp2p_writer = match libp2p_writer.build() {
             Ok(writer) => writer,

--- a/anchor/network/src/discovery.rs
+++ b/anchor/network/src/discovery.rs
@@ -344,8 +344,10 @@ impl Discovery {
     pub fn set_subscribed(&mut self, subnet: SubnetId, subscribed: bool) {
         let enr = self.discv5.local_enr();
 
+        // Get current subnet state from ENR
         let mut subnets = committee_bitfield(&enr).unwrap_or_default();
 
+        // Update the specific subnet requested
         if let Err(err) = subnets.set(*subnet as usize, subscribed) {
             error!(
                 ?err,
@@ -360,7 +362,7 @@ impl Discovery {
         {
             error!(?err, "Unable to update ENR");
         } else {
-            debug!(enr=?self.discv5.local_enr(), "Updated subnets in ENR");
+            info!(enr=?self.discv5.local_enr(), "Updated subnets in ENR");
             save_enr_to_disk(&self.enr_file_path, &self.discv5.local_enr());
         }
     }
@@ -661,7 +663,10 @@ pub fn build_enr(
     }
 
     // set the "subnets" field on our ENR
-    builder.add_value::<Bytes>("subnets", &BitVector::<U128>::new().as_ssz_bytes().into());
+    // Start with empty subnet bitfield - will be populated dynamically via set_subscribed()
+    // when gossipsub subscriptions are established
+    let subnets = BitVector::<U128>::new();
+    builder.add_value::<Bytes>("subnets", &subnets.as_ssz_bytes().into());
 
     // set the "domaintype" field on our ENR
     builder.add_value::<[u8; 4]>("domaintype", &config.domain_type.0);

--- a/anchor/network/src/handshake/mod.rs
+++ b/anchor/network/src/handshake/mod.rs
@@ -11,7 +11,7 @@ use libp2p::{
     },
     swarm::NetworkBehaviour,
 };
-use tracing::trace;
+use tracing::{debug, trace};
 
 use crate::handshake::{codec::Codec, node_info::NodeInfo};
 
@@ -147,7 +147,16 @@ fn handle_response(
 /// Send a handshake request to a specified peer. Should be called after establishing an outgoing
 /// connection.
 pub fn initiate(our_node_info: &NodeInfo, behaviour: &mut Behaviour, peer_id: PeerId) {
-    trace!(?peer_id, "initiating handshake");
+    let subnets_bitfield = our_node_info
+        .metadata
+        .as_ref()
+        .map(|m| m.subnets.as_str())
+        .unwrap_or("none");
+    debug!(
+        ?peer_id,
+        subnets_bitfield = %subnets_bitfield,
+        "Initiating handshake with our subnet bitfield"
+    );
     behaviour.send_request(&peer_id, our_node_info.clone());
 }
 

--- a/anchor/network/src/network.rs
+++ b/anchor/network/src/network.rs
@@ -223,16 +223,26 @@ impl<R: MessageReceiver> Network<R> {
                                     self.check_block_and_prune_peers_by_score();
                                 }
 
-                                // Trigger periodic peer discovery if below target
+                                // Trigger periodic subnet-aware peer discovery if below target
                                 let connected_peers = self.swarm.behaviour().peer_manager.connected_peers();
                                 let target_peers = self.swarm.behaviour().peer_manager.target_peers();
                                 if connected_peers < target_peers {
-                                    debug!(
-                                        connected_peers,
-                                        target_peers,
-                                        "Below target peer count, triggering peer discovery"
-                                    );
-                                    self.swarm.behaviour_mut().discovery.discover_peers(target_peers);
+                                    let needed_subnets: Vec<_> = self.swarm.behaviour()
+                                        .peer_manager
+                                        .needed_subnets()
+                                        .iter()
+                                        .copied()
+                                        .collect();
+
+                                    if !needed_subnets.is_empty() {
+                                        debug!(
+                                            connected_peers,
+                                            target_peers,
+                                            subnets = ?needed_subnets,
+                                            "Below target peer count, triggering subnet-aware peer discovery"
+                                        );
+                                        self.swarm.behaviour_mut().discovery.start_subnet_query(needed_subnets);
+                                    }
                                 }
 
                                 // Disconnect peers that no longer subscribe to any needed subnets

--- a/anchor/network/src/network.rs
+++ b/anchor/network/src/network.rs
@@ -263,9 +263,6 @@ impl<R: MessageReceiver> Network<R> {
                         },
                         SwarmEvent::OutgoingConnectionError { peer_id, error, .. } => {
                             debug!(?peer_id, ?error, "Outgoing connection error");
-                            if let Some(peer_id) = peer_id {
-                                self.peer_manager().record_connection_failure(&peer_id);
-                            }
                         },
                         SwarmEvent::IncomingConnectionError { error, .. } => {
                             debug!(?error, "Incoming connection error");

--- a/anchor/network/src/network.rs
+++ b/anchor/network/src/network.rs
@@ -223,6 +223,18 @@ impl<R: MessageReceiver> Network<R> {
                                     self.check_block_and_prune_peers_by_score();
                                 }
 
+                                // Trigger periodic peer discovery if below target
+                                let connected_peers = self.swarm.behaviour().peer_manager.connected_peers();
+                                let target_peers = self.swarm.behaviour().peer_manager.target_peers();
+                                if connected_peers < target_peers {
+                                    debug!(
+                                        connected_peers,
+                                        target_peers,
+                                        "Below target peer count, triggering peer discovery"
+                                    );
+                                    self.swarm.behaviour_mut().discovery.discover_peers(target_peers);
+                                }
+
                                 // Disconnect peers that no longer subscribe to any needed subnets
                                 let to_disconnect = self
                                     .swarm
@@ -248,6 +260,18 @@ impl<R: MessageReceiver> Network<R> {
                                 &mut self.swarm.behaviour_mut().handshake,
                                 peer_id
                             );
+                        },
+                        SwarmEvent::OutgoingConnectionError { peer_id, error, .. } => {
+                            debug!(?peer_id, ?error, "Outgoing connection error");
+                            if let Some(peer_id) = peer_id {
+                                self.peer_manager().record_connection_failure(&peer_id);
+                            }
+                        },
+                        SwarmEvent::IncomingConnectionError { error, .. } => {
+                            debug!(?error, "Incoming connection error");
+                        },
+                        SwarmEvent::ConnectionClosed { peer_id, cause, .. } => {
+                            debug!(?peer_id, ?cause, "Connection closed");
                         },
                         SwarmEvent::NewListenAddr { listener_id, address } => {
                             self.on_new_listen_addr(listener_id, address);
@@ -474,10 +498,20 @@ impl<R: MessageReceiver> Network<R> {
 
         // update enr and metadata to new state
         self.discovery().set_subscribed(subnet, subscribed);
-        if let Some(metadata) = &mut self.node_info.metadata
-            && let Err(err) = metadata.set_subscribed(subnet, subscribed)
-        {
-            error!(?err, "unable to update node info");
+        if let Some(metadata) = &mut self.node_info.metadata {
+            match metadata.set_subscribed(subnet, subscribed) {
+                Ok(()) => {
+                    info!(
+                        subnet = *subnet,
+                        subscribed = subscribed,
+                        subnets_bitfield = %metadata.subnets,
+                        "Updated node_info metadata subnet bitfield"
+                    );
+                }
+                Err(err) => {
+                    error!(?err, "unable to update node info");
+                }
+            }
         }
     }
 

--- a/anchor/network/src/peer_manager/connection.rs
+++ b/anchor/network/src/peer_manager/connection.rs
@@ -134,10 +134,7 @@ impl ConnectionManager {
         }
 
         // Don't dial peers with too many consecutive failures (unless expired)
-        if let Some(record) = self.peer_failures.get(peer_id)
-            && record.last_failure.elapsed() < FAILURE_EXPIRATION
-            && record.consecutive_failures >= MAX_CONSECUTIVE_FAILURES
-        {
+        if self.is_blacklisted_by_failures(peer_id) {
             return false;
         }
 

--- a/anchor/network/src/peer_manager/connection.rs
+++ b/anchor/network/src/peer_manager/connection.rs
@@ -1,7 +1,6 @@
 use std::{
     collections::{HashMap, HashSet},
     ops::Deref,
-    time::{Duration, Instant},
 };
 
 use discv5::libp2p_identity::PeerId;
@@ -34,20 +33,6 @@ const PRIORITY_PEER_EXCESS: f32 = 0.2;
 /// Minimum number of peers required per subnet
 const MIN_PEERS_PER_SUBNET: usize = 6;
 
-/// Maximum consecutive connection failures before blacklisting a peer
-const MAX_CONSECUTIVE_FAILURES: u32 = 5;
-/// Duration after which failure records expire (1 hour)
-const FAILURE_EXPIRATION: Duration = Duration::from_secs(3600);
-/// Maximum number of failure records to keep (defense-in-depth memory protection)
-const MAX_FAILURE_RECORDS: usize = 1000;
-
-/// Tracks connection failures for a peer
-#[derive(Debug, Clone)]
-struct FailureRecord {
-    consecutive_failures: u32,
-    last_failure: Instant,
-}
-
 /// Specific peer connection errors
 #[derive(Debug, Error)]
 pub enum PeerConnectionError {
@@ -63,8 +48,6 @@ pub struct ConnectionManager {
     pub max_with_priority_peers: usize,
     // Map of observed gossipsub subscriptions per peer. Prefer this over ENR claims.
     observed_peer_subnets: HashMap<PeerId, Bitfield<Fixed<U128>>>,
-    // Tracks connection failures for blacklisting persistently failing peers
-    peer_failures: HashMap<PeerId, FailureRecord>,
     // Track inbound vs outbound connection counts
     inbound_count: usize,
     outbound_count: usize,
@@ -102,7 +85,6 @@ impl ConnectionManager {
             target_peers: config.target_peers,
             max_with_priority_peers: max_priority_peers,
             observed_peer_subnets: HashMap::new(),
-            peer_failures: HashMap::new(),
             inbound_count: 0,
             outbound_count: 0,
         }
@@ -135,11 +117,6 @@ impl ConnectionManager {
     ) -> bool {
         // Don't dial blocked peers
         if blocked_peers.contains(peer_id) {
-            return false;
-        }
-
-        // Don't dial peers with too many consecutive failures (unless expired)
-        if self.is_blacklisted_by_failures(peer_id) {
             return false;
         }
 
@@ -271,8 +248,6 @@ impl ConnectionManager {
 
     /// Handle connection established event
     pub fn on_connection_established(&mut self, peer_id: PeerId, is_outbound: bool) -> bool {
-        // Clear failure record on successful connection
-        self.peer_failures.remove(&peer_id);
         // Initialize with empty bitfield to indicate we're now observing this peer
         // If they never subscribe to anything, we'll know they offer no subnets
         self.observed_peer_subnets.entry(peer_id).or_default();
@@ -438,58 +413,6 @@ impl ConnectionManager {
             .map(|_| ()); // discard handler
 
         self.finish_established_connection(limit_result, peer, peer_store, needed_subnets)
-    }
-
-    /// Record a connection failure for a peer
-    pub fn record_failure(&mut self, peer_id: &PeerId) {
-        // Hard limit check - don't track new peers if we've hit the limit
-        if self.peer_failures.len() >= MAX_FAILURE_RECORDS
-            && !self.peer_failures.contains_key(peer_id)
-        {
-            tracing::debug!("Failure record limit reached, not tracking new peer failures");
-            return;
-        }
-
-        let now = Instant::now();
-        let record = self
-            .peer_failures
-            .entry(*peer_id)
-            .and_modify(|r| {
-                // If previous failure was recent, increment count
-                if r.last_failure.elapsed() < FAILURE_EXPIRATION {
-                    r.consecutive_failures += 1;
-                } else {
-                    // Expired - reset count
-                    r.consecutive_failures = 1;
-                }
-                r.last_failure = now;
-            })
-            .or_insert(FailureRecord {
-                consecutive_failures: 1,
-                last_failure: now,
-            });
-
-        if record.consecutive_failures >= MAX_CONSECUTIVE_FAILURES {
-            tracing::debug!(
-                peer = %peer_id,
-                failures = record.consecutive_failures,
-                "Peer blacklisted after exceeding maximum consecutive failures"
-            );
-        }
-    }
-
-    /// Check if a peer is blacklisted due to too many consecutive failures
-    pub fn is_blacklisted_by_failures(&self, peer_id: &PeerId) -> bool {
-        self.peer_failures.get(peer_id).is_some_and(|record| {
-            record.last_failure.elapsed() < FAILURE_EXPIRATION
-                && record.consecutive_failures >= MAX_CONSECUTIVE_FAILURES
-        })
-    }
-
-    /// Clean up expired failure records to prevent memory leaks
-    pub fn cleanup_expired_failures(&mut self) {
-        self.peer_failures
-            .retain(|_, record| record.last_failure.elapsed() < FAILURE_EXPIRATION);
     }
 
     /// Handle swarm events related to connections

--- a/anchor/network/src/peer_manager/connection.rs
+++ b/anchor/network/src/peer_manager/connection.rs
@@ -65,6 +65,9 @@ pub struct ConnectionManager {
     observed_peer_subnets: HashMap<PeerId, Bitfield<Fixed<U128>>>,
     // Tracks connection failures for blacklisting persistently failing peers
     peer_failures: HashMap<PeerId, FailureRecord>,
+    // Track inbound vs outbound connection counts
+    inbound_count: usize,
+    outbound_count: usize,
 }
 
 impl ConnectionManager {
@@ -100,6 +103,8 @@ impl ConnectionManager {
             max_with_priority_peers: max_priority_peers,
             observed_peer_subnets: HashMap::new(),
             peer_failures: HashMap::new(),
+            inbound_count: 0,
+            outbound_count: 0,
         }
     }
 
@@ -265,20 +270,52 @@ impl ConnectionManager {
     }
 
     /// Handle connection established event
-    pub fn on_connection_established(&mut self, peer_id: PeerId) -> bool {
+    pub fn on_connection_established(&mut self, peer_id: PeerId, is_outbound: bool) -> bool {
         // Clear failure record on successful connection
         self.peer_failures.remove(&peer_id);
         // Initialize with empty bitfield to indicate we're now observing this peer
         // If they never subscribe to anything, we'll know they offer no subnets
         self.observed_peer_subnets.entry(peer_id).or_default();
-        self.connected.insert(peer_id)
+
+        // Track connection direction counter
+        let is_new = self.connected.insert(peer_id);
+        if is_new {
+            if is_outbound {
+                self.outbound_count += 1;
+            } else {
+                self.inbound_count += 1;
+            }
+        }
+
+        is_new
     }
 
     /// Handle connection closed event
-    pub fn on_connection_closed(&mut self, peer_id: &PeerId) -> bool {
+    pub fn on_connection_closed(&mut self, peer_id: &PeerId, was_outbound: bool) -> bool {
         // Clear observed subscriptions on disconnect
         self.observed_peer_subnets.remove(peer_id);
-        self.connected.remove(peer_id)
+
+        // Decrement appropriate counter based on direction
+        let was_connected = self.connected.remove(peer_id);
+        if was_connected {
+            if was_outbound {
+                self.outbound_count = self.outbound_count.saturating_sub(1);
+            } else {
+                self.inbound_count = self.inbound_count.saturating_sub(1);
+            }
+        }
+
+        was_connected
+    }
+
+    /// Get the number of inbound connections
+    pub fn inbound_count(&self) -> usize {
+        self.inbound_count
+    }
+
+    /// Get the number of outbound connections
+    pub fn outbound_count(&self) -> usize {
+        self.outbound_count
     }
 
     /// Update metrics if connection state changed

--- a/anchor/network/src/peer_manager/connection.rs
+++ b/anchor/network/src/peer_manager/connection.rs
@@ -1,6 +1,7 @@
 use std::{
     collections::{HashMap, HashSet},
     ops::Deref,
+    time::{Duration, Instant},
 };
 
 use discv5::libp2p_identity::PeerId;
@@ -33,6 +34,20 @@ const PRIORITY_PEER_EXCESS: f32 = 0.2;
 /// Minimum number of peers required per subnet
 const MIN_PEERS_PER_SUBNET: usize = 6;
 
+/// Maximum consecutive connection failures before blacklisting a peer
+const MAX_CONSECUTIVE_FAILURES: u32 = 5;
+/// Duration after which failure records expire (1 hour)
+const FAILURE_EXPIRATION: Duration = Duration::from_secs(3600);
+/// Maximum number of failure records to keep (defense-in-depth memory protection)
+const MAX_FAILURE_RECORDS: usize = 1000;
+
+/// Tracks connection failures for a peer
+#[derive(Debug, Clone)]
+struct FailureRecord {
+    consecutive_failures: u32,
+    last_failure: Instant,
+}
+
 /// Specific peer connection errors
 #[derive(Debug, Error)]
 pub enum PeerConnectionError {
@@ -48,6 +63,8 @@ pub struct ConnectionManager {
     pub max_with_priority_peers: usize,
     // Map of observed gossipsub subscriptions per peer. Prefer this over ENR claims.
     observed_peer_subnets: HashMap<PeerId, Bitfield<Fixed<U128>>>,
+    // Tracks connection failures for blacklisting persistently failing peers
+    peer_failures: HashMap<PeerId, FailureRecord>,
 }
 
 impl ConnectionManager {
@@ -82,6 +99,7 @@ impl ConnectionManager {
             target_peers: config.target_peers,
             max_with_priority_peers: max_priority_peers,
             observed_peer_subnets: HashMap::new(),
+            peer_failures: HashMap::new(),
         }
     }
 
@@ -112,6 +130,14 @@ impl ConnectionManager {
     ) -> bool {
         // Don't dial blocked peers
         if blocked_peers.contains(peer_id) {
+            return false;
+        }
+
+        // Don't dial peers with too many consecutive failures (unless expired)
+        if let Some(record) = self.peer_failures.get(peer_id)
+            && record.last_failure.elapsed() < FAILURE_EXPIRATION
+            && record.consecutive_failures >= MAX_CONSECUTIVE_FAILURES
+        {
             return false;
         }
 
@@ -243,6 +269,8 @@ impl ConnectionManager {
 
     /// Handle connection established event
     pub fn on_connection_established(&mut self, peer_id: PeerId) -> bool {
+        // Clear failure record on successful connection
+        self.peer_failures.remove(&peer_id);
         // Initialize with empty bitfield to indicate we're now observing this peer
         // If they never subscribe to anything, we'll know they offer no subnets
         self.observed_peer_subnets.entry(peer_id).or_default();
@@ -376,6 +404,58 @@ impl ConnectionManager {
             .map(|_| ()); // discard handler
 
         self.finish_established_connection(limit_result, peer, peer_store, needed_subnets)
+    }
+
+    /// Record a connection failure for a peer
+    pub fn record_failure(&mut self, peer_id: &PeerId) {
+        // Hard limit check - don't track new peers if we've hit the limit
+        if self.peer_failures.len() >= MAX_FAILURE_RECORDS
+            && !self.peer_failures.contains_key(peer_id)
+        {
+            tracing::debug!("Failure record limit reached, not tracking new peer failures");
+            return;
+        }
+
+        let now = Instant::now();
+        let record = self
+            .peer_failures
+            .entry(*peer_id)
+            .and_modify(|r| {
+                // If previous failure was recent, increment count
+                if r.last_failure.elapsed() < FAILURE_EXPIRATION {
+                    r.consecutive_failures += 1;
+                } else {
+                    // Expired - reset count
+                    r.consecutive_failures = 1;
+                }
+                r.last_failure = now;
+            })
+            .or_insert(FailureRecord {
+                consecutive_failures: 1,
+                last_failure: now,
+            });
+
+        if record.consecutive_failures >= MAX_CONSECUTIVE_FAILURES {
+            tracing::debug!(
+                peer = %peer_id,
+                failures = record.consecutive_failures,
+                "Peer blacklisted after exceeding maximum consecutive failures"
+            );
+        }
+    }
+
+    /// Check if a peer is blacklisted due to too many consecutive failures
+    pub fn is_blacklisted_by_failures(&self, peer_id: &PeerId) -> bool {
+        self.peer_failures.get(peer_id).is_some_and(|record| {
+            record.last_failure.elapsed() < FAILURE_EXPIRATION
+                && record.consecutive_failures >= MAX_CONSECUTIVE_FAILURES
+        })
+    }
+
+    /// Clean up expired failure records to prevent memory leaks
+    pub fn cleanup_expired_failures(&mut self) {
+        self.peer_failures
+            .retain(|_, record| record.last_failure.elapsed() < FAILURE_EXPIRATION);
     }
 
     /// Handle swarm events related to connections

--- a/anchor/network/src/peer_manager/discovery.rs
+++ b/anchor/network/src/peer_manager/discovery.rs
@@ -26,6 +26,55 @@ const PEER_OVERDIAL_FACTOR: usize = 2;
 /// Minimum number of peers required per subnet
 const MIN_PEERS_PER_SUBNET: usize = 6;
 
+/// Convert an ENR to multiaddrs, properly handling QUIC ports
+fn enr_to_multiaddrs(enr: &Enr) -> Vec<Multiaddr> {
+    use libp2p::multiaddr::Protocol;
+
+    let mut multiaddrs = Vec::new();
+
+    // Handle IPv4 addresses
+    if let Some(ip4) = enr.ip4() {
+        // Add TCP address if available
+        if let Some(tcp4_port) = enr.tcp4() {
+            let mut addr = Multiaddr::empty();
+            addr.push(Protocol::Ip4(ip4));
+            addr.push(Protocol::Tcp(tcp4_port));
+            multiaddrs.push(addr);
+        }
+
+        // Add QUIC address if available (QUIC uses UDP + quic-v1 protocol)
+        if let Some(quic4_port) = enr.quic4() {
+            let mut addr = Multiaddr::empty();
+            addr.push(Protocol::Ip4(ip4));
+            addr.push(Protocol::Udp(quic4_port));
+            addr.push(Protocol::QuicV1);
+            multiaddrs.push(addr);
+        }
+    }
+
+    // Handle IPv6 addresses
+    if let Some(ip6) = enr.ip6() {
+        // Add TCP address if available
+        if let Some(tcp6_port) = enr.tcp6() {
+            let mut addr = Multiaddr::empty();
+            addr.push(Protocol::Ip6(ip6));
+            addr.push(Protocol::Tcp(tcp6_port));
+            multiaddrs.push(addr);
+        }
+
+        // Add QUIC address if available (QUIC uses UDP + quic-v1 protocol)
+        if let Some(quic6_port) = enr.quic6() {
+            let mut addr = Multiaddr::empty();
+            addr.push(Protocol::Ip6(ip6));
+            addr.push(Protocol::Udp(quic6_port));
+            addr.push(Protocol::QuicV1);
+            multiaddrs.push(addr);
+        }
+    }
+
+    multiaddrs
+}
+
 /// Manages peer discovery and subnet-based peer selection
 pub struct PeerDiscovery;
 
@@ -40,7 +89,7 @@ impl PeerDiscovery {
     ) -> Option<DialOpts> {
         let id = enr.peer_id();
 
-        let multiaddrs = enr.multiaddr();
+        let multiaddrs = enr_to_multiaddrs(&enr);
 
         // Update peer store with the discovered peer
         for multiaddr in multiaddrs.iter() {
@@ -101,6 +150,11 @@ impl PeerDiscovery {
         for (peer, record) in Self::candidate_peers(peer_store, &connection_manager.connected) {
             // Skip blocked peers
             if blocked_peers.contains(peer) {
+                continue;
+            }
+
+            // Skip peers blacklisted due to too many consecutive failures
+            if connection_manager.is_blacklisted_by_failures(peer) {
                 continue;
             }
 

--- a/anchor/network/src/peer_manager/discovery.rs
+++ b/anchor/network/src/peer_manager/discovery.rs
@@ -106,11 +106,6 @@ impl PeerDiscovery {
                 continue;
             }
 
-            // Skip peers blacklisted due to too many consecutive failures
-            if connection_manager.is_blacklisted_by_failures(peer) {
-                continue;
-            }
-
             let Some(enr) = record.get_custom_data() else {
                 continue;
             };

--- a/anchor/network/src/peer_manager/discovery.rs
+++ b/anchor/network/src/peer_manager/discovery.rs
@@ -26,55 +26,6 @@ const PEER_OVERDIAL_FACTOR: usize = 2;
 /// Minimum number of peers required per subnet
 const MIN_PEERS_PER_SUBNET: usize = 6;
 
-/// Convert an ENR to multiaddrs, properly handling QUIC ports
-fn enr_to_multiaddrs(enr: &Enr) -> Vec<Multiaddr> {
-    use libp2p::multiaddr::Protocol;
-
-    let mut multiaddrs = Vec::new();
-
-    // Handle IPv4 addresses
-    if let Some(ip4) = enr.ip4() {
-        // Add TCP address if available
-        if let Some(tcp4_port) = enr.tcp4() {
-            let mut addr = Multiaddr::empty();
-            addr.push(Protocol::Ip4(ip4));
-            addr.push(Protocol::Tcp(tcp4_port));
-            multiaddrs.push(addr);
-        }
-
-        // Add QUIC address if available (QUIC uses UDP + quic-v1 protocol)
-        if let Some(quic4_port) = enr.quic4() {
-            let mut addr = Multiaddr::empty();
-            addr.push(Protocol::Ip4(ip4));
-            addr.push(Protocol::Udp(quic4_port));
-            addr.push(Protocol::QuicV1);
-            multiaddrs.push(addr);
-        }
-    }
-
-    // Handle IPv6 addresses
-    if let Some(ip6) = enr.ip6() {
-        // Add TCP address if available
-        if let Some(tcp6_port) = enr.tcp6() {
-            let mut addr = Multiaddr::empty();
-            addr.push(Protocol::Ip6(ip6));
-            addr.push(Protocol::Tcp(tcp6_port));
-            multiaddrs.push(addr);
-        }
-
-        // Add QUIC address if available (QUIC uses UDP + quic-v1 protocol)
-        if let Some(quic6_port) = enr.quic6() {
-            let mut addr = Multiaddr::empty();
-            addr.push(Protocol::Ip6(ip6));
-            addr.push(Protocol::Udp(quic6_port));
-            addr.push(Protocol::QuicV1);
-            multiaddrs.push(addr);
-        }
-    }
-
-    multiaddrs
-}
-
 /// Manages peer discovery and subnet-based peer selection
 pub struct PeerDiscovery;
 
@@ -89,10 +40,12 @@ impl PeerDiscovery {
     ) -> Option<DialOpts> {
         let id = enr.peer_id();
 
-        let multiaddrs = enr_to_multiaddrs(&enr);
-
-        // Update peer store with the discovered peer
-        for multiaddr in multiaddrs.iter() {
+        // Update peer store with TCP and QUIC addresses (not plain UDP)
+        for multiaddr in enr
+            .multiaddr_tcp()
+            .iter()
+            .chain(enr.multiaddr_quic().iter())
+        {
             peer_store.on_swarm_event(&FromSwarm::NewExternalAddrOfPeer(NewExternalAddrOfPeer {
                 peer_id: id,
                 addr: multiaddr,

--- a/anchor/network/src/peer_manager/mod.rs
+++ b/anchor/network/src/peer_manager/mod.rs
@@ -90,6 +90,8 @@ impl PeerManager {
         info!(
             subnets = self.needed_subnets.len(),
             peers = self.connection_manager.connected.len(),
+            inbound = self.connection_manager.inbound_count(),
+            outbound = self.connection_manager.outbound_count(),
             blocked_peers = self.blocking_manager.blocked_peers_count(),
             "Network status"
         );
@@ -132,6 +134,16 @@ impl PeerManager {
     /// Get the current number of connected peers
     pub fn connected_peers(&self) -> usize {
         self.connection_manager.connected.len()
+    }
+
+    /// Get the number of inbound connections
+    pub fn inbound_peers(&self) -> usize {
+        self.connection_manager.inbound_count()
+    }
+
+    /// Get the number of outbound connections
+    pub fn outbound_peers(&self) -> usize {
+        self.connection_manager.outbound_count()
     }
 
     /// Record a connection failure for a peer
@@ -306,11 +318,19 @@ impl NetworkBehaviour for PeerManager {
     fn on_swarm_event(&mut self, event: FromSwarm) {
         // Handle connection state changes
         let changed_connected = match event {
-            FromSwarm::ConnectionEstablished(ConnectionEstablished { peer_id, .. }) => {
-                self.connection_manager.on_connection_established(peer_id)
+            FromSwarm::ConnectionEstablished(ConnectionEstablished {
+                peer_id, endpoint, ..
+            }) => {
+                let is_outbound = endpoint.is_dialer();
+                self.connection_manager
+                    .on_connection_established(peer_id, is_outbound)
             }
-            FromSwarm::ConnectionClosed(ConnectionClosed { peer_id, .. }) => {
-                self.connection_manager.on_connection_closed(&peer_id)
+            FromSwarm::ConnectionClosed(ConnectionClosed {
+                peer_id, endpoint, ..
+            }) => {
+                let was_outbound = endpoint.is_dialer();
+                self.connection_manager
+                    .on_connection_closed(&peer_id, was_outbound)
             }
             _ => false,
         };

--- a/anchor/network/src/peer_manager/mod.rs
+++ b/anchor/network/src/peer_manager/mod.rs
@@ -143,6 +143,11 @@ impl PeerManager {
         self.connection_manager.outbound_count()
     }
 
+    /// Get the set of subnets we need peers for
+    pub fn needed_subnets(&self) -> &HashSet<SubnetId> {
+        &self.needed_subnets
+    }
+
     /// Update observed gossipsub subscription state for a peer
     pub fn set_peer_subscription(&mut self, peer: PeerId, subnet: SubnetId, subscribed: bool) {
         self.connection_manager

--- a/anchor/network/src/peer_manager/mod.rs
+++ b/anchor/network/src/peer_manager/mod.rs
@@ -99,9 +99,6 @@ impl PeerManager {
         // Check and unblock peers that have been blocked long enough
         self.blocking_manager.check_and_unblock_expired_peers();
 
-        // Clean up expired failure records to prevent memory leaks
-        self.connection_manager.cleanup_expired_failures();
-
         // Check if any subnets need more peers and return dial/discovery actions
         PeerDiscovery::check_subnet_peers(
             &self.needed_subnets,
@@ -144,11 +141,6 @@ impl PeerManager {
     /// Get the number of outbound connections
     pub fn outbound_peers(&self) -> usize {
         self.connection_manager.outbound_count()
-    }
-
-    /// Record a connection failure for a peer
-    pub fn record_connection_failure(&mut self, peer_id: &PeerId) {
-        self.connection_manager.record_failure(peer_id);
     }
 
     /// Update observed gossipsub subscription state for a peer

--- a/anchor/network/src/peer_manager/mod.rs
+++ b/anchor/network/src/peer_manager/mod.rs
@@ -97,6 +97,9 @@ impl PeerManager {
         // Check and unblock peers that have been blocked long enough
         self.blocking_manager.check_and_unblock_expired_peers();
 
+        // Clean up expired failure records to prevent memory leaks
+        self.connection_manager.cleanup_expired_failures();
+
         // Check if any subnets need more peers and return dial/discovery actions
         PeerDiscovery::check_subnet_peers(
             &self.needed_subnets,
@@ -124,6 +127,16 @@ impl PeerManager {
     /// Get the target number of peers
     pub fn target_peers(&self) -> usize {
         self.connection_manager.target_peers
+    }
+
+    /// Get the current number of connected peers
+    pub fn connected_peers(&self) -> usize {
+        self.connection_manager.connected.len()
+    }
+
+    /// Record a connection failure for a peer
+    pub fn record_connection_failure(&mut self, peer_id: &PeerId) {
+        self.connection_manager.record_failure(peer_id);
     }
 
     /// Update observed gossipsub subscription state for a peer


### PR DESCRIPTION
## Issue Addressed

Fixes peer count plateau and connection denial issues caused by generic discovery attempting to connect to peers without needed subnets.

## Proposed Changes

### Subnet-Aware Periodic Discovery
- Trigger discovery every 30s when peer count is below target
- **Uses subnet filtering** via `start_subnet_query()` instead of generic `discover_peers()`
- Only discovers and dials peers that offer our needed subnets
- Prevents `MissingNeededSubnets` connection denials

### Connection Metrics
- Track inbound vs outbound connection counts
- Provides visibility into connection direction distribution
- Helps monitor peer connectivity patterns

### Logging Improvements
- Connection errors logged at debug level (normal P2P behavior)
- Reduces log noise while maintaining debugging capability
- Increased log retention (5 files vs 1) for better historical tracking

## Root Cause Analysis

The original PR #649 added generic `discover_peers()` which found ANY peers on the network:
1. Discovery finds peer with subnets [1, 2, 3]
2. We need subnets [5, 6, 7]
3. We dial the peer
4. Connection attempt succeeds
5. Connection manager checks if peer offers needed subnets
6. Connection **denied** with `MissingNeededSubnets` error
7. Wasted connection attempt, cycle repeats

## Solution

Use subnet-aware discovery that filters ENRs before dialing:
1. Discovery filters by our needed subnets [5, 6, 7]
2. Only peers offering these subnets are discovered
3. We dial filtered peers
4. Connection manager checks subnets
5. Connection **accepted** - peer offers what we need
6. Peer count grows successfully

## Additional Info

This PR intentionally excludes the connection failure blacklist mechanism from PR #649 to evaluate a simpler approach.

**Two complementary discovery mechanisms:**
1. **Per-subnet discovery** (existing `check_subnet_peers`): Ensures minimum 6 peers per subnet
2. **Overall discovery** (new, subnet-aware): Helps reach target peer count by discovering for ALL needed subnets

**Comparison with PR #649:**
- ✅ Includes: Periodic subnet-aware discovery, connection tracking, logging improvements
- ❌ Excludes: Connection failure tracking, peer blacklisting, memory-bounded failure records
- ✅ Fixes: Connection denial bug from generic discovery

**Advantages:**
- Simpler implementation with less state management
- No memory overhead for failure tracking
- Avoids potential issues with false-positive blacklisting
- Prevents wasted connection attempts to unsuitable peers
- Focus on proactive subnet-filtered discovery

**Trade-offs:**
- No automatic avoidance of persistently failing peers
- Relies on discovery to find working peers with correct subnets