### PR TITLE
fix: Allow incomming peers

### DIFF
--- a/anchor/network/src/peer_manager/connection.rs
+++ b/anchor/network/src/peer_manager/connection.rs
@@ -207,9 +207,13 @@ impl ConnectionManager {
         }
 
         let Some(bitfield) = self.get_peer_subnets_with_enr_fallback(peer, peer_store) else {
-            return false;
+            // Most peers that connect to us, that we have never seen, we will not know of their
+            // ENR. We should allow all incoming peers and then later reject them if
+            // they pose no use to us.
+            return true;
         };
 
+        // If we have seen this peer before, and we know it isn't useful, then we can reject it.
         self.bitfield_offers_any_subnet(&bitfield, needed)
     }
 


### PR DESCRIPTION
## Issue Addressed

Currently all new peers that are trial dial us, we reject. In principle, peers should only dial us if we are on a subnet that they need, so optimisitcally they should be useful peers. 

The current logic works as follows:
New peer tries to connect -> We look to see if we know their ENR -> We don't know ENR or subnets as they are new -> We reject them because we don't know anything about them. 

I think we shouldn't blanket reject all incomming peers, rather we should let them connect, and then upon handshake figure out if they are of any use to us and then reject the connection. 

I had a quick look through the code, it looks like we don't fail the handshake if our subnets are not aligned, it also looks like we are hard-coding the subnets field. I think it's related to this: https://github.com/sigp/anchor/issues/645

cc:  @dknopik @diegomrsantos - I think we need to not hard code the subnets in the handshake and use that to disconnect peers. We might get over-run with incoming peers that are no use to us if we don't have that logic. 
