### PR TITLE
feat: Majority Fork Protection

### DIFF
--- a/anchor/common/ssv_types/src/consensus.rs
+++ b/anchor/common/ssv_types/src/consensus.rs
@@ -758,3 +758,223 @@ pub enum BeaconVoteValidationError {
     #[error("Attestation would be slashable: {0}")]
     SlashableAttestation(NotSafe),
 }
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use types::{Checkpoint, Epoch, FixedBytesExtended, MainnetEthSpec};
+
+    use super::*;
+
+    /// Helper function to create a BeaconVoteValidator for testing.
+    /// This validator has slashing protection disabled for simpler testing.
+    fn create_test_validator() -> BeaconVoteValidator<MainnetEthSpec> {
+        let spec = Arc::new(ChainSpec::mainnet());
+        let validator_attestation_committees = HashMap::new();
+        let genesis_validators_root = Hash256::zero();
+        let slot = Slot::new(100);
+
+        BeaconVoteValidator::new(
+            slot,
+            None,
+            spec,
+            validator_attestation_committees,
+            genesis_validators_root,
+        )
+    }
+
+    #[test]
+    fn test_mismatched_source_different_epochs() {
+        let validator = create_test_validator();
+
+        let our_source = Checkpoint {
+            epoch: Epoch::new(2),
+            root: Hash256::from_low_u64_be(1),
+        };
+        let our_target = Checkpoint {
+            epoch: Epoch::new(3),
+            root: Hash256::from_low_u64_be(2),
+        };
+        let our_vote = BeaconVote {
+            block_root: Hash256::random(),
+            source: our_source,
+            target: our_target,
+        };
+
+        // Create a proposed vote with different source epoch
+        let proposed_source = Checkpoint {
+            epoch: Epoch::new(1), // Different epoch
+            root: Hash256::from_low_u64_be(1),
+        };
+        let proposed_vote = BeaconVote {
+            block_root: Hash256::random(),
+            source: proposed_source,
+            target: our_target,
+        };
+
+        let result = validator.do_validation(&proposed_vote, &our_vote);
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            BeaconVoteValidationError::DifferentSource { our, proposed } => {
+                assert_eq!(our, our_source);
+                assert_eq!(proposed, proposed_source);
+            }
+            err => panic!("Expected DifferentSource error, got: {:?}", err),
+        }
+    }
+
+    #[test]
+    fn test_mismatched_source_same_epoch_different_roots() {
+        let validator = create_test_validator();
+
+        let our_source = Checkpoint {
+            epoch: Epoch::new(2),
+            root: Hash256::from_low_u64_be(1),
+        };
+        let our_target = Checkpoint {
+            epoch: Epoch::new(3),
+            root: Hash256::from_low_u64_be(2),
+        };
+        let our_vote = BeaconVote {
+            block_root: Hash256::random(),
+            source: our_source,
+            target: our_target,
+        };
+
+        // Create a proposed vote with same source epoch but different root
+        let proposed_source = Checkpoint {
+            epoch: Epoch::new(2),                // Same epoch
+            root: Hash256::from_low_u64_be(999), // Different root
+        };
+        let proposed_vote = BeaconVote {
+            block_root: Hash256::random(),
+            source: proposed_source,
+            target: our_target,
+        };
+
+        let result = validator.do_validation(&proposed_vote, &our_vote);
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            BeaconVoteValidationError::DifferentSource { our, proposed } => {
+                assert_eq!(our, our_source);
+                assert_eq!(proposed, proposed_source);
+            }
+            err => panic!("Expected DifferentSource error, got: {:?}", err),
+        }
+    }
+
+    #[test]
+    fn test_mismatched_target_different_epochs() {
+        let validator = create_test_validator();
+
+        let our_source = Checkpoint {
+            epoch: Epoch::new(2),
+            root: Hash256::from_low_u64_be(1),
+        };
+        let our_target = Checkpoint {
+            epoch: Epoch::new(3),
+            root: Hash256::from_low_u64_be(2),
+        };
+        let our_vote = BeaconVote {
+            block_root: Hash256::random(),
+            source: our_source,
+            target: our_target,
+        };
+
+        // Create a proposed vote with different target epoch
+        let proposed_target = Checkpoint {
+            epoch: Epoch::new(4), // Different epoch (but still valid, current epoch is 3, max is 4)
+            root: Hash256::from_low_u64_be(2),
+        };
+        let proposed_vote = BeaconVote {
+            block_root: Hash256::random(),
+            source: our_source,
+            target: proposed_target,
+        };
+
+        let result = validator.do_validation(&proposed_vote, &our_vote);
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            BeaconVoteValidationError::DifferentTarget { our, proposed } => {
+                assert_eq!(our, our_target);
+                assert_eq!(proposed, proposed_target);
+            }
+            err => panic!("Expected DifferentTarget error, got: {:?}", err),
+        }
+    }
+
+    #[test]
+    fn test_mismatched_target_same_epoch_different_roots() {
+        let validator = create_test_validator();
+
+        let our_source = Checkpoint {
+            epoch: Epoch::new(2),
+            root: Hash256::from_low_u64_be(1),
+        };
+        let our_target = Checkpoint {
+            epoch: Epoch::new(3),
+            root: Hash256::from_low_u64_be(2),
+        };
+        let our_vote = BeaconVote {
+            block_root: Hash256::random(),
+            source: our_source,
+            target: our_target,
+        };
+
+        // Create a proposed vote with same target epoch but different root
+        let proposed_target = Checkpoint {
+            epoch: Epoch::new(3),                // Same epoch
+            root: Hash256::from_low_u64_be(999), // Different root
+        };
+        let proposed_vote = BeaconVote {
+            block_root: Hash256::random(),
+            source: our_source,
+            target: proposed_target,
+        };
+
+        let result = validator.do_validation(&proposed_vote, &our_vote);
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            BeaconVoteValidationError::DifferentTarget { our, proposed } => {
+                assert_eq!(our, our_target);
+                assert_eq!(proposed, proposed_target);
+            }
+            err => panic!("Expected DifferentTarget error, got: {:?}", err),
+        }
+    }
+
+    #[test]
+    fn test_valid_matching_checkpoints() {
+        let validator = create_test_validator();
+
+        let source = Checkpoint {
+            epoch: Epoch::new(2),
+            root: Hash256::from_low_u64_be(1),
+        };
+        let target = Checkpoint {
+            epoch: Epoch::new(3),
+            root: Hash256::from_low_u64_be(2),
+        };
+
+        let our_vote = BeaconVote {
+            block_root: Hash256::random(),
+            source,
+            target,
+        };
+        // Proposed vote has same source and target (but different head vote)
+        let proposed_vote = BeaconVote {
+            block_root: Hash256::random(),
+            source,
+            target,
+        };
+
+        // This should succeed since checkpoints match
+        let result = validator.do_validation(&proposed_vote, &our_vote);
+        assert!(
+            result.is_ok(),
+            "Expected validation to succeed for matching checkpoints, got error: {:?}",
+            result.unwrap_err()
+        );
+    }
+}

--- a/anchor/common/ssv_types/src/consensus.rs
+++ b/anchor/common/ssv_types/src/consensus.rs
@@ -658,7 +658,7 @@ impl<E: EthSpec> BeaconVoteValidator<E> {
     pub fn do_validation(
         &self,
         value: &BeaconVote,
-        _our_value: &BeaconVote,
+        our_value: &BeaconVote,
     ) -> Result<(), BeaconVoteValidationError> {
         // Check target epoch is not too far in the future
         let current_epoch = self.slot.epoch(E::slots_per_epoch());
@@ -677,6 +677,19 @@ impl<E: EthSpec> BeaconVoteValidator<E> {
                 value.source.epoch.as_u64(),
                 value.target.epoch.as_u64()
             )));
+        }
+
+        if value.source != our_value.source {
+            return Err(BeaconVoteValidationError::DifferentSource {
+                our: our_value.source,
+                proposed: value.source,
+            });
+        }
+        if value.target != our_value.target {
+            return Err(BeaconVoteValidationError::DifferentTarget {
+                our: our_value.source,
+                proposed: value.source,
+            });
         }
 
         // Check slashing protection for all validator public keys
@@ -728,6 +741,16 @@ pub enum BeaconVoteValidationError {
     FarFutureTargetEpoch(String),
     #[error("Invalid epoch order: {0}")]
     TargetNotAfterSource(String),
+    #[error("Different source: our {our:?}, proposed {proposed:?}")]
+    DifferentSource {
+        our: Checkpoint,
+        proposed: Checkpoint,
+    },
+    #[error("Different target: our {our:?}, proposed {proposed:?}")]
+    DifferentTarget {
+        our: Checkpoint,
+        proposed: Checkpoint,
+    },
     #[error("Attestation would be slashable: {0}")]
     SlashableAttestation(NotSafe),
 }

--- a/anchor/common/ssv_types/src/consensus.rs
+++ b/anchor/common/ssv_types/src/consensus.rs
@@ -679,6 +679,10 @@ impl<E: EthSpec> BeaconVoteValidator<E> {
             )));
         }
 
+        // Majority fork protection:
+        // If we disagree on the epoch to finalize, we fail validation to avoid deciding on an
+        // attestation that tries to finalize a potentially faulty fork.
+        // https://github.com/ssvlabs/ssv-spec/issues/555
         if value.source != our_value.source {
             return Err(BeaconVoteValidationError::DifferentSource {
                 our: our_value.source,

--- a/anchor/common/ssv_types/src/consensus.rs
+++ b/anchor/common/ssv_types/src/consensus.rs
@@ -681,17 +681,15 @@ impl<E: EthSpec> BeaconVoteValidator<E> {
         // If we disagree on the epoch to finalize, we fail validation to avoid deciding on an
         // attestation that tries to finalize a potentially faulty fork.
         // https://github.com/ssvlabs/ssv-spec/issues/555
-        if value.source != our_value.source {
-            return Err(BeaconVoteValidationError::DifferentSource {
-                our: our_value.source,
-                proposed: value.source,
-            });
-        }
-        if value.target != our_value.target {
-            return Err(BeaconVoteValidationError::DifferentTarget {
-                our: our_value.target,
-                proposed: value.target,
-            });
+        if value.source != our_value.source || value.target != our_value.target {
+            return Err(BeaconVoteValidationError::CheckpointMismatch(Box::new(
+                CheckpointMismatch {
+                    our_source: our_value.source,
+                    proposed_source: value.source,
+                    our_target: our_value.target,
+                    proposed_target: value.target,
+                },
+            )));
         }
 
         // Check slashing protection for all validator public keys
@@ -737,6 +735,27 @@ impl<E: EthSpec> BeaconVoteValidator<E> {
     }
 }
 
+/// Details about checkpoint mismatches between our vote and a proposed vote.
+///
+/// This struct is needed to avoid the linter complaining about the size of the error enum.
+#[derive(Debug, Clone, PartialEq)]
+pub struct CheckpointMismatch {
+    pub our_source: Checkpoint,
+    pub proposed_source: Checkpoint,
+    pub our_target: Checkpoint,
+    pub proposed_target: Checkpoint,
+}
+
+impl Display for CheckpointMismatch {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "Checkpoint mismatch:\nSOURCE: our {:?}, proposed {:?}.\nTARGET: our {:?}, proposed {:?}",
+            self.our_source, self.proposed_source, self.our_target, self.proposed_target
+        )
+    }
+}
+
 #[derive(Error, Debug)]
 pub enum BeaconVoteValidationError {
     #[error("Unable to validate, bad slot clock")]
@@ -745,16 +764,8 @@ pub enum BeaconVoteValidationError {
     FarFutureTargetEpoch(String),
     #[error("Invalid epoch order: {0}")]
     TargetNotAfterSource(String),
-    #[error("Different source: our {our:?}, proposed {proposed:?}")]
-    DifferentSource {
-        our: Checkpoint,
-        proposed: Checkpoint,
-    },
-    #[error("Different target: our {our:?}, proposed {proposed:?}")]
-    DifferentTarget {
-        our: Checkpoint,
-        proposed: Checkpoint,
-    },
+    #[error("{0}")]
+    CheckpointMismatch(Box<CheckpointMismatch>),
     #[error("Attestation would be slashable: {0}")]
     SlashableAttestation(NotSafe),
 }
@@ -816,11 +827,13 @@ mod tests {
         let result = validator.do_validation(&proposed_vote, &our_vote);
         assert!(result.is_err());
         match result.unwrap_err() {
-            BeaconVoteValidationError::DifferentSource { our, proposed } => {
-                assert_eq!(our, our_source);
-                assert_eq!(proposed, proposed_source);
+            BeaconVoteValidationError::CheckpointMismatch(mismatch) => {
+                assert_eq!(mismatch.our_source, our_source);
+                assert_eq!(mismatch.proposed_source, proposed_source);
+                assert_eq!(mismatch.our_target, our_target);
+                assert_eq!(mismatch.proposed_target, our_target);
             }
-            err => panic!("Expected DifferentSource error, got: {:?}", err),
+            err => panic!("Expected DifferentCheckpoint error, got: {:?}", err),
         }
     }
 
@@ -856,11 +869,13 @@ mod tests {
         let result = validator.do_validation(&proposed_vote, &our_vote);
         assert!(result.is_err());
         match result.unwrap_err() {
-            BeaconVoteValidationError::DifferentSource { our, proposed } => {
-                assert_eq!(our, our_source);
-                assert_eq!(proposed, proposed_source);
+            BeaconVoteValidationError::CheckpointMismatch(mismatch) => {
+                assert_eq!(mismatch.our_source, our_source);
+                assert_eq!(mismatch.proposed_source, proposed_source);
+                assert_eq!(mismatch.our_target, our_target);
+                assert_eq!(mismatch.proposed_target, our_target);
             }
-            err => panic!("Expected DifferentSource error, got: {:?}", err),
+            err => panic!("Expected DifferentCheckpoint error, got: {:?}", err),
         }
     }
 
@@ -896,11 +911,13 @@ mod tests {
         let result = validator.do_validation(&proposed_vote, &our_vote);
         assert!(result.is_err());
         match result.unwrap_err() {
-            BeaconVoteValidationError::DifferentTarget { our, proposed } => {
-                assert_eq!(our, our_target);
-                assert_eq!(proposed, proposed_target);
+            BeaconVoteValidationError::CheckpointMismatch(mismatch) => {
+                assert_eq!(mismatch.our_source, our_source);
+                assert_eq!(mismatch.proposed_source, our_source);
+                assert_eq!(mismatch.our_target, our_target);
+                assert_eq!(mismatch.proposed_target, proposed_target);
             }
-            err => panic!("Expected DifferentTarget error, got: {:?}", err),
+            err => panic!("Expected DifferentCheckpoint error, got: {:?}", err),
         }
     }
 
@@ -936,11 +953,13 @@ mod tests {
         let result = validator.do_validation(&proposed_vote, &our_vote);
         assert!(result.is_err());
         match result.unwrap_err() {
-            BeaconVoteValidationError::DifferentTarget { our, proposed } => {
-                assert_eq!(our, our_target);
-                assert_eq!(proposed, proposed_target);
+            BeaconVoteValidationError::CheckpointMismatch(mismatch) => {
+                assert_eq!(mismatch.our_source, our_source);
+                assert_eq!(mismatch.proposed_source, our_source);
+                assert_eq!(mismatch.our_target, our_target);
+                assert_eq!(mismatch.proposed_target, proposed_target);
             }
-            err => panic!("Expected DifferentTarget error, got: {:?}", err),
+            err => panic!("Expected DifferentCheckpoint error, got: {:?}", err),
         }
     }
 

--- a/anchor/common/ssv_types/src/consensus.rs
+++ b/anchor/common/ssv_types/src/consensus.rs
@@ -615,8 +615,8 @@ impl QbftData for BeaconVote {
 
 pub struct BeaconVoteValidator<E: EthSpec> {
     slot: Slot,
-    slashing_database: Arc<SlashingDatabase>,
-    disable_slashing_protection: bool,
+    // `None` if slashing protection is disabled via CLI.
+    slashing_database: Option<Arc<SlashingDatabase>>,
     spec: Arc<ChainSpec>,
     validator_attestation_committees: HashMap<PublicKeyBytes, u64>,
     genesis_validators_root: Hash256,
@@ -638,8 +638,7 @@ impl<E: EthSpec> QbftDataValidator<BeaconVote> for BeaconVoteValidator<E> {
 impl<E: EthSpec> BeaconVoteValidator<E> {
     pub fn new(
         slot: Slot,
-        slashing_database: Arc<SlashingDatabase>,
-        disable_slashing_protection: bool,
+        slashing_database: Option<Arc<SlashingDatabase>>,
         spec: Arc<ChainSpec>,
         validator_attestation_committees: HashMap<PublicKeyBytes, u64>,
         genesis_validators_root: Hash256,
@@ -647,7 +646,6 @@ impl<E: EthSpec> BeaconVoteValidator<E> {
         Self {
             slot,
             slashing_database,
-            disable_slashing_protection,
             spec,
             validator_attestation_committees,
             genesis_validators_root,
@@ -697,9 +695,7 @@ impl<E: EthSpec> BeaconVoteValidator<E> {
         }
 
         // Check slashing protection for all validator public keys
-        if !self.disable_slashing_protection {
-            self.check_attestation_slashing(value)?;
-        }
+        self.check_attestation_slashing(value)?;
 
         Ok(())
     }
@@ -708,6 +704,10 @@ impl<E: EthSpec> BeaconVoteValidator<E> {
         &self,
         value: &BeaconVote,
     ) -> Result<(), BeaconVoteValidationError> {
+        let Some(slashing_database) = &self.slashing_database else {
+            return Ok(());
+        };
+
         // Create attestation data for slashing protection check
         let mut attestation_data = AttestationData {
             slot: self.slot,
@@ -728,7 +728,7 @@ impl<E: EthSpec> BeaconVoteValidator<E> {
 
         for (validator_pubkey, committee_index) in &self.validator_attestation_committees {
             attestation_data.index = *committee_index;
-            self.slashing_database
+            slashing_database
                 .preliminary_check_attestation(validator_pubkey, &attestation_data, domain_hash)
                 .map_err(BeaconVoteValidationError::SlashableAttestation)?;
         }

--- a/anchor/common/ssv_types/src/consensus.rs
+++ b/anchor/common/ssv_types/src/consensus.rs
@@ -687,8 +687,8 @@ impl<E: EthSpec> BeaconVoteValidator<E> {
         }
         if value.target != our_value.target {
             return Err(BeaconVoteValidationError::DifferentTarget {
-                our: our_value.source,
-                proposed: value.source,
+                our: our_value.target,
+                proposed: value.target,
             });
         }
 

--- a/anchor/validator_store/src/lib.rs
+++ b/anchor/validator_store/src/lib.rs
@@ -562,10 +562,12 @@ impl<T: SlotClock, E: EthSpec> AnchorValidatorStore<T, E> {
         slot: Slot,
         validator_attestation_committees: HashMap<PublicKeyBytes, u64>,
     ) -> Box<BeaconVoteValidator<E>> {
+        let slashing_protection =
+            (!self.disable_slashing_protection).then(|| Arc::clone(&self.slashing_protection));
+
         Box::new(BeaconVoteValidator::new(
             slot,
-            Arc::clone(&self.slashing_protection),
-            self.disable_slashing_protection,
+            slashing_protection,
             self.spec.clone(),
             validator_attestation_committees,
             self.genesis_validators_root,


### PR DESCRIPTION
## Issue Addressed

- #628 

## Proposed Changes

In the `BeaconVoteValidator`, which validates `BeaconVote`s proposed by other nodes, add a step to compare the source, and a step to compare the target, including epoch and checkpoing for each.

## Additional Info

Implements https://github.com/ssvlabs/ssv-spec/issues/555.

See also the Go-SSV implementation: https://github.com/ssvlabs/ssv/pull/2358
