### PR TITLE
feat: metric for own version and startup timestamp

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1837,6 +1837,7 @@ dependencies = [
  "message_receiver",
  "message_sender",
  "message_validator",
+ "metrics",
  "multiaddr",
  "network",
  "network_utils",

--- a/anchor/client/Cargo.toml
+++ b/anchor/client/Cargo.toml
@@ -28,6 +28,7 @@ logging = { workspace = true }
 message_receiver = { workspace = true }
 message_sender = { workspace = true }
 message_validator = { workspace = true }
+metrics = { workspace = true }
 multiaddr = { workspace = true }
 network = { workspace = true }
 network_utils = { workspace = true }

--- a/anchor/client/src/lib.rs
+++ b/anchor/client/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod cli;
 pub mod config;
 mod key;
+mod metrics;
 mod notifier;
 
 use std::{
@@ -156,6 +157,10 @@ impl Client {
             let metrics_future = http_metrics::serve(listener, shared_state.clone(), exit);
 
             executor.spawn_without_exit(metrics_future, "metrics-http");
+
+            metrics::expose_anchor_version();
+            metrics::expose_process_start_time();
+
             Some(shared_state)
         } else {
             info!("HTTP metrics server is disabled");

--- a/anchor/client/src/metrics.rs
+++ b/anchor/client/src/metrics.rs
@@ -1,0 +1,37 @@
+use std::{
+    sync::LazyLock,
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+use metrics::*;
+use tracing::error;
+use version::VERSION;
+
+pub static PROCESS_START_TIME_SECONDS: LazyLock<Result<IntGauge>> = LazyLock::new(|| {
+    try_create_int_gauge(
+        "process_start_time_seconds",
+        "The unix timestamp at which the process was started",
+    )
+});
+
+pub static ANCHOR_VERSION: LazyLock<Result<IntGaugeVec>> = LazyLock::new(|| {
+    try_create_int_gauge_vec(
+        "anchor_info",
+        "The build of Anchor running on the server",
+        &["version"],
+    )
+});
+
+pub fn expose_process_start_time() {
+    match SystemTime::now().duration_since(UNIX_EPOCH) {
+        Ok(duration) => set_gauge(&PROCESS_START_TIME_SECONDS, duration.as_secs() as i64),
+        Err(e) => error!(
+            error = %e,
+            "Failed to read system time"
+        ),
+    }
+}
+
+pub fn expose_anchor_version() {
+    set_gauge_vec(&ANCHOR_VERSION, &[VERSION], 1);
+}


### PR DESCRIPTION
## Issue Addressed

- #652 

## Proposed Changes

Steal some code from LH for version exposure via metrics. While I am at it I also took some code for startup timestamp, because why not.
