### PR TITLE
feat: add blocked peer metrics

### DIFF
--- a/anchor/network/src/metrics.rs
+++ b/anchor/network/src/metrics.rs
@@ -40,13 +40,13 @@ pub static HANDSHAKE_SUBNET_MATCHES: LazyLock<Result<IntGaugeVec>> = LazyLock::n
 pub static PEERS_BLOCKED: LazyLock<Result<IntGauge>> = LazyLock::new(|| {
     try_create_int_gauge(
         "libp2p_peers_blocked",
-        "Count the number of blocked libp2p peers",
+        "Current count of blocked libp2p peers",
     )
 });
 
 pub static PEER_BLOCKED_INBOUND_CONNECTIONS: LazyLock<Result<IntGaugeVec>> = LazyLock::new(|| {
     try_create_int_gauge_vec(
-        "blocked_peers_connecting",
+        "libp2p_blocked_peer_connection_attempts",
         "Count of blocked peers trying to reconnect",
         &["blocked_peer_id"],
     )

--- a/anchor/network/src/metrics.rs
+++ b/anchor/network/src/metrics.rs
@@ -36,3 +36,18 @@ pub static HANDSHAKE_SUBNET_MATCHES: LazyLock<Result<IntGaugeVec>> = LazyLock::n
         &["match_count"],
     )
 });
+
+pub static PEERS_BLOCKED: LazyLock<Result<IntGauge>> = LazyLock::new(|| {
+    try_create_int_gauge(
+        "libp2p_peers_blocked",
+        "Count the number of blocked libp2p peers",
+    )
+});
+
+pub static PEER_BLOCKED_INBOUND_CONNECTIONS: LazyLock<Result<IntGaugeVec>> = LazyLock::new(|| {
+    try_create_int_gauge_vec(
+        "blocked_peers_connecting",
+        "Count of blocked peers trying to reconnect",
+        &["blocked_peer_id"],
+    )
+});

--- a/anchor/network/src/peer_manager/blocking.rs
+++ b/anchor/network/src/peer_manager/blocking.rs
@@ -11,7 +11,10 @@ use libp2p::{
 };
 use tracing::debug;
 
-use crate::scoring::peer_score_config::RETAIN_SCORE_EPOCH_MULTIPLIER;
+use crate::{
+    metrics::{PEER_BLOCKED_INBOUND_CONNECTIONS, PEERS_BLOCKED},
+    scoring::peer_score_config::RETAIN_SCORE_EPOCH_MULTIPLIER,
+};
 
 /// Manages peer blocking functionality
 pub struct BlockingManager {
@@ -38,6 +41,7 @@ impl BlockingManager {
             self.blocked_peers_timestamps
                 .insert(peer_id, tokio::time::Instant::now());
             debug!(?peer_id, "Blocked peer");
+            metrics::inc_gauge(&PEERS_BLOCKED);
             true
         } else {
             false
@@ -50,6 +54,12 @@ impl BlockingManager {
         if was_removed {
             self.blocked_peers_timestamps.remove(&peer_id);
             debug!(?peer_id, "Unblocked peer after retain_score duration");
+            metrics::dec_gauge(&PEERS_BLOCKED);
+            metrics::set_gauge_vec(
+                &PEER_BLOCKED_INBOUND_CONNECTIONS,
+                &[&peer_id.to_base58()],
+                0,
+            );
         }
         was_removed
     }
@@ -103,6 +113,9 @@ impl BlockingManager {
         local_addr: &Multiaddr,
         remote_addr: &Multiaddr,
     ) -> Result<(), ConnectionDenied> {
+        if self.blocked_peers().contains(&peer) {
+            metrics::inc_gauge_vec(&PEER_BLOCKED_INBOUND_CONNECTIONS, &[&peer.to_base58()]);
+        }
         self.block_list
             .handle_established_inbound_connection(connection_id, peer, local_addr, remote_addr)
             .map(|_| ()) // Discard the handler, we just want to know if connection is allowed


### PR DESCRIPTION
## Issue Addressed

Addresses Issue #653 

## Proposed Changes

Adds a few more metrics about blocked peers.
Tracks the number of blocked peers, and how many times a particular blocked peer tried to dial us.

## Additional Info

Can add more metrics if we think anything else is particularly useful
