### PR TITLE
feat: add CORS support for HTTP API and metrics endpoints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3749,6 +3749,7 @@ dependencies = [
  "ssv_types",
  "task_executor",
  "tokio",
+ "tower-http",
  "tracing",
  "version",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1787,6 +1787,7 @@ version = "1.2.0"
 dependencies = [
  "anchor_validator_store",
  "async-broadcast",
+ "axum",
  "beacon_node_fallback",
  "clap",
  "database",
@@ -1798,7 +1799,6 @@ dependencies = [
  "global_config",
  "http_api",
  "http_metrics",
- "hyper",
  "keygen",
  "logging 0.1.0",
  "message_receiver",
@@ -1822,6 +1822,7 @@ dependencies = [
  "subnet_service",
  "task_executor",
  "tokio",
+ "tower-http",
  "tracing",
  "types",
  "validator_metrics",

--- a/anchor/client/Cargo.toml
+++ b/anchor/client/Cargo.toml
@@ -22,7 +22,6 @@ fork = { workspace = true }
 global_config = { workspace = true }
 http_api = { workspace = true }
 http_metrics = { workspace = true }
-hyper = { workspace = true }
 keygen = { workspace = true }
 logging = { workspace = true }
 message_receiver = { workspace = true }
@@ -46,6 +45,7 @@ ssv_types = { workspace = true }
 subnet_service = { workspace = true }
 task_executor = { workspace = true }
 tokio = { workspace = true }
+tower-http = { workspace = true }
 tracing = { workspace = true }
 types = { workspace = true }
 validator_metrics = { workspace = true }

--- a/anchor/client/Cargo.toml
+++ b/anchor/client/Cargo.toml
@@ -9,6 +9,7 @@ name = "client"
 path = "src/lib.rs"
 
 [dependencies]
+axum = { workspace = true }
 anchor_validator_store = { workspace = true }
 async-broadcast = { workspace = true }
 beacon_node_fallback = { workspace = true }

--- a/anchor/client/src/cli.rs
+++ b/anchor/client/src/cli.rs
@@ -4,6 +4,7 @@ use std::{
     path::PathBuf,
 };
 
+use axum::http::HeaderValue;
 use beacon_node_fallback::ApiTopic;
 use clap::{
     Parser,
@@ -184,7 +185,7 @@ pub struct Node {
         display_order = 0,
         requires = "http"
     )]
-    pub http_allow_origin: Option<String>,
+    pub http_allow_origin: Option<HeaderValue>,
 
     // Network related arguments
     #[clap(
@@ -334,7 +335,7 @@ pub struct Node {
         display_order = 0,
         requires = "metrics"
     )]
-    pub metrics_allow_origin: Option<String>,
+    pub metrics_allow_origin: Option<HeaderValue>,
 
     #[clap(
         long,

--- a/anchor/client/src/cli.rs
+++ b/anchor/client/src/cli.rs
@@ -323,8 +323,19 @@ pub struct Node {
         help_heading = FLAG_HEADER
     )]
     pub enable_high_validator_count_metrics: bool,
-    // TODO: Metrics CORS Origin
-    // https://github.com/sigp/anchor/issues/249
+
+    #[clap(
+        long,
+        value_name = "ORIGIN",
+        help = "Set the value of the Access-Control-Allow-Origin response HTTP header \
+                for the metrics server. Use * to allow any origin (not recommended in production). \
+                If no value is supplied, the CORS allowed origin is set to the listen \
+                address of this server (e.g., http://localhost:5164).",
+        display_order = 0,
+        requires = "metrics"
+    )]
+    pub metrics_allow_origin: Option<String>,
+
     #[clap(
         long,
         global = true,

--- a/anchor/client/src/config.rs
+++ b/anchor/client/src/config.rs
@@ -135,7 +135,7 @@ impl Config {
 
 /// Returns a `Default` implementation of `Self` with some parameters modified by the supplied
 /// `cli_args`.
-pub fn from_cli(cli_args: &Node, global_config: GlobalConfig) -> Result<Config, String> {
+pub fn from_cli(mut cli_args: Node, global_config: GlobalConfig) -> Result<Config, String> {
     let mut config = Config::new(global_config);
 
     config.key_file = cli_args.key_file.clone();
@@ -157,7 +157,7 @@ pub fn from_cli(cli_args: &Node, global_config: GlobalConfig) -> Result<Config, 
     config.disable_slashing_protection = cli_args.disable_slashing_protection;
 
     // Network related
-    config.network.listen_addresses = parse_listening_addresses(cli_args)?;
+    config.network.listen_addresses = parse_listening_addresses(&cli_args)?;
 
     for addr in cli_args.boot_nodes.clone() {
         match addr.parse() {
@@ -249,11 +249,8 @@ pub fn from_cli(cli_args: &Node, global_config: GlobalConfig) -> Result<Config, 
         config.http_api.listen_port = port;
     }
 
-    if let Some(allow_origin) = &cli_args.http_allow_origin {
-        let header_value = allow_origin
-            .parse()
-            .map_err(|_| "Invalid allow-origin value")?;
-        config.http_api.allow_origin = Some(AllowOrigin::exact(header_value));
+    if let Some(allow_origin) = cli_args.http_allow_origin.take() {
+        config.http_api.allow_origin = Some(AllowOrigin::exact(allow_origin));
     }
 
     // Prometheus metrics HTTP server
@@ -270,11 +267,8 @@ pub fn from_cli(cli_args: &Node, global_config: GlobalConfig) -> Result<Config, 
         config.http_metrics.listen_port = port;
     }
 
-    if let Some(allow_origin) = &cli_args.metrics_allow_origin {
-        let header_value = allow_origin
-            .parse()
-            .map_err(|_| "Invalid metrics-allow-origin value")?;
-        config.http_metrics.allow_origin = Some(AllowOrigin::exact(header_value));
+    if let Some(allow_origin) = cli_args.metrics_allow_origin.take() {
+        config.http_metrics.allow_origin = Some(AllowOrigin::exact(allow_origin));
     }
 
     config.enable_high_validator_count_metrics = cli_args.enable_high_validator_count_metrics;

--- a/anchor/client/src/config.rs
+++ b/anchor/client/src/config.rs
@@ -271,6 +271,14 @@ pub fn from_cli(cli_args: &Node, global_config: GlobalConfig) -> Result<Config, 
         config.http_metrics.listen_port = port;
     }
 
+    if let Some(allow_origin) = &cli_args.metrics_allow_origin {
+        // Pre-validate the config value to give feedback to the user on node startup.
+        hyper::header::HeaderValue::from_str(allow_origin)
+            .map_err(|_| "Invalid metrics-allow-origin value")?;
+
+        config.http_metrics.allow_origin = Some(allow_origin.to_string());
+    }
+
     config.enable_high_validator_count_metrics = cli_args.enable_high_validator_count_metrics;
 
     config.impostor = cli_args.impostor.map(OperatorId);

--- a/anchor/client/src/config.rs
+++ b/anchor/client/src/config.rs
@@ -12,6 +12,7 @@ use network_utils::unused_port::{
 };
 use sensitive_url::SensitiveUrl;
 use ssv_types::OperatorId;
+use tower_http::cors::AllowOrigin;
 use tracing::{error, warn};
 
 use crate::cli::Node;
@@ -249,12 +250,10 @@ pub fn from_cli(cli_args: &Node, global_config: GlobalConfig) -> Result<Config, 
     }
 
     if let Some(allow_origin) = &cli_args.http_allow_origin {
-        // Pre-validate the config value to give feedback to the user on node startup, instead of
-        // as late as when the first API response is produced.
-        hyper::header::HeaderValue::from_str(allow_origin)
+        let header_value = allow_origin
+            .parse()
             .map_err(|_| "Invalid allow-origin value")?;
-
-        config.http_api.allow_origin = Some(allow_origin.to_string());
+        config.http_api.allow_origin = AllowOrigin::exact(header_value);
     }
 
     // Prometheus metrics HTTP server
@@ -272,11 +271,10 @@ pub fn from_cli(cli_args: &Node, global_config: GlobalConfig) -> Result<Config, 
     }
 
     if let Some(allow_origin) = &cli_args.metrics_allow_origin {
-        // Pre-validate the config value to give feedback to the user on node startup.
-        hyper::header::HeaderValue::from_str(allow_origin)
+        let header_value = allow_origin
+            .parse()
             .map_err(|_| "Invalid metrics-allow-origin value")?;
-
-        config.http_metrics.allow_origin = Some(allow_origin.to_string());
+        config.http_metrics.allow_origin = AllowOrigin::exact(header_value);
     }
 
     config.enable_high_validator_count_metrics = cli_args.enable_high_validator_count_metrics;

--- a/anchor/client/src/config.rs
+++ b/anchor/client/src/config.rs
@@ -253,7 +253,7 @@ pub fn from_cli(cli_args: &Node, global_config: GlobalConfig) -> Result<Config, 
         let header_value = allow_origin
             .parse()
             .map_err(|_| "Invalid allow-origin value")?;
-        config.http_api.allow_origin = AllowOrigin::exact(header_value);
+        config.http_api.allow_origin = Some(AllowOrigin::exact(header_value));
     }
 
     // Prometheus metrics HTTP server
@@ -274,7 +274,7 @@ pub fn from_cli(cli_args: &Node, global_config: GlobalConfig) -> Result<Config, 
         let header_value = allow_origin
             .parse()
             .map_err(|_| "Invalid metrics-allow-origin value")?;
-        config.http_metrics.allow_origin = AllowOrigin::exact(header_value);
+        config.http_metrics.allow_origin = Some(AllowOrigin::exact(header_value));
     }
 
     config.enable_high_validator_count_metrics = cli_args.enable_high_validator_count_metrics;

--- a/anchor/client/src/lib.rs
+++ b/anchor/client/src/lib.rs
@@ -162,7 +162,7 @@ impl Client {
             let metrics_future = http_metrics::serve(
                 listener,
                 shared_state.clone(),
-                config.http_metrics.allow_origin.clone(),
+                config.http_metrics.allow_origin(),
                 exit,
             );
 

--- a/anchor/client/src/lib.rs
+++ b/anchor/client/src/lib.rs
@@ -159,7 +159,12 @@ impl Client {
                 .await
                 .map_err(|e| format!("Unable to bind to metrics server port: {e}"))?;
 
-            let metrics_future = http_metrics::serve(listener, shared_state.clone(), exit);
+            let metrics_future = http_metrics::serve(
+                listener,
+                shared_state.clone(),
+                config.http_metrics.allow_origin.clone(),
+                exit,
+            );
 
             executor.spawn_without_exit(metrics_future, "metrics-http");
 

--- a/anchor/http_api/Cargo.toml
+++ b/anchor/http_api/Cargo.toml
@@ -21,5 +21,6 @@ slot_clock = { workspace = true }
 ssv_types = { workspace = true }
 task_executor = { workspace = true }
 tokio = { workspace = true }
+tower-http = { workspace = true }
 tracing = { workspace = true }
 version = { workspace = true }

--- a/anchor/http_api/src/config.rs
+++ b/anchor/http_api/src/config.rs
@@ -10,7 +10,7 @@ pub struct Config {
     pub enabled: bool,
     pub listen_addr: IpAddr,
     pub listen_port: u16,
-    pub allow_origin: AllowOrigin,
+    pub allow_origin: Option<AllowOrigin>,
 }
 
 impl Default for Config {
@@ -19,7 +19,20 @@ impl Default for Config {
             enabled: false,
             listen_addr: IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
             listen_port: 5062,
-            allow_origin: AllowOrigin::any(),
+            allow_origin: None,
         }
+    }
+}
+
+impl Config {
+    /// Returns the configured `AllowOrigin`, or falls back to the listen address and port.
+    pub fn allow_origin(&self) -> AllowOrigin {
+        self.allow_origin.clone().unwrap_or_else(|| {
+            AllowOrigin::exact(
+                format!("http://{}:{}", self.listen_addr, self.listen_port)
+                    .parse()
+                    .expect("listen address and port should produce a valid header value"),
+            )
+        })
     }
 }

--- a/anchor/http_api/src/config.rs
+++ b/anchor/http_api/src/config.rs
@@ -2,15 +2,15 @@
 
 use std::net::{IpAddr, Ipv4Addr};
 
-use serde::{Deserialize, Serialize};
+use tower_http::cors::AllowOrigin;
 
 /// Configuration for the HTTP server.
-#[derive(PartialEq, Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone)]
 pub struct Config {
     pub enabled: bool,
     pub listen_addr: IpAddr,
     pub listen_port: u16,
-    pub allow_origin: Option<String>,
+    pub allow_origin: AllowOrigin,
 }
 
 impl Default for Config {
@@ -19,7 +19,7 @@ impl Default for Config {
             enabled: false,
             listen_addr: IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
             listen_port: 5062,
-            allow_origin: None,
+            allow_origin: AllowOrigin::any(),
         }
     }
 }

--- a/anchor/http_api/src/lib.rs
+++ b/anchor/http_api/src/lib.rs
@@ -3,12 +3,14 @@ mod router;
 
 use std::{net::SocketAddr, path::PathBuf, sync::Arc};
 
+use axum::http::Method;
 pub use config::Config;
 use database::NetworkState;
 use parking_lot::RwLock;
 use slot_clock::SlotClock;
 use task_executor::TaskExecutor;
 use tokio::{net::TcpListener, sync::watch};
+use tower_http::cors::{AllowOrigin, CorsLayer};
 use tracing::info;
 /// A wrapper around all the items required to spawn the HTTP server.
 ///
@@ -38,11 +40,19 @@ pub async fn run(config: Config, shared_state: Arc<RwLock<Shared>>) -> Result<()
         return Ok(());
     }
 
+    let origin = config
+        .allow_origin
+        .map(|o| AllowOrigin::exact(o.parse().expect("validated in config")))
+        .unwrap_or(AllowOrigin::any());
+
+    let cors = CorsLayer::new()
+        .allow_methods([Method::GET, Method::POST])
+        .allow_origin(origin);
+
     // Generate the axum routes
-    let router = router::new(shared_state);
+    let router = router::new(shared_state).layer(cors);
 
     // Set up a listening address
-
     let socket = SocketAddr::new(config.listen_addr, config.listen_port);
     let listener = TcpListener::bind(socket).await.map_err(|e| e.to_string())?;
 

--- a/anchor/http_api/src/lib.rs
+++ b/anchor/http_api/src/lib.rs
@@ -10,7 +10,7 @@ use parking_lot::RwLock;
 use slot_clock::SlotClock;
 use task_executor::TaskExecutor;
 use tokio::{net::TcpListener, sync::watch};
-use tower_http::cors::{AllowOrigin, CorsLayer};
+use tower_http::cors::CorsLayer;
 use tracing::info;
 /// A wrapper around all the items required to spawn the HTTP server.
 ///
@@ -40,14 +40,9 @@ pub async fn run(config: Config, shared_state: Arc<RwLock<Shared>>) -> Result<()
         return Ok(());
     }
 
-    let origin = config
-        .allow_origin
-        .map(|o| AllowOrigin::exact(o.parse().expect("validated in config")))
-        .unwrap_or(AllowOrigin::any());
-
     let cors = CorsLayer::new()
         .allow_methods([Method::GET, Method::POST])
-        .allow_origin(origin);
+        .allow_origin(config.allow_origin);
 
     // Generate the axum routes
     let router = router::new(shared_state).layer(cors);

--- a/anchor/http_api/src/lib.rs
+++ b/anchor/http_api/src/lib.rs
@@ -42,7 +42,7 @@ pub async fn run(config: Config, shared_state: Arc<RwLock<Shared>>) -> Result<()
 
     let cors = CorsLayer::new()
         .allow_methods([Method::GET, Method::POST])
-        .allow_origin(config.allow_origin);
+        .allow_origin(config.allow_origin());
 
     // Generate the axum routes
     let router = router::new(shared_state).layer(cors);

--- a/anchor/http_metrics/src/lib.rs
+++ b/anchor/http_metrics/src/lib.rs
@@ -22,7 +22,6 @@ use axum::{
 use libp2p::metrics::Registry;
 use parking_lot::RwLock;
 use prometheus_client::encoding::text::encode;
-use serde::{Deserialize, Serialize};
 use slot_clock::{SlotClock, SystemTimeSlotClock};
 use tokio::net::TcpListener;
 use tower_http::cors::{AllowOrigin, CorsLayer};
@@ -41,12 +40,12 @@ pub struct Shared<E: EthSpec> {
 }
 
 /// Configuration for the HTTP server.
-#[derive(PartialEq, Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone)]
 pub struct Config {
     pub enabled: bool,
     pub listen_addr: IpAddr,
     pub listen_port: u16,
-    pub allow_origin: Option<String>,
+    pub allow_origin: AllowOrigin,
 }
 
 impl Default for Config {
@@ -55,24 +54,18 @@ impl Default for Config {
             enabled: false,
             listen_addr: IpAddr::V4(Ipv4Addr::LOCALHOST),
             listen_port: 5164,
-            allow_origin: None,
+            allow_origin: AllowOrigin::any(),
         }
     }
 }
 
 fn create_router<E: EthSpec>(
     shared_state: Arc<RwLock<Shared<E>>>,
-    allow_origin: Option<String>,
+    allow_origin: AllowOrigin,
 ) -> Router {
-    let origin = allow_origin
-        .map(|o| AllowOrigin::exact(o.parse().expect("validated in config")))
-        .unwrap_or(AllowOrigin::any());
-
     let cors = CorsLayer::new()
-        // allow `GET` and `POST` when accessing the resource
         .allow_methods([Method::GET, Method::POST])
-        // allow requests from custom origin
-        .allow_origin(origin);
+        .allow_origin(allow_origin);
 
     Router::new()
         .route("/metrics", get(metrics_handler))
@@ -155,7 +148,7 @@ async fn metrics_handler<E: EthSpec>(
 pub async fn serve<E: EthSpec>(
     listener: TcpListener,
     shared_state: Arc<RwLock<Shared<E>>>,
-    allow_origin: Option<String>,
+    allow_origin: AllowOrigin,
     shutdown: impl Future<Output = ()> + Send + Sync + 'static,
 ) {
     // Generate the axum routes

--- a/anchor/http_metrics/src/lib.rs
+++ b/anchor/http_metrics/src/lib.rs
@@ -45,7 +45,7 @@ pub struct Config {
     pub enabled: bool,
     pub listen_addr: IpAddr,
     pub listen_port: u16,
-    pub allow_origin: AllowOrigin,
+    pub allow_origin: Option<AllowOrigin>,
 }
 
 impl Default for Config {
@@ -54,8 +54,21 @@ impl Default for Config {
             enabled: false,
             listen_addr: IpAddr::V4(Ipv4Addr::LOCALHOST),
             listen_port: 5164,
-            allow_origin: AllowOrigin::any(),
+            allow_origin: None,
         }
+    }
+}
+
+impl Config {
+    /// Returns the configured `AllowOrigin`, or falls back to the listen address and port.
+    pub fn allow_origin(&self) -> AllowOrigin {
+        self.allow_origin.clone().unwrap_or_else(|| {
+            AllowOrigin::exact(
+                format!("http://{}:{}", self.listen_addr, self.listen_port)
+                    .parse()
+                    .expect("listen address and port should produce a valid header value"),
+            )
+        })
     }
 }
 

--- a/anchor/http_metrics/src/lib.rs
+++ b/anchor/http_metrics/src/lib.rs
@@ -25,7 +25,7 @@ use prometheus_client::encoding::text::encode;
 use serde::{Deserialize, Serialize};
 use slot_clock::{SlotClock, SystemTimeSlotClock};
 use tokio::net::TcpListener;
-use tower_http::cors::{Any, CorsLayer};
+use tower_http::cors::{AllowOrigin, CorsLayer};
 use tracing::error;
 use types::EthSpec;
 use validator_services::duties_service::DutiesService;
@@ -60,12 +60,19 @@ impl Default for Config {
     }
 }
 
-fn create_router<E: EthSpec>(shared_state: Arc<RwLock<Shared<E>>>) -> Router {
+fn create_router<E: EthSpec>(
+    shared_state: Arc<RwLock<Shared<E>>>,
+    allow_origin: Option<String>,
+) -> Router {
+    let origin = allow_origin
+        .map(|o| AllowOrigin::exact(o.parse().expect("validated in config")))
+        .unwrap_or(AllowOrigin::any());
+
     let cors = CorsLayer::new()
         // allow `GET` and `POST` when accessing the resource
         .allow_methods([Method::GET, Method::POST])
-        // allow requests from any origin
-        .allow_origin(Any);
+        // allow requests from custom origin
+        .allow_origin(origin);
 
     Router::new()
         .route("/metrics", get(metrics_handler))
@@ -148,10 +155,11 @@ async fn metrics_handler<E: EthSpec>(
 pub async fn serve<E: EthSpec>(
     listener: TcpListener,
     shared_state: Arc<RwLock<Shared<E>>>,
+    allow_origin: Option<String>,
     shutdown: impl Future<Output = ()> + Send + Sync + 'static,
 ) {
     // Generate the axum routes
-    let router = create_router(shared_state);
+    let router = create_router(shared_state, allow_origin);
 
     // Start the http api server
     if let Err(e) = axum::serve(listener, router)

--- a/anchor/src/main.rs
+++ b/anchor/src/main.rs
@@ -107,7 +107,7 @@ fn main() -> Result<(), String> {
     let environment = Environment::default();
 
     match cli.subcommand {
-        AnchorSubcommands::Node(node) => start_anchor(&node, global_config, environment),
+        AnchorSubcommands::Node(node) => start_anchor(*node, global_config, environment),
         AnchorSubcommands::Keysplit(keysplit) => {
             keysplit::run_keysplitter(keysplit, global_config)
                 .map_err(|e| format!("Keysplit error: {e:?}"))?;
@@ -122,7 +122,7 @@ fn main() -> Result<(), String> {
 }
 
 fn start_anchor(
-    anchor_config: &Node,
+    anchor_config: Node,
     global_config: GlobalConfig,
     mut environment: Environment,
 ) -> Result<(), String> {


### PR DESCRIPTION
## Issue Addressed

Closes #249

## Proposed Changes

- Add `--metrics-allow-origin` CLI flag
- Implement CORS for HTTP API, the `--http-allow-origin` flag existed but wasn't wired up.

## Additional Info

None
