### PR TITLE
fix: remove unneeded tracing init in error case

### DIFF
--- a/anchor/src/main.rs
+++ b/anchor/src/main.rs
@@ -88,7 +88,6 @@ fn start_anchor(anchor_config: &Node, global_config: GlobalConfig, mut environme
     let mut config = match config::from_cli(anchor_config, global_config) {
         Ok(config) => config,
         Err(e) => {
-            tracing_subscriber::fmt().init();
             error!(e, "Unable to initialize configuration");
             return;
         }


### PR DESCRIPTION
## Issue Addressed

When this error occurs, the tracing is initialized ad-hoc so that the error can be logged. However, at this point, logging IS already initialized, causing a panic due to double initialization.

## Proposed Changes

Remove the subscriber init.

## Additional Info

I guess this stems from an earlier time when the order of operations was different.
