### PR TITLE
fix: remove newlines from checkpoint mismatch error

### DIFF
--- a/anchor/common/ssv_types/src/consensus.rs
+++ b/anchor/common/ssv_types/src/consensus.rs
@@ -750,7 +750,7 @@ impl Display for CheckpointMismatch {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "Checkpoint mismatch:\nSOURCE: our {:?}, proposed {:?}.\nTARGET: our {:?}, proposed {:?}",
+            "Checkpoint mismatch: SOURCE: our {:?}, proposed {:?}. TARGET: our {:?}, proposed {:?}",
             self.our_source, self.proposed_source, self.our_target, self.proposed_target
         )
     }


### PR DESCRIPTION
## Issue Addressed

The new Majority Fork Protection logs mismatches across multiple lines. On one hand, this is nice as it makes it easier to compare the values, on the other hand, when parsing log lines (i.e. in elastic search or similar), they become "detached" from each other. This is annoying.

## Proposed Changes

Log in one line.
