### PR TITLE
feat: add MinHash subnet calculation algorithm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7790,6 +7790,7 @@ dependencies = [
  "database",
  "ethereum_serde_utils 0.7.0",
  "serde",
+ "sha2 0.10.9",
  "slot_clock",
  "ssv_types",
  "task_executor",

--- a/anchor/message_sender/src/impostor.rs
+++ b/anchor/message_sender/src/impostor.rs
@@ -19,13 +19,13 @@ impl MessageSender for ImpostorMessageSender {
         committee_id: CommitteeId,
         _additional_message_callback: Option<Box<MessageCallback>>,
     ) -> Result<(), Error> {
-        let subnet = SubnetId::from_committee(committee_id, self.subnet_count);
+        let subnet = SubnetId::from_committee_alan(committee_id, self.subnet_count);
         debug!(?msg, ?subnet, "Would send message");
         Ok(())
     }
 
     fn send(&self, msg: SignedSSVMessage, committee_id: CommitteeId) -> Result<(), Error> {
-        let subnet = SubnetId::from_committee(committee_id, self.subnet_count);
+        let subnet = SubnetId::from_committee_alan(committee_id, self.subnet_count);
         debug!(?msg, ?subnet, "Would send message");
         Ok(())
     }

--- a/anchor/message_sender/src/network.rs
+++ b/anchor/message_sender/src/network.rs
@@ -148,7 +148,7 @@ impl<S: SlotClock + 'static, D: DutiesProvider> NetworkMessageSender<S, D> {
             return;
         }
 
-        let subnet = SubnetId::from_committee(committee_id, self.subnet_count);
+        let subnet = SubnetId::from_committee_alan(committee_id, self.subnet_count);
         match self.network_tx.try_send((subnet, message_bytes)) {
             Ok(_) => trace!(?subnet, "Successfully sent message to network"),
             Err(TrySendError::Closed(_)) => warn!("Network queue closed (shutting down?)"),

--- a/anchor/subnet_service/Cargo.toml
+++ b/anchor/subnet_service/Cargo.toml
@@ -9,6 +9,7 @@ alloy = { workspace = true }
 database = { workspace = true }
 ethereum_serde_utils = "0.7.0"
 serde = { workspace = true }
+sha2 = { workspace = true }
 slot_clock = { workspace = true }
 ssv_types = { workspace = true }
 task_executor = { workspace = true }

--- a/anchor/subnet_service/src/lib.rs
+++ b/anchor/subnet_service/src/lib.rs
@@ -44,12 +44,14 @@ impl SubnetId {
 
     /// Calculate subnet using MinHash of operator IDs (new algorithm post-fork)
     ///
-    /// This algorithm ensures that committees with the same operator set always
-    /// map to the same subnet, reducing operator message processing overhead.
+    /// When an operator participates in multiple different operator sets, MinHash
+    /// increases the likelihood those sets map to the same subnet (if that operator
+    /// has the minimum hash). This reduces the number of subnets each operator must
+    /// monitor.
     ///
     /// Algorithm:
     /// 1. For each operator ID, encode as little-endian u64 (8 bytes)
-    /// 2. SHA256 hash each encoded operator ID
+    /// 2. SHA256 hash each encoded operator ID individually
     /// 3. Find the minimum hash value
     /// 4. Return min_hash % subnet_count
     pub fn from_operators(operator_ids: &[OperatorId], subnet_count: usize) -> Self {
@@ -385,4 +387,144 @@ pub fn test_tracker(
     );
 
     rx
+}
+
+#[cfg(test)]
+mod tests {
+    use ssv_types::OperatorId;
+
+    use super::*;
+
+    #[test]
+    fn test_from_operators_minhash() {
+        // Test case with operators [1,2,3,4]
+        // Operator 1: SHA256(0x0100000000000000) =
+        // 7c9fa136d4413fa6173637e883b6998d32e1d675f88cddff9dcbcf331820f4b8 Operator 2:
+        // SHA256(0x0200000000000000) =
+        // d86e8112f3c4c4442126f8e9f44f16867da487f29052bf91b810457db34209a4 Operator 3:
+        // SHA256(0x0300000000000000) =
+        // 35be322d094f9d154a8aba4733b8497f180353bd7ae7b0a15f90b586b549f28b Operator 4:
+        // SHA256(0x0400000000000000) =
+        // f0a0278e4372459cca6159cd5e71cfee638302a7b9ca9b05c34181ac0a65ac5d Min hash is from
+        // operator 3, so subnet = min_hash % 128
+        let operators = vec![OperatorId(1), OperatorId(2), OperatorId(3), OperatorId(4)];
+
+        let subnet = SubnetId::from_operators(&operators, 128);
+
+        // Calculate expected: operator 3's hash is smallest
+        // 0x35be322d094f9d154a8aba4733b8497f180353bd7ae7b0a15f90b586b549f28b % 128
+        // = 11 (from the big-endian modulo)
+        assert_eq!(*subnet, 11);
+    }
+
+    #[test]
+    fn test_from_operators_empty() {
+        let operators = vec![];
+        let subnet = SubnetId::from_operators(&operators, 128);
+        assert_eq!(*subnet, 0);
+    }
+
+    #[test]
+    fn test_from_operators_single() {
+        let operators = vec![OperatorId(42)];
+        let subnet = SubnetId::from_operators(&operators, 128);
+
+        // Should hash operator 42 and return hash % 128
+        // Since we have only one operator, it's automatically the minimum
+        // SHA256(0x2a00000000000000) mod 128
+        assert!((*subnet) < 128);
+    }
+
+    #[test]
+    fn test_from_operators_order_independence() {
+        // MinHash should give same result regardless of operator order
+        let ops1 = vec![OperatorId(1), OperatorId(2), OperatorId(3)];
+        let ops2 = vec![OperatorId(3), OperatorId(1), OperatorId(2)];
+        let ops3 = vec![OperatorId(2), OperatorId(3), OperatorId(1)];
+
+        let subnet1 = SubnetId::from_operators(&ops1, 128);
+        let subnet2 = SubnetId::from_operators(&ops2, 128);
+        let subnet3 = SubnetId::from_operators(&ops3, 128);
+
+        assert_eq!(subnet1, subnet2);
+        assert_eq!(subnet2, subnet3);
+    }
+
+    #[test]
+    fn test_from_operators_different_sets() {
+        // Different operator sets should (very likely) give different subnets
+        let ops1 = vec![OperatorId(1), OperatorId(2), OperatorId(3)];
+        let ops2 = vec![OperatorId(4), OperatorId(5), OperatorId(6)];
+
+        let subnet1 = SubnetId::from_operators(&ops1, 128);
+        let subnet2 = SubnetId::from_operators(&ops2, 128);
+
+        // While theoretically they could collide, it's extremely unlikely
+        // This test mainly ensures the function produces valid output
+        assert!((*subnet1) < 128);
+        assert!((*subnet2) < 128);
+    }
+
+    #[test]
+    fn test_from_operators_same_set_same_subnet() {
+        // Same operator set should always give the same subnet
+        let operators = vec![
+            OperatorId(10),
+            OperatorId(20),
+            OperatorId(30),
+            OperatorId(40),
+        ];
+
+        let subnet1 = SubnetId::from_operators(&operators, 128);
+        let subnet2 = SubnetId::from_operators(&operators, 128);
+
+        assert_eq!(subnet1, subnet2);
+    }
+
+    #[test]
+    fn test_from_committee_alan_unchanged() {
+        // Verify old algorithm still works correctly
+        let committee_id = CommitteeId::from([0x01u8; 32]);
+        let subnet = SubnetId::from_committee_alan(committee_id, 128);
+
+        // committee_id % 128 should give predictable result
+        let expected = U256::from_be_bytes([0x01u8; 32]) % U256::from(128);
+        assert_eq!(*subnet, u64::try_from(expected).unwrap());
+    }
+
+    #[test]
+    fn test_from_committee_alan_various_inputs() {
+        // Test several committee IDs to ensure consistent behavior
+        let committee_ids = vec![
+            CommitteeId::from([0x00u8; 32]),
+            CommitteeId::from([0xffu8; 32]),
+            CommitteeId::from({
+                let mut bytes = [0u8; 32];
+                bytes[31] = 42;
+                bytes
+            }),
+        ];
+
+        for committee_id in committee_ids {
+            let subnet = SubnetId::from_committee_alan(committee_id, 128);
+            assert!((*subnet) < 128);
+        }
+    }
+
+    #[test]
+    fn test_subnet_bounds() {
+        // Ensure both algorithms always return subnets within bounds
+        let operators = vec![
+            OperatorId(u64::MAX),
+            OperatorId(u64::MIN),
+            OperatorId(12345),
+        ];
+
+        let subnet_new = SubnetId::from_operators(&operators, 128);
+        assert!((*subnet_new) < 128);
+
+        let committee_id = CommitteeId::from([0xffu8; 32]);
+        let subnet_old = SubnetId::from_committee_alan(committee_id, 128);
+        assert!((*subnet_old) < 128);
+    }
 }

--- a/anchor/subnet_service/src/lib.rs
+++ b/anchor/subnet_service/src/lib.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashSet, ops::Deref, sync::Arc, time::Duration};
+use std::{collections::HashSet, num::NonZeroU64, ops::Deref, sync::Arc, time::Duration};
 
 use alloy::primitives::ruint::aliases::U256;
 use database::{NetworkState, NonUniqueIndex, UniqueIndex};
@@ -64,29 +64,22 @@ impl SubnetId {
     /// # Errors
     ///
     /// - `SubnetCalculationError::EmptyOperatorList` if `operator_ids` is empty
-    /// - `SubnetCalculationError::InvalidSubnetCount` if `subnet_count` is zero
     pub fn from_operators(
         operator_ids: &[OperatorId],
-        subnet_count: usize,
+        subnet_count: NonZeroU64,
     ) -> Result<Self, SubnetCalculationError> {
-        if subnet_count == 0 {
-            return Err(SubnetCalculationError::InvalidSubnetCount);
-        }
-
-        let min_hash = operator_ids
+        let min_hash: [u8; 32] = operator_ids
             .iter()
-            .map(|&operator_id| {
-                let operator_bytes = (*operator_id).to_le_bytes();
-                let mut hasher = Sha256::new();
-                hasher.update(operator_bytes);
-                hasher.finalize().into()
-            })
+            .copied()
+            .map(|operator_id| Sha256::digest(operator_id.to_le_bytes()).into())
             .min()
             .ok_or(SubnetCalculationError::EmptyOperatorList)?;
 
         let id = U256::from_be_bytes(min_hash);
+        let modulus = U256::from(subnet_count.get());
+
         // Safe: x % subnet_count is always < subnet_count, which fits in u64
-        let subnet_id = (id % U256::from(subnet_count)).as_limbs()[0];
+        let subnet_id = (id % modulus).as_limbs()[0];
 
         Ok(SubnetId(subnet_id))
     }
@@ -401,6 +394,8 @@ mod tests {
 
     use super::*;
 
+    const SUBNET_COUNT_NZ: NonZeroU64 = NonZeroU64::new(SUBNET_COUNT as u64).unwrap();
+
     #[test]
     fn test_from_operators_minhash() {
         // Test case with operators [1,2,3,4]
@@ -415,7 +410,8 @@ mod tests {
         // operator 3, so subnet = min_hash % 128
         let operators = vec![OperatorId(1), OperatorId(2), OperatorId(3), OperatorId(4)];
 
-        let subnet = SubnetId::from_operators(&operators, 128).expect("valid operators");
+        let subnet =
+            SubnetId::from_operators(&operators, SUBNET_COUNT_NZ).expect("valid operators");
 
         // Calculate expected: operator 3's hash is smallest
         // 0x35be322d094f9d154a8aba4733b8497f180353bd7ae7b0a15f90b586b549f28b % 128
@@ -426,21 +422,15 @@ mod tests {
     #[test]
     fn test_from_operators_empty() {
         let operators = vec![];
-        let result = SubnetId::from_operators(&operators, 128);
+        let result = SubnetId::from_operators(&operators, SUBNET_COUNT_NZ);
         assert_eq!(result, Err(SubnetCalculationError::EmptyOperatorList));
-    }
-
-    #[test]
-    fn test_from_operators_invalid_subnet_count() {
-        let operators = vec![OperatorId(1), OperatorId(2)];
-        let result = SubnetId::from_operators(&operators, 0);
-        assert_eq!(result, Err(SubnetCalculationError::InvalidSubnetCount));
     }
 
     #[test]
     fn test_from_operators_single() {
         let operators = vec![OperatorId(42)];
-        let subnet = SubnetId::from_operators(&operators, 128).expect("valid operators");
+        let subnet =
+            SubnetId::from_operators(&operators, SUBNET_COUNT_NZ).expect("valid operators");
 
         // Should hash operator 42 and return hash % 128
         // Since we have only one operator, it's automatically the minimum
@@ -455,9 +445,9 @@ mod tests {
         let ops2 = vec![OperatorId(3), OperatorId(1), OperatorId(2)];
         let ops3 = vec![OperatorId(2), OperatorId(3), OperatorId(1)];
 
-        let subnet1 = SubnetId::from_operators(&ops1, 128).expect("valid operators");
-        let subnet2 = SubnetId::from_operators(&ops2, 128).expect("valid operators");
-        let subnet3 = SubnetId::from_operators(&ops3, 128).expect("valid operators");
+        let subnet1 = SubnetId::from_operators(&ops1, SUBNET_COUNT_NZ).expect("valid operators");
+        let subnet2 = SubnetId::from_operators(&ops2, SUBNET_COUNT_NZ).expect("valid operators");
+        let subnet3 = SubnetId::from_operators(&ops3, SUBNET_COUNT_NZ).expect("valid operators");
 
         assert_eq!(subnet1, subnet2);
         assert_eq!(subnet2, subnet3);
@@ -469,8 +459,8 @@ mod tests {
         let ops1 = vec![OperatorId(1), OperatorId(2), OperatorId(3)];
         let ops2 = vec![OperatorId(4), OperatorId(5), OperatorId(6)];
 
-        let subnet1 = SubnetId::from_operators(&ops1, 128).expect("valid operators");
-        let subnet2 = SubnetId::from_operators(&ops2, 128).expect("valid operators");
+        let subnet1 = SubnetId::from_operators(&ops1, SUBNET_COUNT_NZ).expect("valid operators");
+        let subnet2 = SubnetId::from_operators(&ops2, SUBNET_COUNT_NZ).expect("valid operators");
 
         // While theoretically they could collide, it's extremely unlikely
         // This test mainly ensures the function produces valid output
@@ -488,8 +478,10 @@ mod tests {
             OperatorId(40),
         ];
 
-        let subnet1 = SubnetId::from_operators(&operators, 128).expect("valid operators");
-        let subnet2 = SubnetId::from_operators(&operators, 128).expect("valid operators");
+        let subnet1 =
+            SubnetId::from_operators(&operators, SUBNET_COUNT_NZ).expect("valid operators");
+        let subnet2 =
+            SubnetId::from_operators(&operators, SUBNET_COUNT_NZ).expect("valid operators");
 
         assert_eq!(subnet1, subnet2);
     }
@@ -533,7 +525,8 @@ mod tests {
             OperatorId(12345),
         ];
 
-        let subnet_new = SubnetId::from_operators(&operators, 128).expect("valid operators");
+        let subnet_new =
+            SubnetId::from_operators(&operators, SUBNET_COUNT_NZ).expect("valid operators");
         assert!((*subnet_new) < 128);
 
         let committee_id = CommitteeId::from([0xffu8; 32]);

--- a/anchor/subnet_service/src/lib.rs
+++ b/anchor/subnet_service/src/lib.rs
@@ -455,17 +455,15 @@ mod tests {
 
     #[test]
     fn test_from_operators_different_sets() {
-        // Different operator sets should (very likely) give different subnets
+        // Different operator sets should produce different subnets
         let ops1 = vec![OperatorId(1), OperatorId(2), OperatorId(3)];
         let ops2 = vec![OperatorId(4), OperatorId(5), OperatorId(6)];
 
         let subnet1 = SubnetId::from_operators(&ops1, SUBNET_COUNT_NZ).expect("valid operators");
         let subnet2 = SubnetId::from_operators(&ops2, SUBNET_COUNT_NZ).expect("valid operators");
 
-        // While theoretically they could collide, it's extremely unlikely
-        // This test mainly ensures the function produces valid output
-        assert!((*subnet1) < 128);
-        assert!((*subnet2) < 128);
+        // Different sets should produce different subnets (collision possible but extremely unlikely)
+        assert_ne!(subnet1, subnet2);
     }
 
     #[test]

--- a/anchor/subnet_service/src/lib.rs
+++ b/anchor/subnet_service/src/lib.rs
@@ -23,6 +23,7 @@ pub type SubnetBits = [u8; SUBNET_COUNT / 8];
 pub enum SubnetCalculationError {
     EmptyOperatorList,
     InvalidSubnetCount,
+    SubnetIdOutOfRange,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -64,6 +65,7 @@ impl SubnetId {
     /// # Errors
     ///
     /// - `SubnetCalculationError::EmptyOperatorList` if `operator_ids` is empty
+    /// - `SubnetCalculationError::SubnetIdOutOfRange` if the modulo result cannot fit in `u64`
     pub fn from_operators(
         operator_ids: &[OperatorId],
         subnet_count: NonZeroU64,
@@ -78,8 +80,10 @@ impl SubnetId {
         let id = U256::from_be_bytes(min_hash);
         let modulus = U256::from(subnet_count.get());
 
-        // Safe: x % subnet_count is always < subnet_count, which fits in u64
-        let subnet_id = (id % modulus).as_limbs()[0];
+        // Safe: x % subnet_count is always < subnet_count, which is a u64.
+        let subnet_id: u64 = (id % modulus)
+            .try_into()
+            .map_err(|_| SubnetCalculationError::SubnetIdOutOfRange)?;
 
         Ok(SubnetId(subnet_id))
     }

--- a/anchor/subnet_service/src/lib.rs
+++ b/anchor/subnet_service/src/lib.rs
@@ -19,6 +19,12 @@ pub mod message_rate;
 pub const SUBNET_COUNT: usize = 128;
 pub type SubnetBits = [u8; SUBNET_COUNT / 8];
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SubnetCalculationError {
+    EmptyOperatorList,
+    InvalidSubnetCount,
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(transparent)]
 pub struct SubnetId(#[serde(with = "serde_utils::quoted_u64")] u64);
@@ -54,35 +60,35 @@ impl SubnetId {
     /// 2. SHA256 hash each encoded operator ID individually
     /// 3. Find the minimum hash value
     /// 4. Return min_hash % subnet_count
-    pub fn from_operators(operator_ids: &[OperatorId], subnet_count: usize) -> Self {
-        if operator_ids.is_empty() {
-            return SubnetId(0);
+    ///
+    /// # Errors
+    ///
+    /// - `SubnetCalculationError::EmptyOperatorList` if `operator_ids` is empty
+    /// - `SubnetCalculationError::InvalidSubnetCount` if `subnet_count` is zero
+    pub fn from_operators(
+        operator_ids: &[OperatorId],
+        subnet_count: usize,
+    ) -> Result<Self, SubnetCalculationError> {
+        if subnet_count == 0 {
+            return Err(SubnetCalculationError::InvalidSubnetCount);
         }
 
-        let mut min_hash: Option<[u8; 32]> = None;
+        let min_hash = operator_ids
+            .iter()
+            .map(|&operator_id| {
+                let operator_bytes = (*operator_id).to_le_bytes();
+                let mut hasher = Sha256::new();
+                hasher.update(operator_bytes);
+                hasher.finalize().into()
+            })
+            .min()
+            .ok_or(SubnetCalculationError::EmptyOperatorList)?;
 
-        for &operator_id in operator_ids {
-            // Encode operator ID as little-endian u64
-            let operator_bytes = (*operator_id).to_le_bytes();
+        let id = U256::from_be_bytes(min_hash);
+        // Safe: x % subnet_count is always < subnet_count, which fits in u64
+        let subnet_id = (id % U256::from(subnet_count)).as_limbs()[0];
 
-            // SHA256 hash
-            let mut hasher = Sha256::new();
-            hasher.update(operator_bytes);
-            let hash: [u8; 32] = hasher.finalize().into();
-
-            // Track minimum hash
-            if min_hash.is_none() || hash < min_hash.unwrap() {
-                min_hash = Some(hash);
-            }
-        }
-
-        // Convert min hash to U256 and modulo
-        let id = U256::from_be_bytes(min_hash.unwrap());
-        SubnetId(
-            (id % U256::from(subnet_count))
-                .try_into()
-                .expect("modulo must be < subnet_count"),
-        )
+        Ok(SubnetId(subnet_id))
     }
 }
 
@@ -409,7 +415,7 @@ mod tests {
         // operator 3, so subnet = min_hash % 128
         let operators = vec![OperatorId(1), OperatorId(2), OperatorId(3), OperatorId(4)];
 
-        let subnet = SubnetId::from_operators(&operators, 128);
+        let subnet = SubnetId::from_operators(&operators, 128).expect("valid operators");
 
         // Calculate expected: operator 3's hash is smallest
         // 0x35be322d094f9d154a8aba4733b8497f180353bd7ae7b0a15f90b586b549f28b % 128
@@ -420,14 +426,21 @@ mod tests {
     #[test]
     fn test_from_operators_empty() {
         let operators = vec![];
-        let subnet = SubnetId::from_operators(&operators, 128);
-        assert_eq!(*subnet, 0);
+        let result = SubnetId::from_operators(&operators, 128);
+        assert_eq!(result, Err(SubnetCalculationError::EmptyOperatorList));
+    }
+
+    #[test]
+    fn test_from_operators_invalid_subnet_count() {
+        let operators = vec![OperatorId(1), OperatorId(2)];
+        let result = SubnetId::from_operators(&operators, 0);
+        assert_eq!(result, Err(SubnetCalculationError::InvalidSubnetCount));
     }
 
     #[test]
     fn test_from_operators_single() {
         let operators = vec![OperatorId(42)];
-        let subnet = SubnetId::from_operators(&operators, 128);
+        let subnet = SubnetId::from_operators(&operators, 128).expect("valid operators");
 
         // Should hash operator 42 and return hash % 128
         // Since we have only one operator, it's automatically the minimum
@@ -442,9 +455,9 @@ mod tests {
         let ops2 = vec![OperatorId(3), OperatorId(1), OperatorId(2)];
         let ops3 = vec![OperatorId(2), OperatorId(3), OperatorId(1)];
 
-        let subnet1 = SubnetId::from_operators(&ops1, 128);
-        let subnet2 = SubnetId::from_operators(&ops2, 128);
-        let subnet3 = SubnetId::from_operators(&ops3, 128);
+        let subnet1 = SubnetId::from_operators(&ops1, 128).expect("valid operators");
+        let subnet2 = SubnetId::from_operators(&ops2, 128).expect("valid operators");
+        let subnet3 = SubnetId::from_operators(&ops3, 128).expect("valid operators");
 
         assert_eq!(subnet1, subnet2);
         assert_eq!(subnet2, subnet3);
@@ -456,8 +469,8 @@ mod tests {
         let ops1 = vec![OperatorId(1), OperatorId(2), OperatorId(3)];
         let ops2 = vec![OperatorId(4), OperatorId(5), OperatorId(6)];
 
-        let subnet1 = SubnetId::from_operators(&ops1, 128);
-        let subnet2 = SubnetId::from_operators(&ops2, 128);
+        let subnet1 = SubnetId::from_operators(&ops1, 128).expect("valid operators");
+        let subnet2 = SubnetId::from_operators(&ops2, 128).expect("valid operators");
 
         // While theoretically they could collide, it's extremely unlikely
         // This test mainly ensures the function produces valid output
@@ -475,8 +488,8 @@ mod tests {
             OperatorId(40),
         ];
 
-        let subnet1 = SubnetId::from_operators(&operators, 128);
-        let subnet2 = SubnetId::from_operators(&operators, 128);
+        let subnet1 = SubnetId::from_operators(&operators, 128).expect("valid operators");
+        let subnet2 = SubnetId::from_operators(&operators, 128).expect("valid operators");
 
         assert_eq!(subnet1, subnet2);
     }
@@ -520,7 +533,7 @@ mod tests {
             OperatorId(12345),
         ];
 
-        let subnet_new = SubnetId::from_operators(&operators, 128);
+        let subnet_new = SubnetId::from_operators(&operators, 128).expect("valid operators");
         assert!((*subnet_new) < 128);
 
         let committee_id = CommitteeId::from([0xffu8; 32]);

--- a/anchor/subnet_service/src/lib.rs
+++ b/anchor/subnet_service/src/lib.rs
@@ -462,7 +462,8 @@ mod tests {
         let subnet1 = SubnetId::from_operators(&ops1, SUBNET_COUNT_NZ).expect("valid operators");
         let subnet2 = SubnetId::from_operators(&ops2, SUBNET_COUNT_NZ).expect("valid operators");
 
-        // Different sets should produce different subnets (collision possible but extremely unlikely)
+        // Different sets should produce different subnets (collision possible but extremely
+        // unlikely)
         assert_ne!(subnet1, subnet2);
     }
 

--- a/anchor/subnet_service/src/lib.rs
+++ b/anchor/subnet_service/src/lib.rs
@@ -3,8 +3,9 @@ use std::{collections::HashSet, ops::Deref, sync::Arc, time::Duration};
 use alloy::primitives::ruint::aliases::U256;
 use database::{NetworkState, NonUniqueIndex, UniqueIndex};
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 use slot_clock::SlotClock;
-use ssv_types::{CommitteeId, CommitteeInfo};
+use ssv_types::{CommitteeId, CommitteeInfo, OperatorId};
 use task_executor::TaskExecutor;
 use tokio::{
     sync::{mpsc, watch},
@@ -34,6 +35,47 @@ impl SubnetId {
     pub fn from_committee_alan(committee_id: CommitteeId, subnet_count: usize) -> Self {
         // Derive a numeric "committee ID" and convert to an index in [0..subnet_count].
         let id = U256::from_be_bytes(*committee_id);
+        SubnetId(
+            (id % U256::from(subnet_count))
+                .try_into()
+                .expect("modulo must be < subnet_count"),
+        )
+    }
+
+    /// Calculate subnet using MinHash of operator IDs (new algorithm post-fork)
+    ///
+    /// This algorithm ensures that committees with the same operator set always
+    /// map to the same subnet, reducing operator message processing overhead.
+    ///
+    /// Algorithm:
+    /// 1. For each operator ID, encode as little-endian u64 (8 bytes)
+    /// 2. SHA256 hash each encoded operator ID
+    /// 3. Find the minimum hash value
+    /// 4. Return min_hash % subnet_count
+    pub fn from_operators(operator_ids: &[OperatorId], subnet_count: usize) -> Self {
+        if operator_ids.is_empty() {
+            return SubnetId(0);
+        }
+
+        let mut min_hash: Option<[u8; 32]> = None;
+
+        for &operator_id in operator_ids {
+            // Encode operator ID as little-endian u64
+            let operator_bytes = (*operator_id).to_le_bytes();
+
+            // SHA256 hash
+            let mut hasher = Sha256::new();
+            hasher.update(operator_bytes);
+            let hash: [u8; 32] = hasher.finalize().into();
+
+            // Track minimum hash
+            if min_hash.is_none() || hash < min_hash.unwrap() {
+                min_hash = Some(hash);
+            }
+        }
+
+        // Convert min hash to U256 and modulo
+        let id = U256::from_be_bytes(min_hash.unwrap());
         SubnetId(
             (id % U256::from(subnet_count))
                 .try_into()

--- a/anchor/subnet_service/src/lib.rs
+++ b/anchor/subnet_service/src/lib.rs
@@ -27,7 +27,11 @@ impl SubnetId {
         id.into()
     }
 
-    pub fn from_committee(committee_id: CommitteeId, subnet_count: usize) -> Self {
+    /// Calculate subnet using committee ID (Alan fork algorithm)
+    ///
+    /// This is the pre-fork algorithm that derives the subnet from the committee ID.
+    /// Algorithm: `committee_id % subnet_count`
+    pub fn from_committee_alan(committee_id: CommitteeId, subnet_count: usize) -> Self {
         // Derive a numeric "committee ID" and convert to an index in [0..subnet_count].
         let id = U256::from_be_bytes(*committee_id);
         SubnetId(
@@ -201,7 +205,7 @@ async fn handle_subnet_changes<E: EthSpec>(
         let state = db.borrow();
         for cluster_id in state.get_own_clusters() {
             if let Some(cluster) = state.clusters().get_by(cluster_id) {
-                let subnet_id = SubnetId::from_committee(cluster.committee_id(), subnet_count);
+                let subnet_id = SubnetId::from_committee_alan(cluster.committee_id(), subnet_count);
                 current_subnets.insert(subnet_id);
             }
         }
@@ -297,7 +301,8 @@ pub fn get_committee_info_for_subnet(
         .clusters()
         .values()
         .filter(|cluster| {
-            let cluster_subnet = SubnetId::from_committee(cluster.committee_id(), SUBNET_COUNT);
+            let cluster_subnet =
+                SubnetId::from_committee_alan(cluster.committee_id(), SUBNET_COUNT);
             cluster_subnet == *subnet
         })
         .map(|cluster| {


### PR DESCRIPTION
## Issue Addressed

Ports the core algorithm changes from Go PR https://github.com/ssvlabs/ssv/pull/2302

## Proposed Changes

Implements the MinHash-based subnet calculation algorithm alongside the existing Alan algorithm:

- Add `SubnetId::from_operators()` - new MinHash algorithm that hashes each operator ID individually
- Rename `SubnetId::from_committee()` to `from_committee_alan()` for clarity
- Add comprehensive tests for both algorithms

**Key algorithmic property**: When an operator participates in multiple operator sets, MinHash increases the likelihood those sets map to the same subnet if that operator has the minimum hash value. This reduces the number of subnets each operator must monitor.

## Additional Info

This PR implements only the core algorithm without fork transition logic (dual-subscription, message validation switching, etc.). Fork transition will be added in a follow-up PR after receiving feedback on the digest versioning proposal for smooth fork coordination.

The new algorithm is tested but not yet used - all existing code continues using `from_committee_alan()`.