### PR TITLE
chore: add client version in metrics

### DIFF
--- a/anchor/network/src/lib.rs
+++ b/anchor/network/src/lib.rs
@@ -15,3 +15,4 @@ pub use config::{Config, DEFAULT_DISC_PORT, DEFAULT_QUIC_PORT, DEFAULT_TCP_PORT}
 pub use network::Network;
 pub use network_utils::listen_addr::{ListenAddr, ListenAddress};
 pub type Enr = discv5::enr::Enr<discv5::enr::CombinedKey>;
+pub use peer_manager::types::{ClientType, PeerInfo};

--- a/anchor/network/src/metrics.rs
+++ b/anchor/network/src/metrics.rs
@@ -5,3 +5,11 @@ use metrics::*;
 pub static PEERS_CONNECTED: LazyLock<Result<IntGauge>> = LazyLock::new(|| {
     try_create_int_gauge("libp2p_peers", "Count of libp2p peers currently connected")
 });
+
+pub static PEERS_BY_CLIENT: LazyLock<Result<IntGaugeVec>> = LazyLock::new(|| {
+    try_create_int_gauge_vec(
+        "libp2p_peers_by_client",
+        "Count of connected peers by client type (anchor, go-ssv, unknown)",
+        &["client_type"],
+    )
+});

--- a/anchor/network/src/network.rs
+++ b/anchor/network/src/network.rs
@@ -31,15 +31,16 @@ use types::{ChainSpec, EthSpec};
 use version::version_with_platform;
 
 use crate::{
-    Config, Enr,
+    ClientType, Config, Enr,
     behaviour::{AnchorBehaviour, AnchorBehaviourEvent, BehaviourError},
     discovery::{DiscoveredPeers, Discovery, DiscoveryError},
-    handshake,
-    handshake::node_info::{NodeInfo, NodeMetadata},
+    handshake::{
+        self,
+        node_info::{NodeInfo, NodeMetadata},
+    },
     keypair_utils::load_private_key,
     network::NetworkError::SwarmConfig,
-    peer_manager,
-    peer_manager::{ConnectActions, PeerManager},
+    peer_manager::{self, ConnectActions, PeerManager},
     scoring::topic_score_config::topic_score_params_for_subnet_with_rate,
     transport::build_transport,
 };
@@ -512,7 +513,42 @@ impl<R: MessageReceiver> Network<R> {
                 their_info,
             }) => {
                 debug!(%peer_id, ?their_info, "Handshake completed");
-                // Update peer store with their_info
+
+                if let Some(metadata) = their_info.metadata {
+                    let client_type = ClientType::from(metadata.node_version);
+
+                    let peer_info_opt = self
+                        .swarm
+                        .behaviour()
+                        .peer_manager
+                        .peer_store
+                        .store()
+                        .get_custom_data(&peer_id)
+                        .cloned();
+
+                    if let Some(mut peer_info) = peer_info_opt {
+                        // Update the client type
+                        peer_info.client_type = Some(client_type);
+
+                        // Insert back into peer store
+                        {
+                            let behaviour = self.swarm.behaviour_mut();
+                            behaviour
+                                .peer_manager
+                                .peer_store
+                                .store_mut()
+                                .insert_custom_data(&peer_id, peer_info);
+                        }
+
+                        // Trigger metric recalculation
+                        let behaviour = self.swarm.behaviour();
+                        let store_ref = behaviour.peer_manager.peer_store.store();
+                        behaviour
+                            .peer_manager
+                            .connection_manager
+                            .update_metrics_if_changed(true, Some(store_ref));
+                    }
+                }
             }
             Err(handshake::Failed { peer_id, error }) => {
                 debug!(%peer_id, ?error, "Handshake failed");

--- a/anchor/network/src/network.rs
+++ b/anchor/network/src/network.rs
@@ -31,7 +31,7 @@ use types::{ChainSpec, EthSpec};
 use version::version_with_platform;
 
 use crate::{
-    ClientType, Config, Enr, PeerInfo,
+    Config, Enr,
     behaviour::{AnchorBehaviour, AnchorBehaviourEvent, BehaviourError},
     discovery::{DiscoveredPeers, Discovery, DiscoveryError},
     handshake::{
@@ -566,6 +566,36 @@ impl<R: MessageReceiver> Network<R> {
         }
     }
 
+    /// Record metrics about subnet overlap after successful handshake.
+    fn record_handshake_subnet_match_metrics(
+        &self,
+        peer_id: PeerId,
+        their_metadata: &NodeMetadata,
+    ) {
+        if let Some(our_metadata) = &self.node_info.metadata {
+            let matching_count =
+                count_matching_subnets(&our_metadata.subnets, &their_metadata.subnets);
+
+            debug!(
+                %peer_id,
+                our_subnets = %our_metadata.subnets,
+                their_subnets = %their_metadata.subnets,
+                matching_subnets = matching_count,
+                "Handshake completed"
+            );
+
+            // Record subnet match count metric
+            if let Ok(gauge_vec) = crate::metrics::HANDSHAKE_SUBNET_MATCHES.as_ref() {
+                let label = &matching_count.to_string();
+                if let Ok(gauge) = gauge_vec.get_metric_with_label_values(&[label]) {
+                    gauge.inc();
+                }
+            }
+        } else {
+            debug!(%peer_id, "Handshake completed");
+        }
+    }
+
     fn handle_handshake_result(&mut self, result: Result<handshake::Completed, handshake::Failed>) {
         match result {
             Ok(handshake::Completed {
@@ -577,61 +607,12 @@ impl<R: MessageReceiver> Network<R> {
                     counter.inc();
                 }
 
-                let store_ref = self
-                    .swarm
-                    .behaviour_mut()
-                    .peer_manager
-                    .peer_store
-                    .store_mut();
-
                 if let Some(metadata) = their_info.metadata {
-                    let client_type = ClientType::from(metadata.node_version.clone());
+                    self.peer_manager()
+                        .handle_handshake_completed(peer_id, metadata.node_version.clone());
 
-                    // Update client type in peer store
-                    if let Some(peer_info) = store_ref.get_custom_data_mut(&peer_id) {
-                        peer_info.set_client_type(client_type);
-                    } else {
-                        // If no peer info yet, create new peer info
-                        store_ref.insert_custom_data(
-                            &peer_id,
-                            PeerInfo {
-                                enr: None,
-                                client_type: Some(client_type),
-                            },
-                        );
-                    }
-
-                    // Count and record matching subnets
-                    if let Some(our_metadata) = &self.node_info.metadata {
-                        let matching_count =
-                            count_matching_subnets(&our_metadata.subnets, &metadata.subnets);
-
-                        debug!(
-                            %peer_id,
-                            our_subnets = %our_metadata.subnets,
-                            their_subnets = %metadata.subnets,
-                            matching_subnets = matching_count,
-                            "Handshake completed"
-                        );
-
-                        // Record subnet match count
-                        if let Ok(gauge_vec) = crate::metrics::HANDSHAKE_SUBNET_MATCHES.as_ref() {
-                            let label = &matching_count.to_string();
-                            if let Ok(gauge) = gauge_vec.get_metric_with_label_values(&[label]) {
-                                gauge.inc();
-                            }
-                        }
-                    } else {
-                        debug!(%peer_id, "Handshake completed");
-                    }
-
-                    // Trigger metric recalculation
-                    let behaviour = self.swarm.behaviour();
-                    let store_ref = behaviour.peer_manager.peer_store.store();
-                    behaviour
-                        .peer_manager
-                        .connection_manager
-                        .update_metrics_if_changed(true, store_ref);
+                    // Record subnet matching metrics
+                    self.record_handshake_subnet_match_metrics(peer_id, &metadata);
                 } else {
                     debug!(%peer_id, ?their_info, "Handshake completed without metadata");
                 }

--- a/anchor/network/src/network.rs
+++ b/anchor/network/src/network.rs
@@ -31,7 +31,7 @@ use types::{ChainSpec, EthSpec};
 use version::version_with_platform;
 
 use crate::{
-    ClientType, Config, Enr,
+    ClientType, Config, Enr, PeerInfo,
     behaviour::{AnchorBehaviour, AnchorBehaviourEvent, BehaviourError},
     discovery::{DiscoveredPeers, Discovery, DiscoveryError},
     handshake::{
@@ -514,40 +514,38 @@ impl<R: MessageReceiver> Network<R> {
             }) => {
                 debug!(%peer_id, ?their_info, "Handshake completed");
 
+                let store_ref = self
+                    .swarm
+                    .behaviour_mut()
+                    .peer_manager
+                    .peer_store
+                    .store_mut();
+
                 if let Some(metadata) = their_info.metadata {
                     let client_type = ClientType::from(metadata.node_version);
 
-                    let peer_info_opt = self
-                        .swarm
-                        .behaviour()
-                        .peer_manager
-                        .peer_store
-                        .store()
-                        .get_custom_data(&peer_id)
-                        .cloned();
+                    let peer_info_opt = store_ref.get_custom_data_mut(&peer_id);
 
-                    if let Some(mut peer_info) = peer_info_opt {
+                    if let Some(peer_info) = peer_info_opt {
                         // Update the client type
-                        peer_info.client_type = Some(client_type);
-
-                        // Insert back into peer store
-                        {
-                            let behaviour = self.swarm.behaviour_mut();
-                            behaviour
-                                .peer_manager
-                                .peer_store
-                                .store_mut()
-                                .insert_custom_data(&peer_id, peer_info);
-                        }
-
-                        // Trigger metric recalculation
-                        let behaviour = self.swarm.behaviour();
-                        let store_ref = behaviour.peer_manager.peer_store.store();
-                        behaviour
-                            .peer_manager
-                            .connection_manager
-                            .update_metrics_if_changed(true, Some(store_ref));
+                        peer_info.set_client_type(client_type);
+                    } else {
+                        // If no peer info yet, create new peer info
+                        store_ref.insert_custom_data(
+                            &peer_id,
+                            PeerInfo {
+                                enr: None,
+                                client_type: Some(client_type),
+                            },
+                        )
                     }
+                    // Trigger metric recalculation
+                    let behaviour = self.swarm.behaviour();
+                    let store_ref = behaviour.peer_manager.peer_store.store();
+                    behaviour
+                        .peer_manager
+                        .connection_manager
+                        .update_metrics_if_changed(true, store_ref);
                 }
             }
             Err(handshake::Failed { peer_id, error }) => {

--- a/anchor/network/src/peer_manager/connection.rs
+++ b/anchor/network/src/peer_manager/connection.rs
@@ -15,7 +15,7 @@ use ssz_types::{Bitfield, length::Fixed, typenum::U128};
 use subnet_service::SubnetId;
 use thiserror::Error;
 
-use crate::{Config, Enr, discovery, metrics::PEERS_CONNECTED};
+use crate::{ClientType, Config, PeerInfo, discovery, metrics::PEERS_CONNECTED};
 
 /// A fraction of `target_peers` that we allow to connect to us in excess of
 /// `target_peers`. For clarity, if `target_peers` is 50 and
@@ -106,7 +106,7 @@ impl ConnectionManager {
     pub fn should_dial_peer(
         &self,
         peer_id: &PeerId,
-        peer_store: &MemoryStore<Enr>,
+        peer_store: &MemoryStore<PeerInfo>,
         needed_subnets: &HashSet<SubnetId>,
         blocked_peers: &HashSet<PeerId>,
     ) -> bool {
@@ -125,7 +125,7 @@ impl ConnectionManager {
     pub fn qualifies_for_priority_connection(
         &self,
         peer_id: &PeerId,
-        peer_store: &MemoryStore<Enr>,
+        peer_store: &MemoryStore<PeerInfo>,
         needed_subnets: &HashSet<SubnetId>,
     ) -> bool {
         let Some(subnets) = self.get_peer_subnets_with_enr_fallback(peer_id, peer_store) else {
@@ -194,7 +194,7 @@ impl ConnectionManager {
     pub fn peer_offers_needed_subnets_with_enr_fallback(
         &self,
         peer: &PeerId,
-        peer_store: &MemoryStore<Enr>,
+        peer_store: &MemoryStore<PeerInfo>,
         needed: &HashSet<SubnetId>,
     ) -> bool {
         if needed.is_empty() {
@@ -232,11 +232,11 @@ impl ConnectionManager {
     fn get_peer_subnets_with_enr_fallback(
         &self,
         peer: &PeerId,
-        peer_store: &MemoryStore<Enr>,
+        peer_store: &MemoryStore<PeerInfo>,
     ) -> Option<Bitfield<Fixed<U128>>> {
         self.get_peer_subnets_observed_only(peer).or_else(|| {
             // Fallback to ENR
-            let enr = peer_store.get_custom_data(peer)?;
+            let enr = &peer_store.get_custom_data(peer)?.enr;
             discovery::committee_bitfield(enr).ok()
         })
     }
@@ -257,12 +257,43 @@ impl ConnectionManager {
     }
 
     /// Update metrics if connection state changed
-    pub fn update_metrics_if_changed(&self, changed: bool) {
+    pub fn update_metrics_if_changed(
+        &self,
+        changed: bool,
+        peer_store: Option<&MemoryStore<PeerInfo>>,
+    ) {
         if changed {
             metrics::set_gauge(
                 &PEERS_CONNECTED,
                 self.connected.len().try_into().unwrap_or(0),
             );
+
+            if let Some(peer_store) = peer_store {
+                let mut anchor_count = 0;
+                let mut go_ssv_count = 0;
+                let mut unknown_count = 0;
+
+                // Count all connected peers by client type
+                for peer_id in self.connected.iter() {
+                    if let Some(data) = peer_store.get_custom_data(peer_id) {
+                        match data.client_type {
+                            Some(ClientType::Anchor) => anchor_count += 1,
+                            Some(ClientType::GoSSV) => go_ssv_count += 1,
+                            None => unknown_count += 1,
+                        }
+                    } else {
+                        unknown_count += 1;
+                    }
+                }
+
+                metrics::set_gauge_vec(&crate::metrics::PEERS_BY_CLIENT, &["anchor"], anchor_count);
+                metrics::set_gauge_vec(&crate::metrics::PEERS_BY_CLIENT, &["go-ssv"], go_ssv_count);
+                metrics::set_gauge_vec(
+                    &crate::metrics::PEERS_BY_CLIENT,
+                    &["unknown"],
+                    unknown_count,
+                );
+            }
         }
     }
 
@@ -285,7 +316,7 @@ impl ConnectionManager {
         &self,
         limit_result: Result<(), ConnectionDenied>,
         peer: PeerId,
-        peer_store: &MemoryStore<Enr>,
+        peer_store: &MemoryStore<PeerInfo>,
         needed_subnets: &HashSet<SubnetId>,
     ) -> Result<(), ConnectionDenied> {
         match limit_result {
@@ -325,7 +356,7 @@ impl ConnectionManager {
         peer: PeerId,
         local_addr: &Multiaddr,
         remote_addr: &Multiaddr,
-        peer_store: &MemoryStore<Enr>,
+        peer_store: &MemoryStore<PeerInfo>,
         needed_subnets: &HashSet<SubnetId>,
     ) -> Result<(), ConnectionDenied> {
         let limit_result = self
@@ -361,7 +392,7 @@ impl ConnectionManager {
         addr: &Multiaddr,
         role_override: Endpoint,
         port_use: PortUse,
-        peer_store: &MemoryStore<Enr>,
+        peer_store: &MemoryStore<PeerInfo>,
         needed_subnets: &HashSet<SubnetId>,
     ) -> Result<(), ConnectionDenied> {
         let limit_result = self

--- a/anchor/network/src/peer_manager/connection.rs
+++ b/anchor/network/src/peer_manager/connection.rs
@@ -236,8 +236,11 @@ impl ConnectionManager {
     ) -> Option<Bitfield<Fixed<U128>>> {
         self.get_peer_subnets_observed_only(peer).or_else(|| {
             // Fallback to ENR
-            let enr = &peer_store.get_custom_data(peer)?.enr;
-            discovery::committee_bitfield(enr).ok()
+            peer_store
+                .get_custom_data(peer)?
+                .enr
+                .as_ref()
+                .and_then(|enr| discovery::committee_bitfield(&enr).ok())
         })
     }
 
@@ -257,43 +260,37 @@ impl ConnectionManager {
     }
 
     /// Update metrics if connection state changed
-    pub fn update_metrics_if_changed(
-        &self,
-        changed: bool,
-        peer_store: Option<&MemoryStore<PeerInfo>>,
-    ) {
+    pub fn update_metrics_if_changed(&self, changed: bool, peer_store: &MemoryStore<PeerInfo>) {
         if changed {
             metrics::set_gauge(
                 &PEERS_CONNECTED,
                 self.connected.len().try_into().unwrap_or(0),
             );
 
-            if let Some(peer_store) = peer_store {
-                let mut anchor_count = 0;
-                let mut go_ssv_count = 0;
-                let mut unknown_count = 0;
+            let mut anchor_count = 0;
+            let mut go_ssv_count = 0;
+            let mut unknown_count = 0;
 
-                // Count all connected peers by client type
-                for peer_id in self.connected.iter() {
-                    if let Some(data) = peer_store.get_custom_data(peer_id) {
-                        match data.client_type {
-                            Some(ClientType::Anchor) => anchor_count += 1,
-                            Some(ClientType::GoSSV) => go_ssv_count += 1,
-                            None => unknown_count += 1,
-                        }
-                    } else {
-                        unknown_count += 1;
+            // Count all connected peers by client type
+            for peer_id in self.connected.iter() {
+                if let Some(data) = peer_store.get_custom_data(peer_id) {
+                    match data.client_type {
+                        Some(ClientType::Anchor) => anchor_count += 1,
+                        Some(ClientType::GoSSV) => go_ssv_count += 1,
+                        None => unknown_count += 1,
                     }
+                } else {
+                    unknown_count += 1;
                 }
-
-                metrics::set_gauge_vec(&crate::metrics::PEERS_BY_CLIENT, &["anchor"], anchor_count);
-                metrics::set_gauge_vec(&crate::metrics::PEERS_BY_CLIENT, &["go-ssv"], go_ssv_count);
-                metrics::set_gauge_vec(
-                    &crate::metrics::PEERS_BY_CLIENT,
-                    &["unknown"],
-                    unknown_count,
-                );
             }
+
+            metrics::set_gauge_vec(&crate::metrics::PEERS_BY_CLIENT, &["anchor"], anchor_count);
+            metrics::set_gauge_vec(&crate::metrics::PEERS_BY_CLIENT, &["go-ssv"], go_ssv_count);
+            metrics::set_gauge_vec(
+                &crate::metrics::PEERS_BY_CLIENT,
+                &["unknown"],
+                unknown_count,
+            );
         }
     }
 

--- a/anchor/network/src/peer_manager/connection.rs
+++ b/anchor/network/src/peer_manager/connection.rs
@@ -240,7 +240,7 @@ impl ConnectionManager {
                 .get_custom_data(peer)?
                 .enr
                 .as_ref()
-                .and_then(|enr| discovery::committee_bitfield(&enr).ok())
+                .and_then(|enr| discovery::committee_bitfield(enr).ok())
         })
     }
 

--- a/anchor/network/src/peer_manager/discovery.rs
+++ b/anchor/network/src/peer_manager/discovery.rs
@@ -50,8 +50,8 @@ impl PeerDiscovery {
             }));
         }
 
-        if let Some(potential) = peer_store.get_custom_data_mut(&id) {
-            potential.set_enr(enr);
+        if let Some(peer_info) = peer_store.get_custom_data_mut(&id) {
+            peer_info.set_enr(enr);
         } else {
             peer_store.insert_custom_data(
                 &id,
@@ -115,15 +115,14 @@ impl PeerDiscovery {
                 continue;
             }
 
-            let Some(peer_info) = record.get_custom_data() else {
+            let Some(enr) = record
+                .get_custom_data()
+                .and_then(|peer_info| peer_info.enr.as_ref())
+            else {
                 continue;
             };
 
-            let subnets = peer_info
-                .enr
-                .as_ref()
-                .and_then(|enr| discovery::committee_bitfield(enr).ok())
-                .unwrap_or_default();
+            let subnets = discovery::committee_bitfield(enr).unwrap_or_default();
 
             let mut relevant = false;
             for subnet in subnets

--- a/anchor/network/src/peer_manager/discovery.rs
+++ b/anchor/network/src/peer_manager/discovery.rs
@@ -49,13 +49,18 @@ impl PeerDiscovery {
                 addr: multiaddr,
             }));
         }
-        peer_store.insert_custom_data(
-            &id,
-            PeerInfo {
-                enr,
-                client_type: None,
-            },
-        );
+
+        if let Some(potential) = peer_store.get_custom_data_mut(&id) {
+            potential.set_enr(enr);
+        } else {
+            peer_store.insert_custom_data(
+                &id,
+                PeerInfo {
+                    enr: Some(enr),
+                    client_type: None,
+                },
+            )
+        }
 
         // Check if we should dial this peer
         let should_dial =
@@ -114,7 +119,11 @@ impl PeerDiscovery {
                 continue;
             };
 
-            let subnets = discovery::committee_bitfield(&peer_info.enr).unwrap_or_default();
+            let subnets = peer_info
+                .enr
+                .as_ref()
+                .and_then(|enr| discovery::committee_bitfield(&enr).ok())
+                .unwrap_or_default();
 
             let mut relevant = false;
             for subnet in subnets

--- a/anchor/network/src/peer_manager/discovery.rs
+++ b/anchor/network/src/peer_manager/discovery.rs
@@ -18,7 +18,7 @@ use subnet_service::SubnetId;
 use tracing::debug;
 
 use super::{connection::ConnectionManager, types::ConnectActions};
-use crate::{Enr, discovery};
+use crate::{Enr, PeerInfo, discovery};
 
 /// Number of times we overdial when we need peers for a subnet
 const PEER_OVERDIAL_FACTOR: usize = 2;
@@ -33,7 +33,7 @@ impl PeerDiscovery {
     /// Process a discovered peer and return dial options if we should connect
     pub fn process_discovered_peer(
         enr: Enr,
-        peer_store: &mut MemoryStore<Enr>,
+        peer_store: &mut MemoryStore<PeerInfo>,
         connection_manager: &ConnectionManager,
         needed_subnets: &HashSet<SubnetId>,
         blocked_peers: &HashSet<PeerId>,
@@ -49,7 +49,13 @@ impl PeerDiscovery {
                 addr: multiaddr,
             }));
         }
-        peer_store.insert_custom_data(&id, enr.clone());
+        peer_store.insert_custom_data(
+            &id,
+            PeerInfo {
+                enr,
+                client_type: None,
+            },
+        );
 
         // Check if we should dial this peer
         let should_dial =
@@ -66,7 +72,7 @@ impl PeerDiscovery {
     pub fn track_subnet_peers(
         subnet_id: SubnetId,
         needed_subnets: &mut HashSet<SubnetId>,
-        peer_store: &MemoryStore<Enr>,
+        peer_store: &MemoryStore<PeerInfo>,
         connection_manager: &ConnectionManager,
         blocked_peers: &HashSet<PeerId>,
     ) -> ConnectActions {
@@ -83,7 +89,7 @@ impl PeerDiscovery {
     /// Determine what actions to take for the given subnets
     pub fn determine_actions_for_subnets(
         subnets: &[SubnetId],
-        peer_store: &MemoryStore<Enr>,
+        peer_store: &MemoryStore<PeerInfo>,
         connection_manager: &ConnectionManager,
         blocked_peers: &HashSet<PeerId>,
     ) -> ConnectActions {
@@ -104,11 +110,11 @@ impl PeerDiscovery {
                 continue;
             }
 
-            let Some(enr) = record.get_custom_data() else {
+            let Some(peer_info) = record.get_custom_data() else {
                 continue;
             };
 
-            let subnets = discovery::committee_bitfield(enr).unwrap_or_default();
+            let subnets = discovery::committee_bitfield(&peer_info.enr).unwrap_or_default();
 
             let mut relevant = false;
             for subnet in subnets
@@ -140,7 +146,7 @@ impl PeerDiscovery {
     /// Check if any subnets need more peers and return dial/discovery actions
     pub fn check_subnet_peers(
         needed_subnets: &HashSet<SubnetId>,
-        peer_store: &MemoryStore<Enr>,
+        peer_store: &MemoryStore<PeerInfo>,
         connection_manager: &ConnectionManager,
         blocked_peers: &HashSet<PeerId>,
     ) -> Option<ConnectActions> {
@@ -160,9 +166,9 @@ impl PeerDiscovery {
 
     /// Get candidate peers that we could potentially dial
     fn candidate_peers<'a>(
-        peer_store: &'a MemoryStore<Enr>,
+        peer_store: &'a MemoryStore<PeerInfo>,
         connected: &HashSet<PeerId>,
-    ) -> Vec<(&'a PeerId, &'a PeerRecord<Enr>)> {
+    ) -> Vec<(&'a PeerId, &'a PeerRecord<PeerInfo>)> {
         let mut peers = peer_store
             .record_iter()
             .filter(|(peer, record)| {
@@ -174,7 +180,7 @@ impl PeerDiscovery {
     }
 
     /// Convert a peer ID to dial options
-    fn peer_to_dial_opts(peer: &PeerId, peer_store: &MemoryStore<Enr>) -> DialOpts {
+    fn peer_to_dial_opts(peer: &PeerId, peer_store: &MemoryStore<PeerInfo>) -> DialOpts {
         let addresses = peer_store
             .addresses_of_peer(peer)
             .into_iter()

--- a/anchor/network/src/peer_manager/discovery.rs
+++ b/anchor/network/src/peer_manager/discovery.rs
@@ -122,7 +122,7 @@ impl PeerDiscovery {
             let subnets = peer_info
                 .enr
                 .as_ref()
-                .and_then(|enr| discovery::committee_bitfield(&enr).ok())
+                .and_then(|enr| discovery::committee_bitfield(enr).ok())
                 .unwrap_or_default();
 
             let mut relevant = false;

--- a/anchor/network/src/peer_manager/mod.rs
+++ b/anchor/network/src/peer_manager/mod.rs
@@ -304,7 +304,7 @@ impl NetworkBehaviour for PeerManager {
 
         // Update metrics if connection state changed
         self.connection_manager
-            .update_metrics_if_changed(changed_connected, Some(self.peer_store.store()));
+            .update_metrics_if_changed(changed_connected, self.peer_store.store());
 
         // Delegate to sub-components
         self.blocking_manager.on_swarm_event(event);

--- a/anchor/network/src/peer_manager/mod.rs
+++ b/anchor/network/src/peer_manager/mod.rs
@@ -18,7 +18,7 @@ use peer_store::memory_store::{self, MemoryStore};
 use subnet_service::SubnetId;
 use tracing::info;
 
-use crate::{Config, Enr};
+use crate::{Config, Enr, peer_manager::types::PeerInfo};
 
 pub mod blocking;
 pub mod connection;
@@ -34,8 +34,8 @@ pub use types::{ConnectActions, Event};
 
 /// Main peer manager that coordinates all peer management functionality
 pub struct PeerManager {
-    peer_store: peer_store::Behaviour<MemoryStore<Enr>>,
-    connection_manager: ConnectionManager,
+    pub peer_store: peer_store::Behaviour<MemoryStore<PeerInfo>>,
+    pub connection_manager: ConnectionManager,
     heartbeat_manager: HeartbeatManager,
     blocking_manager: BlockingManager,
     needed_subnets: HashSet<SubnetId>,
@@ -304,7 +304,7 @@ impl NetworkBehaviour for PeerManager {
 
         // Update metrics if connection state changed
         self.connection_manager
-            .update_metrics_if_changed(changed_connected);
+            .update_metrics_if_changed(changed_connected, Some(self.peer_store.store()));
 
         // Delegate to sub-components
         self.blocking_manager.on_swarm_event(event);

--- a/anchor/network/src/peer_manager/mod.rs
+++ b/anchor/network/src/peer_manager/mod.rs
@@ -18,7 +18,7 @@ use peer_store::memory_store::{self, MemoryStore};
 use subnet_service::SubnetId;
 use tracing::info;
 
-use crate::{Config, Enr, peer_manager::types::PeerInfo};
+use crate::{ClientType, Config, Enr, peer_manager::types::PeerInfo};
 
 pub mod blocking;
 pub mod connection;
@@ -34,8 +34,8 @@ pub use types::{ConnectActions, Event};
 
 /// Main peer manager that coordinates all peer management functionality
 pub struct PeerManager {
-    pub peer_store: peer_store::Behaviour<MemoryStore<PeerInfo>>,
-    pub connection_manager: ConnectionManager,
+    peer_store: peer_store::Behaviour<MemoryStore<PeerInfo>>,
+    connection_manager: ConnectionManager,
     heartbeat_manager: HeartbeatManager,
     blocking_manager: BlockingManager,
     needed_subnets: HashSet<SubnetId>,
@@ -152,6 +152,28 @@ impl PeerManager {
     pub fn set_peer_subscription(&mut self, peer: PeerId, subnet: SubnetId, subscribed: bool) {
         self.connection_manager
             .set_peer_subscribed(peer, subnet, subscribed);
+    }
+
+    /// Handle a completed handshake by updating peer client type and triggering metrics update.
+    pub fn handle_handshake_completed(&mut self, peer_id: PeerId, node_version: String) {
+        let client_type = ClientType::from(node_version);
+
+        // Update client type in peer store
+        if let Some(peer_info) = self.peer_store.store_mut().get_custom_data_mut(&peer_id) {
+            peer_info.set_client_type(client_type);
+        } else {
+            self.peer_store.store_mut().insert_custom_data(
+                &peer_id,
+                PeerInfo {
+                    enr: None,
+                    client_type: Some(client_type),
+                },
+            );
+        }
+
+        // Trigger metric recalculation
+        self.connection_manager
+            .update_metrics_if_changed(true, self.peer_store.store());
     }
 
     /// Returns true if a connected peer should be disconnected because it doesn't offer any needed

--- a/anchor/network/src/peer_manager/types.rs
+++ b/anchor/network/src/peer_manager/types.rs
@@ -1,6 +1,8 @@
 use libp2p::swarm::dial_opts::DialOpts;
 use subnet_service::SubnetId;
 
+use crate::Enr;
+
 /// Actions that the peer manager can request from the network
 #[derive(Debug)]
 pub struct ConnectActions {
@@ -26,4 +28,36 @@ impl ConnectActions {
 pub enum Event {
     PeerStore(peer_store::memory_store::Event),
     Heartbeat(crate::peer_manager::heartbeat::Event),
+}
+
+/// Different types of clients
+#[derive(Debug, Clone, Copy)]
+pub enum ClientType {
+    Anchor,
+    GoSSV,
+}
+
+// Not sure how to get ClientType properly from Handshake data
+impl From<String> for ClientType {
+    fn from(value: String) -> Self {
+        if value.starts_with("Anchor/") {
+            Self::Anchor
+        } else {
+            Self::GoSSV
+        }
+    }
+}
+#[derive(Clone)]
+pub struct PeerInfo {
+    pub enr: Enr,
+    pub client_type: Option<ClientType>,
+}
+
+impl PeerInfo {
+    pub fn set_client_type(&mut self, client_type: ClientType) -> Self {
+        PeerInfo {
+            enr: self.enr.clone(),
+            client_type: Some(client_type),
+        }
+    }
 }

--- a/anchor/network/src/peer_manager/types.rs
+++ b/anchor/network/src/peer_manager/types.rs
@@ -49,15 +49,16 @@ impl From<String> for ClientType {
 }
 #[derive(Clone)]
 pub struct PeerInfo {
-    pub enr: Enr,
+    pub enr: Option<Enr>,
     pub client_type: Option<ClientType>,
 }
 
 impl PeerInfo {
-    pub fn set_client_type(&mut self, client_type: ClientType) -> Self {
-        PeerInfo {
-            enr: self.enr.clone(),
-            client_type: Some(client_type),
-        }
+    pub fn set_enr(&mut self, enr: Enr) {
+        self.enr = Some(enr)
+    }
+
+    pub fn set_client_type(&mut self, client_type: ClientType) {
+        self.client_type = Some(client_type)
     }
 }

--- a/anchor/network/src/peer_manager/types.rs
+++ b/anchor/network/src/peer_manager/types.rs
@@ -37,7 +37,6 @@ pub enum ClientType {
     GoSSV,
 }
 
-// Not sure how to get ClientType properly from Handshake data
 impl From<String> for ClientType {
     fn from(value: String) -> Self {
         if value.starts_with("Anchor/") {


### PR DESCRIPTION
## Issue Addressed

Addresses Issue #652 

## Proposed Changes

No longer just save `Enr` in `PeerStore`, but a new `PeerInfo` struct which lets us hold its `Enr` and `ClientType` (`Anchor` or `go-ssv`)
Then, add metric to count how many `go-ssv` vs `Anchor` nodes are connected to us.

## Additional Info

I expose two fields in the `PeerManager` struct as `public` (`peer_store` and `connection_manager`).
