### PR TITLE
chore: Update to Lighthouse v8.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1384,7 +1384,7 @@ checksum = "55248b47b0caf0546f7988906588779981c43bb1bc9d0c44087278f80cdb44ba"
 [[package]]
 name = "beacon_node_fallback"
 version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?rev=b59feb04#b59feb042c13fa74304acb920e720efde885d3bd"
+source = "git+https://github.com/sigp/lighthouse?rev=e3ee7feb#e3ee7febce64c1b5a85c3ab0be0619571ee92d58"
 dependencies = [
  "clap",
  "eth2",
@@ -1492,7 +1492,7 @@ dependencies = [
 [[package]]
 name = "bls"
 version = "0.2.0"
-source = "git+https://github.com/sigp/lighthouse?rev=b59feb04#b59feb042c13fa74304acb920e720efde885d3bd"
+source = "git+https://github.com/sigp/lighthouse?rev=e3ee7feb#e3ee7febce64c1b5a85c3ab0be0619571ee92d58"
 dependencies = [
  "alloy-primitives 1.4.1",
  "arbitrary",
@@ -1852,7 +1852,7 @@ checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 [[package]]
 name = "compare_fields"
 version = "0.2.0"
-source = "git+https://github.com/sigp/lighthouse?rev=b59feb04#b59feb042c13fa74304acb920e720efde885d3bd"
+source = "git+https://github.com/sigp/lighthouse?rev=e3ee7feb#e3ee7febce64c1b5a85c3ab0be0619571ee92d58"
 dependencies = [
  "itertools 0.10.5",
 ]
@@ -1860,7 +1860,7 @@ dependencies = [
 [[package]]
 name = "compare_fields_derive"
 version = "0.2.0"
-source = "git+https://github.com/sigp/lighthouse?rev=b59feb04#b59feb042c13fa74304acb920e720efde885d3bd"
+source = "git+https://github.com/sigp/lighthouse?rev=e3ee7feb#e3ee7febce64c1b5a85c3ab0be0619571ee92d58"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -1928,7 +1928,7 @@ checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 [[package]]
 name = "context_deserialize"
 version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?rev=b59feb04#b59feb042c13fa74304acb920e720efde885d3bd"
+source = "git+https://github.com/sigp/lighthouse?rev=e3ee7feb#e3ee7febce64c1b5a85c3ab0be0619571ee92d58"
 dependencies = [
  "context_deserialize_derive",
  "milhouse",
@@ -1939,7 +1939,7 @@ dependencies = [
 [[package]]
 name = "context_deserialize_derive"
 version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?rev=b59feb04#b59feb042c13fa74304acb920e720efde885d3bd"
+source = "git+https://github.com/sigp/lighthouse?rev=e3ee7feb#e3ee7febce64c1b5a85c3ab0be0619571ee92d58"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -2620,7 +2620,7 @@ dependencies = [
 [[package]]
 name = "eip_3076"
 version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?rev=b59feb04#b59feb042c13fa74304acb920e720efde885d3bd"
+source = "git+https://github.com/sigp/lighthouse?rev=e3ee7feb#e3ee7febce64c1b5a85c3ab0be0619571ee92d58"
 dependencies = [
  "ethereum_serde_utils 0.8.0",
  "serde",
@@ -2873,7 +2873,7 @@ dependencies = [
 [[package]]
 name = "eth2"
 version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?rev=b59feb04#b59feb042c13fa74304acb920e720efde885d3bd"
+source = "git+https://github.com/sigp/lighthouse?rev=e3ee7feb#e3ee7febce64c1b5a85c3ab0be0619571ee92d58"
 dependencies = [
  "derivative",
  "eip_3076",
@@ -2905,7 +2905,7 @@ dependencies = [
 [[package]]
 name = "eth2_config"
 version = "0.2.0"
-source = "git+https://github.com/sigp/lighthouse?rev=b59feb04#b59feb042c13fa74304acb920e720efde885d3bd"
+source = "git+https://github.com/sigp/lighthouse?rev=e3ee7feb#e3ee7febce64c1b5a85c3ab0be0619571ee92d58"
 dependencies = [
  "paste",
  "types",
@@ -2914,7 +2914,7 @@ dependencies = [
 [[package]]
 name = "eth2_interop_keypairs"
 version = "0.2.0"
-source = "git+https://github.com/sigp/lighthouse?rev=b59feb04#b59feb042c13fa74304acb920e720efde885d3bd"
+source = "git+https://github.com/sigp/lighthouse?rev=e3ee7feb#e3ee7febce64c1b5a85c3ab0be0619571ee92d58"
 dependencies = [
  "bls",
  "ethereum_hashing",
@@ -2927,7 +2927,7 @@ dependencies = [
 [[package]]
 name = "eth2_key_derivation"
 version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?rev=b59feb04#b59feb042c13fa74304acb920e720efde885d3bd"
+source = "git+https://github.com/sigp/lighthouse?rev=e3ee7feb#e3ee7febce64c1b5a85c3ab0be0619571ee92d58"
 dependencies = [
  "bls",
  "num-bigint-dig",
@@ -2939,7 +2939,7 @@ dependencies = [
 [[package]]
 name = "eth2_keystore"
 version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?rev=b59feb04#b59feb042c13fa74304acb920e720efde885d3bd"
+source = "git+https://github.com/sigp/lighthouse?rev=e3ee7feb#e3ee7febce64c1b5a85c3ab0be0619571ee92d58"
 dependencies = [
  "aes 0.7.5",
  "bls",
@@ -2961,7 +2961,7 @@ dependencies = [
 [[package]]
 name = "eth2_network_config"
 version = "0.2.0"
-source = "git+https://github.com/sigp/lighthouse?rev=b59feb04#b59feb042c13fa74304acb920e720efde885d3bd"
+source = "git+https://github.com/sigp/lighthouse?rev=e3ee7feb#e3ee7febce64c1b5a85c3ab0be0619571ee92d58"
 dependencies = [
  "bytes",
  "discv5",
@@ -3160,7 +3160,7 @@ dependencies = [
 [[package]]
 name = "filesystem"
 version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?rev=b59feb04#b59feb042c13fa74304acb920e720efde885d3bd"
+source = "git+https://github.com/sigp/lighthouse?rev=e3ee7feb#e3ee7febce64c1b5a85c3ab0be0619571ee92d58"
 dependencies = [
  "winapi",
  "windows-acl",
@@ -3187,7 +3187,7 @@ dependencies = [
 [[package]]
 name = "fixed_bytes"
 version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?rev=b59feb04#b59feb042c13fa74304acb920e720efde885d3bd"
+source = "git+https://github.com/sigp/lighthouse?rev=e3ee7feb#e3ee7febce64c1b5a85c3ab0be0619571ee92d58"
 dependencies = [
  "alloy-primitives 1.4.1",
  "safe_arith",
@@ -3484,7 +3484,7 @@ dependencies = [
 [[package]]
 name = "graffiti_file"
 version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?rev=b59feb04#b59feb042c13fa74304acb920e720efde885d3bd"
+source = "git+https://github.com/sigp/lighthouse?rev=e3ee7feb#e3ee7febce64c1b5a85c3ab0be0619571ee92d58"
 dependencies = [
  "bls",
  "serde",
@@ -3622,7 +3622,7 @@ dependencies = [
 [[package]]
 name = "health_metrics"
 version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?rev=b59feb04#b59feb042c13fa74304acb920e720efde885d3bd"
+source = "git+https://github.com/sigp/lighthouse?rev=e3ee7feb#e3ee7febce64c1b5a85c3ab0be0619571ee92d58"
 dependencies = [
  "eth2",
  "metrics",
@@ -4251,7 +4251,7 @@ dependencies = [
 [[package]]
 name = "int_to_bytes"
 version = "0.2.0"
-source = "git+https://github.com/sigp/lighthouse?rev=b59feb04#b59feb042c13fa74304acb920e720efde885d3bd"
+source = "git+https://github.com/sigp/lighthouse?rev=e3ee7feb#e3ee7febce64c1b5a85c3ab0be0619571ee92d58"
 dependencies = [
  "bytes",
 ]
@@ -4435,7 +4435,7 @@ dependencies = [
 [[package]]
 name = "kzg"
 version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?rev=b59feb04#b59feb042c13fa74304acb920e720efde885d3bd"
+source = "git+https://github.com/sigp/lighthouse?rev=e3ee7feb#e3ee7febce64c1b5a85c3ab0be0619571ee92d58"
 dependencies = [
  "arbitrary",
  "c-kzg",
@@ -4971,7 +4971,7 @@ dependencies = [
 [[package]]
 name = "logging"
 version = "0.2.0"
-source = "git+https://github.com/sigp/lighthouse?rev=b59feb04#b59feb042c13fa74304acb920e720efde885d3bd"
+source = "git+https://github.com/sigp/lighthouse?rev=e3ee7feb#e3ee7febce64c1b5a85c3ab0be0619571ee92d58"
 dependencies = [
  "chrono",
  "logroller",
@@ -5035,7 +5035,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 [[package]]
 name = "lru_cache"
 version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?rev=b59feb04#b59feb042c13fa74304acb920e720efde885d3bd"
+source = "git+https://github.com/sigp/lighthouse?rev=e3ee7feb#e3ee7febce64c1b5a85c3ab0be0619571ee92d58"
 dependencies = [
  "fnv",
 ]
@@ -5116,7 +5116,7 @@ dependencies = [
 [[package]]
 name = "merkle_proof"
 version = "0.2.0"
-source = "git+https://github.com/sigp/lighthouse?rev=b59feb04#b59feb042c13fa74304acb920e720efde885d3bd"
+source = "git+https://github.com/sigp/lighthouse?rev=e3ee7feb#e3ee7febce64c1b5a85c3ab0be0619571ee92d58"
 dependencies = [
  "alloy-primitives 1.4.1",
  "ethereum_hashing",
@@ -5214,7 +5214,7 @@ dependencies = [
 [[package]]
 name = "metrics"
 version = "0.2.0"
-source = "git+https://github.com/sigp/lighthouse?rev=b59feb04#b59feb042c13fa74304acb920e720efde885d3bd"
+source = "git+https://github.com/sigp/lighthouse?rev=e3ee7feb#e3ee7febce64c1b5a85c3ab0be0619571ee92d58"
 dependencies = [
  "prometheus",
 ]
@@ -5487,7 +5487,7 @@ dependencies = [
 [[package]]
 name = "network_utils"
 version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?rev=b59feb04#b59feb042c13fa74304acb920e720efde885d3bd"
+source = "git+https://github.com/sigp/lighthouse?rev=e3ee7feb#e3ee7febce64c1b5a85c3ab0be0619571ee92d58"
 dependencies = [
  "discv5",
  "libp2p-identity",
@@ -6063,7 +6063,7 @@ dependencies = [
 [[package]]
 name = "pretty_reqwest_error"
 version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?rev=b59feb04#b59feb042c13fa74304acb920e720efde885d3bd"
+source = "git+https://github.com/sigp/lighthouse?rev=e3ee7feb#e3ee7febce64c1b5a85c3ab0be0619571ee92d58"
 dependencies = [
  "reqwest 0.11.27",
  "sensitive_url",
@@ -6210,7 +6210,7 @@ dependencies = [
 [[package]]
 name = "proto_array"
 version = "0.2.0"
-source = "git+https://github.com/sigp/lighthouse?rev=b59feb04#b59feb042c13fa74304acb920e720efde885d3bd"
+source = "git+https://github.com/sigp/lighthouse?rev=e3ee7feb#e3ee7febce64c1b5a85c3ab0be0619571ee92d58"
 dependencies = [
  "ethereum_ssz",
  "ethereum_ssz_derive",
@@ -7194,7 +7194,7 @@ checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
 [[package]]
 name = "sensitive_url"
 version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?rev=b59feb04#b59feb042c13fa74304acb920e720efde885d3bd"
+source = "git+https://github.com/sigp/lighthouse?rev=e3ee7feb#e3ee7febce64c1b5a85c3ab0be0619571ee92d58"
 dependencies = [
  "serde",
  "url",
@@ -7452,7 +7452,7 @@ checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
 [[package]]
 name = "slashing_protection"
 version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?rev=b59feb04#b59feb042c13fa74304acb920e720efde885d3bd"
+source = "git+https://github.com/sigp/lighthouse?rev=e3ee7feb#e3ee7febce64c1b5a85c3ab0be0619571ee92d58"
 dependencies = [
  "arbitrary",
  "eip_3076",
@@ -7471,7 +7471,7 @@ dependencies = [
 [[package]]
 name = "slot_clock"
 version = "0.2.0"
-source = "git+https://github.com/sigp/lighthouse?rev=b59feb04#b59feb042c13fa74304acb920e720efde885d3bd"
+source = "git+https://github.com/sigp/lighthouse?rev=e3ee7feb#e3ee7febce64c1b5a85c3ab0be0619571ee92d58"
 dependencies = [
  "metrics",
  "parking_lot",
@@ -7720,7 +7720,7 @@ dependencies = [
 [[package]]
 name = "swap_or_not_shuffle"
 version = "0.2.0"
-source = "git+https://github.com/sigp/lighthouse?rev=b59feb04#b59feb042c13fa74304acb920e720efde885d3bd"
+source = "git+https://github.com/sigp/lighthouse?rev=e3ee7feb#e3ee7febce64c1b5a85c3ab0be0619571ee92d58"
 dependencies = [
  "alloy-primitives 1.4.1",
  "ethereum_hashing",
@@ -7850,7 +7850,7 @@ checksum = "c63f48baada5c52e65a29eef93ab4f8982681b67f9e8d29c7b05abcfec2b9ffe"
 [[package]]
 name = "task_executor"
 version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?rev=b59feb04#b59feb042c13fa74304acb920e720efde885d3bd"
+source = "git+https://github.com/sigp/lighthouse?rev=e3ee7feb#e3ee7febce64c1b5a85c3ab0be0619571ee92d58"
 dependencies = [
  "async-channel 1.9.0",
  "futures",
@@ -7887,7 +7887,7 @@ dependencies = [
 [[package]]
 name = "test_random_derive"
 version = "0.2.0"
-source = "git+https://github.com/sigp/lighthouse?rev=b59feb04#b59feb042c13fa74304acb920e720efde885d3bd"
+source = "git+https://github.com/sigp/lighthouse?rev=e3ee7feb#e3ee7febce64c1b5a85c3ab0be0619571ee92d58"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -8356,7 +8356,7 @@ checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 [[package]]
 name = "types"
 version = "0.2.1"
-source = "git+https://github.com/sigp/lighthouse?rev=b59feb04#b59feb042c13fa74304acb920e720efde885d3bd"
+source = "git+https://github.com/sigp/lighthouse?rev=e3ee7feb#e3ee7febce64c1b5a85c3ab0be0619571ee92d58"
 dependencies = [
  "alloy-primitives 1.4.1",
  "alloy-rlp",
@@ -8558,7 +8558,7 @@ dependencies = [
 [[package]]
 name = "validator_metrics"
 version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?rev=b59feb04#b59feb042c13fa74304acb920e720efde885d3bd"
+source = "git+https://github.com/sigp/lighthouse?rev=e3ee7feb#e3ee7febce64c1b5a85c3ab0be0619571ee92d58"
 dependencies = [
  "metrics",
 ]
@@ -8566,7 +8566,7 @@ dependencies = [
 [[package]]
 name = "validator_services"
 version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?rev=b59feb04#b59feb042c13fa74304acb920e720efde885d3bd"
+source = "git+https://github.com/sigp/lighthouse?rev=e3ee7feb#e3ee7febce64c1b5a85c3ab0be0619571ee92d58"
 dependencies = [
  "beacon_node_fallback",
  "bls",
@@ -8590,7 +8590,7 @@ dependencies = [
 [[package]]
 name = "validator_store"
 version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?rev=b59feb04#b59feb042c13fa74304acb920e720efde885d3bd"
+source = "git+https://github.com/sigp/lighthouse?rev=e3ee7feb#e3ee7febce64c1b5a85c3ab0be0619571ee92d58"
 dependencies = [
  "eth2",
  "slashing_protection",
@@ -9319,7 +9319,7 @@ checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 [[package]]
 name = "workspace_members"
 version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?rev=b59feb04#b59feb042c13fa74304acb920e720efde885d3bd"
+source = "git+https://github.com/sigp/lighthouse?rev=e3ee7feb#e3ee7febce64c1b5a85c3ab0be0619571ee92d58"
 dependencies = [
  "cargo_metadata",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,24 +64,24 @@ ssv_types = { path = "anchor/common/ssv_types" }
 subnet_service = { path = "anchor/subnet_service" }
 version = { path = "anchor/common/version" }
 
-# Lighthouse commit is `v8.0.0-rc.2`
-beacon_node_fallback = { git = "https://github.com/sigp/lighthouse", rev = "b59feb04" }
-bls = { git = "https://github.com/sigp/lighthouse", rev = "b59feb04" }
-eth2 = { git = "https://github.com/sigp/lighthouse", rev = "b59feb04" }
-eth2_keystore = { git = "https://github.com/sigp/lighthouse", rev = "b59feb04" }
-eth2_network_config = { git = "https://github.com/sigp/lighthouse", rev = "b59feb04" }
-health_metrics = { git = "https://github.com/sigp/lighthouse", rev = "b59feb04" }
-metrics = { git = "https://github.com/sigp/lighthouse", rev = "b59feb04" }
-network_utils = { git = "https://github.com/sigp/lighthouse", rev = "b59feb04" }
-sensitive_url = { git = "https://github.com/sigp/lighthouse", rev = "b59feb04" }
-slashing_protection = { git = "https://github.com/sigp/lighthouse", rev = "b59feb04" }
-slot_clock = { git = "https://github.com/sigp/lighthouse", rev = "b59feb04" }
-task_executor = { git = "https://github.com/sigp/lighthouse", rev = "b59feb04" }
-types = { git = "https://github.com/sigp/lighthouse", rev = "b59feb04" }
-validator_metrics = { git = "https://github.com/sigp/lighthouse", rev = "b59feb04" }
-validator_services = { git = "https://github.com/sigp/lighthouse", rev = "b59feb04" }
-validator_store = { git = "https://github.com/sigp/lighthouse", rev = "b59feb04" }
-workspace_members = { git = "https://github.com/sigp/lighthouse", rev = "b59feb04" }
+# Lighthouse commit is `v8.0.0`
+beacon_node_fallback = { git = "https://github.com/sigp/lighthouse", rev = "e3ee7feb" }
+bls = { git = "https://github.com/sigp/lighthouse", rev = "e3ee7feb" }
+eth2 = { git = "https://github.com/sigp/lighthouse", rev = "e3ee7feb" }
+eth2_keystore = { git = "https://github.com/sigp/lighthouse", rev = "e3ee7feb" }
+eth2_network_config = { git = "https://github.com/sigp/lighthouse", rev = "e3ee7feb" }
+health_metrics = { git = "https://github.com/sigp/lighthouse", rev = "e3ee7feb" }
+metrics = { git = "https://github.com/sigp/lighthouse", rev = "e3ee7feb" }
+network_utils = { git = "https://github.com/sigp/lighthouse", rev = "e3ee7feb" }
+sensitive_url = { git = "https://github.com/sigp/lighthouse", rev = "e3ee7feb" }
+slashing_protection = { git = "https://github.com/sigp/lighthouse", rev = "e3ee7feb" }
+slot_clock = { git = "https://github.com/sigp/lighthouse", rev = "e3ee7feb" }
+task_executor = { git = "https://github.com/sigp/lighthouse", rev = "e3ee7feb" }
+types = { git = "https://github.com/sigp/lighthouse", rev = "e3ee7feb" }
+validator_metrics = { git = "https://github.com/sigp/lighthouse", rev = "e3ee7feb" }
+validator_services = { git = "https://github.com/sigp/lighthouse", rev = "e3ee7feb" }
+validator_store = { git = "https://github.com/sigp/lighthouse", rev = "e3ee7feb" }
+workspace_members = { git = "https://github.com/sigp/lighthouse", rev = "e3ee7feb" }
 
 alloy = { version = "1.0.22", features = [
     "sol-types",


### PR DESCRIPTION
## Proposed Changes

Update to Lighthouse's stable release `v8.0.0`, which sets the Mainnet Pectra fork epoch.