### PR TITLE
feat: add gossipsub topic validation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5197,6 +5197,7 @@ version = "0.1.0"
 dependencies = [
  "database",
  "ethereum_ssz",
+ "libp2p-gossipsub",
  "message_validator",
  "openssl",
  "processor",
@@ -5228,6 +5229,7 @@ dependencies = [
  "sha2 0.10.9",
  "slot_clock",
  "ssv_types",
+ "subnet_service",
  "task_executor",
  "thiserror 2.0.17",
  "tokio",
@@ -7794,6 +7796,7 @@ dependencies = [
  "slot_clock",
  "ssv_types",
  "task_executor",
+ "thiserror 2.0.17",
  "tokio",
  "tracing",
  "types",

--- a/anchor/message_receiver/src/lib.rs
+++ b/anchor/message_receiver/src/lib.rs
@@ -1,6 +1,6 @@
 mod manager;
 
-use gossipsub::{Message, MessageId};
+use gossipsub::{Message, MessageId, TopicHash};
 use libp2p::PeerId;
 use thiserror::Error;
 
@@ -12,6 +12,7 @@ pub trait MessageReceiver {
         propagation_source: PeerId,
         message_id: MessageId,
         message: Message,
+        topic: TopicHash,
     ) -> Result<(), Error>;
 }
 

--- a/anchor/message_receiver/src/manager.rs
+++ b/anchor/message_receiver/src/manager.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use database::{NetworkState, NonUniqueIndex, UniqueIndex};
-use gossipsub::{Message, MessageAcceptance, MessageId};
+use gossipsub::{Message, MessageAcceptance, MessageId, TopicHash};
 use libp2p::PeerId;
 use message_validator::{
     DutiesProvider, ValidatedMessage, ValidatedSSVMessage, ValidationResult, Validator,
@@ -69,6 +69,7 @@ impl<S: SlotClock + 'static, D: DutiesProvider> MessageReceiver
         propagation_source: PeerId,
         message_id: MessageId,
         message: Message,
+        topic: TopicHash,
     ) -> Result<(), crate::Error> {
         let receiver = self.clone();
         self.processor.urgent_consensus.send_blocking(
@@ -76,7 +77,7 @@ impl<S: SlotClock + 'static, D: DutiesProvider> MessageReceiver
                 let span = debug_span!("message_receiver", msg=%message_id);
                 let _enter = span.enter();
 
-                let result = receiver.validator.validate(&message.data);
+                let result = receiver.validator.validate(&message.data, &topic);
 
                 let mut action = MessageAcceptance::from(&result);
 

--- a/anchor/message_sender/Cargo.toml
+++ b/anchor/message_sender/Cargo.toml
@@ -10,6 +10,7 @@ testing = []
 [dependencies]
 database = { workspace = true }
 ethereum_ssz = { workspace = true }
+gossipsub = { workspace = true }
 message_validator = { workspace = true }
 openssl = { workspace = true }
 processor = { workspace = true }

--- a/anchor/message_sender/src/network.rs
+++ b/anchor/message_sender/src/network.rs
@@ -132,23 +132,27 @@ impl<S: SlotClock + 'static, D: DutiesProvider> NetworkMessageSender<S, D> {
 
     fn do_send(&self, message: SignedSSVMessage, committee_id: CommitteeId) {
         let message_bytes = message.as_ssz_bytes();
+        let subnet = SubnetId::from_committee_alan(committee_id, self.subnet_count);
 
-        if let Some(validator) = self.validator.as_ref()
-            && let Err(err) = validator.validate(&message_bytes).as_result()
-        {
-            // `Reject` is more severe and can be punished by other peers. We should not have
-            // created this message ever, while `Ignore` can be triggered simply because the message
-            // is irrelevant by now.
-            if let MessageAcceptance::Reject = MessageAcceptance::from(err) {
-                warn!(?err, "Validation of outgoing message failed (Reject)");
-                debug!(msg = %message, "Failing message");
-            } else {
-                debug!(?err, "Validation of outgoing message failed (Ignore)");
+        if let Some(validator) = self.validator.as_ref() {
+            // Create topic for validation
+            let topic_string = format!("ssv.v2.{}", *subnet);
+            let topic = gossipsub::TopicHash::from_raw(topic_string);
+
+            if let Err(err) = validator.validate(&message_bytes, &topic).as_result() {
+                // `Reject` is more severe and can be punished by other peers. We should not have
+                // created this message ever, while `Ignore` can be triggered simply because the
+                // message is irrelevant by now.
+                if let MessageAcceptance::Reject = MessageAcceptance::from(err) {
+                    warn!(?err, "Validation of outgoing message failed (Reject)");
+                    debug!(msg = %message, "Failing message");
+                } else {
+                    debug!(?err, "Validation of outgoing message failed (Ignore)");
+                }
+                return;
             }
-            return;
         }
 
-        let subnet = SubnetId::from_committee_alan(committee_id, self.subnet_count);
         match self.network_tx.try_send((subnet, message_bytes)) {
             Ok(_) => trace!(?subnet, "Successfully sent message to network"),
             Err(TrySendError::Closed(_)) => warn!("Network queue closed (shutting down?)"),

--- a/anchor/message_validator/Cargo.toml
+++ b/anchor/message_validator/Cargo.toml
@@ -21,6 +21,7 @@ safe_arith = { workspace = true }
 sha2 = { workspace = true }
 slot_clock = { workspace = true }
 ssv_types = { workspace = true }
+subnet_service = { workspace = true }
 task_executor = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }

--- a/anchor/message_validator/src/lib.rs
+++ b/anchor/message_validator/src/lib.rs
@@ -32,7 +32,7 @@ use ssv_types::{
 use ssz::{Decode, DecodeError, Encode};
 use task_executor::TaskExecutor;
 use tokio::{sync::watch::Receiver, time::sleep};
-use tracing::{debug, trace};
+use tracing::trace;
 use types::{Epoch, Slot};
 
 use crate::{
@@ -473,7 +473,7 @@ fn validate_topic(
     committee_id: CommitteeId,
 ) -> Result<(), ValidationFailure> {
     let received_subnet = subnet_service::topic_to_subnet(topic.as_str()).map_err(|e| {
-        debug!(?e, topic = topic.as_str(), "Failed to parse topic");
+        trace!(?e, topic = topic.as_str(), "Failed to parse topic");
         ValidationFailure::IncorrectTopic
     })?;
 
@@ -481,7 +481,7 @@ fn validate_topic(
         subnet_service::SubnetId::from_committee_alan(committee_id, subnet_service::SUBNET_COUNT);
 
     if *received_subnet != *expected_subnet {
-        debug!(
+        trace!(
             committee_id = ?committee_id,
             expected_subnet = *expected_subnet,
             received_subnet = *received_subnet,

--- a/anchor/message_validator/src/lib.rs
+++ b/anchor/message_validator/src/lib.rs
@@ -10,7 +10,7 @@ use std::{
 };
 
 use dashmap::{DashMap, mapref::one::RefMut};
-use database::NetworkState;
+use database::{NetworkState, UniqueIndex};
 pub use duties_tracker::DutiesProvider;
 pub use gossipsub::MessageAcceptance;
 use openssl::{
@@ -32,7 +32,7 @@ use ssv_types::{
 use ssz::{Decode, DecodeError, Encode};
 use task_executor::TaskExecutor;
 use tokio::{sync::watch::Receiver, time::sleep};
-use tracing::trace;
+use tracing::{debug, trace};
 use types::{Epoch, Slot};
 
 use crate::{
@@ -301,11 +301,11 @@ impl<S: SlotClock + 'static, D: DutiesProvider> Validator<S, D> {
         validator
     }
 
-    pub fn validate(&self, message_data: &[u8]) -> ValidationResult {
+    pub fn validate(&self, message_data: &[u8], topic: &gossipsub::TopicHash) -> ValidationResult {
         match SignedSSVMessage::from_ssz_bytes(message_data) {
             Ok(signed_ssv_message) => {
                 trace!(msg = ?signed_ssv_message, "SignedSSVMessage deserialized");
-                match self.validate_decoded_message(&signed_ssv_message) {
+                match self.validate_decoded_message(&signed_ssv_message, topic) {
                     Ok(validated_message) => ValidationResult::Success(validated_message),
                     Err(failure) => {
                         ValidationResult::PostDecodeFailure(failure, signed_ssv_message)
@@ -321,6 +321,7 @@ impl<S: SlotClock + 'static, D: DutiesProvider> Validator<S, D> {
     fn validate_decoded_message(
         &self,
         signed_ssv_message: &SignedSSVMessage,
+        topic: &gossipsub::TopicHash,
     ) -> Result<ValidatedMessage, ValidationFailure> {
         // Get the role from message ID
         let ssv_message = signed_ssv_message.ssv_message();
@@ -329,17 +330,18 @@ impl<S: SlotClock + 'static, D: DutiesProvider> Validator<S, D> {
             .role()
             .ok_or(ValidationFailure::InvalidRole)?;
 
-        // Get committee info based on role and duty executor
+        // Get committee info and committee ID based on role and duty executor
         let network_state = self.network_state_rx.borrow();
-        let committee_info = match role {
+        let (committee_info, committee_id) = match role {
             Role::Committee => {
                 let committee_id = match ssv_message.msg_id().duty_executor() {
                     Some(DutyExecutor::Committee(id)) => id,
                     _ => return Err(ValidationFailure::NonExistentCommitteeID),
                 };
-                network_state
+                let info = network_state
                     .get_committee_info_by_committee_id(&committee_id)
-                    .ok_or(ValidationFailure::NonExistentCommitteeID)?
+                    .ok_or(ValidationFailure::NonExistentCommitteeID)?;
+                (info, committee_id)
             }
             _ => {
                 let validator_pk = match ssv_message.msg_id().duty_executor() {
@@ -347,15 +349,51 @@ impl<S: SlotClock + 'static, D: DutiesProvider> Validator<S, D> {
                     _ => return Err(ValidationFailure::UnknownValidator),
                 };
 
-                network_state
+                let info = network_state
                     .get_committee_info_by_validator_pk(&validator_pk)
-                    .ok_or(ValidationFailure::UnknownValidator)?
+                    .ok_or(ValidationFailure::UnknownValidator)?;
+
+                // Get committee ID from the cluster
+                let share = network_state
+                    .shares()
+                    .get_by(&validator_pk)
+                    .ok_or(ValidationFailure::UnknownValidator)?;
+                let cluster = network_state
+                    .clusters()
+                    .get_by(&share.cluster_id)
+                    .ok_or(ValidationFailure::UnknownValidator)?;
+                let committee_id = cluster.committee_id();
+
+                (info, committee_id)
             }
         };
         let operator_pub_keys =
             &get_operator_pub_keys(&network_state, &committee_info.committee_members);
 
         drop(network_state);
+
+        // Validate topic correctness
+        // Extract subnet from received topic
+        let received_subnet = subnet_service::topic_to_subnet(topic.as_str())
+            .map_err(|_| ValidationFailure::IncorrectTopic)?;
+
+        // Calculate expected subnet from committee ID
+        let expected_subnet = subnet_service::SubnetId::from_committee_alan(
+            committee_id,
+            subnet_service::SUBNET_COUNT,
+        );
+
+        // Check if received subnet matches expected subnet
+        if *received_subnet != *expected_subnet {
+            debug!(
+                committee_id = ?committee_id,
+                expected_subnet = *expected_subnet,
+                received_subnet = *received_subnet,
+                topic = topic.as_str(),
+                "Message published to incorrect topic"
+            );
+            return Err(ValidationFailure::IncorrectTopic);
+        }
 
         let mut duty_state = self.get_duty_state(ssv_message.msg_id(), self.slots_per_epoch);
 

--- a/anchor/message_validator/src/lib.rs
+++ b/anchor/message_validator/src/lib.rs
@@ -472,8 +472,10 @@ fn validate_topic(
     topic: &gossipsub::TopicHash,
     committee_id: CommitteeId,
 ) -> Result<(), ValidationFailure> {
-    let received_subnet = subnet_service::topic_to_subnet(topic.as_str())
-        .map_err(|_| ValidationFailure::IncorrectTopic)?;
+    let received_subnet = subnet_service::topic_to_subnet(topic.as_str()).map_err(|e| {
+        debug!(?e, topic = topic.as_str(), "Failed to parse topic");
+        ValidationFailure::IncorrectTopic
+    })?;
 
     let expected_subnet =
         subnet_service::SubnetId::from_committee_alan(committee_id, subnet_service::SUBNET_COUNT);
@@ -1152,5 +1154,80 @@ mod tests {
             hash_data(&data1),
             "Same data should produce the same hash"
         );
+    }
+
+    // ---------------------------------------------------------------------
+    // Topic validation tests
+    // ---------------------------------------------------------------------
+
+    #[test]
+    fn test_validate_topic_correct() {
+        use gossipsub::TopicHash;
+
+        use crate::validate_topic;
+
+        // Create a committee ID and calculate its expected subnet
+        let committee_id = CommitteeId([1u8; 32]);
+        let expected_subnet = subnet_service::SubnetId::from_committee_alan(
+            committee_id,
+            subnet_service::SUBNET_COUNT,
+        );
+        let topic = TopicHash::from_raw(format!("ssv.v2.{}", *expected_subnet));
+
+        assert!(validate_topic(&topic, committee_id).is_ok());
+    }
+
+    #[test]
+    fn test_validate_topic_incorrect_subnet() {
+        use gossipsub::TopicHash;
+
+        use crate::validate_topic;
+
+        let committee_id = CommitteeId([1u8; 32]);
+        let expected_subnet = subnet_service::SubnetId::from_committee_alan(
+            committee_id,
+            subnet_service::SUBNET_COUNT,
+        );
+
+        // Use a different subnet than expected
+        let wrong_subnet = (*expected_subnet + 1) % 128;
+        let wrong_topic = TopicHash::from_raw(format!("ssv.v2.{}", wrong_subnet));
+
+        let result = validate_topic(&wrong_topic, committee_id);
+        assert!(matches!(result, Err(ValidationFailure::IncorrectTopic)));
+    }
+
+    #[test]
+    fn test_validate_topic_invalid_format() {
+        use gossipsub::TopicHash;
+
+        use crate::validate_topic;
+
+        let committee_id = CommitteeId([1u8; 32]);
+
+        // Invalid topic format
+        let invalid_topic = TopicHash::from_raw("invalid.topic");
+        let result = validate_topic(&invalid_topic, committee_id);
+        assert!(matches!(result, Err(ValidationFailure::IncorrectTopic)));
+    }
+
+    #[test]
+    fn test_validate_topic_incorrect_returns_ignore() {
+        use gossipsub::{MessageAcceptance, TopicHash};
+
+        use crate::validate_topic;
+
+        let committee_id = CommitteeId([1u8; 32]);
+        let wrong_topic = TopicHash::from_raw("ssv.v2.99");
+
+        let result = validate_topic(&wrong_topic, committee_id);
+        assert!(result.is_err());
+
+        // Verify IncorrectTopic maps to Ignore, not Reject
+        let failure = result.unwrap_err();
+        assert!(matches!(
+            MessageAcceptance::from(&failure),
+            MessageAcceptance::Ignore
+        ));
     }
 }

--- a/anchor/message_validator/src/lib.rs
+++ b/anchor/message_validator/src/lib.rs
@@ -23,7 +23,7 @@ use safe_arith::SafeArith;
 use sha2::{Digest, Sha256};
 use slot_clock::SlotClock;
 use ssv_types::{
-    CommitteeInfo, IndexSet, OperatorId, ValidatorIndex,
+    CommitteeId, CommitteeInfo, IndexSet, OperatorId, ValidatorIndex,
     consensus::QbftMessage,
     message::{MsgType, SignedSSVMessage},
     msgid::{DutyExecutor, MessageId, Role},
@@ -373,27 +373,7 @@ impl<S: SlotClock + 'static, D: DutiesProvider> Validator<S, D> {
         drop(network_state);
 
         // Validate topic correctness
-        // Extract subnet from received topic
-        let received_subnet = subnet_service::topic_to_subnet(topic.as_str())
-            .map_err(|_| ValidationFailure::IncorrectTopic)?;
-
-        // Calculate expected subnet from committee ID
-        let expected_subnet = subnet_service::SubnetId::from_committee_alan(
-            committee_id,
-            subnet_service::SUBNET_COUNT,
-        );
-
-        // Check if received subnet matches expected subnet
-        if *received_subnet != *expected_subnet {
-            debug!(
-                committee_id = ?committee_id,
-                expected_subnet = *expected_subnet,
-                received_subnet = *received_subnet,
-                topic = topic.as_str(),
-                "Message published to incorrect topic"
-            );
-            return Err(ValidationFailure::IncorrectTopic);
-        }
+        validate_topic(topic, committee_id)?;
 
         let mut duty_state = self.get_duty_state(ssv_message.msg_id(), self.slots_per_epoch);
 
@@ -482,6 +462,34 @@ fn validate_ssv_message(
             validate_partial_signature_message(validation_context, duty_state, duty_provider)
         }
     }
+}
+
+/// Validates that a message was published to the correct gossipsub topic.
+///
+/// The expected topic is determined by the committee ID - messages should be published
+/// to the subnet corresponding to their committee.
+fn validate_topic(
+    topic: &gossipsub::TopicHash,
+    committee_id: CommitteeId,
+) -> Result<(), ValidationFailure> {
+    let received_subnet = subnet_service::topic_to_subnet(topic.as_str())
+        .map_err(|_| ValidationFailure::IncorrectTopic)?;
+
+    let expected_subnet =
+        subnet_service::SubnetId::from_committee_alan(committee_id, subnet_service::SUBNET_COUNT);
+
+    if *received_subnet != *expected_subnet {
+        debug!(
+            committee_id = ?committee_id,
+            expected_subnet = *expected_subnet,
+            received_subnet = *received_subnet,
+            topic = topic.as_str(),
+            "Message published to incorrect topic"
+        );
+        return Err(ValidationFailure::IncorrectTopic);
+    }
+
+    Ok(())
 }
 
 fn verify_message_signature(

--- a/anchor/network/src/network.rs
+++ b/anchor/network/src/network.rs
@@ -175,18 +175,28 @@ impl<R: MessageReceiver> Network<R> {
                                             id = ?message_id,
                                             "Received SignedSSVMessage"
                                         );
-                                        if let Err(err) = self.message_receiver.receive(propagation_source, message_id, message) {
+                                        if let Err(err) = self.message_receiver.receive(propagation_source, message_id, message.clone(), message.topic.clone()) {
                                             error!(?err, "Unable to pass message to message receiver");
                                         }
                                     }
                                     gossipsub::Event::Subscribed { peer_id, topic } => {
-                                        if let Some(subnet) = topic_to_subnet(&topic) {
-                                            self.peer_manager().set_peer_subscription(peer_id, subnet, true);
+                                        match topic_to_subnet(&topic) {
+                                            Ok(subnet) => {
+                                                self.peer_manager().set_peer_subscription(peer_id, subnet, true);
+                                            }
+                                            Err(err) => {
+                                                warn!(topic = topic.as_str(), ?err, "Failed to parse subscription topic");
+                                            }
                                         }
                                     }
                                     gossipsub::Event::Unsubscribed { peer_id, topic } => {
-                                        if let Some(subnet) = topic_to_subnet(&topic) {
-                                            self.peer_manager().set_peer_subscription(peer_id, subnet, false);
+                                        match topic_to_subnet(&topic) {
+                                            Ok(subnet) => {
+                                                self.peer_manager().set_peer_subscription(peer_id, subnet, false);
+                                            }
+                                            Err(err) => {
+                                                warn!(topic = topic.as_str(), ?err, "Failed to parse unsubscription topic");
+                                            }
                                         }
                                     }
                                     _ => {
@@ -759,10 +769,6 @@ fn subnet_to_topic(subnet: SubnetId) -> IdentTopic {
     IdentTopic::new(format!("ssv.v2.{}", *subnet))
 }
 
-fn topic_to_subnet(topic: &TopicHash) -> Option<SubnetId> {
-    let s = topic.as_str();
-    // Our topics use the form "ssv.v2.<number>".
-    s.strip_prefix("ssv.v2.")
-        .and_then(|rest| rest.parse::<u64>().ok())
-        .map(SubnetId::from)
+fn topic_to_subnet(topic: &TopicHash) -> Result<SubnetId, subnet_service::TopicParseError> {
+    subnet_service::topic_to_subnet(topic.as_str())
 }

--- a/anchor/subnet_service/Cargo.toml
+++ b/anchor/subnet_service/Cargo.toml
@@ -13,6 +13,7 @@ sha2 = { workspace = true }
 slot_clock = { workspace = true }
 ssv_types = { workspace = true }
 task_executor = { workspace = true }
+thiserror = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
 types = { workspace = true }

--- a/anchor/subnet_service/src/lib.rs
+++ b/anchor/subnet_service/src/lib.rs
@@ -103,6 +103,34 @@ impl Deref for SubnetId {
     }
 }
 
+/// Error type for topic parsing failures
+#[derive(Debug, thiserror::Error)]
+pub enum TopicParseError {
+    #[error("Topic missing 'ssv.v2.' prefix")]
+    MissingPrefix,
+    #[error("Invalid subnet number in topic: {0}")]
+    InvalidSubnetNumber(String),
+}
+
+/// Parse a topic string into a SubnetId
+///
+/// Topics have the format "ssv.v2.<subnet_number>". This function extracts
+/// the subnet number and returns it as a SubnetId.
+///
+/// # Errors
+///
+/// Returns `TopicParseError::MissingPrefix` if the topic doesn't start with "ssv.v2."
+/// Returns `TopicParseError::InvalidSubnetNumber` if the subnet number cannot be parsed
+pub fn topic_to_subnet(topic: &str) -> Result<SubnetId, TopicParseError> {
+    let rest = topic
+        .strip_prefix("ssv.v2.")
+        .ok_or(TopicParseError::MissingPrefix)?;
+
+    rest.parse::<u64>()
+        .map(SubnetId::from)
+        .map_err(|_| TopicParseError::InvalidSubnetNumber(rest.to_string()))
+}
+
 pub enum SubnetEvent {
     Join(SubnetId, Option<f64>), // subnet_id and optional message_rate
     Leave(SubnetId),

--- a/anchor/subnet_service/src/lib.rs
+++ b/anchor/subnet_service/src/lib.rs
@@ -564,4 +564,43 @@ mod tests {
         let subnet_old = SubnetId::from_committee_alan(committee_id, 128);
         assert!((*subnet_old) < 128);
     }
+
+    #[test]
+    fn test_topic_to_subnet_valid() {
+        assert_eq!(*topic_to_subnet("ssv.v2.0").unwrap(), 0);
+        assert_eq!(*topic_to_subnet("ssv.v2.42").unwrap(), 42);
+        assert_eq!(*topic_to_subnet("ssv.v2.127").unwrap(), 127);
+    }
+
+    #[test]
+    fn test_topic_to_subnet_missing_prefix() {
+        assert!(matches!(
+            topic_to_subnet("invalid.42"),
+            Err(TopicParseError::MissingPrefix)
+        ));
+        assert!(matches!(
+            topic_to_subnet("ssv.v1.42"),
+            Err(TopicParseError::MissingPrefix)
+        ));
+        assert!(matches!(
+            topic_to_subnet("42"),
+            Err(TopicParseError::MissingPrefix)
+        ));
+    }
+
+    #[test]
+    fn test_topic_to_subnet_invalid_number() {
+        assert!(matches!(
+            topic_to_subnet("ssv.v2.notanumber"),
+            Err(TopicParseError::InvalidSubnetNumber(_))
+        ));
+        assert!(matches!(
+            topic_to_subnet("ssv.v2."),
+            Err(TopicParseError::InvalidSubnetNumber(_))
+        ));
+        assert!(matches!(
+            topic_to_subnet("ssv.v2.-1"),
+            Err(TopicParseError::InvalidSubnetNumber(_))
+        ));
+    }
 }

--- a/anchor/subnet_service/src/lib.rs
+++ b/anchor/subnet_service/src/lib.rs
@@ -106,8 +106,8 @@ impl Deref for SubnetId {
 /// Error type for topic parsing failures
 #[derive(Debug, thiserror::Error)]
 pub enum TopicParseError {
-    #[error("Topic missing 'ssv.v2.' prefix")]
-    MissingPrefix,
+    #[error("Topic '{0}' missing required 'ssv.v2.' prefix")]
+    MissingPrefix(String),
     #[error("Invalid subnet number in topic: {0}")]
     InvalidSubnetNumber(String),
 }
@@ -124,7 +124,7 @@ pub enum TopicParseError {
 pub fn topic_to_subnet(topic: &str) -> Result<SubnetId, TopicParseError> {
     let rest = topic
         .strip_prefix("ssv.v2.")
-        .ok_or(TopicParseError::MissingPrefix)?;
+        .ok_or_else(|| TopicParseError::MissingPrefix(topic.to_string()))?;
 
     rest.parse::<u64>()
         .map(SubnetId::from)
@@ -576,15 +576,15 @@ mod tests {
     fn test_topic_to_subnet_missing_prefix() {
         assert!(matches!(
             topic_to_subnet("invalid.42"),
-            Err(TopicParseError::MissingPrefix)
+            Err(TopicParseError::MissingPrefix(_))
         ));
         assert!(matches!(
             topic_to_subnet("ssv.v1.42"),
-            Err(TopicParseError::MissingPrefix)
+            Err(TopicParseError::MissingPrefix(_))
         ));
         assert!(matches!(
             topic_to_subnet("42"),
-            Err(TopicParseError::MissingPrefix)
+            Err(TopicParseError::MissingPrefix(_))
         ));
     }
 


### PR DESCRIPTION
## Issue Addressed

N/A - Feature parity with go-ssv.

## Proposed Changes

Adds validation that SSV messages are published to the correct gossipsub topic.

**Why this matters:** Each SSV committee has a deterministic subnet assignment based on its committee ID. A message published to the wrong topic indicates either a bug or misconfigured node. Without validation, these messages would be processed normally despite being incorrectly routed.

**How it works:** When a message arrives, we extract the committee ID from the message content and calculate the expected subnet using `SubnetId::from_committee_alan()`. If the topic the message arrived on doesn't match, we return `Ignore` (not `Reject`) to avoid harshly penalizing nodes that may simply be misconfigured.

**Changes:**
- Add `topic_to_subnet()` helper in subnet_service for parsing topic strings
- Thread `TopicHash` through the validation chain (network → message_receiver → validator)
- Add `validate_topic()` helper that compares expected vs received subnet
- Validate outgoing messages before sending (defense in depth)

## Additional Info

This matches [go-ssv's implementation](https://github.com/ssvlabs/ssv/blob/main/message/validation/validation.go#L218-L234) which performs the same validation in `committeeChecks()`.