### PR TITLE
fix: only store one node info and update that

### DIFF
--- a/anchor/network/src/handshake/mod.rs
+++ b/anchor/network/src/handshake/mod.rs
@@ -73,6 +73,31 @@ impl Behaviour {
     fn verify_and_emit_event(&mut self, peer_id: PeerId, their_info: NodeInfo) {
         match verify_node_info(&self.node_info, &their_info) {
             Ok(()) => {
+                // Log handshake completion and record metrics
+                if let Some(metadata) = &their_info.metadata {
+                    if let Some(our_metadata) = self.node_metadata() {
+                        let matching_count =
+                            count_matching_subnets(&our_metadata.subnets, &metadata.subnets);
+                        debug!(
+                            %peer_id,
+                            our_subnets = %our_metadata.subnets,
+                            their_subnets = %metadata.subnets,
+                            node_version = %metadata.node_version,
+                            matching_subnets = matching_count,
+                            "Handshake completed"
+                        );
+
+                        // Record subnet match count metric
+                        if let Ok(gauge_vec) = crate::metrics::HANDSHAKE_SUBNET_MATCHES.as_ref() {
+                            let label = &matching_count.to_string();
+                            if let Ok(gauge) = gauge_vec.get_metric_with_label_values(&[label]) {
+                                gauge.inc();
+                            }
+                        }
+                    }
+                } else {
+                    debug!(%peer_id, "Handshake completed without metadata");
+                }
                 self.events.push_back(Event::Completed {
                     peer_id,
                     their_info,
@@ -134,37 +159,6 @@ impl Behaviour {
             Some(&conn_est.peer_id)
         } else {
             None
-        }
-    }
-
-    /// Record metrics about subnet overlap after successful handshake.
-    pub fn record_handshake_subnet_match_metrics(
-        &self,
-        peer_id: PeerId,
-        their_metadata: &node_info::NodeMetadata,
-    ) {
-        if let Some(our_metadata) = self.node_metadata() {
-            let matching_count =
-                count_matching_subnets(&our_metadata.subnets, &their_metadata.subnets);
-
-            debug!(
-                %peer_id,
-                our_subnets = %our_metadata.subnets,
-                their_subnets = %their_metadata.subnets,
-                node_version = %their_metadata.node_version,
-                matching_subnets = matching_count,
-                "Handshake completed"
-            );
-
-            // Record subnet match count metric
-            if let Ok(gauge_vec) = crate::metrics::HANDSHAKE_SUBNET_MATCHES.as_ref() {
-                let label = &matching_count.to_string();
-                if let Ok(gauge) = gauge_vec.get_metric_with_label_values(&[label]) {
-                    gauge.inc();
-                }
-            }
-        } else {
-            debug!(%peer_id, "Handshake completed");
         }
     }
 

--- a/anchor/network/src/handshake/mod.rs
+++ b/anchor/network/src/handshake/mod.rs
@@ -16,7 +16,7 @@ use libp2p::{
     },
     swarm::{NetworkBehaviour, THandlerInEvent, ToSwarm},
 };
-use tracing::trace;
+use tracing::{debug, trace};
 
 use crate::handshake::{codec::Codec, node_info::NodeInfo};
 
@@ -137,6 +137,37 @@ impl Behaviour {
         }
     }
 
+    /// Record metrics about subnet overlap after successful handshake.
+    pub fn record_handshake_subnet_match_metrics(
+        &self,
+        peer_id: PeerId,
+        their_metadata: &node_info::NodeMetadata,
+    ) {
+        if let Some(our_metadata) = self.node_metadata() {
+            let matching_count =
+                count_matching_subnets(&our_metadata.subnets, &their_metadata.subnets);
+
+            debug!(
+                %peer_id,
+                our_subnets = %our_metadata.subnets,
+                their_subnets = %their_metadata.subnets,
+                node_version = %their_metadata.node_version,
+                matching_subnets = matching_count,
+                "Handshake completed"
+            );
+
+            // Record subnet match count metric
+            if let Ok(gauge_vec) = crate::metrics::HANDSHAKE_SUBNET_MATCHES.as_ref() {
+                let label = &matching_count.to_string();
+                if let Ok(gauge) = gauge_vec.get_metric_with_label_values(&[label]) {
+                    gauge.inc();
+                }
+            }
+        } else {
+            debug!(%peer_id, "Handshake completed");
+        }
+    }
+
     pub fn node_metadata(&self) -> &Option<node_info::NodeMetadata> {
         &self.node_info.metadata
     }
@@ -144,6 +175,26 @@ impl Behaviour {
     pub fn node_metadata_mut(&mut self) -> &mut Option<node_info::NodeMetadata> {
         &mut self.node_info.metadata
     }
+}
+
+/// Count the number of matching subnet bits between two hex-encoded subnet strings
+fn count_matching_subnets(our_subnets: &str, their_subnets: &str) -> usize {
+    // Decode both subnet strings
+    let our_bytes = match hex::decode(our_subnets) {
+        Ok(bytes) => bytes,
+        Err(_) => return 0,
+    };
+    let their_bytes = match hex::decode(their_subnets) {
+        Ok(bytes) => bytes,
+        Err(_) => return 0,
+    };
+
+    // Count matching bits using bitwise AND
+    our_bytes
+        .iter()
+        .zip(their_bytes.iter())
+        .map(|(a, b)| (a & b).count_ones() as usize)
+        .sum()
 }
 
 fn verify_node_info(ours: &NodeInfo, theirs: &NodeInfo) -> Result<(), Error> {

--- a/anchor/network/src/handshake/mod.rs
+++ b/anchor/network/src/handshake/mod.rs
@@ -136,6 +136,14 @@ impl Behaviour {
             None
         }
     }
+
+    pub fn node_metadata(&self) -> &Option<node_info::NodeMetadata> {
+        &self.node_info.metadata
+    }
+
+    pub fn node_metadata_mut(&mut self) -> &mut Option<node_info::NodeMetadata> {
+        &mut self.node_info.metadata
+    }
 }
 
 fn verify_node_info(ours: &NodeInfo, theirs: &NodeInfo) -> Result<(), Error> {

--- a/anchor/network/src/network.rs
+++ b/anchor/network/src/network.rs
@@ -33,7 +33,7 @@ use crate::{
     Config, Enr,
     behaviour::{AnchorBehaviour, AnchorBehaviourEvent, BehaviourError},
     discovery::{DiscoveredPeers, Discovery, DiscoveryError},
-    handshake::{self, node_info::NodeMetadata},
+    handshake,
     keypair_utils::load_private_key,
     network::NetworkError::SwarmConfig,
     peer_manager::{self, ConnectActions, PeerManager},
@@ -488,7 +488,7 @@ impl<R: MessageReceiver> Network<R> {
 
         // update enr and metadata to new state
         self.discovery().set_subscribed(subnet, subscribed);
-        if let Some(metadata) = self.node_metadata_mut() {
+        if let Some(metadata) = self.handshake().node_metadata_mut() {
             match metadata.set_subscribed(subnet, subscribed) {
                 Ok(()) => {
                     info!(
@@ -513,12 +513,8 @@ impl<R: MessageReceiver> Network<R> {
         &mut self.swarm.behaviour_mut().gossipsub
     }
 
-    fn node_metadata(&self) -> &Option<NodeMetadata> {
-        self.swarm.behaviour().handshake.node_metadata()
-    }
-
-    fn node_metadata_mut(&mut self) -> &mut Option<NodeMetadata> {
-        self.swarm.behaviour_mut().handshake.node_metadata_mut()
+    fn handshake(&mut self) -> &mut handshake::Behaviour {
+        &mut self.swarm.behaviour_mut().handshake
     }
 
     fn discovery(&mut self) -> &mut Discovery {

--- a/anchor/network/src/network.rs
+++ b/anchor/network/src/network.rs
@@ -43,26 +43,6 @@ use crate::{
 
 const MAX_TRANSMIT_SIZE_BYTES: usize = 5_000_000;
 
-/// Count the number of matching subnet bits between two hex-encoded subnet strings
-fn count_matching_subnets(our_subnets: &str, their_subnets: &str) -> usize {
-    // Decode both subnet strings
-    let our_bytes = match hex::decode(our_subnets) {
-        Ok(bytes) => bytes,
-        Err(_) => return 0,
-    };
-    let their_bytes = match hex::decode(their_subnets) {
-        Ok(bytes) => bytes,
-        Err(_) => return 0,
-    };
-
-    // Count matching bits using bitwise AND
-    our_bytes
-        .iter()
-        .zip(their_bytes.iter())
-        .map(|(a, b)| (a & b).count_ones() as usize)
-        .sum()
-}
-
 #[derive(Debug, Error)]
 pub enum NetworkError {
     #[error("Unable to listen on address {address}: {source}")]
@@ -557,37 +537,6 @@ impl<R: MessageReceiver> Network<R> {
         }
     }
 
-    /// Record metrics about subnet overlap after successful handshake.
-    fn record_handshake_subnet_match_metrics(
-        &self,
-        peer_id: PeerId,
-        their_metadata: &NodeMetadata,
-    ) {
-        if let Some(our_metadata) = self.node_metadata() {
-            let matching_count =
-                count_matching_subnets(&our_metadata.subnets, &their_metadata.subnets);
-
-            debug!(
-                %peer_id,
-                our_subnets = %our_metadata.subnets,
-                their_subnets = %their_metadata.subnets,
-                node_version = %their_metadata.node_version,
-                matching_subnets = matching_count,
-                "Handshake completed"
-            );
-
-            // Record subnet match count metric
-            if let Ok(gauge_vec) = crate::metrics::HANDSHAKE_SUBNET_MATCHES.as_ref() {
-                let label = &matching_count.to_string();
-                if let Ok(gauge) = gauge_vec.get_metric_with_label_values(&[label]) {
-                    gauge.inc();
-                }
-            }
-        } else {
-            debug!(%peer_id, "Handshake completed");
-        }
-    }
-
     fn handle_handshake_result(&mut self, event: handshake::Event) {
         match event {
             handshake::Event::Completed {
@@ -604,7 +553,10 @@ impl<R: MessageReceiver> Network<R> {
                         .handle_handshake_completed(peer_id, metadata.node_version.clone());
 
                     // Record subnet matching metrics
-                    self.record_handshake_subnet_match_metrics(peer_id, &metadata);
+                    self.swarm
+                        .behaviour()
+                        .handshake
+                        .record_handshake_subnet_match_metrics(peer_id, &metadata);
                 } else {
                     debug!(%peer_id, ?their_info, "Handshake completed without metadata");
                 }

--- a/anchor/network/src/network.rs
+++ b/anchor/network/src/network.rs
@@ -28,16 +28,12 @@ use thiserror::Error;
 use tokio::sync::mpsc;
 use tracing::{debug, error, info, trace, warn};
 use types::{ChainSpec, EthSpec};
-use version::version_with_platform;
 
 use crate::{
     Config, Enr,
     behaviour::{AnchorBehaviour, AnchorBehaviourEvent, BehaviourError},
     discovery::{DiscoveredPeers, Discovery, DiscoveryError},
-    handshake::{
-        self,
-        node_info::{NodeInfo, NodeMetadata},
-    },
+    handshake::{self, node_info::NodeMetadata},
     keypair_utils::load_private_key,
     network::NetworkError::SwarmConfig,
     peer_manager::{self, ConnectActions, PeerManager},
@@ -94,7 +90,6 @@ pub struct Network<R: MessageReceiver> {
     subnet_event_receiver: mpsc::Receiver<SubnetEvent>,
     message_rx: mpsc::Receiver<(SubnetId, Vec<u8>)>,
     peer_id: PeerId,
-    node_info: NodeInfo,
     message_receiver: Arc<R>,
     outcome_rx: mpsc::Receiver<Outcome>,
     domain_type: DomainType,
@@ -131,16 +126,6 @@ impl<R: MessageReceiver> Network<R> {
                 .map_err(|e| Box::new(NetworkError::Behaviour(e)))?;
 
         let peer_id = local_keypair.public().to_peer_id();
-        let domain_type: String = config.domain_type.into();
-        let node_info = NodeInfo::new(
-            domain_type,
-            Some(NodeMetadata {
-                node_version: version_with_platform(),
-                execution_node: "geth/v1.10.8".to_string(),
-                consensus_node: "lighthouse/v1.5.0".to_string(),
-                subnets: "00000000000000000000000000000000".to_string(),
-            }),
-        );
 
         let mut network = Network {
             swarm: build_swarm(
@@ -153,7 +138,6 @@ impl<R: MessageReceiver> Network<R> {
             subnet_event_receiver,
             message_rx,
             peer_id,
-            node_info,
             message_receiver,
             outcome_rx,
             domain_type: config.domain_type,
@@ -524,7 +508,7 @@ impl<R: MessageReceiver> Network<R> {
 
         // update enr and metadata to new state
         self.discovery().set_subscribed(subnet, subscribed);
-        if let Some(metadata) = &mut self.node_info.metadata {
+        if let Some(metadata) = self.node_metadata_mut() {
             match metadata.set_subscribed(subnet, subscribed) {
                 Ok(()) => {
                     info!(
@@ -549,6 +533,14 @@ impl<R: MessageReceiver> Network<R> {
         &mut self.swarm.behaviour_mut().gossipsub
     }
 
+    fn node_metadata(&self) -> &Option<NodeMetadata> {
+        self.swarm.behaviour().handshake.node_metadata()
+    }
+
+    fn node_metadata_mut(&mut self) -> &mut Option<NodeMetadata> {
+        self.swarm.behaviour_mut().handshake.node_metadata_mut()
+    }
+
     fn discovery(&mut self) -> &mut Discovery {
         &mut self.swarm.behaviour_mut().discovery
     }
@@ -571,7 +563,7 @@ impl<R: MessageReceiver> Network<R> {
         peer_id: PeerId,
         their_metadata: &NodeMetadata,
     ) {
-        if let Some(our_metadata) = &self.node_info.metadata {
+        if let Some(our_metadata) = self.node_metadata() {
             let matching_count =
                 count_matching_subnets(&our_metadata.subnets, &their_metadata.subnets);
 

--- a/anchor/network/src/network.rs
+++ b/anchor/network/src/network.rs
@@ -551,14 +551,6 @@ impl<R: MessageReceiver> Network<R> {
                 if let Some(metadata) = their_info.metadata {
                     self.peer_manager()
                         .handle_handshake_completed(peer_id, metadata.node_version.clone());
-
-                    // Record subnet matching metrics
-                    self.swarm
-                        .behaviour()
-                        .handshake
-                        .record_handshake_subnet_match_metrics(peer_id, &metadata);
-                } else {
-                    debug!(%peer_id, ?their_info, "Handshake completed without metadata");
                 }
             }
             handshake::Event::Failed { peer_id, error } => {


### PR DESCRIPTION
## Issue Addressed

We recently introduced a regression where we fail all handshakes. The root cause for this is that we started storing the `NodeInfo` in a new place but did not adjust all places to use this.

## Proposed Changes

- Remove the field `Network::node_info`
- Add accessors for the node metadata
- Adjust old references of `Network::node_info` to use new accessors instead
