### PR TITLE
fix: metrics scraping bug

### DIFF
--- a/metrics/scrape-targets/scrape-targets.json
+++ b/metrics/scrape-targets/scrape-targets.json
@@ -4,7 +4,7 @@
       "job": "nodes"
     },
     "targets": [
-      "localhost:5154",
+      "host.docker.internal:5154"
     ]
   }
 ]


### PR DESCRIPTION
## Issue Addressed

Fixes Prometheus unable to scrape metrics from Anchor when running in Docker.

## Proposed Changes

Fix a trailing comma and change to `host.docker.internal:5154`

## Additional Info

When Prometheus runs in Docker, `localhost` refers to the container, not the host. `host.docker.internal` is Docker's DNS name for accessing the host machine from containers (macOS/Windows). 
