### PR TITLE
fix: only fetch the sync duties once per committee period

### DIFF
--- a/anchor/duties_tracker/src/duties_tracker.rs
+++ b/anchor/duties_tracker/src/duties_tracker.rs
@@ -90,40 +90,46 @@ impl<T: SlotClock + 'static> DutiesTracker<T> {
         };
 
         // If duties aren't known for the current period, poll for them.
-        let missing_duties = sync_duties
-            .get_missing_indices_for_period(current_sync_committee_period, &validator_indices);
-        if !missing_duties.is_empty() {
-            self.poll_sync_committee_duties_for_period(
-                missing_duties.as_slice(),
-                current_sync_committee_period,
-            )
-            .await?;
-
-            // Prune previous duties.
-            sync_duties.prune(current_sync_committee_period);
-        }
+        self.poll_missing_sync_committee_duties_for_period(
+            validator_indices.as_slice(),
+            current_sync_committee_period,
+        )
+        .await?;
 
         // If we're past the point in the current period where we should determine duties for the
         // next period and they are not yet known, then poll.
         if current_epoch.as_u64() % spec.epochs_per_sync_committee_period.as_u64()
             >= epoch_offset(spec)
         {
-            let missing_duties = sync_duties
-                .get_missing_indices_for_period(next_sync_committee_period, &validator_indices);
-
-            if !missing_duties.is_empty() {
-                self.poll_sync_committee_duties_for_period(
-                    &validator_indices,
-                    next_sync_committee_period,
-                )
-                .await?;
-            }
-
-            // Prune (this is the main code path for updating duties, so we should almost always hit
-            // this prune).
-            sync_duties.prune(current_sync_committee_period);
+            self.poll_missing_sync_committee_duties_for_period(
+                validator_indices.as_slice(),
+                next_sync_committee_period,
+            )
+            .await?;
         }
 
+        // Prune previous duties.
+        sync_duties.prune(current_sync_committee_period);
+
+        Ok(())
+    }
+
+    async fn poll_missing_sync_committee_duties_for_period(
+        &self,
+        validator_indices: &[u64],
+        sync_committee_period: u64,
+    ) -> Result<(), Error> {
+        let missing_duties = self
+            .duties
+            .sync_duties
+            .get_missing_indices_for_period(sync_committee_period, validator_indices);
+        if !missing_duties.is_empty() {
+            self.poll_sync_committee_duties_for_period(
+                missing_duties.as_slice(),
+                sync_committee_period,
+            )
+            .await?;
+        }
         Ok(())
     }
 

--- a/anchor/duties_tracker/src/duties_tracker.rs
+++ b/anchor/duties_tracker/src/duties_tracker.rs
@@ -12,7 +12,7 @@ use tokio::{sync::watch, time::sleep};
 use tracing::{debug, error, trace, warn};
 use types::{ChainSpec, Epoch, Slot};
 
-use crate::{Duties, DutiesProvider, voluntary_exit_tracker::VoluntaryExitTracker};
+use crate::{Duties, DutiesProvider, MembershipKey, voluntary_exit_tracker::VoluntaryExitTracker};
 
 /// Only retain `HISTORICAL_DUTIES_EPOCHS` duties prior to the current epoch.
 const HISTORICAL_DUTIES_EPOCHS: u64 = 2;
@@ -90,9 +90,11 @@ impl<T: SlotClock + 'static> DutiesTracker<T> {
         };
 
         // If duties aren't known for the current period, poll for them.
-        if !sync_duties.all_duties_known(current_sync_committee_period, &validator_indices) {
+        let missing_duties = sync_duties
+            .get_missing_indices_for_period(current_sync_committee_period, &validator_indices);
+        if !missing_duties.is_empty() {
             self.poll_sync_committee_duties_for_period(
-                validator_indices.as_slice(),
+                missing_duties.as_slice(),
                 current_sync_committee_period,
             )
             .await?;
@@ -105,13 +107,17 @@ impl<T: SlotClock + 'static> DutiesTracker<T> {
         // next period and they are not yet known, then poll.
         if current_epoch.as_u64() % spec.epochs_per_sync_committee_period.as_u64()
             >= epoch_offset(spec)
-            && !sync_duties.all_duties_known(next_sync_committee_period, &validator_indices)
         {
-            self.poll_sync_committee_duties_for_period(
-                &validator_indices,
-                next_sync_committee_period,
-            )
-            .await?;
+            let missing_duties = sync_duties
+                .get_missing_indices_for_period(next_sync_committee_period, &validator_indices);
+
+            if !missing_duties.is_empty() {
+                self.poll_sync_committee_duties_for_period(
+                    &validator_indices,
+                    next_sync_committee_period,
+                )
+                .await?;
+            }
 
             // Prune (this is the main code path for updating duties, so we should almost always hit
             // this prune).
@@ -165,23 +171,26 @@ impl<T: SlotClock + 'static> DutiesTracker<T> {
 
         debug!(count = duties.len(), "Fetched sync duties from BN");
 
-        // Get or create the HashSet for this committee period
-        let mut validators = self
-            .duties
-            .sync_duties
-            .committees
-            .entry(sync_committee_period)
-            .or_default();
+        for &validator_index in validator_indices {
+            let has_duty = duties
+                .iter()
+                .any(|duty| duty.validator_index == validator_index);
 
-        // Insert only validators that have duties
-        for duty in duties {
-            debug!(
-                validator_index = duty.validator_index,
-                sync_committee_period, "Validator in sync committee"
-            );
+            if has_duty {
+                debug!(
+                    validator_index,
+                    sync_committee_period, "Validator in sync committee"
+                );
+            }
 
             // Insert the validator index
-            validators.insert(duty.validator_index);
+            self.duties.sync_duties.committee_membership.insert(
+                MembershipKey {
+                    committee_period: sync_committee_period,
+                    validator_index,
+                },
+                has_duty,
+            );
         }
 
         Ok(())

--- a/anchor/duties_tracker/src/lib.rs
+++ b/anchor/duties_tracker/src/lib.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 
 use bls::PublicKeyBytes;
 use dashmap::DashMap;
@@ -26,33 +26,46 @@ pub mod voluntary_exit_tracker;
 /// having duties.
 #[derive(Debug)]
 pub struct SyncCommitteePerPeriod {
-    /// Map from sync committee period to validators that are members of that sync committee.
-    /// Only validators with actual duties are stored in the HashSet for each period.
-    committees: DashMap<u64, HashSet<u64>>,
+    /// Map from sync committee period and validator index to whether the validator is in the sync
+    /// committee for that period.
+    committee_membership: DashMap<MembershipKey, bool>,
+}
+
+#[derive(Hash, Debug, Clone, Copy, Eq, PartialEq)]
+struct MembershipKey {
+    committee_period: u64,
+    validator_index: u64,
 }
 
 impl SyncCommitteePerPeriod {
     fn new() -> Self {
         Self {
-            committees: DashMap::new(),
+            committee_membership: DashMap::new(),
         }
     }
 
     /// Check if duties are already known for all of the given validators for `committee_period`.
-    fn all_duties_known(&self, committee_period: u64, validator_indices: &[u64]) -> bool {
-        self.committees
-            .get(&committee_period)
-            .is_some_and(|validators| {
-                validator_indices
-                    .iter()
-                    .all(|index| validators.contains(index))
+    fn get_missing_indices_for_period(
+        &self,
+        committee_period: u64,
+        validator_indices: &[u64],
+    ) -> Vec<u64> {
+        validator_indices
+            .iter()
+            .copied()
+            .filter(|&validator_index| {
+                !self.committee_membership.contains_key(&MembershipKey {
+                    committee_period,
+                    validator_index,
+                })
             })
+            .collect()
     }
 
     /// Prune duties for past sync committee periods from the map.
     fn prune(&self, current_sync_committee_period: u64) {
-        self.committees
-            .retain(|period, _| *period >= current_sync_committee_period)
+        self.committee_membership
+            .retain(|key, _| key.committee_period >= current_sync_committee_period)
     }
 
     pub fn is_validator_in_sync_committee(
@@ -60,9 +73,14 @@ impl SyncCommitteePerPeriod {
         committee_period: u64,
         validator_index: u64,
     ) -> bool {
-        self.committees
-            .get(&committee_period)
-            .is_some_and(|validator_indices| validator_indices.contains(&validator_index))
+        self.committee_membership
+            .get(&MembershipKey {
+                committee_period,
+                validator_index,
+            })
+            .as_deref()
+            .copied()
+            .unwrap_or(false)
     }
 }
 


### PR DESCRIPTION
## Issue Addressed

Currently, we fetch the sync duties for all validators in the SSV network at the beginning of every slot.

This is needless, we only need to do that once per period and for added validators.

## Proposed Changes

Change our duty map to hold a boolean for every (period, validator) pair. Check if an entry already exists before sending the request, and only send a request for containing unknown validators.

## Additional Info

This is still not ideal - better would be some kind of notification system for added validators, so that we can avoid checking every slot if we already have the data. But better than asking the BN every slot.
