### PR TITLE
chore: Remove "not prod ready" warnings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -395,7 +395,6 @@ When writing PR descriptions, follow these guidelines for maintainable and revie
 ## Development Tips
 
 - This is a Rust project that follows standard Rust development practices
-- The project is currently under active development and not ready for production
 - Sigma Prime maintains two permanent branches:
     - `stable`: Always points to the latest stable release, ideal for most users
     - `unstable`: Used for development, contains the latest PRs, base branch for contributions

--- a/README.md
+++ b/README.md
@@ -14,11 +14,6 @@ in Rust and maintained by [Sigma Prime](https://github.com/sigp).
 [unstable]: https://github.com/sigp/anchor/tree/unstable
 [blog]: https://blog.sigmaprime.io
 
-## Overview
-
-This client implementation is currently under active development and should not
-be used for production until a formal production release has been made.
-
 ## Documentation
 
 The [Anchor Docs](https://anchor.sigmaprime.io) contains information for users and

--- a/docs/docs/pages/introduction.mdx
+++ b/docs/docs/pages/introduction.mdx
@@ -1,9 +1,3 @@
-
-:::warning
-The Anchor client is currently under active development and should not be used in a
-production setting.
-:::
-
 # Welcome to Anchor
 
 **Anchor** is a high-performance Secret Shared Validators (SSV) client written in Rust, designed to enable distributed validator technology for Ethereum staking.


### PR DESCRIPTION
## Issue Addressed

As we release `v1.0.0`, "do not use" warnings in our docs become inappropriate.

## Proposed Changes

Remove any warnings about not using Anchor in PROD.