### PR TITLE
chore!: Remove builder proposals flag

### DIFF
--- a/anchor/client/src/cli.rs
+++ b/anchor/client/src/cli.rs
@@ -442,6 +442,16 @@ pub struct Node {
 
     #[clap(
         long,
+        alias = "private-tx-proposals",
+        help = "Deprecated and ignored. Validator registrations are now always created.",
+        display_order = 0,
+        help_heading = FLAG_HEADER,
+        hide = true
+    )]
+    pub builder_proposals: bool,
+
+    #[clap(
+        long,
         value_name = "UINT64",
         help = "Defines the boost factor, \
                 a percentage multiplier to apply to the builder's payload value \

--- a/anchor/client/src/cli.rs
+++ b/anchor/client/src/cli.rs
@@ -433,24 +433,12 @@ pub struct Node {
         long,
         value_name = "INTEGER",
         default_value_t = 36_000_000,
-        requires = "builder_proposals",
         help = "The gas limit to be used in all builder proposals for all validators managed. \
                 Note this will not necessarily be used if the gas limit \
                 set here moves too far from the previous block's gas limit.",
         display_order = 0
     )]
     pub gas_limit: u64,
-
-    #[clap(
-        long,
-        alias = "private-tx-proposals",
-        help = "If this flag is set, Anchor will query the Beacon Node for only block \
-                headers during proposals and will sign over headers. Useful for outsourcing \
-                execution payload construction during proposals.",
-        display_order = 0,
-        help_heading = FLAG_HEADER
-    )]
-    pub builder_proposals: bool,
 
     #[clap(
         long,

--- a/anchor/client/src/config.rs
+++ b/anchor/client/src/config.rs
@@ -201,7 +201,8 @@ pub fn from_cli(cli_args: &Node, global_config: GlobalConfig) -> Result<Config, 
 
     if cli_args.builder_proposals {
         warn!(
-            "The --builder-proposals flag is deprecated and ignored. Validator registrations are now always created."
+            "The --builder-proposals flag is deprecated and ignored. Validator registrations are \
+             now always created. This flag will be removed in a future release and will error then."
         );
     }
 

--- a/anchor/client/src/config.rs
+++ b/anchor/client/src/config.rs
@@ -64,8 +64,6 @@ pub struct Config {
     pub impostor: Option<OperatorId>,
     /// Gas limit on blocks
     pub gas_limit: u64,
-    /// Should payload construction be outsourced
-    pub builder_proposals: bool,
     /// Block boost factor
     pub builder_boost_factor: Option<u64>,
     /// Should external payloads always be preferred
@@ -114,7 +112,6 @@ impl Config {
             processor: <_>::default(),
             disable_slashing_protection: false,
             impostor: None,
-            builder_proposals: false,
             builder_boost_factor: None,
             prefer_builder_proposals: false,
             gas_limit: 36_000_000,
@@ -199,7 +196,6 @@ pub fn from_cli(cli_args: &Node, global_config: GlobalConfig) -> Result<Config, 
     config.execution_nodes_tls_certs = cli_args.execution_nodes_tls_certs.clone();
 
     // MEV options
-    config.builder_proposals = cli_args.builder_proposals;
     config.builder_boost_factor = cli_args.builder_boost_factor;
     config.prefer_builder_proposals = cli_args.prefer_builder_proposals;
 

--- a/anchor/client/src/config.rs
+++ b/anchor/client/src/config.rs
@@ -199,6 +199,12 @@ pub fn from_cli(cli_args: &Node, global_config: GlobalConfig) -> Result<Config, 
     config.builder_boost_factor = cli_args.builder_boost_factor;
     config.prefer_builder_proposals = cli_args.prefer_builder_proposals;
 
+    if cli_args.builder_proposals {
+        warn!(
+            "The --builder-proposals flag is deprecated and ignored. Validator registrations are now always created."
+        );
+    }
+
     config.gas_limit = cli_args.gas_limit;
 
     // Http API server

--- a/anchor/client/src/lib.rs
+++ b/anchor/client/src/lib.rs
@@ -533,7 +533,6 @@ impl Client {
             genesis_validators_root,
             config.impostor.is_none().then_some(key),
             config.gas_limit,
-            config.builder_proposals,
             config.builder_boost_factor,
             config.prefer_builder_proposals,
             is_synced.clone(),

--- a/anchor/validator_store/src/lib.rs
+++ b/anchor/validator_store/src/lib.rs
@@ -109,7 +109,6 @@ pub struct AnchorValidatorStore<T: SlotClock + 'static, E: EthSpec> {
     gas_limit: u64,
     // MEV configuration is applied at the operator level and applies to all validators this
     // operator controls
-    builder_proposals: bool,
     builder_boost_factor: Option<u64>,
     prefer_builder_proposals: bool,
     is_synced: watch::Receiver<bool>,
@@ -128,7 +127,6 @@ impl<T: SlotClock, E: EthSpec> AnchorValidatorStore<T, E> {
         genesis_validators_root: Hash256,
         private_key: Option<Rsa<Private>>,
         gas_limit: u64,
-        builder_proposals: bool,
         builder_boost_factor: Option<u64>,
         prefer_builder_proposals: bool,
         is_synced: watch::Receiver<bool>,
@@ -147,7 +145,6 @@ impl<T: SlotClock, E: EthSpec> AnchorValidatorStore<T, E> {
             private_key,
             slot_metadata: watch::channel(None).0,
             gas_limit,
-            builder_proposals,
             builder_boost_factor,
             prefer_builder_proposals,
             is_synced,
@@ -853,12 +850,7 @@ impl<T: SlotClock, E: EthSpec> ValidatorStore for AnchorValidatorStore<T, E> {
             return Some(u64::MAX);
         }
 
-        self.builder_boost_factor.or_else(|| {
-            if !self.builder_proposals {
-                return Some(0);
-            }
-            None
-        })
+        self.builder_boost_factor
     }
 
     async fn randao_reveal(
@@ -1668,7 +1660,7 @@ impl<T: SlotClock, E: EthSpec> ValidatorStore for AnchorValidatorStore<T, E> {
             validator_index,
             fee_recipient,
             gas_limit: self.gas_limit,
-            builder_proposals: self.builder_proposals,
+            builder_proposals: true,
         })
     }
 }

--- a/anchor/validator_store/src/registration_service.rs
+++ b/anchor/validator_store/src/registration_service.rs
@@ -18,7 +18,7 @@ use beacon_node_fallback::BeaconNodeFallback;
 use futures::future::join_all;
 use slot_clock::SlotClock;
 use task_executor::TaskExecutor;
-use tokio::time::{sleep, Duration};
+use tokio::time::{Duration, sleep};
 use tracing::{debug, error, info, warn};
 use types::{
     ChainSpec, EthSpec, PublicKeyBytes, SignedValidatorRegistrationData, Slot,
@@ -197,11 +197,29 @@ impl<S: ValidatorStore + 'static, T: SlotClock + 'static> Inner<S, T> {
                     count = signed.len(),
                     "Published validator registrations to the builder network"
                 ),
-                Err(err) => debug!(
-                    %err,
-                    "Unable to publish validator registrations to the builder network. \
-                     This is expected if no relay is configured in your Beacon Node."
-                ),
+                Err(err) => {
+                    let is_builder_missing = err.0.iter().any(|(_, e)| {
+                        matches!(
+                            e,
+                            beacon_node_fallback::Error::RequestFailed(
+                                eth2::Error::ServerMessage(msg)
+                            ) if msg.message.contains("BuilderMissing")
+                        )
+                    });
+
+                    if is_builder_missing {
+                        debug!(
+                            %err,
+                            "Unable to publish validator registrations to the builder network. \
+                             This is expected if no relay is configured in your Beacon Node."
+                        );
+                    } else {
+                        warn!(
+                            %err,
+                            "Unable to publish validator registrations to the builder network"
+                        );
+                    }
+                }
             }
         }
     }

--- a/anchor/validator_store/src/registration_service.rs
+++ b/anchor/validator_store/src/registration_service.rs
@@ -198,27 +198,11 @@ impl<S: ValidatorStore + 'static, T: SlotClock + 'static> Inner<S, T> {
                     "Published validator registrations to the builder network"
                 ),
                 Err(err) => {
-                    let is_builder_missing = err.0.iter().any(|(_, e)| {
-                        matches!(
-                            e,
-                            beacon_node_fallback::Error::RequestFailed(
-                                eth2::Error::ServerMessage(msg)
-                            ) if msg.message.contains("BuilderMissing")
-                        )
-                    });
-
-                    if is_builder_missing {
-                        debug!(
-                            %err,
-                            "Unable to publish validator registrations to the builder network. \
-                             This is expected if no relay is configured in your Beacon Node."
-                        );
-                    } else {
-                        warn!(
-                            %err,
-                            "Unable to publish validator registrations to the builder network"
-                        );
-                    }
+                    debug!(
+                        %err,
+                        "Unable to publish validator registrations to the builder network. \
+                         This is expected if no relay is configured in your Beacon Node."
+                    );
                 }
             }
         }

--- a/anchor/validator_store/src/registration_service.rs
+++ b/anchor/validator_store/src/registration_service.rs
@@ -18,8 +18,8 @@ use beacon_node_fallback::BeaconNodeFallback;
 use futures::future::join_all;
 use slot_clock::SlotClock;
 use task_executor::TaskExecutor;
-use tokio::time::{Duration, sleep};
-use tracing::{error, info, warn};
+use tokio::time::{sleep, Duration};
+use tracing::{debug, error, info, warn};
 use types::{
     ChainSpec, EthSpec, PublicKeyBytes, SignedValidatorRegistrationData, Slot,
     ValidatorRegistrationData,
@@ -148,16 +148,14 @@ impl<S: ValidatorStore + 'static, T: SlotClock + 'static> Inner<S, T> {
 
         // We don't log for missing fee recipients here because this will be logged more
         // frequently in `collect_preparation_data`.
-        proposal_data.fee_recipient.and_then(|fee_recipient| {
-            proposal_data
-                .builder_proposals
-                .then_some(ValidatorRegistrationData {
-                    fee_recipient,
-                    gas_limit: proposal_data.gas_limit,
-                    pubkey,
-                    timestamp,
-                })
-        })
+        proposal_data
+            .fee_recipient
+            .map(|fee_recipient| ValidatorRegistrationData {
+                fee_recipient,
+                gas_limit: proposal_data.gas_limit,
+                pubkey,
+                timestamp,
+            })
     }
 
     async fn sign_registration_data(
@@ -199,9 +197,10 @@ impl<S: ValidatorStore + 'static, T: SlotClock + 'static> Inner<S, T> {
                     count = signed.len(),
                     "Published validator registrations to the builder network"
                 ),
-                Err(err) => warn!(
+                Err(err) => debug!(
                     %err,
-                    "Unable to publish validator registrations to the builder network"
+                    "Unable to publish validator registrations to the builder network. \
+                     This is expected if no relay is configured in your Beacon Node."
                 ),
             }
         }

--- a/docs/docs/pages/cli-node.mdx
+++ b/docs/docs/pages/cli-node.mdx
@@ -70,7 +70,6 @@ anchor node [OPTIONS]
 
 | Option | Description | Default |
 | --- | --- | ---|
-| `--builder-proposals` | Query Beacon Node for only block headers during proposals and sign over headers | Disabled |
 | `--builder-boost-factor <UINT64>` | Percentage multiplier to apply to builder's payload value | None |
 | `--prefer-builder-proposals` | Always prefer builder blocks regardless of payload value | Disabled |
 | `--gas-limit <INTEGER>` | Gas limit for all builder proposals for all validators | `36000000` |


### PR DESCRIPTION
## Issue Addressed
Closes #746

## Proposed Changes
- Remove the `--builder-proposals` CLI flag
- Always create validator registrations
- Change the log level for builder registration failures from `warn` to `debug`

## Additional Info
### Why this change: 
In DVT, validator registrations require threshold signatures from multiple operators. If some operators had `--builder-proposals` disabled, they wouldn't participate in signing registrations, potentially causing the registration to fail for the entire committee

### User impact: 
Users who previously used `--builder-proposals` will see a CLI error when trying to use the flag
