### PR TITLE
refactor: relax BeaconVote validation to epoch-only comparison

### DIFF
--- a/anchor/client/src/cli.rs
+++ b/anchor/client/src/cli.rs
@@ -518,6 +518,18 @@ pub struct Node {
     )]
     pub operator_dg_wait_epochs: u64,
 
+    // Majority fork protection
+    #[clap(
+        long,
+        help = "Enable strict majority fork protection. When enabled, the node will not \
+                participate in attestation production if the checkpoint roots mismatch. \
+                Using this flag might reduce validator performance if cluster operators have \
+                struggling nodes, but can help to avoid finalization of a faulty majority fork.",
+        display_order = 0,
+        help_heading = FLAG_HEADER,
+    )]
+    pub strict_mfp: bool,
+
     #[clap(flatten)]
     pub logging_flags: FileLoggingFlags,
 }

--- a/anchor/client/src/config.rs
+++ b/anchor/client/src/config.rs
@@ -76,6 +76,8 @@ pub struct Config {
     pub operator_dg: bool,
     /// Number of epochs to monitor for twins after grace period
     pub operator_dg_wait_epochs: u64,
+    /// Whether to check for matching checkpoint roots in QBFT.
+    pub strict_mfp: bool,
 }
 
 impl Config {
@@ -121,6 +123,7 @@ impl Config {
             disable_latency_measurement_service: false,
             operator_dg: false,
             operator_dg_wait_epochs: 2,
+            strict_mfp: false,
         }
     }
 }
@@ -254,6 +257,9 @@ pub fn from_cli(cli_args: &Node, global_config: GlobalConfig) -> Result<Config, 
     // Operator doppelgänger protection
     config.operator_dg = cli_args.operator_dg;
     config.operator_dg_wait_epochs = cli_args.operator_dg_wait_epochs;
+
+    // Majority fork protection
+    config.strict_mfp = cli_args.strict_mfp;
 
     // Performance options
     if let Some(max_workers) = cli_args.max_workers {

--- a/anchor/client/src/lib.rs
+++ b/anchor/client/src/lib.rs
@@ -536,6 +536,7 @@ impl Client {
             config.builder_proposals,
             config.builder_boost_factor,
             config.prefer_builder_proposals,
+            config.strict_mfp,
             is_synced.clone(),
         );
 

--- a/anchor/common/ssv_types/src/consensus.rs
+++ b/anchor/common/ssv_types/src/consensus.rs
@@ -677,17 +677,31 @@ impl<E: EthSpec> BeaconVoteValidator<E> {
             )));
         }
 
-        // Majority fork protection:
-        // If we disagree on the epoch to finalize, we fail validation to avoid deciding on an
-        // attestation that tries to finalize a potentially faulty fork.
-        // https://github.com/ssvlabs/ssv-spec/issues/555
-        if value.source != our_value.source || value.target != our_value.target {
-            return Err(BeaconVoteValidationError::CheckpointMismatch(Box::new(
-                CheckpointMismatch {
-                    our_source: our_value.source,
-                    proposed_source: value.source,
-                    our_target: our_value.target,
-                    proposed_target: value.target,
+        // Epoch-only validation (SIP):
+        // Previously: Compared full checkpoints (epoch AND root) to prevent operators from voting
+        // on different forks. This caused liveness issues during benign reorgs when operators' BNs
+        // temporarily saw different target roots.
+        //
+        // Now: Only compare epochs. Root differences are allowed to maintain liveness during
+        // reorgs.
+        //
+        // Note: This change prioritizes liveness over fork protection. The broader question of
+        // whether DVs should actively prevent justifying a potentially wrong fork (vs.
+        // focusing solely on slashing protection) remains an open design question. This
+        // implementation focuses the SIP on core slashing protection, while cluster-level
+        // fork heuristics may be explored separately.
+        //
+        // See: https://github.com/ssvlabs/ssv-spec/issues/555 (original issue)
+        //      https://github.com/ssvlabs/ssv-spec/pull/589 (spec change)
+        if value.source.epoch != our_value.source.epoch
+            || value.target.epoch != our_value.target.epoch
+        {
+            return Err(BeaconVoteValidationError::EpochMismatch(Box::new(
+                EpochMismatch {
+                    our_source_epoch: our_value.source.epoch,
+                    proposed_source_epoch: value.source.epoch,
+                    our_target_epoch: our_value.target.epoch,
+                    proposed_target_epoch: value.target.epoch,
                 },
             )));
         }
@@ -735,23 +749,26 @@ impl<E: EthSpec> BeaconVoteValidator<E> {
     }
 }
 
-/// Details about checkpoint mismatches between our vote and a proposed vote.
+/// Details about epoch mismatches between our vote and a proposed vote.
 ///
 /// This struct is needed to avoid the linter complaining about the size of the error enum.
 #[derive(Debug, Clone, PartialEq)]
-pub struct CheckpointMismatch {
-    pub our_source: Checkpoint,
-    pub proposed_source: Checkpoint,
-    pub our_target: Checkpoint,
-    pub proposed_target: Checkpoint,
+pub struct EpochMismatch {
+    pub our_source_epoch: types::Epoch,
+    pub proposed_source_epoch: types::Epoch,
+    pub our_target_epoch: types::Epoch,
+    pub proposed_target_epoch: types::Epoch,
 }
 
-impl Display for CheckpointMismatch {
+impl Display for EpochMismatch {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "Checkpoint mismatch: SOURCE: our {:?}, proposed {:?}. TARGET: our {:?}, proposed {:?}",
-            self.our_source, self.proposed_source, self.our_target, self.proposed_target
+            "Epoch mismatch: SOURCE: our {}, proposed {}. TARGET: our {}, proposed {}",
+            self.our_source_epoch,
+            self.proposed_source_epoch,
+            self.our_target_epoch,
+            self.proposed_target_epoch
         )
     }
 }
@@ -765,7 +782,7 @@ pub enum BeaconVoteValidationError {
     #[error("Invalid epoch order: {0}")]
     TargetNotAfterSource(String),
     #[error("{0}")]
-    CheckpointMismatch(Box<CheckpointMismatch>),
+    EpochMismatch(Box<EpochMismatch>),
     #[error("Attestation would be slashable: {0}")]
     SlashableAttestation(NotSafe),
 }
@@ -827,55 +844,13 @@ mod tests {
         let result = validator.do_validation(&proposed_vote, &our_vote);
         assert!(result.is_err());
         match result.unwrap_err() {
-            BeaconVoteValidationError::CheckpointMismatch(mismatch) => {
-                assert_eq!(mismatch.our_source, our_source);
-                assert_eq!(mismatch.proposed_source, proposed_source);
-                assert_eq!(mismatch.our_target, our_target);
-                assert_eq!(mismatch.proposed_target, our_target);
+            BeaconVoteValidationError::EpochMismatch(mismatch) => {
+                assert_eq!(mismatch.our_source_epoch, our_source.epoch);
+                assert_eq!(mismatch.proposed_source_epoch, proposed_source.epoch);
+                assert_eq!(mismatch.our_target_epoch, our_target.epoch);
+                assert_eq!(mismatch.proposed_target_epoch, our_target.epoch);
             }
-            err => panic!("Expected DifferentCheckpoint error, got: {:?}", err),
-        }
-    }
-
-    #[test]
-    fn test_mismatched_source_same_epoch_different_roots() {
-        let validator = create_test_validator();
-
-        let our_source = Checkpoint {
-            epoch: Epoch::new(2),
-            root: Hash256::from_low_u64_be(1),
-        };
-        let our_target = Checkpoint {
-            epoch: Epoch::new(3),
-            root: Hash256::from_low_u64_be(2),
-        };
-        let our_vote = BeaconVote {
-            block_root: Hash256::random(),
-            source: our_source,
-            target: our_target,
-        };
-
-        // Create a proposed vote with same source epoch but different root
-        let proposed_source = Checkpoint {
-            epoch: Epoch::new(2),                // Same epoch
-            root: Hash256::from_low_u64_be(999), // Different root
-        };
-        let proposed_vote = BeaconVote {
-            block_root: Hash256::random(),
-            source: proposed_source,
-            target: our_target,
-        };
-
-        let result = validator.do_validation(&proposed_vote, &our_vote);
-        assert!(result.is_err());
-        match result.unwrap_err() {
-            BeaconVoteValidationError::CheckpointMismatch(mismatch) => {
-                assert_eq!(mismatch.our_source, our_source);
-                assert_eq!(mismatch.proposed_source, proposed_source);
-                assert_eq!(mismatch.our_target, our_target);
-                assert_eq!(mismatch.proposed_target, our_target);
-            }
-            err => panic!("Expected DifferentCheckpoint error, got: {:?}", err),
+            err => panic!("Expected EpochMismatch error, got: {:?}", err),
         }
     }
 
@@ -911,55 +886,13 @@ mod tests {
         let result = validator.do_validation(&proposed_vote, &our_vote);
         assert!(result.is_err());
         match result.unwrap_err() {
-            BeaconVoteValidationError::CheckpointMismatch(mismatch) => {
-                assert_eq!(mismatch.our_source, our_source);
-                assert_eq!(mismatch.proposed_source, our_source);
-                assert_eq!(mismatch.our_target, our_target);
-                assert_eq!(mismatch.proposed_target, proposed_target);
+            BeaconVoteValidationError::EpochMismatch(mismatch) => {
+                assert_eq!(mismatch.our_source_epoch, our_source.epoch);
+                assert_eq!(mismatch.proposed_source_epoch, our_source.epoch);
+                assert_eq!(mismatch.our_target_epoch, our_target.epoch);
+                assert_eq!(mismatch.proposed_target_epoch, proposed_target.epoch);
             }
-            err => panic!("Expected DifferentCheckpoint error, got: {:?}", err),
-        }
-    }
-
-    #[test]
-    fn test_mismatched_target_same_epoch_different_roots() {
-        let validator = create_test_validator();
-
-        let our_source = Checkpoint {
-            epoch: Epoch::new(2),
-            root: Hash256::from_low_u64_be(1),
-        };
-        let our_target = Checkpoint {
-            epoch: Epoch::new(3),
-            root: Hash256::from_low_u64_be(2),
-        };
-        let our_vote = BeaconVote {
-            block_root: Hash256::random(),
-            source: our_source,
-            target: our_target,
-        };
-
-        // Create a proposed vote with same target epoch but different root
-        let proposed_target = Checkpoint {
-            epoch: Epoch::new(3),                // Same epoch
-            root: Hash256::from_low_u64_be(999), // Different root
-        };
-        let proposed_vote = BeaconVote {
-            block_root: Hash256::random(),
-            source: our_source,
-            target: proposed_target,
-        };
-
-        let result = validator.do_validation(&proposed_vote, &our_vote);
-        assert!(result.is_err());
-        match result.unwrap_err() {
-            BeaconVoteValidationError::CheckpointMismatch(mismatch) => {
-                assert_eq!(mismatch.our_source, our_source);
-                assert_eq!(mismatch.proposed_source, our_source);
-                assert_eq!(mismatch.our_target, our_target);
-                assert_eq!(mismatch.proposed_target, proposed_target);
-            }
-            err => panic!("Expected DifferentCheckpoint error, got: {:?}", err),
+            err => panic!("Expected EpochMismatch error, got: {:?}", err),
         }
     }
 
@@ -988,11 +921,53 @@ mod tests {
             target,
         };
 
-        // This should succeed since checkpoints match
+        // This should succeed since epochs match
         let result = validator.do_validation(&proposed_vote, &our_vote);
         assert!(
             result.is_ok(),
-            "Expected validation to succeed for matching checkpoints, got error: {:?}",
+            "Expected validation to succeed for matching epochs, got error: {:?}",
+            result.unwrap_err()
+        );
+    }
+
+    #[test]
+    fn test_valid_matching_epochs_different_roots() {
+        let validator = create_test_validator();
+
+        let our_source = Checkpoint {
+            epoch: Epoch::new(2),
+            root: Hash256::from_low_u64_be(1),
+        };
+        let our_target = Checkpoint {
+            epoch: Epoch::new(3),
+            root: Hash256::from_low_u64_be(2),
+        };
+        let our_vote = BeaconVote {
+            block_root: Hash256::random(),
+            source: our_source,
+            target: our_target,
+        };
+
+        // Proposed vote has same epochs but different roots (simulating reorg)
+        let proposed_source = Checkpoint {
+            epoch: Epoch::new(2),                // Same epoch
+            root: Hash256::from_low_u64_be(999), // Different root
+        };
+        let proposed_target = Checkpoint {
+            epoch: Epoch::new(3),                // Same epoch
+            root: Hash256::from_low_u64_be(888), // Different root
+        };
+        let proposed_vote = BeaconVote {
+            block_root: Hash256::random(),
+            source: proposed_source,
+            target: proposed_target,
+        };
+
+        // This should succeed since epochs match (roots don't need to match)
+        let result = validator.do_validation(&proposed_vote, &our_vote);
+        assert!(
+            result.is_ok(),
+            "Expected validation to succeed for matching epochs with different roots, got error: {:?}",
             result.unwrap_err()
         );
     }

--- a/anchor/common/ssv_types/src/consensus.rs
+++ b/anchor/common/ssv_types/src/consensus.rs
@@ -678,12 +678,20 @@ impl<E: EthSpec> BeaconVoteValidator<E> {
         }
 
         // Epoch-only validation (SIP):
-        // Previously: Compared full checkpoints (epoch AND root) to prevent operators from voting
-        // on different forks. This caused liveness issues during benign reorgs when operators' BNs
-        // temporarily saw different target roots.
+        // The target checkpoint refers to the first block of the current epoch on each BN's view.
+        // At epoch boundaries (slot 0 of each epoch), BNs are most likely to disagree on that
+        // block due to:
+        // 1. Network propagation delays at the exact moment of epoch transition
+        // 2. The target being the most recent, least-settled block
+        // 3. Temporary chain view differences (including benign reorgs)
+        //
+        // Requiring full checkpoint agreement (epoch AND root) causes systematic liveness issues
+        // at the first slot of every epoch, not just during reorgs. This pattern is evidenced by
+        // existing special handling for RANDAO signatures at epoch boundaries (see
+        // message_validator/src/lib.rs:527-533).
         //
         // Now: Only compare epochs. Root differences are allowed to maintain liveness during
-        // reorgs.
+        // epoch transitions and reorgs, while still preventing slashing.
         //
         // Note: This change prioritizes liveness over fork protection. The broader question of
         // whether DVs should actively prevent justifying a potentially wrong fork (vs.

--- a/anchor/common/ssv_types/src/consensus.rs
+++ b/anchor/common/ssv_types/src/consensus.rs
@@ -805,7 +805,7 @@ impl Display for CheckpointMismatch {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "Epoch mismatch: SOURCE: our {:?}, proposed {:?}. TARGET: our {:?}, proposed {:?}",
+            "Checkpoint mismatch: SOURCE: our {:?}, proposed {:?}. TARGET: our {:?}, proposed {:?}",
             self.our_source, self.proposed_source, self.our_target, self.proposed_target
         )
     }

--- a/anchor/common/ssv_types/src/consensus.rs
+++ b/anchor/common/ssv_types/src/consensus.rs
@@ -620,6 +620,7 @@ pub struct BeaconVoteValidator<E: EthSpec> {
     spec: Arc<ChainSpec>,
     validator_attestation_committees: HashMap<PublicKeyBytes, u64>,
     genesis_validators_root: Hash256,
+    strict_mfp: bool,
     _phantom: PhantomData<E>,
 }
 
@@ -642,6 +643,7 @@ impl<E: EthSpec> BeaconVoteValidator<E> {
         spec: Arc<ChainSpec>,
         validator_attestation_committees: HashMap<PublicKeyBytes, u64>,
         genesis_validators_root: Hash256,
+        strict_mfp: bool,
     ) -> Self {
         Self {
             slot,
@@ -649,6 +651,7 @@ impl<E: EthSpec> BeaconVoteValidator<E> {
             spec,
             validator_attestation_committees,
             genesis_validators_root,
+            strict_mfp,
             _phantom: PhantomData,
         }
     }
@@ -687,8 +690,7 @@ impl<E: EthSpec> BeaconVoteValidator<E> {
         //
         // Requiring full checkpoint agreement (epoch AND root) causes systematic liveness issues
         // at the first slot of every epoch, not just during reorgs. This pattern is evidenced by
-        // existing special handling for RANDAO signatures at epoch boundaries (see
-        // message_validator/src/lib.rs:527-533).
+        // existing special handling for RANDAO signatures at epoch boundaries.
         //
         // Now: Only compare epochs. Root differences are allowed to maintain liveness during
         // epoch transitions and reorgs, while still preventing slashing.
@@ -701,23 +703,54 @@ impl<E: EthSpec> BeaconVoteValidator<E> {
         //
         // See: https://github.com/ssvlabs/ssv-spec/issues/555 (original issue)
         //      https://github.com/ssvlabs/ssv-spec/pull/589 (spec change)
-        if value.source.epoch != our_value.source.epoch
-            || value.target.epoch != our_value.target.epoch
-        {
-            return Err(BeaconVoteValidationError::EpochMismatch(Box::new(
-                EpochMismatch {
-                    our_source_epoch: our_value.source.epoch,
-                    proposed_source_epoch: value.source.epoch,
-                    our_target_epoch: our_value.target.epoch,
-                    proposed_target_epoch: value.target.epoch,
-                },
-            )));
+        if self.strict_mfp {
+            Self::strict_majority_fork_protection(value, our_value)?;
+        } else {
+            Self::epoch_majority_fork_protection(value, our_value)?;
         }
 
         // Check slashing protection for all validator public keys
         self.check_attestation_slashing(value)?;
 
         Ok(())
+    }
+
+    fn epoch_majority_fork_protection(
+        value: &BeaconVote,
+        our_value: &BeaconVote,
+    ) -> Result<(), BeaconVoteValidationError> {
+        if value.source.epoch != our_value.source.epoch
+            || value.target.epoch != our_value.target.epoch
+        {
+            Err(BeaconVoteValidationError::EpochMismatch(Box::new(
+                EpochMismatch {
+                    our_source_epoch: our_value.source.epoch,
+                    proposed_source_epoch: value.source.epoch,
+                    our_target_epoch: our_value.target.epoch,
+                    proposed_target_epoch: value.target.epoch,
+                },
+            )))
+        } else {
+            Ok(())
+        }
+    }
+
+    fn strict_majority_fork_protection(
+        value: &BeaconVote,
+        our_value: &BeaconVote,
+    ) -> Result<(), BeaconVoteValidationError> {
+        if value.source != our_value.source || value.target != our_value.target {
+            Err(BeaconVoteValidationError::CheckpointMismatch(Box::new(
+                CheckpointMismatch {
+                    our_source: our_value.source,
+                    proposed_source: value.source,
+                    our_target: our_value.target,
+                    proposed_target: value.target,
+                },
+            )))
+        } else {
+            Ok(())
+        }
     }
 
     fn check_attestation_slashing(
@@ -761,6 +794,27 @@ impl<E: EthSpec> BeaconVoteValidator<E> {
 ///
 /// This struct is needed to avoid the linter complaining about the size of the error enum.
 #[derive(Debug, Clone, PartialEq)]
+pub struct CheckpointMismatch {
+    pub our_source: Checkpoint,
+    pub proposed_source: Checkpoint,
+    pub our_target: Checkpoint,
+    pub proposed_target: Checkpoint,
+}
+
+impl Display for CheckpointMismatch {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "Epoch mismatch: SOURCE: our {:?}, proposed {:?}. TARGET: our {:?}, proposed {:?}",
+            self.our_source, self.proposed_source, self.our_target, self.proposed_target
+        )
+    }
+}
+
+/// Details about epoch mismatches between our vote and a proposed vote.
+///
+/// This struct is needed to avoid the linter complaining about the size of the error enum.
+#[derive(Debug, Clone, PartialEq)]
 pub struct EpochMismatch {
     pub our_source_epoch: types::Epoch,
     pub proposed_source_epoch: types::Epoch,
@@ -790,6 +844,8 @@ pub enum BeaconVoteValidationError {
     #[error("Invalid epoch order: {0}")]
     TargetNotAfterSource(String),
     #[error("{0}")]
+    CheckpointMismatch(Box<CheckpointMismatch>),
+    #[error("{0}")]
     EpochMismatch(Box<EpochMismatch>),
     #[error("Attestation would be slashable: {0}")]
     SlashableAttestation(NotSafe),
@@ -805,7 +861,7 @@ mod tests {
 
     /// Helper function to create a BeaconVoteValidator for testing.
     /// This validator has slashing protection disabled for simpler testing.
-    fn create_test_validator() -> BeaconVoteValidator<MainnetEthSpec> {
+    fn create_test_validator(strict_mfp: bool) -> BeaconVoteValidator<MainnetEthSpec> {
         let spec = Arc::new(ChainSpec::mainnet());
         let validator_attestation_committees = HashMap::new();
         let genesis_validators_root = Hash256::zero();
@@ -817,12 +873,13 @@ mod tests {
             spec,
             validator_attestation_committees,
             genesis_validators_root,
+            strict_mfp,
         )
     }
 
     #[test]
     fn test_mismatched_source_different_epochs() {
-        let validator = create_test_validator();
+        let validator = create_test_validator(false);
 
         let our_source = Checkpoint {
             epoch: Epoch::new(2),
@@ -864,7 +921,7 @@ mod tests {
 
     #[test]
     fn test_mismatched_target_different_epochs() {
-        let validator = create_test_validator();
+        let validator = create_test_validator(false);
 
         let our_source = Checkpoint {
             epoch: Epoch::new(2),
@@ -906,41 +963,43 @@ mod tests {
 
     #[test]
     fn test_valid_matching_checkpoints() {
-        let validator = create_test_validator();
+        for strict_mfp in [true, false] {
+            let validator = create_test_validator(strict_mfp);
 
-        let source = Checkpoint {
-            epoch: Epoch::new(2),
-            root: Hash256::from_low_u64_be(1),
-        };
-        let target = Checkpoint {
-            epoch: Epoch::new(3),
-            root: Hash256::from_low_u64_be(2),
-        };
+            let source = Checkpoint {
+                epoch: Epoch::new(2),
+                root: Hash256::from_low_u64_be(1),
+            };
+            let target = Checkpoint {
+                epoch: Epoch::new(3),
+                root: Hash256::from_low_u64_be(2),
+            };
 
-        let our_vote = BeaconVote {
-            block_root: Hash256::random(),
-            source,
-            target,
-        };
-        // Proposed vote has same source and target (but different head vote)
-        let proposed_vote = BeaconVote {
-            block_root: Hash256::random(),
-            source,
-            target,
-        };
+            let our_vote = BeaconVote {
+                block_root: Hash256::random(),
+                source,
+                target,
+            };
+            // Proposed vote has same source and target (but different head vote)
+            let proposed_vote = BeaconVote {
+                block_root: Hash256::random(),
+                source,
+                target,
+            };
 
-        // This should succeed since epochs match
-        let result = validator.do_validation(&proposed_vote, &our_vote);
-        assert!(
-            result.is_ok(),
-            "Expected validation to succeed for matching epochs, got error: {:?}",
-            result.unwrap_err()
-        );
+            // This should succeed since epochs match
+            let result = validator.do_validation(&proposed_vote, &our_vote);
+            assert!(
+                result.is_ok(),
+                "Expected validation to succeed for matching epochs, got error: {:?}",
+                result.unwrap_err()
+            );
+        }
     }
 
     #[test]
     fn test_valid_matching_epochs_different_roots() {
-        let validator = create_test_validator();
+        let validator = create_test_validator(false);
 
         let our_source = Checkpoint {
             epoch: Epoch::new(2),
@@ -978,5 +1037,47 @@ mod tests {
             "Expected validation to succeed for matching epochs with different roots, got error: {:?}",
             result.unwrap_err()
         );
+    }
+
+    #[test]
+    fn test_strict_mismatched_target_different_roots() {
+        let validator = create_test_validator(true);
+
+        let our_source = Checkpoint {
+            epoch: Epoch::new(2),
+            root: Hash256::from_low_u64_be(1),
+        };
+        let our_target = Checkpoint {
+            epoch: Epoch::new(3),
+            root: Hash256::from_low_u64_be(2),
+        };
+        let our_vote = BeaconVote {
+            block_root: Hash256::random(),
+            source: our_source,
+            target: our_target,
+        };
+
+        // Create a proposed vote with same target epoch but different root
+        let proposed_target = Checkpoint {
+            epoch: Epoch::new(3),                // Same epoch
+            root: Hash256::from_low_u64_be(999), // Different root
+        };
+        let proposed_vote = BeaconVote {
+            block_root: Hash256::random(),
+            source: our_source,
+            target: proposed_target,
+        };
+
+        let result = validator.do_validation(&proposed_vote, &our_vote);
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            BeaconVoteValidationError::CheckpointMismatch(mismatch) => {
+                assert_eq!(mismatch.our_source, our_source);
+                assert_eq!(mismatch.proposed_source, our_source);
+                assert_eq!(mismatch.our_target, our_target);
+                assert_eq!(mismatch.proposed_target, proposed_target);
+            }
+            err => panic!("Expected DifferentCheckpoint error, got: {:?}", err),
+        }
     }
 }

--- a/anchor/validator_store/src/lib.rs
+++ b/anchor/validator_store/src/lib.rs
@@ -112,6 +112,7 @@ pub struct AnchorValidatorStore<T: SlotClock + 'static, E: EthSpec> {
     builder_proposals: bool,
     builder_boost_factor: Option<u64>,
     prefer_builder_proposals: bool,
+    strict_mfp: bool,
     is_synced: watch::Receiver<bool>,
 }
 
@@ -131,6 +132,7 @@ impl<T: SlotClock, E: EthSpec> AnchorValidatorStore<T, E> {
         builder_proposals: bool,
         builder_boost_factor: Option<u64>,
         prefer_builder_proposals: bool,
+        strict_mfp: bool,
         is_synced: watch::Receiver<bool>,
     ) -> Arc<AnchorValidatorStore<T, E>> {
         Arc::new(Self {
@@ -150,6 +152,7 @@ impl<T: SlotClock, E: EthSpec> AnchorValidatorStore<T, E> {
             builder_proposals,
             builder_boost_factor,
             prefer_builder_proposals,
+            strict_mfp,
             is_synced,
         })
     }
@@ -571,6 +574,7 @@ impl<T: SlotClock, E: EthSpec> AnchorValidatorStore<T, E> {
             self.spec.clone(),
             validator_attestation_committees,
             self.genesis_validators_root,
+            self.strict_mfp,
         ))
     }
 


### PR DESCRIPTION
## Issue Addressed

Addresses liveness issues during reorgs caused by strict checkpoint validation, as discussed in the SSV spec:
- https://github.com/ssvlabs/ssv-spec/issues/555
- https://github.com/ssvlabs/ssv-spec/pull/589

## Proposed Changes

Modified `BeaconVoteValidator` to compare only checkpoint epochs instead of full checkpoints (epoch + root):

- **Validation logic**: Now accepts attestations with matching epochs but different roots, allowing DVs to remain live during benign reorgs when operators' beacon nodes temporarily see different chain heads
- **Error handling**: Renamed `CheckpointMismatch` to `EpochMismatch` and simplified to store only epoch values
- **Test coverage**: Removed tests for same-epoch different-root failures, added test verifying this scenario now succeeds

## Additional Info

This change prioritizes validator liveness over fork protection. Slashing protection remains active and prevents actual slashable attestations.

The broader design question of whether DVs should actively prevent justifying potentially wrong forks (vs. focusing solely on slashing protection) remains open. This implementation keeps the SIP focused on core slashing protection, while cluster-level fork heuristics may be explored separately in the future.