### PR TITLE
fix: Re-add node version to Handshake completed

### DIFF
--- a/anchor/network/src/network.rs
+++ b/anchor/network/src/network.rs
@@ -580,6 +580,7 @@ impl<R: MessageReceiver> Network<R> {
                 %peer_id,
                 our_subnets = %our_metadata.subnets,
                 their_subnets = %their_metadata.subnets,
+                node_version = %their_metadata.node_version,
                 matching_subnets = matching_count,
                 "Handshake completed"
             );


### PR DESCRIPTION
## Issue Addressed

In `rc.1`, we (accidentally?) removed logging the node version after a completed handshake.

## Proposed Changes

This info is very useful for debugging, e.g. if we see repeated invalid messages from a certain peer and we want to know what software sent those messages. This PR readds the field.