### PR TITLE
ci: add timeout and debug logging to claude-pr-review workflow

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -85,6 +85,9 @@ jobs:
 
             - name: Run Claude Code Action
               if: steps.check.outputs.is_member == 'true'
+              timeout-minutes: 15
+              env:
+                  ACTIONS_STEP_DEBUG: true
               uses: anthropics/claude-code-action@v1
               with:
                   github_token: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
## Issue Addressed

Fixes workflow hanging indefinitely during Claude Code Action execution.

## Proposed Changes

Added safety measures to the `claude-pr-review.yml` workflow:

1. **Timeout Protection** (`timeout-minutes: 15`):
   - Prevents workflow from running indefinitely
   - Terminates the step after 15 minutes if it hangs

2. **Debug Logging** (`ACTIONS_STEP_DEBUG: true`):
   - Enables detailed debug output for troubleshooting
   - Helps diagnose where the action hangs

## Additional Info

**Observed Behavior:**
- First workflow run: ✅ Completes successfully
- Subsequent runs: ❌ Hangs at "Setting up Claude Code..." step


With these changes, the workflow will fail fast (15 minutes) instead of hanging, and provide detailed logs to identify the issue.