### PR TITLE
feat: add CLI options for BeaconNodeFallback configuration

### DIFF
--- a/anchor/client/src/cli.rs
+++ b/anchor/client/src/cli.rs
@@ -4,6 +4,7 @@ use std::{
     path::PathBuf,
 };
 
+use beacon_node_fallback::ApiTopic;
 use clap::{
     Parser,
     builder::{ArgAction, ArgPredicate},
@@ -79,6 +80,38 @@ pub struct Node {
         display_order = 0
     )]
     pub beacon_nodes_tls_certs: Option<Vec<PathBuf>>,
+
+    #[clap(
+        long,
+        value_name = "API_TOPICS",
+        value_delimiter = ',',
+        help = "Comma-separated list of beacon API topics to broadcast to all beacon nodes. \
+                Possible values are: none, attestations, blocks, subscriptions, sync-committee. \
+                Default (when flag is omitted) is to broadcast subscriptions only.",
+        display_order = 0
+    )]
+    pub broadcast: Option<Vec<ApiTopic>>,
+
+    #[clap(
+        long,
+        value_name = "SYNC_TOLERANCES",
+        value_delimiter = ',',
+        default_value = "8,8,48",
+        help = "A comma-separated list of 3 values which sets the size of each sync distance range when \
+                determining the health of each connected beacon node. \
+                The first value determines the `Synced` range. If a connected beacon node is synced to within \
+                this number of slots it is considered 'Synced'. \
+                The second value determines the `Small` sync distance range. This range starts immediately after \
+                the `Synced` range. \
+                The third value determines the `Medium` sync distance range. This range starts immediately after \
+                the `Small` range. \
+                Any sync distance larger than the `Medium` range is considered `Large`. \
+                For example, a value of '8,8,48' would mean: \
+                Synced: 0..=8, Small: 9..=16, Medium: 17..=64, Large: 65..",
+        display_order = 0,
+        help_heading = FLAG_HEADER
+    )]
+    pub beacon_nodes_sync_tolerances: Vec<u64>,
 
     #[clap(
         long,

--- a/anchor/client/src/config.rs
+++ b/anchor/client/src/config.rs
@@ -3,6 +3,7 @@
 
 use std::{net::IpAddr, path::PathBuf};
 
+use beacon_node_fallback::{ApiTopic, beacon_node_health::BeaconNodeSyncDistanceTiers};
 use global_config::GlobalConfig;
 use multiaddr::{Multiaddr, Protocol};
 use network::{DEFAULT_DISC_PORT, DEFAULT_TCP_PORT, ListenAddr, ListenAddress};
@@ -56,6 +57,10 @@ pub struct Config {
     /// A list of custom certificates that the validator client will additionally use when
     /// connecting to an execution node over SSL/TLS.
     pub execution_nodes_tls_certs: Option<Vec<PathBuf>>,
+    /// Configuration for beacon node fallback (sync tolerances).
+    pub beacon_node_fallback: beacon_node_fallback::Config,
+    /// Topics to broadcast to all beacon nodes.
+    pub broadcast_topics: Vec<ApiTopic>,
     /// Configuration for the processor
     pub processor: processor::Config,
     /// If slashing protection is disabled
@@ -113,6 +118,8 @@ impl Config {
             network: network_config,
             beacon_nodes_tls_certs: None,
             execution_nodes_tls_certs: None,
+            beacon_node_fallback: <_>::default(),
+            broadcast_topics: vec![ApiTopic::Subscriptions],
             processor: <_>::default(),
             disable_slashing_protection: false,
             impostor: None,
@@ -200,6 +207,15 @@ pub fn from_cli(cli_args: &Node, global_config: GlobalConfig) -> Result<Config, 
 
     config.beacon_nodes_tls_certs = cli_args.beacon_nodes_tls_certs.clone();
     config.execution_nodes_tls_certs = cli_args.execution_nodes_tls_certs.clone();
+
+    // Beacon node fallback configuration
+    config.beacon_node_fallback.sync_tolerances =
+        BeaconNodeSyncDistanceTiers::from_vec(&cli_args.beacon_nodes_sync_tolerances)?;
+
+    if let Some(mut broadcast_topics) = cli_args.broadcast.clone() {
+        broadcast_topics.retain(|topic| *topic != ApiTopic::None);
+        config.broadcast_topics = broadcast_topics;
+    }
 
     // MEV options
     config.builder_proposals = cli_args.builder_proposals;

--- a/anchor/client/src/lib.rs
+++ b/anchor/client/src/lib.rs
@@ -18,7 +18,7 @@ use anchor_validator_store::{
     registration_service::RegistrationService,
 };
 use beacon_node_fallback::{
-    ApiTopic, BeaconNodeFallback, CandidateBeaconNode, start_fallback_updater_service,
+    BeaconNodeFallback, CandidateBeaconNode, start_fallback_updater_service,
 };
 pub use cli::Node;
 use config::Config;
@@ -318,19 +318,17 @@ impl Client {
         // Initialize the number of connected, available beacon nodes to 0.
         set_gauge(&validator_metrics::AVAILABLE_BEACON_NODES_COUNT, 0);
 
-        // TODO: make beacon_node_fallback::Config and broadcast_topics configurable
-        // https://github.com/sigp/anchor/issues/248
         let mut beacon_nodes: BeaconNodeFallback<_> = BeaconNodeFallback::new(
             candidates,
-            beacon_node_fallback::Config::default(),
-            vec![ApiTopic::Subscriptions],
+            config.beacon_node_fallback,
+            config.broadcast_topics.clone(),
             spec.clone(),
         );
 
         let mut proposer_nodes: BeaconNodeFallback<_> = BeaconNodeFallback::new(
             proposer_candidates,
-            beacon_node_fallback::Config::default(),
-            vec![ApiTopic::Subscriptions],
+            config.beacon_node_fallback,
+            config.broadcast_topics.clone(),
             spec.clone(),
         );
 


### PR DESCRIPTION
## Issue Addressed

Closes #248

## Proposed Changes

- Add `--broadcast` flag to configure which API topics are sent to all beacon nodes
- Add `--beacon-nodes-sync-tolerances` flag to configure sync distance thresholds

## Additional Info

None
