### PR TITLE
chore: change default network to Mainnet

### DIFF
--- a/anchor/common/global_config/src/lib.rs
+++ b/anchor/common/global_config/src/lib.rs
@@ -9,7 +9,7 @@ use tracing::Level;
 use crate::data_dir::DataDir;
 
 /// Default network, used to partition the data storage
-pub const DEFAULT_HARDCODED_NETWORK: &str = "hoodi";
+pub const DEFAULT_HARDCODED_NETWORK: &str = "mainnet";
 
 /// Config that applies to all subcommands: The resolved network and datadir. This avoids repeated
 /// logic matching the datadir from the actual CLI definition.

--- a/docs/docs/pages/cli.mdx
+++ b/docs/docs/pages/cli.mdx
@@ -22,6 +22,6 @@ Where `<COMMAND>` is one of:
 | --- | --- |-----------------------|
 | `--data-dir <DIR>` | Data directory for node files | `~/.anchor/{network}` |
 | `--testnet-dir <DIR>` | Directory containing testnet specs | None                  |
-| `--network <NETWORK>` | Network to use (Mainnet, Holesky, Hoodi) | `hoodi`               |
+| `--network <NETWORK>` | Network to use (Mainnet, Holesky, Hoodi) | `mainnet`               |
 | `--help` | Display help information | Unset                 |
 


### PR DESCRIPTION
## Issue Addressed

We decided undo the default network change previously, rolling back to Hoodi. 

## Proposed Changes

As we are now releasing the actual `v1.0.0`, we change the default network to Mainnet, mirroring many Ethereum clients as well as go-ssv.