### PR TITLE
chore: Fix libp2p metrics feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,7 @@ docs/docs/dist/
 
 # Claude Code files
 /.claude/settings.local.json
+
+# User directories
+/for_claude/
+/kingy_scripts/

--- a/anchor/network/Cargo.toml
+++ b/anchor/network/Cargo.toml
@@ -25,6 +25,7 @@ libp2p = { workspace = true, default-features = false, features = [
   "ping",
   "request-response",
   "dns",
+  "metrics",
 ] }
 message_receiver = { workspace = true }
 metrics = { workspace = true }


### PR DESCRIPTION
with_bandwidth_metrics requires feature flag for metrics in libp2p 
