### PR TITLE
fix: Rpc Error handling

### DIFF
--- a/anchor/eth/src/sync.rs
+++ b/anchor/eth/src/sync.rs
@@ -264,7 +264,8 @@ impl SsvEventSyncer {
         let mut retry_count = 0;
         let mut current_backoff_ms = INITIAL_BACKOFF_MS;
 
-        while (self.rpc_client.get_block_number().await).is_err() {
+        while let Err(error) = self.rpc_client.get_block_number().await {
+            warn!(?error, "RPC Error");
             self.apply_backoff(&mut retry_count, &mut current_backoff_ms)
                 .await;
         }
@@ -306,7 +307,7 @@ impl SsvEventSyncer {
         warn!(
             retry_count,
             backoff_ms = current_backoff_ms,
-            "Conneciton error, backing off before retry"
+            "Connection error, backing off before retry"
         );
         *retry_count += 1;
 


### PR DESCRIPTION
## Issue Addressed

In my naiviety, I tried specifying just an execution-rpc and got a warning requiring a websockets link. 

So I removed the --execution-rpc CLI flag and replaced it with a websockets one. Then anchor wouldn't progress. It simply continued doing a back-off without any real warning about why. 

This PR adds a warning log when the RPC fails (which I know it can happen naturally in sync) but it can happen if the RPC is actually dead. This fix, allowed me to realize I needed also an RPC endpoint. 

I also fixed a typo. 
