### PR TITLE
feat: add panic hook for logging

### DIFF
--- a/anchor/src/main.rs
+++ b/anchor/src/main.rs
@@ -1,3 +1,5 @@
+use std::backtrace::Backtrace;
+
 use clap::Parser;
 use client::{Client, Node, config};
 use environment::Environment;
@@ -261,6 +263,16 @@ pub fn enable_logging(
         .with(logging_layers)
         .try_init()
         .map_err(|e| format!("Failed to initialize logging: {e}"))?;
+
+    std::panic::set_hook(Box::new(move |info| {
+        error!(
+            location = info.location().map(ToString::to_string),
+            message = info.payload().downcast_ref::<String>(),
+            backtrace = %Backtrace::capture(),
+            advice = "Please check above for a backtrace and notify the developers",
+            "TASK PANIC. This is a bug!"
+        );
+    }));
 
     Ok(guards)
 }


### PR DESCRIPTION
## Issue Addressed

When going through LH's and Anchor's startup procedures, I noticed that Anchor does not have a panic hook, causing panics to only be printed on stderr, but not in logs. This is bad in cases where the user only retains logs, but not stderr.

## Proposed Changes

Steal panic hook code from LH, logging the panic properly.
