### PR TITLE
chore: update anchor to latest lighthouse package versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,25 +20,12 @@ dependencies = [
 
 [[package]]
 name = "aes"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e8b47f52ea9bae42228d07ec09eb676433d7c4ed1ebdf0f1d1c29ed446f1ab8"
-dependencies = [
- "cfg-if",
- "cipher 0.3.0",
- "cpufeatures",
- "ctr 0.8.0",
- "opaque-debug",
-]
-
-[[package]]
-name = "aes"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
- "cipher 0.4.4",
+ "cipher",
  "cpufeatures",
 ]
 
@@ -49,9 +36,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
 dependencies = [
  "aead",
- "aes 0.8.4",
- "cipher 0.4.4",
- "ctr 0.9.2",
+ "aes",
+ "cipher",
+ "ctr",
  "ghash",
  "subtle",
 ]
@@ -116,7 +103,7 @@ checksum = "b163ff4acf0eac29af05a911397cc418a76e153467b859398adc26cb9335a611"
 dependencies = [
  "alloy-primitives 1.5.2",
  "num_enum",
- "strum 0.27.2",
+ "strum",
 ]
 
 [[package]]
@@ -269,7 +256,7 @@ dependencies = [
  "either",
  "serde",
  "serde_with",
- "sha2 0.10.9",
+ "sha2",
  "thiserror 2.0.17",
 ]
 
@@ -308,7 +295,7 @@ checksum = "d4ab3330e491053e9608b2a315f147357bb8acb9377a988c1203f2e8e2b296c9"
 dependencies = [
  "alloy-primitives 1.5.2",
  "alloy-sol-types",
- "http 1.4.0",
+ "http",
  "serde",
  "serde_json",
  "thiserror 2.0.17",
@@ -441,7 +428,7 @@ dependencies = [
  "lru 0.13.0",
  "parking_lot",
  "pin-project",
- "reqwest 0.12.28",
+ "reqwest",
  "serde",
  "serde_json",
  "thiserror 2.0.17",
@@ -509,7 +496,7 @@ dependencies = [
  "alloy-transport-ws",
  "futures",
  "pin-project",
- "reqwest 0.12.28",
+ "reqwest",
  "serde",
  "serde_json",
  "tokio",
@@ -629,7 +616,7 @@ dependencies = [
  "alloy-json-abi",
  "alloy-sol-macro-input",
  "const-hex",
- "heck 0.5.0",
+ "heck",
  "indexmap 2.12.1",
  "proc-macro-error2",
  "proc-macro2",
@@ -648,7 +635,7 @@ dependencies = [
  "alloy-json-abi",
  "const-hex",
  "dunce",
- "heck 0.5.0",
+ "heck",
  "macro-string",
  "proc-macro2",
  "quote",
@@ -687,7 +674,7 @@ checksum = "bec1fb08ee484e615f24867c0b154fff5722bb00176102a16868c6532b7c3623"
 dependencies = [
  "alloy-json-rpc",
  "auto_impl",
- "base64 0.22.1",
+ "base64",
  "derive_more 2.1.1",
  "futures",
  "futures-utils-wasm",
@@ -710,7 +697,7 @@ checksum = "64b722073c76f2de7e118d546ee1921c50710f97feb32aed50db94cfa5b663e1"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
- "reqwest 0.12.28",
+ "reqwest",
  "serde_json",
  "tower",
  "tracing",
@@ -726,7 +713,7 @@ dependencies = [
  "alloy-pubsub",
  "alloy-transport",
  "futures",
- "http 1.4.0",
+ "http",
  "serde_json",
  "tokio",
  "tokio-tungstenite",
@@ -772,7 +759,7 @@ dependencies = [
  "clap",
  "client",
  "dirs",
- "ethereum_hashing",
+ "ethereum_hashing 0.7.0",
  "futures",
  "global_config",
  "keygen",
@@ -782,7 +769,7 @@ dependencies = [
  "predicates",
  "serde",
  "ssv_network_config",
- "strum 0.27.2",
+ "strum",
  "task_executor",
  "tempfile",
  "tokio",
@@ -798,6 +785,7 @@ name = "anchor_validator_store"
 version = "0.1.0"
 dependencies = [
  "beacon_node_fallback",
+ "bls",
  "database",
  "eth2",
  "ethereum_ssz",
@@ -1213,7 +1201,7 @@ dependencies = [
  "futures-lite",
  "parking",
  "polling",
- "rustix 1.1.3",
+ "rustix",
  "slab",
  "windows-sys 0.61.2",
 ]
@@ -1287,8 +1275,8 @@ version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16e2cdb6d5ed835199484bb92bb8b3edd526effe995c61732580439c1a67e2e9"
 dependencies = [
- "base64 0.22.1",
- "http 1.4.0",
+ "base64",
+ "http",
  "log",
  "url",
 ]
@@ -1320,10 +1308,10 @@ dependencies = [
  "bytes",
  "form_urlencoded",
  "futures-util",
- "http 1.4.0",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "http-body-util",
- "hyper 1.8.1",
+ "hyper",
  "hyper-util",
  "itoa",
  "matchit",
@@ -1335,7 +1323,7 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "tokio",
  "tower",
  "tower-layer",
@@ -1351,12 +1339,12 @@ checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.4.0",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "http-body-util",
  "mime",
  "pin-project-lite",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -1386,12 +1374,6 @@ dependencies = [
 
 [[package]]
 name = "base64"
-version = "0.21.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
-
-[[package]]
-name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
@@ -1405,8 +1387,9 @@ checksum = "0e050f626429857a27ddccb31e0aca21356bfa709c04041aefddac081a8f068a"
 [[package]]
 name = "beacon_node_fallback"
 version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?rev=e3ee7feb#e3ee7febce64c1b5a85c3ab0be0619571ee92d58"
+source = "git+https://github.com/sigp/lighthouse?rev=58b153cac#58b153cac5a078d849bf8478bd21baedfe98d9ee"
 dependencies = [
+ "bls",
  "clap",
  "eth2",
  "futures",
@@ -1414,7 +1397,7 @@ dependencies = [
  "sensitive_url",
  "serde",
  "slot_clock",
- "strum 0.24.1",
+ "strum",
  "task_executor",
  "tokio",
  "tracing",
@@ -1494,15 +1477,6 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
-name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
@@ -1513,12 +1487,12 @@ dependencies = [
 [[package]]
 name = "bls"
 version = "0.2.0"
-source = "git+https://github.com/sigp/lighthouse?rev=e3ee7feb#e3ee7febce64c1b5a85c3ab0be0619571ee92d58"
+source = "git+https://github.com/sigp/lighthouse?rev=58b153cac#58b153cac5a078d849bf8478bd21baedfe98d9ee"
 dependencies = [
  "alloy-primitives 1.5.2",
  "arbitrary",
  "blst",
- "ethereum_hashing",
+ "ethereum_hashing 0.8.0",
  "ethereum_serde_utils 0.8.0",
  "ethereum_ssz",
  "fixed_bytes",
@@ -1639,26 +1613,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bzip2"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdb116a6ef3f6c3698828873ad02c3014b3c85cadb88496095628e3ef1e347f8"
-dependencies = [
- "bzip2-sys",
- "libc",
-]
-
-[[package]]
-name = "bzip2-sys"
-version = "0.1.13+1.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "225bff33b2141874fe80d71e07d6eec4f85c5c216453dd96388240f96e1acc14"
-dependencies = [
- "cc",
- "pkg-config",
-]
-
-[[package]]
 name = "c-kzg"
 version = "2.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1712,8 +1666,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a0aeaff4ff1a90589618835a598e545176939b97874f7abc7851caa0618f203"
 dependencies = [
  "find-msvc-tools",
- "jobserver",
- "libc",
  "shlex",
 ]
 
@@ -1736,7 +1688,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
 dependencies = [
  "cfg-if",
- "cipher 0.4.4",
+ "cipher",
  "cpufeatures",
 ]
 
@@ -1748,7 +1700,7 @@ checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
 dependencies = [
  "aead",
  "chacha20",
- "cipher 0.4.4",
+ "cipher",
  "poly1305",
  "zeroize",
 ]
@@ -1765,15 +1717,6 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-link",
-]
-
-[[package]]
-name = "cipher"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ee52072ec15386f770805afd189a01c8841be8696bed250fa2f13c4c0d6dfb7"
-dependencies = [
- "generic-array",
 ]
 
 [[package]]
@@ -1816,7 +1759,7 @@ version = "4.5.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a0b5487afeab2deb2ff4e03a807ad1a03ac532ff5a2cee5d86884440c7f7671"
 dependencies = [
- "heck 0.5.0",
+ "heck",
  "proc-macro2",
  "quote",
  "syn 2.0.112",
@@ -1845,7 +1788,7 @@ dependencies = [
  "global_config",
  "http_api",
  "http_metrics",
- "hyper 1.8.1",
+ "hyper",
  "keygen",
  "logging 0.1.0",
  "message_receiver",
@@ -1869,7 +1812,7 @@ dependencies = [
  "slot_clock",
  "ssv_network_config",
  "ssv_types",
- "strum 0.27.2",
+ "strum",
  "subnet_service",
  "task_executor",
  "tokio",
@@ -1889,19 +1832,22 @@ checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "compare_fields"
-version = "0.2.0"
-source = "git+https://github.com/sigp/lighthouse?rev=e3ee7feb#e3ee7febce64c1b5a85c3ab0be0619571ee92d58"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f45d0b4d61b582303179fb7a1a142bc9d647b7583db3b0d5f25a21d286fab9"
 dependencies = [
- "itertools 0.10.5",
+ "compare_fields_derive",
+ "itertools 0.14.0",
 ]
 
 [[package]]
 name = "compare_fields_derive"
-version = "0.2.0"
-source = "git+https://github.com/sigp/lighthouse?rev=e3ee7feb#e3ee7febce64c1b5a85c3ab0be0619571ee92d58"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92ff1dbbda10d495b2c92749c002b2025e0be98f42d1741ecc9ff820d2f04dce"
 dependencies = [
  "quote",
- "syn 1.0.109",
+ "syn 2.0.112",
 ]
 
 [[package]]
@@ -1958,29 +1904,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "constant_time_eq"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
-
-[[package]]
 name = "context_deserialize"
-version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?rev=e3ee7feb#e3ee7febce64c1b5a85c3ab0be0619571ee92d58"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c523eea4af094b5970c321f4604abc42c5549d3cbae332e98325403fbbdbf70"
 dependencies = [
  "context_deserialize_derive",
- "milhouse",
  "serde",
- "ssz_types",
 ]
 
 [[package]]
 name = "context_deserialize_derive"
-version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?rev=e3ee7feb#e3ee7febce64c1b5a85c3ab0be0619571ee92d58"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b7bf98c48ffa511b14bb3c76202c24a8742cea1efa9570391c5d41373419a09"
 dependencies = [
  "quote",
- "syn 1.0.109",
+ "syn 2.0.112",
 ]
 
 [[package]]
@@ -2120,31 +2060,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "crypto-mac"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25fab6889090c8133f3deb8f73ba3c65a7f456f66436fc012a1b1e272b1e103e"
-dependencies = [
- "generic-array",
- "subtle",
-]
-
-[[package]]
-name = "ctr"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "049bb91fb4aaf0e3c7efa6cd5ef877dbbbd15b39dad06d9948de4ec8a75761ea"
-dependencies = [
- "cipher 0.3.0",
-]
-
-[[package]]
 name = "ctr"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
 dependencies = [
- "cipher 0.4.4",
+ "cipher",
 ]
 
 [[package]]
@@ -2205,6 +2126,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
+]
+
+[[package]]
 name = "darling_core"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2248,6 +2179,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim 0.11.1",
+ "syn 2.0.112",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2276,6 +2220,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
  "darling_core 0.21.3",
+ "quote",
+ "syn 2.0.112",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core 0.23.0",
  "quote",
  "syn 2.0.112",
 ]
@@ -2337,14 +2292,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d162beedaa69905488a8da94f5ac3edb4dd4788b732fadb7bd120b2625c1976"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.112",
 ]
 
 [[package]]
 name = "database"
 version = "0.1.0"
 dependencies = [
- "base64 0.22.1",
+ "base64",
+ "bls",
  "once_cell",
  "openssl",
  "r2d2",
@@ -2481,7 +2437,7 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer 0.10.4",
+ "block-buffer",
  "const-oid",
  "crypto-common",
  "subtle",
@@ -2514,11 +2470,11 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f170f4f6ed0e1df52bf43b403899f0081917ecf1500bfe312505cc3b515a8899"
 dependencies = [
- "aes 0.8.4",
+ "aes",
  "aes-gcm",
  "alloy-rlp",
  "arrayvec",
- "ctr 0.9.2",
+ "ctr",
  "delay_map",
  "enr",
  "fnv",
@@ -2625,7 +2581,7 @@ dependencies = [
  "ed25519",
  "rand_core 0.6.4",
  "serde",
- "sha2 0.10.9",
+ "sha2",
  "subtle",
  "zeroize",
 ]
@@ -2658,15 +2614,17 @@ dependencies = [
  "itertools 0.14.0",
  "serde",
  "serde_json",
- "sha2 0.10.9",
+ "sha2",
 ]
 
 [[package]]
 name = "eip_3076"
 version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?rev=e3ee7feb#e3ee7febce64c1b5a85c3ab0be0619571ee92d58"
+source = "git+https://github.com/sigp/lighthouse?rev=58b153cac#58b153cac5a078d849bf8478bd21baedfe98d9ee"
 dependencies = [
+ "bls",
  "ethereum_serde_utils 0.8.0",
+ "fixed_bytes",
  "serde",
  "serde_json",
  "types",
@@ -2720,7 +2678,7 @@ dependencies = [
  "ekzg-bls12-381",
  "ekzg-maybe-rayon",
  "ekzg-polynomial",
- "sha2 0.10.9",
+ "sha2",
 ]
 
 [[package]]
@@ -2803,7 +2761,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "851bd664a3d3a3c175cff92b2f0df02df3c541b4895d0ae307611827aae46152"
 dependencies = [
  "alloy-rlp",
- "base64 0.22.1",
+ "base64",
  "bytes",
  "ed25519-dalek",
  "hex",
@@ -2821,7 +2779,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
 dependencies = [
- "heck 0.5.0",
+ "heck",
  "proc-macro2",
  "quote",
  "syn 2.0.112",
@@ -2869,7 +2827,7 @@ version = "0.1.0"
 dependencies = [
  "alloy",
  "anchor_validator_store",
- "base64 0.22.1",
+ "base64",
  "beacon_node_fallback",
  "bls",
  "bls_lagrange",
@@ -2882,7 +2840,7 @@ dependencies = [
  "indexmap 2.12.1",
  "metrics",
  "rand 0.9.2",
- "reqwest 0.12.28",
+ "reqwest",
  "rusqlite",
  "sensitive_url",
  "slashing_protection",
@@ -2901,31 +2859,25 @@ dependencies = [
 [[package]]
 name = "eth2"
 version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?rev=e3ee7feb#e3ee7febce64c1b5a85c3ab0be0619571ee92d58"
+source = "git+https://github.com/sigp/lighthouse?rev=58b153cac#58b153cac5a078d849bf8478bd21baedfe98d9ee"
 dependencies = [
- "derivative",
+ "bls",
+ "context_deserialize",
+ "educe",
  "eip_3076",
- "either",
- "enr",
  "eth2_keystore",
  "ethereum_serde_utils 0.8.0",
  "ethereum_ssz",
  "ethereum_ssz_derive",
- "futures",
- "futures-util",
- "libp2p-identity",
  "mediatype",
- "multiaddr",
  "pretty_reqwest_error",
  "proto_array",
- "rand 0.9.2",
- "reqwest 0.11.27",
- "reqwest-eventsource",
+ "reqwest",
  "sensitive_url",
  "serde",
  "serde_json",
  "ssz_types",
- "test_random_derive",
+ "superstruct",
  "types",
  "zeroize",
 ]
@@ -2933,7 +2885,7 @@ dependencies = [
 [[package]]
 name = "eth2_config"
 version = "0.2.0"
-source = "git+https://github.com/sigp/lighthouse?rev=e3ee7feb#e3ee7febce64c1b5a85c3ab0be0619571ee92d58"
+source = "git+https://github.com/sigp/lighthouse?rev=58b153cac#58b153cac5a078d849bf8478bd21baedfe98d9ee"
 dependencies = [
  "paste",
  "types",
@@ -2942,10 +2894,10 @@ dependencies = [
 [[package]]
 name = "eth2_interop_keypairs"
 version = "0.2.0"
-source = "git+https://github.com/sigp/lighthouse?rev=e3ee7feb#e3ee7febce64c1b5a85c3ab0be0619571ee92d58"
+source = "git+https://github.com/sigp/lighthouse?rev=58b153cac#58b153cac5a078d849bf8478bd21baedfe98d9ee"
 dependencies = [
  "bls",
- "ethereum_hashing",
+ "ethereum_hashing 0.8.0",
  "hex",
  "num-bigint",
  "serde",
@@ -2955,32 +2907,34 @@ dependencies = [
 [[package]]
 name = "eth2_key_derivation"
 version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?rev=e3ee7feb#e3ee7febce64c1b5a85c3ab0be0619571ee92d58"
+source = "git+https://github.com/sigp/lighthouse?rev=58b153cac#58b153cac5a078d849bf8478bd21baedfe98d9ee"
 dependencies = [
  "bls",
  "num-bigint-dig",
  "ring",
- "sha2 0.9.9",
+ "sha2",
  "zeroize",
 ]
 
 [[package]]
 name = "eth2_keystore"
 version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?rev=e3ee7feb#e3ee7febce64c1b5a85c3ab0be0619571ee92d58"
+source = "git+https://github.com/sigp/lighthouse?rev=58b153cac#58b153cac5a078d849bf8478bd21baedfe98d9ee"
 dependencies = [
- "aes 0.7.5",
+ "aes",
  "bls",
+ "cipher",
+ "ctr",
  "eth2_key_derivation",
  "hex",
- "hmac 0.11.0",
- "pbkdf2 0.8.0",
+ "hmac",
+ "pbkdf2",
  "rand 0.9.2",
  "scrypt",
  "serde",
  "serde_json",
  "serde_repr",
- "sha2 0.9.9",
+ "sha2",
  "unicode-normalization",
  "uuid 0.8.2",
  "zeroize",
@@ -2989,17 +2943,18 @@ dependencies = [
 [[package]]
 name = "eth2_network_config"
 version = "0.2.0"
-source = "git+https://github.com/sigp/lighthouse?rev=e3ee7feb#e3ee7febce64c1b5a85c3ab0be0619571ee92d58"
+source = "git+https://github.com/sigp/lighthouse?rev=58b153cac#58b153cac5a078d849bf8478bd21baedfe98d9ee"
 dependencies = [
  "bytes",
  "discv5",
  "eth2_config",
+ "fixed_bytes",
  "kzg",
  "pretty_reqwest_error",
- "reqwest 0.11.27",
+ "reqwest",
  "sensitive_url",
  "serde_yaml",
- "sha2 0.9.9",
+ "sha2",
  "tracing",
  "types",
  "url",
@@ -3014,7 +2969,18 @@ checksum = "c853bd72c9e5787f8aafc3df2907c2ed03cff3150c3acd94e2e53a98ab70a8ab"
 dependencies = [
  "cpufeatures",
  "ring",
- "sha2 0.10.9",
+ "sha2",
+]
+
+[[package]]
+name = "ethereum_hashing"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aa93f58bb1eb3d1e556e4f408ef1dac130bad01ac37db4e7ade45de40d1c86a"
+dependencies = [
+ "cpufeatures",
+ "ring",
+ "sha2",
 ]
 
 [[package]]
@@ -3045,13 +3011,14 @@ dependencies = [
 
 [[package]]
 name = "ethereum_ssz"
-version = "0.9.1"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dcddb2554d19cde19b099fadddde576929d7a4d0c1cd3512d1fd95cf174375c"
+checksum = "2128a84f7a3850d54ee343334e3392cca61f9f6aa9441eec481b9394b43c238b"
 dependencies = [
  "alloy-primitives 1.5.2",
+ "context_deserialize",
  "ethereum_serde_utils 0.8.0",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "serde",
  "serde_derive",
  "smallvec",
@@ -3060,11 +3027,11 @@ dependencies = [
 
 [[package]]
 name = "ethereum_ssz_derive"
-version = "0.9.1"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a657b6b3b7e153637dc6bdc6566ad9279d9ee11a15b12cfb24a2e04360637e9f"
+checksum = "cd596f91cff004fc8d02be44c21c0f9b93140a04b66027ae052f5f8e05b48eba"
 dependencies = [
- "darling 0.20.11",
+ "darling 0.23.0",
  "proc-macro2",
  "quote",
  "syn 2.0.112",
@@ -3094,17 +3061,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
 dependencies = [
  "event-listener 5.4.1",
- "pin-project-lite",
-]
-
-[[package]]
-name = "eventsource-stream"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74fef4569247a5f429d9156b9d0a2599914385dd189c539334c625d8099d90ab"
-dependencies = [
- "futures-core",
- "nom",
  "pin-project-lite",
 ]
 
@@ -3188,7 +3144,7 @@ dependencies = [
 [[package]]
 name = "filesystem"
 version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?rev=e3ee7feb#e3ee7febce64c1b5a85c3ab0be0619571ee92d58"
+source = "git+https://github.com/sigp/lighthouse?rev=58b153cac#58b153cac5a078d849bf8478bd21baedfe98d9ee"
 dependencies = [
  "winapi",
  "windows-acl",
@@ -3215,7 +3171,7 @@ dependencies = [
 [[package]]
 name = "fixed_bytes"
 version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?rev=e3ee7feb#e3ee7febce64c1b5a85c3ab0be0619571ee92d58"
+source = "git+https://github.com/sigp/lighthouse?rev=58b153cac#58b153cac5a078d849bf8478bd21baedfe98d9ee"
 dependencies = [
  "alloy-primitives 1.5.2",
  "safe_arith",
@@ -3228,6 +3184,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfe33edd8e85a12a67454e37f8c75e730830d83e313556ab9ebf9ee7fbeb3bfb"
 dependencies = [
  "crc32fast",
+ "libz-rs-sys",
  "miniz_oxide",
 ]
 
@@ -3387,7 +3344,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f2f12607f92c69b12ed746fabf9ca4f5c482cba46679c1a75b874ed7c26adb"
 dependencies = [
  "futures-io",
- "rustls 0.23.35",
+ "rustls",
  "rustls-pki-types",
 ]
 
@@ -3522,7 +3479,7 @@ dependencies = [
 [[package]]
 name = "graffiti_file"
 version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?rev=e3ee7feb#e3ee7febce64c1b5a85c3ab0be0619571ee92d58"
+source = "git+https://github.com/sigp/lighthouse?rev=58b153cac#58b153cac5a078d849bf8478bd21baedfe98d9ee"
 dependencies = [
  "bls",
  "serde",
@@ -3545,25 +3502,6 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0beca50380b1fc32983fc1cb4587bfa4bb9e78fc259aad4a0032d2080309222d"
-dependencies = [
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "futures-util",
- "http 0.2.12",
- "indexmap 2.12.1",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
-name = "h2"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3c0b69cfcb4e1b9f1bf2f53f95f766e4661169728ec61cd3fe5a0166f2d1386"
@@ -3573,7 +3511,7 @@ dependencies = [
  "fnv",
  "futures-core",
  "futures-sink",
- "http 1.4.0",
+ "http",
  "indexmap 2.12.1",
  "slab",
  "tokio",
@@ -3652,7 +3590,7 @@ dependencies = [
 [[package]]
 name = "health_metrics"
 version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?rev=e3ee7feb#e3ee7febce64c1b5a85c3ab0be0619571ee92d58"
+source = "git+https://github.com/sigp/lighthouse?rev=58b153cac#58b153cac5a078d849bf8478bd21baedfe98d9ee"
 dependencies = [
  "eth2",
  "metrics",
@@ -3662,21 +3600,9 @@ dependencies = [
 
 [[package]]
 name = "heck"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
-
-[[package]]
-name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
-
-[[package]]
-name = "hermit-abi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
 name = "hermit-abi"
@@ -3758,17 +3684,7 @@ version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
 dependencies = [
- "hmac 0.12.1",
-]
-
-[[package]]
-name = "hmac"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a2a2320eb7ec0ebe8da8f744d7812d9fc4cb4d09344ac01898dbcb6a20ae69b"
-dependencies = [
- "crypto-mac",
- "digest 0.9.0",
+ "hmac",
 ]
 
 [[package]]
@@ -3778,17 +3694,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest 0.10.7",
-]
-
-[[package]]
-name = "http"
-version = "0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
-dependencies = [
- "bytes",
- "fnv",
- "itoa",
 ]
 
 [[package]]
@@ -3803,23 +3708,12 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
-dependencies = [
- "bytes",
- "http 0.2.12",
- "pin-project-lite",
-]
-
-[[package]]
-name = "http-body"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http 1.4.0",
+ "http",
 ]
 
 [[package]]
@@ -3830,8 +3724,8 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.4.0",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "pin-project-lite",
 ]
 
@@ -3893,30 +3787,6 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
-version = "0.14.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
-dependencies = [
- "bytes",
- "futures-channel",
- "futures-core",
- "futures-util",
- "h2 0.3.27",
- "http 0.2.12",
- "http-body 0.4.6",
- "httparse",
- "httpdate",
- "itoa",
- "pin-project-lite",
- "socket2 0.5.10",
- "tokio",
- "tower-service",
- "tracing",
- "want",
-]
-
-[[package]]
-name = "hyper"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
@@ -3925,9 +3795,9 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2 0.4.12",
- "http 1.4.0",
- "http-body 1.0.1",
+ "h2",
+ "http",
+ "http-body",
  "httparse",
  "httpdate",
  "itoa",
@@ -3940,46 +3810,19 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.24.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
-dependencies = [
- "futures-util",
- "http 0.2.12",
- "hyper 0.14.32",
- "rustls 0.21.12",
- "tokio",
- "tokio-rustls 0.24.1",
-]
-
-[[package]]
-name = "hyper-rustls"
 version = "0.27.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
 dependencies = [
- "http 1.4.0",
- "hyper 1.8.1",
+ "http",
+ "hyper",
  "hyper-util",
- "rustls 0.23.35",
+ "rustls",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tower-service",
  "webpki-roots 1.0.5",
-]
-
-[[package]]
-name = "hyper-tls"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
-dependencies = [
- "bytes",
- "hyper 0.14.32",
- "native-tls",
- "tokio",
- "tokio-native-tls",
 ]
 
 [[package]]
@@ -3990,7 +3833,7 @@ checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
 dependencies = [
  "bytes",
  "http-body-util",
- "hyper 1.8.1",
+ "hyper",
  "hyper-util",
  "native-tls",
  "tokio",
@@ -4004,20 +3847,20 @@ version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "727805d60e7938b76b826a6ef209eb70eaa1812794f9424d4a4e2d740662df5f"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "bytes",
  "futures-channel",
  "futures-core",
  "futures-util",
- "http 1.4.0",
- "http-body 1.0.1",
- "hyper 1.8.1",
+ "http",
+ "http-body",
+ "hyper",
  "ipnet",
  "libc",
  "percent-encoding",
  "pin-project-lite",
  "socket2 0.6.1",
- "system-configuration 0.6.1",
+ "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
@@ -4184,7 +4027,7 @@ dependencies = [
  "netlink-proto",
  "netlink-sys",
  "rtnetlink",
- "system-configuration 0.6.1",
+ "system-configuration",
  "tokio",
  "windows",
 ]
@@ -4199,9 +4042,9 @@ dependencies = [
  "attohttpc",
  "bytes",
  "futures",
- "http 1.4.0",
+ "http",
  "http-body-util",
- "hyper 1.8.1",
+ "hyper",
  "hyper-util",
  "log",
  "rand 0.9.2",
@@ -4265,20 +4108,9 @@ dependencies = [
 [[package]]
 name = "int_to_bytes"
 version = "0.2.0"
-source = "git+https://github.com/sigp/lighthouse?rev=e3ee7feb#e3ee7febce64c1b5a85c3ab0be0619571ee92d58"
+source = "git+https://github.com/sigp/lighthouse?rev=58b153cac#58b153cac5a078d849bf8478bd21baedfe98d9ee"
 dependencies = [
  "bytes",
-]
-
-[[package]]
-name = "io-lifetimes"
-version = "1.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
-dependencies = [
- "hermit-abi 0.3.9",
- "libc",
- "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -4349,16 +4181,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
-name = "jobserver"
-version = "0.1.34"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
-dependencies = [
- "getrandom 0.3.4",
- "libc",
-]
-
-[[package]]
 name = "js-sys"
 version = "0.3.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4379,7 +4201,7 @@ dependencies = [
  "elliptic-curve",
  "once_cell",
  "serdect",
- "sha2 0.10.9",
+ "sha2",
  "signature",
 ]
 
@@ -4406,7 +4228,7 @@ dependencies = [
 name = "keygen"
 version = "1.2.0"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "clap",
  "global_config",
  "openssl",
@@ -4424,7 +4246,8 @@ name = "keysplit"
 version = "1.2.0"
 dependencies = [
  "alloy",
- "base64 0.22.1",
+ "base64",
+ "bls",
  "bls_lagrange",
  "chrono",
  "clap",
@@ -4450,12 +4273,12 @@ dependencies = [
 [[package]]
 name = "kzg"
 version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?rev=e3ee7feb#e3ee7febce64c1b5a85c3ab0be0619571ee92d58"
+source = "git+https://github.com/sigp/lighthouse?rev=58b153cac#58b153cac5a078d849bf8478bd21baedfe98d9ee"
 dependencies = [
  "arbitrary",
  "c-kzg",
- "derivative",
- "ethereum_hashing",
+ "educe",
+ "ethereum_hashing 0.8.0",
  "ethereum_serde_utils 0.8.0",
  "ethereum_ssz",
  "ethereum_ssz_derive",
@@ -4588,11 +4411,11 @@ dependencies = [
 [[package]]
 name = "libp2p-gossipsub"
 version = "0.50.0"
-source = "git+https://github.com/sigp/rust-libp2p.git?rev=fabf27f#fabf27f2021ba582d9b0d1c15ca47babef453497"
+source = "git+https://github.com/sigp/rust-libp2p.git?rev=5acdf89a65d64098f9346efa5769e57bcd19dea9#5acdf89a65d64098f9346efa5769e57bcd19dea9"
 dependencies = [
  "async-channel 2.5.0",
  "asynchronous-codec",
- "base64 0.22.1",
+ "base64",
  "byteorder",
  "bytes",
  "either",
@@ -4610,7 +4433,7 @@ dependencies = [
  "quick-protobuf-codec",
  "rand 0.8.5",
  "regex",
- "sha2 0.10.9",
+ "sha2",
  "tracing",
  "web-time",
 ]
@@ -4650,7 +4473,7 @@ dependencies = [
  "multihash",
  "quick-protobuf",
  "rand 0.8.5",
- "sha2 0.10.9",
+ "sha2",
  "thiserror 2.0.17",
  "tracing",
  "zeroize",
@@ -4772,7 +4595,7 @@ dependencies = [
  "quinn",
  "rand 0.8.5",
  "ring",
- "rustls 0.23.35",
+ "rustls",
  "socket2 0.5.10",
  "thiserror 2.0.17",
  "tokio",
@@ -4824,7 +4647,7 @@ version = "0.35.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd297cf53f0cb3dee4d2620bb319ae47ef27c702684309f682bdb7e55a18ae9c"
 dependencies = [
- "heck 0.5.0",
+ "heck",
  "quote",
  "syn 2.0.112",
 ]
@@ -4875,8 +4698,8 @@ dependencies = [
  "libp2p-identity",
  "rcgen",
  "ring",
- "rustls 0.23.35",
- "rustls-webpki 0.103.8",
+ "rustls",
+ "rustls-webpki",
  "thiserror 2.0.17",
  "x509-parser",
  "yasna",
@@ -4934,10 +4757,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "linux-raw-sys"
-version = "0.1.4"
+name = "libz-rs-sys"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
+checksum = "c10501e7805cee23da17c7790e59df2870c0d4043ec6d03f67d31e2b53e77415"
+dependencies = [
+ "zlib-rs",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -4986,7 +4812,7 @@ dependencies = [
 [[package]]
 name = "logging"
 version = "0.2.0"
-source = "git+https://github.com/sigp/lighthouse?rev=e3ee7feb#e3ee7febce64c1b5a85c3ab0be0619571ee92d58"
+source = "git+https://github.com/sigp/lighthouse?rev=58b153cac#58b153cac5a078d849bf8478bd21baedfe98d9ee"
 dependencies = [
  "chrono",
  "logroller",
@@ -5050,7 +4876,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 [[package]]
 name = "lru_cache"
 version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?rev=e3ee7feb#e3ee7febce64c1b5a85c3ab0be0619571ee92d58"
+source = "git+https://github.com/sigp/lighthouse?rev=58b153cac#58b153cac5a078d849bf8478bd21baedfe98d9ee"
 dependencies = [
  "fnv",
 ]
@@ -5131,10 +4957,10 @@ dependencies = [
 [[package]]
 name = "merkle_proof"
 version = "0.2.0"
-source = "git+https://github.com/sigp/lighthouse?rev=e3ee7feb#e3ee7febce64c1b5a85c3ab0be0619571ee92d58"
+source = "git+https://github.com/sigp/lighthouse?rev=58b153cac#58b153cac5a078d849bf8478bd21baedfe98d9ee"
 dependencies = [
  "alloy-primitives 1.5.2",
- "ethereum_hashing",
+ "ethereum_hashing 0.8.0",
  "fixed_bytes",
  "safe_arith",
 ]
@@ -5194,7 +5020,7 @@ dependencies = [
  "parking_lot",
  "processor",
  "safe_arith",
- "sha2 0.10.9",
+ "sha2",
  "slot_clock",
  "ssv_types",
  "task_executor",
@@ -5231,20 +5057,21 @@ dependencies = [
 [[package]]
 name = "metrics"
 version = "0.2.0"
-source = "git+https://github.com/sigp/lighthouse?rev=e3ee7feb#e3ee7febce64c1b5a85c3ab0be0619571ee92d58"
+source = "git+https://github.com/sigp/lighthouse?rev=58b153cac#58b153cac5a078d849bf8478bd21baedfe98d9ee"
 dependencies = [
  "prometheus",
 ]
 
 [[package]]
 name = "milhouse"
-version = "0.7.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bdb104e38d3a8c5ffb7e9d2c43c522e6bcc34070edbadba565e722f0dee56c7"
+checksum = "259dd9da2ae5e0278b95da0b7ecef9c18c309d0a2d9e6db57ed33b9e8910c5e7"
 dependencies = [
  "alloy-primitives 1.5.2",
+ "context_deserialize",
  "educe",
- "ethereum_hashing",
+ "ethereum_hashing 0.8.0",
  "ethereum_ssz",
  "ethereum_ssz_derive",
  "itertools 0.13.0",
@@ -5482,6 +5309,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "twox-hash",
+ "typenum",
  "types",
  "version",
 ]
@@ -5489,7 +5317,7 @@ dependencies = [
 [[package]]
 name = "network_utils"
 version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?rev=e3ee7feb#e3ee7febce64c1b5a85c3ab0be0619571ee92d58"
+source = "git+https://github.com/sigp/lighthouse?rev=58b153cac#58b153cac5a078d849bf8478bd21baedfe98d9ee"
 dependencies = [
  "discv5",
  "libp2p-identity",
@@ -5623,7 +5451,7 @@ version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
 dependencies = [
- "hermit-abi 0.5.2",
+ "hermit-abi",
  "libc",
 ]
 
@@ -5768,7 +5596,7 @@ dependencies = [
 name = "operator_key"
 version = "0.1.0"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "eth2_keystore",
  "openssl",
  "rand 0.9.2",
@@ -5851,17 +5679,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "password-hash"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7676374caaee8a325c9e7a2ae557f216c5563a171d6997b0ef8a65af35147700"
-dependencies = [
- "base64ct",
- "rand_core 0.6.4",
- "subtle",
-]
-
-[[package]]
 name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5869,23 +5686,12 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pbkdf2"
-version = "0.8.0"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d95f5254224e617595d2cc3cc73ff0a5eaf2637519e25f03388154e9378b6ffa"
-dependencies = [
- "crypto-mac",
-]
-
-[[package]]
-name = "pbkdf2"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
+checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
 dependencies = [
  "digest 0.10.7",
- "hmac 0.12.1",
- "password-hash",
- "sha2 0.10.9",
+ "hmac",
 ]
 
 [[package]]
@@ -5894,7 +5700,7 @@ version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "serde_core",
 ]
 
@@ -5986,9 +5792,9 @@ checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
 dependencies = [
  "cfg-if",
  "concurrent-queue",
- "hermit-abi 0.5.2",
+ "hermit-abi",
  "pin-project-lite",
- "rustix 1.1.3",
+ "rustix",
  "windows-sys 0.61.2",
 ]
 
@@ -6078,9 +5884,9 @@ dependencies = [
 [[package]]
 name = "pretty_reqwest_error"
 version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?rev=e3ee7feb#e3ee7febce64c1b5a85c3ab0be0619571ee92d58"
+source = "git+https://github.com/sigp/lighthouse?rev=58b153cac#58b153cac5a078d849bf8478bd21baedfe98d9ee"
 dependencies = [
- "reqwest 0.11.27",
+ "reqwest",
  "sensitive_url",
 ]
 
@@ -6152,17 +5958,23 @@ dependencies = [
 
 [[package]]
 name = "procfs"
-version = "0.15.1"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "943ca7f9f29bab5844ecd8fdb3992c5969b6622bb9609b9502fef9b4310e3f1f"
+checksum = "25485360a54d6861439d60facef26de713b1e126bf015ec8f98239467a2b82f7"
 dependencies = [
- "bitflags 1.3.2",
- "byteorder",
- "chrono",
- "flate2",
+ "bitflags 2.10.0",
+ "procfs-core",
+ "rustix",
+]
+
+[[package]]
+name = "procfs-core"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6401bf7b6af22f78b563665d15a22e9aef27775b79b149a66ca022468a4e405"
+dependencies = [
+ "bitflags 2.10.0",
  "hex",
- "lazy_static",
- "rustix 0.36.17",
 ]
 
 [[package]]
@@ -6224,10 +6036,11 @@ dependencies = [
 [[package]]
 name = "proto_array"
 version = "0.2.0"
-source = "git+https://github.com/sigp/lighthouse?rev=e3ee7feb#e3ee7febce64c1b5a85c3ab0be0619571ee92d58"
+source = "git+https://github.com/sigp/lighthouse?rev=58b153cac#58b153cac5a078d849bf8478bd21baedfe98d9ee"
 dependencies = [
  "ethereum_ssz",
  "ethereum_ssz_derive",
+ "fixed_bytes",
  "safe_arith",
  "serde",
  "serde_yaml",
@@ -6264,7 +6077,7 @@ dependencies = [
  "ethereum_ssz_derive",
  "hex",
  "indexmap 2.12.1",
- "sha2 0.10.9",
+ "sha2",
  "ssv_types",
  "tracing",
  "tracing-subscriber",
@@ -6277,6 +6090,7 @@ name = "qbft_manager"
 version = "0.1.0"
 dependencies = [
  "async-channel 1.9.0",
+ "bls",
  "dashmap",
  "database",
  "ethereum_ssz",
@@ -6334,7 +6148,7 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash",
- "rustls 0.23.35",
+ "rustls",
  "socket2 0.6.1",
  "thiserror 2.0.17",
  "tokio",
@@ -6354,7 +6168,7 @@ dependencies = [
  "rand 0.9.2",
  "ring",
  "rustc-hash",
- "rustls 0.23.35",
+ "rustls",
  "rustls-pki-types",
  "slab",
  "thiserror 2.0.17",
@@ -6612,67 +6426,23 @@ checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
 name = "reqwest"
-version = "0.11.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
-dependencies = [
- "base64 0.21.7",
- "bytes",
- "encoding_rs",
- "futures-core",
- "futures-util",
- "h2 0.3.27",
- "http 0.2.12",
- "http-body 0.4.6",
- "hyper 0.14.32",
- "hyper-rustls 0.24.2",
- "hyper-tls 0.5.0",
- "ipnet",
- "js-sys",
- "log",
- "mime",
- "native-tls",
- "once_cell",
- "percent-encoding",
- "pin-project-lite",
- "rustls 0.21.12",
- "rustls-pemfile",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "sync_wrapper 0.1.2",
- "system-configuration 0.5.1",
- "tokio",
- "tokio-native-tls",
- "tokio-rustls 0.24.1",
- "tokio-util",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "wasm-streams",
- "web-sys",
- "webpki-roots 0.25.4",
- "winreg",
-]
-
-[[package]]
-name = "reqwest"
 version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "bytes",
  "encoding_rs",
+ "futures-channel",
  "futures-core",
- "h2 0.4.12",
- "http 1.4.0",
- "http-body 1.0.1",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
  "http-body-util",
- "hyper 1.8.1",
- "hyper-rustls 0.27.7",
- "hyper-tls 0.6.0",
+ "hyper",
+ "hyper-rustls",
+ "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
@@ -6681,39 +6451,25 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.35",
+ "rustls",
  "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "tokio",
  "tokio-native-tls",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
+ "tokio-util",
  "tower",
  "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
  "webpki-roots 1.0.5",
-]
-
-[[package]]
-name = "reqwest-eventsource"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f529a5ff327743addc322af460761dff5b50e0c826b9e6ac44c3195c50bb2026"
-dependencies = [
- "eventsource-stream",
- "futures-core",
- "futures-timer",
- "mime",
- "nom",
- "pin-project-lite",
- "reqwest 0.11.27",
- "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -6728,7 +6484,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
 dependencies = [
- "hmac 0.12.1",
+ "hmac",
  "subtle",
 ]
 
@@ -6910,20 +6666,6 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.36.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "305efbd14fde4139eb501df5f136994bb520b033fa9fbdce287507dc23b8c7ed"
-dependencies = [
- "bitflags 1.3.2",
- "errno",
- "io-lifetimes",
- "libc",
- "linux-raw-sys 0.1.4",
- "windows-sys 0.45.0",
-]
-
-[[package]]
-name = "rustix"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
@@ -6931,20 +6673,8 @@ dependencies = [
  "bitflags 2.10.0",
  "errno",
  "libc",
- "linux-raw-sys 0.11.0",
+ "linux-raw-sys",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "rustls"
-version = "0.21.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
-dependencies = [
- "log",
- "ring",
- "rustls-webpki 0.101.7",
- "sct",
 ]
 
 [[package]]
@@ -6956,18 +6686,9 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.8",
+ "rustls-webpki",
  "subtle",
  "zeroize",
-]
-
-[[package]]
-name = "rustls-pemfile"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
-dependencies = [
- "base64 0.21.7",
 ]
 
 [[package]]
@@ -6978,16 +6699,6 @@ checksum = "21e6f2ab2928ca4291b86736a8bd920a277a399bba1589409d72154ff87c1282"
 dependencies = [
  "web-time",
  "zeroize",
-]
-
-[[package]]
-name = "rustls-webpki"
-version = "0.101.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
-dependencies = [
- "ring",
- "untrusted",
 ]
 
 [[package]]
@@ -7044,11 +6755,11 @@ checksum = "b147bb6111014916d3ef9d4c85173124a8e12193a67f6176d67244afd558d6c1"
 
 [[package]]
 name = "salsa20"
-version = "0.8.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecbd2eb639fd7cab5804a0837fe373cc2172d15437e804c054a9fb885cb923b0"
+checksum = "97a22f5af31f73a954c10289c93e8a50cc23d971e80ee446f1f6f7137a088213"
 dependencies = [
- "cipher 0.3.0",
+ "cipher",
 ]
 
 [[package]]
@@ -7101,24 +6812,13 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "scrypt"
-version = "0.7.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "879588d8f90906e73302547e20fffefdd240eb3e0e744e142321f5d49dea0518"
+checksum = "0516a385866c09368f0b5bcd1caff3366aace790fcd46e2bb032697bb172fd1f"
 dependencies = [
- "hmac 0.11.0",
- "pbkdf2 0.8.0",
+ "pbkdf2",
  "salsa20",
- "sha2 0.9.9",
-]
-
-[[package]]
-name = "sct"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
-dependencies = [
- "ring",
- "untrusted",
+ "sha2",
 ]
 
 [[package]]
@@ -7217,7 +6917,8 @@ checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
 [[package]]
 name = "sensitive_url"
 version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?rev=e3ee7feb#e3ee7febce64c1b5a85c3ab0be0619571ee92d58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb7b0221fa9905eec4163dbf7660b1876cc95663af1deddc3e19ebe49167c58c"
 dependencies = [
  "serde",
  "url",
@@ -7306,7 +7007,7 @@ version = "3.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fa237f2807440d238e0364a218270b98f767a00d3dada77b1c53ae88940e2e7"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "chrono",
  "hex",
  "indexmap 1.9.3",
@@ -7363,19 +7064,6 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest 0.10.7",
-]
-
-[[package]]
-name = "sha2"
-version = "0.9.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
-dependencies = [
- "block-buffer 0.9.0",
- "cfg-if",
- "cpufeatures",
- "digest 0.9.0",
- "opaque-debug",
 ]
 
 [[package]]
@@ -7448,6 +7136,7 @@ dependencies = [
 name = "signature_collector"
 version = "0.1.0"
 dependencies = [
+ "bls",
  "bls_lagrange",
  "dashmap",
  "database",
@@ -7476,12 +7165,14 @@ checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
 [[package]]
 name = "slashing_protection"
 version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?rev=e3ee7feb#e3ee7febce64c1b5a85c3ab0be0619571ee92d58"
+source = "git+https://github.com/sigp/lighthouse?rev=58b153cac#58b153cac5a078d849bf8478bd21baedfe98d9ee"
 dependencies = [
  "arbitrary",
+ "bls",
  "eip_3076",
  "ethereum_serde_utils 0.8.0",
  "filesystem",
+ "fixed_bytes",
  "r2d2",
  "r2d2_sqlite",
  "rusqlite",
@@ -7495,7 +7186,7 @@ dependencies = [
 [[package]]
 name = "slot_clock"
 version = "0.2.0"
-source = "git+https://github.com/sigp/lighthouse?rev=e3ee7feb#e3ee7febce64c1b5a85c3ab0be0619571ee92d58"
+source = "git+https://github.com/sigp/lighthouse?rev=58b153cac#58b153cac5a078d849bf8478bd21baedfe98d9ee"
 dependencies = [
  "metrics",
  "parking_lot",
@@ -7525,7 +7216,7 @@ dependencies = [
  "rand_core 0.6.4",
  "ring",
  "rustc_version 0.4.1",
- "sha2 0.10.9",
+ "sha2",
  "subtle",
 ]
 
@@ -7585,7 +7276,8 @@ name = "ssv_types"
 version = "0.1.0"
 dependencies = [
  "arbitrary",
- "base64 0.22.1",
+ "base64",
+ "bls",
  "derive_more 2.1.1",
  "eth2",
  "ethereum_ssz",
@@ -7598,10 +7290,10 @@ dependencies = [
  "rusqlite",
  "serde",
  "serde_json",
- "sha2 0.10.9",
+ "sha2",
  "slashing_protection",
  "ssz_types",
- "strum 0.27.2",
+ "strum",
  "thiserror 2.0.17",
  "tracing",
  "tree_hash",
@@ -7613,13 +7305,15 @@ dependencies = [
 
 [[package]]
 name = "ssz_types"
-version = "0.11.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75b55bedc9a18ed2860a46d6beb4f4082416ee1d60be0cc364cebdcdddc7afd4"
+checksum = "1fc20a89bab2dabeee65e9c9eb96892dc222c23254b401e1319b85efd852fa31"
 dependencies = [
+ "context_deserialize",
+ "educe",
  "ethereum_serde_utils 0.8.0",
  "ethereum_ssz",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "serde",
  "serde_derive",
  "smallvec",
@@ -7653,33 +7347,11 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
-version = "0.24.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
-dependencies = [
- "strum_macros 0.24.3",
-]
-
-[[package]]
-name = "strum"
 version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
 dependencies = [
- "strum_macros 0.27.2",
-]
-
-[[package]]
-name = "strum_macros"
-version = "0.24.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
-dependencies = [
- "heck 0.4.1",
- "proc-macro2",
- "quote",
- "rustversion",
- "syn 1.0.109",
+ "strum_macros",
 ]
 
 [[package]]
@@ -7688,7 +7360,7 @@ version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
 dependencies = [
- "heck 0.5.0",
+ "heck",
  "proc-macro2",
  "quote",
  "syn 2.0.112",
@@ -7702,12 +7374,13 @@ dependencies = [
  "database",
  "ethereum_serde_utils 0.7.0",
  "serde",
- "sha2 0.10.9",
+ "sha2",
  "slot_clock",
  "ssv_types",
  "task_executor",
  "tokio",
  "tracing",
+ "typenum",
  "types",
 ]
 
@@ -7734,10 +7407,10 @@ dependencies = [
 [[package]]
 name = "swap_or_not_shuffle"
 version = "0.2.0"
-source = "git+https://github.com/sigp/lighthouse?rev=e3ee7feb#e3ee7febce64c1b5a85c3ab0be0619571ee92d58"
+source = "git+https://github.com/sigp/lighthouse?rev=58b153cac#58b153cac5a078d849bf8478bd21baedfe98d9ee"
 dependencies = [
  "alloy-primitives 1.5.2",
- "ethereum_hashing",
+ "ethereum_hashing 0.8.0",
  "fixed_bytes",
 ]
 
@@ -7777,12 +7450,6 @@ dependencies = [
 
 [[package]]
 name = "sync_wrapper"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
-
-[[package]]
-name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
@@ -7803,34 +7470,13 @@ dependencies = [
 
 [[package]]
 name = "system-configuration"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
-dependencies = [
- "bitflags 1.3.2",
- "core-foundation",
- "system-configuration-sys 0.5.0",
-]
-
-[[package]]
-name = "system-configuration"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
 dependencies = [
  "bitflags 2.10.0",
  "core-foundation",
- "system-configuration-sys 0.6.0",
-]
-
-[[package]]
-name = "system-configuration-sys"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
-dependencies = [
- "core-foundation-sys",
- "libc",
+ "system-configuration-sys",
 ]
 
 [[package]]
@@ -7864,7 +7510,7 @@ checksum = "c63f48baada5c52e65a29eef93ab4f8982681b67f9e8d29c7b05abcfec2b9ffe"
 [[package]]
 name = "task_executor"
 version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?rev=e3ee7feb#e3ee7febce64c1b5a85c3ab0be0619571ee92d58"
+source = "git+https://github.com/sigp/lighthouse?rev=58b153cac#58b153cac5a078d849bf8478bd21baedfe98d9ee"
 dependencies = [
  "async-channel 1.9.0",
  "futures",
@@ -7884,7 +7530,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.3.4",
  "once_cell",
- "rustix 1.1.3",
+ "rustix",
  "windows-sys 0.61.2",
 ]
 
@@ -7894,7 +7540,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60b8cb979cb11c32ce1603f8137b22262a9d131aaa5c37b5678025f22b8becd0"
 dependencies = [
- "rustix 1.1.3",
+ "rustix",
  "windows-sys 0.60.2",
 ]
 
@@ -7907,10 +7553,10 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 [[package]]
 name = "test_random_derive"
 version = "0.2.0"
-source = "git+https://github.com/sigp/lighthouse?rev=e3ee7feb#e3ee7febce64c1b5a85c3ab0be0619571ee92d58"
+source = "git+https://github.com/sigp/lighthouse?rev=58b153cac#58b153cac5a078d849bf8478bd21baedfe98d9ee"
 dependencies = [
  "quote",
- "syn 1.0.109",
+ "syn 2.0.112",
 ]
 
 [[package]]
@@ -8075,21 +7721,11 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.24.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
-dependencies = [
- "rustls 0.21.12",
- "tokio",
-]
-
-[[package]]
-name = "tokio-rustls"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
- "rustls 0.23.35",
+ "rustls",
  "tokio",
 ]
 
@@ -8113,10 +7749,10 @@ checksum = "7a9daff607c6d2bf6c16fd681ccb7eecc83e4e2cdc1ca067ffaadfca5de7f084"
 dependencies = [
  "futures-util",
  "log",
- "rustls 0.23.35",
+ "rustls",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tungstenite",
  "webpki-roots 0.26.11",
 ]
@@ -8174,7 +7810,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "pin-project-lite",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "tokio",
  "tower-layer",
  "tower-service",
@@ -8190,8 +7826,8 @@ dependencies = [
  "bitflags 2.10.0",
  "bytes",
  "futures-util",
- "http 1.4.0",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "iri-string",
  "pin-project-lite",
  "tower",
@@ -8300,12 +7936,12 @@ dependencies = [
 
 [[package]]
 name = "tree_hash"
-version = "0.10.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee44f4cef85f88b4dea21c0b1f58320bdf35715cf56d840969487cff00613321"
+checksum = "f7fd51aa83d2eb83b04570808430808b5d24fdbf479a4d5ac5dee4a2e2dd2be4"
 dependencies = [
  "alloy-primitives 1.5.2",
- "ethereum_hashing",
+ "ethereum_hashing 0.8.0",
  "ethereum_ssz",
  "smallvec",
  "typenum",
@@ -8313,11 +7949,11 @@ dependencies = [
 
 [[package]]
 name = "tree_hash_derive"
-version = "0.10.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bee2ea1551f90040ab0e34b6fb7f2fa3bad8acc925837ac654f2c78a13e3089"
+checksum = "8840ad4d852e325d3afa7fde8a50b2412f89dce47d7eb291c0cc7f87cd040f38"
 dependencies = [
- "darling 0.20.11",
+ "darling 0.23.0",
  "proc-macro2",
  "quote",
  "syn 2.0.112",
@@ -8347,11 +7983,11 @@ checksum = "4793cb5e56680ecbb1d843515b23b6de9a75eb04b66643e256a396d43be33c13"
 dependencies = [
  "bytes",
  "data-encoding",
- "http 1.4.0",
+ "http",
  "httparse",
  "log",
  "rand 0.9.2",
- "rustls 0.23.35",
+ "rustls",
  "rustls-pki-types",
  "sha1",
  "thiserror 2.0.17",
@@ -8376,17 +8012,16 @@ checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 [[package]]
 name = "types"
 version = "0.2.1"
-source = "git+https://github.com/sigp/lighthouse?rev=e3ee7feb#e3ee7febce64c1b5a85c3ab0be0619571ee92d58"
+source = "git+https://github.com/sigp/lighthouse?rev=58b153cac#58b153cac5a078d849bf8478bd21baedfe98d9ee"
 dependencies = [
  "alloy-primitives 1.5.2",
  "alloy-rlp",
  "bls",
  "compare_fields",
- "compare_fields_derive",
  "context_deserialize",
- "derivative",
+ "educe",
  "eth2_interop_keypairs",
- "ethereum_hashing",
+ "ethereum_hashing 0.8.0",
  "ethereum_serde_utils 0.8.0",
  "ethereum_ssz",
  "ethereum_ssz_derive",
@@ -8419,6 +8054,7 @@ dependencies = [
  "tracing",
  "tree_hash",
  "tree_hash_derive",
+ "typenum",
 ]
 
 [[package]]
@@ -8578,7 +8214,7 @@ dependencies = [
 [[package]]
 name = "validator_metrics"
 version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?rev=e3ee7feb#e3ee7febce64c1b5a85c3ab0be0619571ee92d58"
+source = "git+https://github.com/sigp/lighthouse?rev=58b153cac#58b153cac5a078d849bf8478bd21baedfe98d9ee"
 dependencies = [
  "metrics",
 ]
@@ -8586,7 +8222,7 @@ dependencies = [
 [[package]]
 name = "validator_services"
 version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?rev=e3ee7feb#e3ee7febce64c1b5a85c3ab0be0619571ee92d58"
+source = "git+https://github.com/sigp/lighthouse?rev=58b153cac#58b153cac5a078d849bf8478bd21baedfe98d9ee"
 dependencies = [
  "beacon_node_fallback",
  "bls",
@@ -8610,8 +8246,9 @@ dependencies = [
 [[package]]
 name = "validator_store"
 version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?rev=e3ee7feb#e3ee7febce64c1b5a85c3ab0be0619571ee92d58"
+source = "git+https://github.com/sigp/lighthouse?rev=58b153cac#58b153cac5a078d849bf8478bd21baedfe98d9ee"
 dependencies = [
+ "bls",
  "eth2",
  "slashing_protection",
  "types",
@@ -8790,12 +8427,6 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.25.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
-
-[[package]]
-name = "webpki-roots"
 version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
@@ -8959,15 +8590,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.45.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
-dependencies = [
- "windows-targets 0.42.2",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
@@ -9009,21 +8631,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
-dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -9076,12 +8683,6 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
@@ -9100,12 +8701,6 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
@@ -9121,12 +8716,6 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -9160,12 +8749,6 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
@@ -9181,12 +8764,6 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -9208,12 +8785,6 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
@@ -9229,12 +8800,6 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -9282,7 +8847,7 @@ checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 [[package]]
 name = "workspace_members"
 version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?rev=e3ee7feb#e3ee7febce64c1b5a85c3ab0be0619571ee92d58"
+source = "git+https://github.com/sigp/lighthouse?rev=58b153cac#58b153cac5a078d849bf8478bd21baedfe98d9ee"
 dependencies = [
  "cargo_metadata",
  "quote",
@@ -9526,23 +9091,23 @@ dependencies = [
 
 [[package]]
 name = "zip"
-version = "0.6.6"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "760394e246e4c28189f19d488c058bf16f564016aefac5d32bb1f3b51d5e9261"
+checksum = "eb2a05c7c36fde6c09b08576c9f7fb4cda705990f73b58fe011abf7dfb24168b"
 dependencies = [
- "aes 0.8.4",
- "byteorder",
- "bzip2",
- "constant_time_eq",
+ "arbitrary",
  "crc32fast",
- "crossbeam-utils",
  "flate2",
- "hmac 0.12.1",
- "pbkdf2 0.11.0",
- "sha1",
- "time",
- "zstd",
+ "indexmap 2.12.1",
+ "memchr",
+ "zopfli",
 ]
+
+[[package]]
+name = "zlib-rs"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40990edd51aae2c2b6907af74ffb635029d5788228222c4bb811e9351c0caad3"
 
 [[package]]
 name = "zmij"
@@ -9551,30 +9116,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "317f17ff091ac4515f17cc7a190d2769a8c9a96d227de5d64b500b01cda8f2cd"
 
 [[package]]
-name = "zstd"
-version = "0.11.2+zstd.1.5.2"
+name = "zopfli"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20cc960326ece64f010d2d2107537f26dc589a6573a316bd5b1dba685fa5fde4"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
 dependencies = [
- "zstd-safe",
-]
-
-[[package]]
-name = "zstd-safe"
-version = "5.0.2+zstd.1.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d2a5585e04f9eea4b2a3d1eca508c4dee9592a89ef6f450c11719da0726f4db"
-dependencies = [
- "libc",
- "zstd-sys",
-]
-
-[[package]]
-name = "zstd-sys"
-version = "2.0.16+zstd.1.5.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
-dependencies = [
- "cc",
- "pkg-config",
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7145,6 +7145,7 @@ dependencies = [
  "processor",
  "slot_clock",
  "ssv_types",
+ "thiserror 2.0.17",
  "tokio",
  "tracing",
  "types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,7 +107,7 @@ derive_more = { version = "2.0.1", features = ["full"] }
 dirs = "6.0.0"
 discv5 = { version = "0.10", features = ["libp2p"] }
 enr = "0.13.0"
-ethereum_ssz = { version = "0.10.0", features = ["context_deserialize"] }
+ethereum_ssz = "0.10.0"
 ethereum_ssz_derive = "0.10.0"
 futures = "0.3.30"
 # Target sigp-gossipsub (Aug 20 2025) - matching Lighthouse
@@ -133,12 +133,12 @@ reqwest = "0.12.12"
 rpassword = "7.4.0"
 rusqlite = "0.28.0"
 safe_arith = "0.1.0"
-sensitive_url = { version = "0.1", features = ["serde"] }
+sensitive_url = "0.1"
 serde = { version = "1.0.208", features = ["derive"] }
 serde_json = "1.0.140"
 serde_yaml = "0.9"
 sha2 = "0.10.8"
-ssz_types = { version = "0.14.0", features = ["context_deserialize", "runtime_types"] }
+ssz_types = "0.14.0"
 strum = { version = "0.27.0", features = ["derive"] }
 thiserror = "2.0.11"
 tokio = { version = "1.39.2", features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,24 +68,23 @@ ssv_types = { path = "anchor/common/ssv_types" }
 subnet_service = { path = "anchor/subnet_service" }
 version = { path = "anchor/common/version" }
 
-# Lighthouse commit is `v8.0.0`
-beacon_node_fallback = { git = "https://github.com/sigp/lighthouse", rev = "e3ee7feb" }
-bls = { git = "https://github.com/sigp/lighthouse", rev = "e3ee7feb" }
-eth2 = { git = "https://github.com/sigp/lighthouse", rev = "e3ee7feb" }
-eth2_keystore = { git = "https://github.com/sigp/lighthouse", rev = "e3ee7feb" }
-eth2_network_config = { git = "https://github.com/sigp/lighthouse", rev = "e3ee7feb" }
-health_metrics = { git = "https://github.com/sigp/lighthouse", rev = "e3ee7feb" }
-metrics = { git = "https://github.com/sigp/lighthouse", rev = "e3ee7feb" }
-network_utils = { git = "https://github.com/sigp/lighthouse", rev = "e3ee7feb" }
-sensitive_url = { git = "https://github.com/sigp/lighthouse", rev = "e3ee7feb" }
-slashing_protection = { git = "https://github.com/sigp/lighthouse", rev = "e3ee7feb" }
-slot_clock = { git = "https://github.com/sigp/lighthouse", rev = "e3ee7feb" }
-task_executor = { git = "https://github.com/sigp/lighthouse", rev = "e3ee7feb" }
-types = { git = "https://github.com/sigp/lighthouse", rev = "e3ee7feb" }
-validator_metrics = { git = "https://github.com/sigp/lighthouse", rev = "e3ee7feb" }
-validator_services = { git = "https://github.com/sigp/lighthouse", rev = "e3ee7feb" }
-validator_store = { git = "https://github.com/sigp/lighthouse", rev = "e3ee7feb" }
-workspace_members = { git = "https://github.com/sigp/lighthouse", rev = "e3ee7feb" }
+# Lighthouse commit is unstable branch `58b153cac` as of 1/19/2026
+beacon_node_fallback = { git = "https://github.com/sigp/lighthouse", rev = "58b153cac" }
+bls = { git = "https://github.com/sigp/lighthouse", rev = "58b153cac" }
+eth2 = { git = "https://github.com/sigp/lighthouse", rev = "58b153cac" }
+eth2_keystore = { git = "https://github.com/sigp/lighthouse", rev = "58b153cac" }
+eth2_network_config = { git = "https://github.com/sigp/lighthouse", rev = "58b153cac" }
+health_metrics = { git = "https://github.com/sigp/lighthouse", rev = "58b153cac" }
+metrics = { git = "https://github.com/sigp/lighthouse", rev = "58b153cac" }
+network_utils = { git = "https://github.com/sigp/lighthouse", rev = "58b153cac" }
+slashing_protection = { git = "https://github.com/sigp/lighthouse", rev = "58b153cac" }
+slot_clock = { git = "https://github.com/sigp/lighthouse", rev = "58b153cac" }
+task_executor = { git = "https://github.com/sigp/lighthouse", rev = "58b153cac" }
+types = { git = "https://github.com/sigp/lighthouse", rev = "58b153cac" }
+validator_metrics = { git = "https://github.com/sigp/lighthouse", rev = "58b153cac" }
+validator_services = { git = "https://github.com/sigp/lighthouse", rev = "58b153cac" }
+validator_store = { git = "https://github.com/sigp/lighthouse", rev = "58b153cac" }
+workspace_members = { git = "https://github.com/sigp/lighthouse", rev = "58b153cac" }
 
 alloy = { version = "1.2.1", features = [
     "sol-types",
@@ -108,11 +107,11 @@ derive_more = { version = "2.0.1", features = ["full"] }
 dirs = "6.0.0"
 discv5 = { version = "0.10", features = ["libp2p"] }
 enr = "0.13.0"
-ethereum_ssz = "0.9"
-ethereum_ssz_derive = "0.9"
+ethereum_ssz = { version = "0.10.0", features = ["context_deserialize"] }
+ethereum_ssz_derive = "0.10.0"
 futures = "0.3.30"
-# Target sigp-gossipsub as of 2/10/25
-gossipsub = { package = "libp2p-gossipsub", git = "https://github.com/sigp/rust-libp2p.git", rev = "fabf27f", features = [
+# Target sigp-gossipsub (Aug 20 2025) - matching Lighthouse
+gossipsub = { package = "libp2p-gossipsub", git = "https://github.com/sigp/rust-libp2p.git", rev = "5acdf89a65d64098f9346efa5769e57bcd19dea9", features = [
     "metrics",
 ] }
 hex = "0.4.3"
@@ -134,11 +133,12 @@ reqwest = "0.12.12"
 rpassword = "7.4.0"
 rusqlite = "0.28.0"
 safe_arith = "0.1.0"
+sensitive_url = { version = "0.1", features = ["serde"] }
 serde = { version = "1.0.208", features = ["derive"] }
 serde_json = "1.0.140"
 serde_yaml = "0.9"
 sha2 = "0.10.8"
-ssz_types = "0.11.0"
+ssz_types = { version = "0.14.0", features = ["context_deserialize", "runtime_types"] }
 strum = { version = "0.27.0", features = ["derive"] }
 thiserror = "2.0.11"
 tokio = { version = "1.39.2", features = [
@@ -153,8 +153,8 @@ tower-http = { version = "0.6", features = ["cors"] }
 tracing = "0.1.40"
 tracing-appender = "0.2"
 tracing-subscriber = { version = "0.3.18", features = ["fmt", "env-filter"] }
-tree_hash = "0.10"
-tree_hash_derive = "0.10"
+tree_hash = "0.12.0"
+tree_hash_derive = "0.12.0"
 typenum = "1.18"
 zeroize = "1.8.1"
 

--- a/anchor/common/qbft/src/lib.rs
+++ b/anchor/common/qbft/src/lib.rs
@@ -22,8 +22,8 @@ use ssv_types::{
 };
 use ssz::{Decode, Encode};
 use tracing::{debug, error, warn};
-use typenum::U13;
-use types::{Hash256, Unsigned};
+use typenum::{U13, Unsigned};
+use types::Hash256;
 
 use crate::{error::QbftError, msg_container::MessageContainer};
 

--- a/anchor/common/qbft/src/tests.rs
+++ b/anchor/common/qbft/src/tests.rs
@@ -11,7 +11,7 @@ use std::{
 use qbft_types::DefaultLeaderFunction;
 use sha2::{Digest, Sha256};
 use ssv_types::{
-    OperatorId, RSA_SIGNATURE_SIZE,
+    OperatorId, RSA_SIGNATURE_SIZE, VariableList,
     consensus::{NoDataValidation, QbftMessageType},
     message::SignedSSVMessage,
 };
@@ -281,11 +281,12 @@ fn test_round_change_validation_skips_round_one_prepared_values() {
         qbft_message_type: QbftMessageType::RoundChange,
         height: 0,
         round: 2,
-        identifier: [0; 56].to_vec().into(),
+        identifier: VariableList::new([0; 56].to_vec()).unwrap(),
         root: test_data.hash(),
         data_round: 1, // Claims preparation in round 1 - this is the bug trigger!
-        round_change_justification: vec![].into(),
-        prepare_justification: vec![].into(), // INVALID: No justifications for claimed preparation!
+        round_change_justification: VariableList::new(vec![]).unwrap(),
+        prepare_justification: VariableList::new(vec![]).unwrap(), /* INVALID: No justifications
+                                                                    * for claimed preparation! */
     };
 
     // Create signed round change messages (need quorum of 3 for 3-node committee)
@@ -314,15 +315,18 @@ fn test_round_change_validation_skips_round_one_prepared_values() {
         qbft_message_type: QbftMessageType::Proposal,
         height: 0,
         round: 2,
-        identifier: [0; 56].to_vec().into(),
+        identifier: VariableList::new([0; 56].to_vec()).unwrap(),
         root: test_data.hash(),
         data_round: 1, // Proposing the "prepared" value from round 1
-        round_change_justification: signed_round_changes
-            .into_iter()
-            .map(|msg| msg.as_ssz_bytes().into())
-            .collect::<Vec<_>>()
-            .into(),
-        prepare_justification: vec![].into(), // Proposals don't need prepare justifications
+        round_change_justification: VariableList::new(
+            signed_round_changes
+                .into_iter()
+                .map(|msg| VariableList::new(msg.as_ssz_bytes()).unwrap())
+                .collect::<Vec<_>>(),
+        )
+        .unwrap(),
+        prepare_justification: VariableList::new(vec![]).unwrap(), /* Proposals don't need
+                                                                    * prepare justifications */
     };
 
     // Create the SSVMessage for the proposal
@@ -435,12 +439,14 @@ fn test_leader_waits_when_highest_prepared_data_missing() {
             qbft_message_type: QbftMessageType::RoundChange,
             height: 0,
             round: 2, // Moving to round 2
-            identifier: [0; 56].to_vec().into(),
+            identifier: VariableList::new([0; 56].to_vec()).unwrap(),
             root: prepared_hash, // Claims this hash was prepared
             data_round: 1,       // Claims preparation happened in round 1
-            round_change_justification: vec![].into(), // No RC justifications needed for this test
-            prepare_justification: vec![].into(), /* Should have prepare messages but we'll skip
-                                  * validation */
+            round_change_justification: VariableList::new(vec![]).unwrap(), /* No RC justifications needed for this test */
+            prepare_justification: VariableList::new(vec![]).unwrap(),      /* Should have
+                                                                             * prepare messages
+                                                                             * but we'll skip
+                                                                             * validation */
         };
 
         let ssv_message = SSVMessage::new(

--- a/anchor/common/qbft/src/tests.rs
+++ b/anchor/common/qbft/src/tests.rs
@@ -281,12 +281,12 @@ fn test_round_change_validation_skips_round_one_prepared_values() {
         qbft_message_type: QbftMessageType::RoundChange,
         height: 0,
         round: 2,
-        identifier: VariableList::new([0; 56].to_vec()).unwrap(),
+        identifier: VariableList::repeat_full(0),
         root: test_data.hash(),
         data_round: 1, // Claims preparation in round 1 - this is the bug trigger!
-        round_change_justification: VariableList::new(vec![]).unwrap(),
-        prepare_justification: VariableList::new(vec![]).unwrap(), /* INVALID: No justifications
-                                                                    * for claimed preparation! */
+        round_change_justification: VariableList::empty(),
+        prepare_justification: VariableList::empty(), /* INVALID: No justifications for claimed
+                                                       * preparation! */
     };
 
     // Create signed round change messages (need quorum of 3 for 3-node committee)
@@ -315,7 +315,7 @@ fn test_round_change_validation_skips_round_one_prepared_values() {
         qbft_message_type: QbftMessageType::Proposal,
         height: 0,
         round: 2,
-        identifier: VariableList::new([0; 56].to_vec()).unwrap(),
+        identifier: VariableList::repeat_full(0),
         root: test_data.hash(),
         data_round: 1, // Proposing the "prepared" value from round 1
         round_change_justification: VariableList::new(
@@ -325,8 +325,8 @@ fn test_round_change_validation_skips_round_one_prepared_values() {
                 .collect::<Vec<_>>(),
         )
         .unwrap(),
-        prepare_justification: VariableList::new(vec![]).unwrap(), /* Proposals don't need
-                                                                    * prepare justifications */
+        prepare_justification: VariableList::empty(), /* Proposals don't need prepare
+                                                       * justifications */
     };
 
     // Create the SSVMessage for the proposal
@@ -439,14 +439,12 @@ fn test_leader_waits_when_highest_prepared_data_missing() {
             qbft_message_type: QbftMessageType::RoundChange,
             height: 0,
             round: 2, // Moving to round 2
-            identifier: VariableList::new([0; 56].to_vec()).unwrap(),
+            identifier: VariableList::repeat_full(0),
             root: prepared_hash, // Claims this hash was prepared
             data_round: 1,       // Claims preparation happened in round 1
-            round_change_justification: VariableList::new(vec![]).unwrap(), /* No RC justifications needed for this test */
-            prepare_justification: VariableList::new(vec![]).unwrap(),      /* Should have
-                                                                             * prepare messages
-                                                                             * but we'll skip
-                                                                             * validation */
+            round_change_justification: VariableList::empty(), /* No RC justifications needed for this test */
+            prepare_justification: VariableList::empty(),      /* Should have prepare messages but
+                                                                * we'll skip validation */
         };
 
         let ssv_message = SSVMessage::new(

--- a/anchor/common/qbft/src/tests.rs
+++ b/anchor/common/qbft/src/tests.rs
@@ -442,9 +442,10 @@ fn test_leader_waits_when_highest_prepared_data_missing() {
             identifier: VariableList::repeat_full(0),
             root: prepared_hash, // Claims this hash was prepared
             data_round: 1,       // Claims preparation happened in round 1
-            round_change_justification: VariableList::empty(), /* No RC justifications needed for this test */
-            prepare_justification: VariableList::empty(),      /* Should have prepare messages but
-                                                                * we'll skip validation */
+            round_change_justification: VariableList::empty(), /* No RC justifications needed for
+                                  * this test */
+            prepare_justification: VariableList::empty(), /* Should have prepare messages but
+                                                           * we'll skip validation */
         };
 
         let ssv_message = SSVMessage::new(

--- a/anchor/common/ssv_types/Cargo.toml
+++ b/anchor/common/ssv_types/Cargo.toml
@@ -10,6 +10,7 @@ arbitrary-fuzz = ["arbitrary"]
 [dependencies]
 arbitrary = { workspace = true, optional = true }
 base64 = { workspace = true }
+bls = { workspace = true }
 derive_more = { workspace = true }
 eth2 = { workspace = true }
 ethereum_ssz = { workspace = true }

--- a/anchor/common/ssv_types/src/cluster.rs
+++ b/anchor/common/ssv_types/src/cluster.rs
@@ -1,9 +1,10 @@
 use std::fmt::Debug;
 
+use bls::PublicKeyBytes;
 use derive_more::{Deref, Display, From};
 use indexmap::IndexSet;
 use ssz_derive::{Decode, Encode};
-use types::{Address, Graffiti, PublicKeyBytes};
+use types::{Address, Graffiti};
 
 use crate::{OperatorId, committee::CommitteeId};
 

--- a/anchor/common/ssv_types/src/consensus.rs
+++ b/anchor/common/ssv_types/src/consensus.rs
@@ -7,24 +7,25 @@ use std::{
     sync::Arc,
 };
 
+use bls::{PublicKeyBytes, Signature};
 use derive_more::{From, Into};
 use eth2::types::FullBlockContents;
 use sha2::{Digest, Sha256};
 use slashing_protection::{NotSafe, SlashingDatabase};
 use ssz::{Decode, DecodeError, Encode};
 use ssz_derive::{Decode, Encode};
+use ssz_types::VariableList;
 use thiserror::Error;
 use tracing::warn;
 use tree_hash::{PackedEncoding, TreeHash, TreeHashType};
 use tree_hash_derive::TreeHash;
+use typenum::{
+    Pow, Prod, Sum, U2, U3, U4, U5, U11, U13, U23, U56, U64, U131, U308, U700, U852, U1000, U10000,
+};
 use types::{
     AggregateAndProofBase, AggregateAndProofElectra, AttestationBase, AttestationData,
     AttestationElectra, BlindedBeaconBlock, ChainSpec, Checkpoint, CommitteeIndex, Domain, EthSpec,
-    ForkName, Hash256, PublicKeyBytes, Signature, Slot, SyncCommitteeContribution, VariableList,
-    typenum::{
-        Pow, Prod, Sum, U2, U3, U4, U5, U11, U13, U23, U56, U64, U131, U308, U700, U852, U1000,
-        U10000,
-    },
+    ForkName, Hash256, Slot, SyncCommitteeContribution,
 };
 
 use crate::{ValidatorIndex, message::*};
@@ -1106,11 +1107,9 @@ pub enum BeaconVoteValidationError {
 mod tests {
     use std::collections::HashMap;
 
-    use ssz_types::BitList;
-    use types::{
-        AggregateSignature, BitVector, Checkpoint, Epoch, FixedBytesExtended, MainnetEthSpec,
-        SyncCommitteeContribution,
-    };
+    use bls::{AggregateSignature, FixedBytesExtended};
+    use ssz_types::{BitList, BitVector};
+    use types::{Checkpoint, Epoch, MainnetEthSpec, SyncCommitteeContribution};
 
     use super::*;
 

--- a/anchor/common/ssv_types/src/consensus.rs
+++ b/anchor/common/ssv_types/src/consensus.rs
@@ -1213,7 +1213,7 @@ mod tests {
             },
             signature: AggregateSignature::infinity(),
         };
-        VariableList::from(attestation.as_ssz_bytes())
+        VariableList::new(attestation.as_ssz_bytes()).unwrap()
     }
 
     /// Creates a populated AggregatorCommitteeConsensusData for testing
@@ -1223,9 +1223,10 @@ mod tests {
 
         AggregatorCommitteeConsensusData {
             version: DataVersion::from(ForkName::Deneb),
-            aggregators: VariableList::from(aggregators),
-            aggregator_committee_indexes: VariableList::from(vec![5]),
-            aggregated_attestations: VariableList::from(vec![create_test_attestation_bytes(5)]),
+            aggregators: VariableList::new(aggregators).unwrap(),
+            aggregator_committee_indexes: VariableList::new(vec![5]).unwrap(),
+            aggregated_attestations: VariableList::new(vec![create_test_attestation_bytes(5)])
+                .unwrap(),
             contributors: VariableList::empty(),
             sync_committee_contributions: VariableList::empty(),
         }
@@ -1296,9 +1297,9 @@ mod tests {
         let validator = create_aggregator_committee_validator();
         let data = AggregatorCommitteeConsensusData::<MainnetEthSpec> {
             version: DataVersion::from(ForkName::Deneb),
-            aggregators: VariableList::from(vec![create_assigned_aggregator(100, 5)]),
-            aggregator_committee_indexes: VariableList::from(vec![5, 10]), // 2 indexes
-            aggregated_attestations: VariableList::from(vec![create_attestation_bytes(5)]), /* 1 attestation */
+            aggregators: VariableList::new(vec![create_assigned_aggregator(100, 5)]).unwrap(),
+            aggregator_committee_indexes: VariableList::new(vec![5, 10]).unwrap(), // 2 indexes
+            aggregated_attestations: VariableList::new(vec![create_attestation_bytes(5)]).unwrap(), /* 1 attestation */
             contributors: VariableList::empty(),
             sync_committee_contributions: VariableList::empty(),
         };
@@ -1320,15 +1321,17 @@ mod tests {
         let validator = create_aggregator_committee_validator();
         let data = AggregatorCommitteeConsensusData::<MainnetEthSpec> {
             version: DataVersion::from(ForkName::Deneb),
-            aggregators: VariableList::from(vec![
+            aggregators: VariableList::new(vec![
                 create_assigned_aggregator(100, 5),
                 create_assigned_aggregator(101, 5),
-            ]),
-            aggregator_committee_indexes: VariableList::from(vec![5, 5]), // Duplicate!
-            aggregated_attestations: VariableList::from(vec![
+            ])
+            .unwrap(),
+            aggregator_committee_indexes: VariableList::new(vec![5, 5]).unwrap(), // Duplicate!
+            aggregated_attestations: VariableList::new(vec![
                 create_attestation_bytes(5),
                 create_attestation_bytes(5),
-            ]),
+            ])
+            .unwrap(),
             contributors: VariableList::empty(),
             sync_committee_contributions: VariableList::empty(),
         };
@@ -1347,12 +1350,13 @@ mod tests {
         let validator = create_aggregator_committee_validator();
         let data = AggregatorCommitteeConsensusData::<MainnetEthSpec> {
             version: DataVersion::from(ForkName::Deneb),
-            aggregators: VariableList::from(vec![
+            aggregators: VariableList::new(vec![
                 create_assigned_aggregator(100, 5),
                 create_assigned_aggregator(101, 99), // References index 99 which doesn't exist
-            ]),
-            aggregator_committee_indexes: VariableList::from(vec![5]),
-            aggregated_attestations: VariableList::from(vec![create_attestation_bytes(5)]),
+            ])
+            .unwrap(),
+            aggregator_committee_indexes: VariableList::new(vec![5]).unwrap(),
+            aggregated_attestations: VariableList::new(vec![create_attestation_bytes(5)]).unwrap(),
             contributors: VariableList::empty(),
             sync_committee_contributions: VariableList::empty(),
         };
@@ -1369,12 +1373,14 @@ mod tests {
         let validator = create_aggregator_committee_validator();
         let data = AggregatorCommitteeConsensusData::<MainnetEthSpec> {
             version: DataVersion::from(ForkName::Deneb),
-            aggregators: VariableList::from(vec![create_assigned_aggregator(100, 5)]), /* Only uses index 5 */
-            aggregator_committee_indexes: VariableList::from(vec![5, 10]), // Has unused index 10
-            aggregated_attestations: VariableList::from(vec![
+            aggregators: VariableList::new(vec![create_assigned_aggregator(100, 5)]).unwrap(), /* Only uses index 5 */
+            aggregator_committee_indexes: VariableList::new(vec![5, 10]).unwrap(), /* Has unused
+                                                                                    * index 10 */
+            aggregated_attestations: VariableList::new(vec![
                 create_attestation_bytes(5),
                 create_attestation_bytes(10),
-            ]),
+            ])
+            .unwrap(),
             contributors: VariableList::empty(),
             sync_committee_contributions: VariableList::empty(),
         };
@@ -1394,14 +1400,16 @@ mod tests {
             aggregators: VariableList::empty(),
             aggregator_committee_indexes: VariableList::empty(),
             aggregated_attestations: VariableList::empty(),
-            contributors: VariableList::from(vec![
+            contributors: VariableList::new(vec![
                 create_assigned_aggregator(100, 0),
                 create_assigned_aggregator(101, 0),
-            ]),
-            sync_committee_contributions: VariableList::from(vec![
+            ])
+            .unwrap(),
+            sync_committee_contributions: VariableList::new(vec![
                 create_sync_contribution(0),
                 create_sync_contribution(0), // Duplicate subcommittee!
-            ]),
+            ])
+            .unwrap(),
         };
 
         let result = validator.do_validation(&data);
@@ -1419,12 +1427,14 @@ mod tests {
             aggregators: VariableList::empty(),
             aggregator_committee_indexes: VariableList::empty(),
             aggregated_attestations: VariableList::empty(),
-            contributors: VariableList::from(vec![
+            contributors: VariableList::new(vec![
                 create_assigned_aggregator(100, 0),
                 create_assigned_aggregator(101, 3), /* References subcommittee 3 which doesn't
                                                      * exist */
-            ]),
-            sync_committee_contributions: VariableList::from(vec![create_sync_contribution(0)]),
+            ])
+            .unwrap(),
+            sync_committee_contributions: VariableList::new(vec![create_sync_contribution(0)])
+                .unwrap(),
         };
 
         let result = validator.do_validation(&data);
@@ -1442,11 +1452,12 @@ mod tests {
             aggregators: VariableList::empty(),
             aggregator_committee_indexes: VariableList::empty(),
             aggregated_attestations: VariableList::empty(),
-            contributors: VariableList::from(vec![create_assigned_aggregator(100, 0)]), /* Only uses subcommittee 0 */
-            sync_committee_contributions: VariableList::from(vec![
+            contributors: VariableList::new(vec![create_assigned_aggregator(100, 0)]).unwrap(), /* Only uses subcommittee 0 */
+            sync_committee_contributions: VariableList::new(vec![
                 create_sync_contribution(0),
                 create_sync_contribution(1), // Unused subcommittee 1
-            ]),
+            ])
+            .unwrap(),
         };
 
         let result = validator.do_validation(&data);
@@ -1461,11 +1472,12 @@ mod tests {
         let validator = create_aggregator_committee_validator();
         let data = AggregatorCommitteeConsensusData::<MainnetEthSpec> {
             version: DataVersion::from(ForkName::Deneb),
-            aggregators: VariableList::from(vec![create_assigned_aggregator(100, 5)]),
-            aggregator_committee_indexes: VariableList::from(vec![5]),
-            aggregated_attestations: VariableList::from(vec![
-                VariableList::from(vec![0u8; 10]), // Invalid attestation bytes
-            ]),
+            aggregators: VariableList::new(vec![create_assigned_aggregator(100, 5)]).unwrap(),
+            aggregator_committee_indexes: VariableList::new(vec![5]).unwrap(),
+            aggregated_attestations: VariableList::new(vec![
+                VariableList::new(vec![0u8; 10]).unwrap(), // Invalid attestation bytes
+            ])
+            .unwrap(),
             contributors: VariableList::empty(),
             sync_committee_contributions: VariableList::empty(),
         };
@@ -1488,16 +1500,18 @@ mod tests {
         let validator = create_aggregator_committee_validator();
         let data = AggregatorCommitteeConsensusData::<MainnetEthSpec> {
             version: DataVersion::from(ForkName::Deneb),
-            aggregators: VariableList::from(vec![
+            aggregators: VariableList::new(vec![
                 create_assigned_aggregator(100, 5),
                 create_assigned_aggregator(101, 5),
                 create_assigned_aggregator(200, 10),
-            ]),
-            aggregator_committee_indexes: VariableList::from(vec![5, 10]),
-            aggregated_attestations: VariableList::from(vec![
+            ])
+            .unwrap(),
+            aggregator_committee_indexes: VariableList::new(vec![5, 10]).unwrap(),
+            aggregated_attestations: VariableList::new(vec![
                 create_attestation_bytes(5),
                 create_attestation_bytes(10),
-            ]),
+            ])
+            .unwrap(),
             contributors: VariableList::empty(),
             sync_committee_contributions: VariableList::empty(),
         };
@@ -1514,17 +1528,19 @@ mod tests {
             aggregators: VariableList::empty(),
             aggregator_committee_indexes: VariableList::empty(),
             aggregated_attestations: VariableList::empty(),
-            contributors: VariableList::from(vec![
+            contributors: VariableList::new(vec![
                 create_assigned_aggregator(100, 0),
                 create_assigned_aggregator(101, 0),
                 create_assigned_aggregator(200, 1),
                 create_assigned_aggregator(201, 2),
-            ]),
-            sync_committee_contributions: VariableList::from(vec![
+            ])
+            .unwrap(),
+            sync_committee_contributions: VariableList::new(vec![
                 create_sync_contribution(0),
                 create_sync_contribution(1),
                 create_sync_contribution(2),
-            ]),
+            ])
+            .unwrap(),
         };
 
         let result = validator.do_validation(&data);
@@ -1536,23 +1552,27 @@ mod tests {
         let validator = create_aggregator_committee_validator();
         let data = AggregatorCommitteeConsensusData::<MainnetEthSpec> {
             version: DataVersion::from(ForkName::Deneb),
-            aggregators: VariableList::from(vec![
+            aggregators: VariableList::new(vec![
                 create_assigned_aggregator(100, 5),
                 create_assigned_aggregator(101, 10),
-            ]),
-            aggregator_committee_indexes: VariableList::from(vec![5, 10]),
-            aggregated_attestations: VariableList::from(vec![
+            ])
+            .unwrap(),
+            aggregator_committee_indexes: VariableList::new(vec![5, 10]).unwrap(),
+            aggregated_attestations: VariableList::new(vec![
                 create_attestation_bytes(5),
                 create_attestation_bytes(10),
-            ]),
-            contributors: VariableList::from(vec![
+            ])
+            .unwrap(),
+            contributors: VariableList::new(vec![
                 create_assigned_aggregator(200, 0),
                 create_assigned_aggregator(201, 1),
-            ]),
-            sync_committee_contributions: VariableList::from(vec![
+            ])
+            .unwrap(),
+            sync_committee_contributions: VariableList::new(vec![
                 create_sync_contribution(0),
                 create_sync_contribution(1),
-            ]),
+            ])
+            .unwrap(),
         };
 
         let result = validator.do_validation(&data);
@@ -1585,11 +1605,12 @@ mod tests {
 
         let data = AggregatorCommitteeConsensusData::<MainnetEthSpec> {
             version: DataVersion::from(ForkName::Electra),
-            aggregators: VariableList::from(vec![create_assigned_aggregator(100, 5)]),
-            aggregator_committee_indexes: VariableList::from(vec![5]),
-            aggregated_attestations: VariableList::from(vec![VariableList::from(
-                attestation.as_ssz_bytes(),
-            )]),
+            aggregators: VariableList::new(vec![create_assigned_aggregator(100, 5)]).unwrap(),
+            aggregator_committee_indexes: VariableList::new(vec![5]).unwrap(),
+            aggregated_attestations: VariableList::new(vec![
+                VariableList::new(attestation.as_ssz_bytes()).unwrap(),
+            ])
+            .unwrap(),
             contributors: VariableList::empty(),
             sync_committee_contributions: VariableList::empty(),
         };

--- a/anchor/common/ssv_types/src/lib.rs
+++ b/anchor/common/ssv_types/src/lib.rs
@@ -20,8 +20,8 @@ pub mod test_utils;
 pub use indexmap::IndexSet;
 pub use round::Round;
 pub use share::ENCRYPTED_KEY_LENGTH;
-pub use ssz_types::VariableList;
-use ssz_types::typenum::Unsigned;
+pub use ssz_types::{VariableList, typenum};
+use typenum::Unsigned;
 pub use types::{Epoch, Slot};
 
 // Shared constants used across message types

--- a/anchor/common/ssv_types/src/lib.rs
+++ b/anchor/common/ssv_types/src/lib.rs
@@ -20,8 +20,9 @@ pub mod test_utils;
 pub use indexmap::IndexSet;
 pub use round::Round;
 pub use share::ENCRYPTED_KEY_LENGTH;
+pub use ssz_types::VariableList;
 use ssz_types::typenum::Unsigned;
-pub use types::{Epoch, Slot, VariableList};
+pub use types::{Epoch, Slot};
 
 // Shared constants used across message types
 pub const RSA_SIGNATURE_SIZE: usize = 256;
@@ -36,9 +37,5 @@ where
     let vec_len = vec.len();
     let max_len = N::to_usize();
 
-    if vec_len <= max_len {
-        Ok(VariableList::from(vec))
-    } else {
-        Err(error_fn(vec_len, max_len))
-    }
+    VariableList::new(vec).map_err(|_| error_fn(vec_len, max_len))
 }

--- a/anchor/common/ssv_types/src/message.rs
+++ b/anchor/common/ssv_types/src/message.rs
@@ -280,15 +280,6 @@ pub enum SignedSSVMessageError {
         sig_length: usize,
     },
 
-    #[error(
-        "Signature bytes conversion failed at index {index}: {length} bytes exceeds maximum {max_length}."
-    )]
-    SignatureBytesConversionFailed {
-        index: usize,
-        length: usize,
-        max_length: usize,
-    },
-
     #[error("Too many operator IDs: provided {provided}, maximum allowed is {max}.")]
     TooManyOperatorIDs { provided: usize, max: usize },
 
@@ -451,22 +442,12 @@ impl SignedSSVMessage {
         // Convert Vec<[u8; 256]> to VariableList<VariableList<u8, U256>, U13>
         // First convert each [u8; 256] to VariableList<u8, U256>
         // This will always succeed since sig is [u8; 256] and U256 = 256
-        // but we handle the error explicitly for robustness.
         let signature_variable_lists: Vec<VariableList<u8, U256>> = signatures
             .into_iter()
-            .enumerate()
-            .map(|(index, sig)| {
-                let sig_vec = sig.to_vec();
-                let length = sig_vec.len();
-                VariableList::new(sig_vec).map_err(|_| {
-                    SignedSSVMessageError::SignatureBytesConversionFailed {
-                        index,
-                        length,
-                        max_length: U256::USIZE,
-                    }
-                })
+            .map(|sig| {
+                VariableList::new(sig.to_vec()).expect("256-byte array always fits in U256 bound")
             })
-            .collect::<Result<Vec<_>, _>>()?;
+            .collect();
 
         // Then convert the Vec of VariableLists to VariableList<VariableList<u8, U256>, U13>
         // This can fail if we have more than 13 signatures

--- a/anchor/common/ssv_types/src/message.rs
+++ b/anchor/common/ssv_types/src/message.rs
@@ -441,13 +441,20 @@ impl SignedSSVMessage {
     ) -> Result<Self, SignedSSVMessageError> {
         // Convert Vec<[u8; 256]> to VariableList<VariableList<u8, U256>, U13>
         // First convert each [u8; 256] to VariableList<u8, U256>
-        // This will always succeed since sig is [u8; 256] and U256 = 256
         let signature_variable_lists: Vec<VariableList<u8, U256>> = signatures
             .into_iter()
-            .map(|sig| {
-                VariableList::new(sig.to_vec()).expect("256-byte array always fits in U256 bound")
+            .enumerate()
+            .map(|(index, sig)| {
+                let length = sig.len();
+                VariableList::new(sig.to_vec()).map_err(|_| {
+                    SignedSSVMessageError::WrongRSASignatureSize {
+                        index,
+                        length,
+                        sig_length: RSA_SIGNATURE_SIZE,
+                    }
+                })
             })
-            .collect();
+            .collect::<Result<Vec<_>, _>>()?;
 
         // Then convert the Vec of VariableLists to VariableList<VariableList<u8, U256>, U13>
         // This can fail if we have more than 13 signatures

--- a/anchor/common/ssv_types/src/message.rs
+++ b/anchor/common/ssv_types/src/message.rs
@@ -9,11 +9,8 @@ use ssz_types::VariableList;
 use thiserror::Error;
 use tree_hash::{PackedEncoding, TreeHash, TreeHashType};
 use tree_hash_derive::TreeHash;
-use typenum::Unsigned;
-use types::{
-    Hash256,
-    typenum::{Prod, Sum, U8, U13, U256, U388, U412, U722, U836, U1000, U1000000},
-};
+use typenum::{Prod, Sum, U8, U13, U256, U388, U412, U722, U836, U1000, U1000000, Unsigned};
+use types::Hash256;
 
 use crate::{
     MAX_SIGNATURES, OperatorId, RSA_SIGNATURE_SIZE,
@@ -283,6 +280,15 @@ pub enum SignedSSVMessageError {
         sig_length: usize,
     },
 
+    #[error(
+        "Signature bytes conversion failed at index {index}: {length} bytes exceeds maximum {max_length}."
+    )]
+    SignatureBytesConversionFailed {
+        index: usize,
+        length: usize,
+        max_length: usize,
+    },
+
     #[error("Too many operator IDs: provided {provided}, maximum allowed is {max}.")]
     TooManyOperatorIDs { provided: usize, max: usize },
 
@@ -445,10 +451,22 @@ impl SignedSSVMessage {
         // Convert Vec<[u8; 256]> to VariableList<VariableList<u8, U256>, U13>
         // First convert each [u8; 256] to VariableList<u8, U256>
         // This will always succeed since sig is [u8; 256] and U256 = 256
-        let signature_variable_lists: Vec<_> = signatures
+        // but we handle the error explicitly for robustness.
+        let signature_variable_lists: Vec<VariableList<u8, U256>> = signatures
             .into_iter()
-            .map(|sig| VariableList::from(sig.to_vec()))
-            .collect();
+            .enumerate()
+            .map(|(index, sig)| {
+                let sig_vec = sig.to_vec();
+                let length = sig_vec.len();
+                VariableList::new(sig_vec).map_err(|_| {
+                    SignedSSVMessageError::SignatureBytesConversionFailed {
+                        index,
+                        length,
+                        max_length: U256::USIZE,
+                    }
+                })
+            })
+            .collect::<Result<Vec<_>, _>>()?;
 
         // Then convert the Vec of VariableLists to VariableList<VariableList<u8, U256>, U13>
         // This can fail if we have more than 13 signatures
@@ -642,8 +660,9 @@ impl SignedSSVMessage {
 mod tests {
     use std::iter;
 
+    use bls::Signature;
     use ssz::{Decode, Encode};
-    use types::{Signature, Unsigned};
+    use typenum::Unsigned;
 
     use super::*;
     use crate::{

--- a/anchor/common/ssv_types/src/msgid.rs
+++ b/anchor/common/ssv_types/src/msgid.rs
@@ -1,9 +1,11 @@
 use std::fmt::{Debug, Formatter};
 
+use bls::PublicKeyBytes;
 use derive_more::{Display, From, Into};
 use ssz::{Decode, DecodeError, Encode};
+use ssz_types::VariableList;
 use tree_hash::{PackedEncoding, TreeHash, TreeHashType};
-use types::{PublicKeyBytes, VariableList, typenum::U56};
+use typenum::U56;
 
 use crate::{committee::CommitteeId, domain_type::DomainType};
 
@@ -155,7 +157,14 @@ impl TryFrom<&[u8]> for MessageId {
 
 impl From<&MessageId> for VariableList<u8, U56> {
     fn from(value: &MessageId) -> Self {
-        value.0.to_vec().into()
+        // SAFETY: This conversion is mathematically infallible.
+        // - MessageId is defined as `[u8; 56]` (see MESSAGE_ID_LEN = 56)
+        // - VariableList<u8, U56> has max capacity of 56 bytes (U56::USIZE = 56)
+        // - Therefore, value.0.to_vec() always produces exactly 56 bytes, which fits within the
+        //   VariableList's capacity.
+        // The From trait requires infallible conversion; TryFrom would be used
+        // if this could fail, but the type system guarantees success here.
+        VariableList::new(value.0.to_vec()).expect("infallible: MessageId is [u8; 56] and U56 = 56")
     }
 }
 

--- a/anchor/common/ssv_types/src/partial_sig.rs
+++ b/anchor/common/ssv_types/src/partial_sig.rs
@@ -1,11 +1,11 @@
+use bls::Signature;
 use ssz::{Decode, DecodeError, Encode};
 use ssz_derive::{Decode, Encode};
+use ssz_types::VariableList;
 use tree_hash::{PackedEncoding, TreeHash, TreeHashType};
 use tree_hash_derive::TreeHash;
-use types::{
-    Hash256, Signature, Slot, VariableList,
-    typenum::{Sum, U512, U1000},
-};
+use typenum::{Sum, U512, U1000};
+use types::{Hash256, Slot};
 
 use crate::{OperatorId, ValidatorIndex};
 

--- a/anchor/common/ssv_types/src/share.rs
+++ b/anchor/common/ssv_types/src/share.rs
@@ -1,4 +1,4 @@
-use types::PublicKeyBytes;
+use bls::PublicKeyBytes;
 
 use crate::{ClusterId, OperatorId};
 

--- a/anchor/common/ssv_types/src/sql_conversions.rs
+++ b/anchor/common/ssv_types/src/sql_conversions.rs
@@ -4,9 +4,10 @@ use std::{
 };
 
 use base64::prelude::*;
+use bls::PublicKeyBytes;
 use openssl::rsa::Rsa;
 use rusqlite::{Error as SqlError, Row, types::Type};
-use types::{Address, GRAFFITI_BYTES_LEN, Graffiti, PublicKeyBytes};
+use types::{Address, GRAFFITI_BYTES_LEN, Graffiti};
 
 use crate::{
     Cluster, ClusterId, ClusterMember, ENCRYPTED_KEY_LENGTH, Operator, OperatorId, Share,

--- a/anchor/database/Cargo.toml
+++ b/anchor/database/Cargo.toml
@@ -9,6 +9,7 @@ test-utils = []
 
 [dependencies]
 base64 = { workspace = true }
+bls = { workspace = true }
 once_cell = { workspace = true }
 openssl = { workspace = true }
 r2d2 = { workspace = true }

--- a/anchor/database/src/cluster_operations.rs
+++ b/anchor/database/src/cluster_operations.rs
@@ -1,6 +1,7 @@
+use bls::PublicKeyBytes;
 use rusqlite::{Transaction, params};
 use ssv_types::{Cluster, ClusterId, OperatorId, Share, ValidatorMetadata};
-use types::{Address, PublicKeyBytes};
+use types::Address;
 
 use super::{DatabaseError, NetworkDatabase, NonUniqueIndex, UniqueIndex, sql_operations};
 

--- a/anchor/database/src/lib.rs
+++ b/anchor/database/src/lib.rs
@@ -4,6 +4,7 @@ use std::{
     time::Duration,
 };
 
+use bls::PublicKeyBytes;
 use once_cell::sync::OnceCell;
 use openssl::{pkey::Public, rsa::Rsa};
 use r2d2::CustomizeConnection;
@@ -17,7 +18,7 @@ use tokio::sync::{
     watch,
     watch::{Receiver, Ref},
 };
-use types::{Address, PublicKeyBytes};
+use types::Address;
 
 pub use crate::{
     error::DatabaseError,

--- a/anchor/database/src/share_operations.rs
+++ b/anchor/database/src/share_operations.rs
@@ -1,6 +1,6 @@
+use bls::PublicKeyBytes;
 use rusqlite::{Transaction, params};
 use ssv_types::Share;
-use types::PublicKeyBytes;
 
 use super::{DatabaseError, NetworkDatabase, sql_operations};
 

--- a/anchor/database/src/slashing.rs
+++ b/anchor/database/src/slashing.rs
@@ -8,8 +8,8 @@
 //! The trait enables dependency injection and makes code testable without needing
 //! slashing protection infrastructure.
 
+use bls::PublicKeyBytes;
 use slashing_protection::SlashingDatabase;
-use types::PublicKeyBytes;
 
 /// Trait for slashing protection implementations.
 ///

--- a/anchor/database/src/state.rs
+++ b/anchor/database/src/state.rs
@@ -4,13 +4,14 @@ use std::{
 };
 
 use base64::prelude::*;
+use bls::PublicKeyBytes;
 use openssl::{pkey::Public, rsa::Rsa};
 use rusqlite::{Error as SqlError, OptionalExtension, params, types::Type};
 use ssv_types::{
     Cluster, ClusterId, ClusterMember, CommitteeId, CommitteeInfo, IndexSet, Operator, OperatorId,
     Share, ValidatorIndex, ValidatorMetadata,
 };
-use types::{Address, PublicKeyBytes};
+use types::Address;
 
 use crate::{
     ClusterMultiIndexMap, DatabaseError, MetadataMultiIndexMap, MultiIndexMap, MultiState,

--- a/anchor/database/src/tests/utils.rs
+++ b/anchor/database/src/tests/utils.rs
@@ -1,5 +1,6 @@
 use std::path::PathBuf;
 
+use bls::PublicKeyBytes;
 use openssl::{pkey::Public, rsa::Rsa};
 use rand::Rng;
 use rusqlite::{Transaction, params};
@@ -9,8 +10,8 @@ use ssv_types::{
 };
 use tempfile::TempDir;
 use types::{
-    Address, Graffiti, PublicKeyBytes,
-    test_utils::{SeedableRng, TestRandom, XorShiftRng},
+    Address, Graffiti,
+    test_utils::{SeedableRng, XorShiftRng},
 };
 
 use crate::{NetworkDatabase, multi_index::UniqueIndex};
@@ -288,7 +289,8 @@ pub mod generators {
     }
 
     pub mod pubkey {
-        use types::PublicKeyBytes;
+        use bls::PublicKeyBytes;
+        use types::test_utils::TestRandom;
 
         use super::*;
 
@@ -329,9 +331,9 @@ pub mod generators {
 pub mod queries {
     use std::str::FromStr;
 
+    use bls::PublicKeyBytes;
     use rusqlite::Connection;
     use ssv_types::{ClusterId, OperatorId};
-    use types::PublicKeyBytes;
 
     use super::*;
 
@@ -603,7 +605,7 @@ pub mod assertions {
 
     //
     pub mod share {
-        use types::PublicKeyBytes;
+        use bls::PublicKeyBytes;
 
         use super::*;
         fn data(s1: &Share, s2: &Share) {

--- a/anchor/database/src/validator_operations.rs
+++ b/anchor/database/src/validator_operations.rs
@@ -1,9 +1,10 @@
 use std::{collections::HashMap, str::FromStr};
 
+use bls::PublicKeyBytes;
 use rusqlite::{Transaction, params};
 use ssv_types::ValidatorIndex;
 use tracing::debug;
-use types::{Address, Graffiti, PublicKeyBytes};
+use types::{Address, Graffiti};
 
 use crate::{
     DatabaseError, NetworkDatabase, NonUniqueIndex, multi_index::UniqueIndex, sql_operations,

--- a/anchor/duties_tracker/src/voluntary_exit_tracker.rs
+++ b/anchor/duties_tracker/src/voluntary_exit_tracker.rs
@@ -1,8 +1,9 @@
 use std::collections::HashMap;
 
+use bls::PublicKeyBytes;
 use dashmap::DashMap;
 use ssv_types::ValidatorIndex;
-use types::{PublicKeyBytes, Slot};
+use types::Slot;
 
 /// Represents an exit request scheduled for processing
 #[derive(Debug, Clone)]

--- a/anchor/eth/Cargo.toml
+++ b/anchor/eth/Cargo.toml
@@ -8,6 +8,7 @@ authors = ["Sigma Prime <contact@sigmaprime.io>"]
 alloy = { workspace = true }
 anchor_validator_store = { workspace = true }
 beacon_node_fallback = { workspace = true }
+bls = { workspace = true }
 database = { workspace = true }
 duties_tracker = { workspace = true }
 eth2 = { workspace = true }

--- a/anchor/eth/src/event_processor.rs
+++ b/anchor/eth/src/event_processor.rs
@@ -1,8 +1,8 @@
 use std::sync::Arc;
 
 use alloy::{primitives::Address, rpc::types::Log, sol_types::SolEvent};
+use bls::PublicKeyBytes;
 use database::{NetworkDatabase, SlashingProtection, UniqueIndex};
-use eth2::types::PublicKeyBytes;
 use indexmap::IndexSet;
 use rusqlite::Transaction;
 use ssv_types::{Cluster, ClusterId, Operator, OperatorId, ValidatorIndex};

--- a/anchor/eth/src/index_sync.rs
+++ b/anchor/eth/src/index_sync.rs
@@ -1,6 +1,7 @@
 use std::{collections::HashMap, sync::Arc, time::Duration};
 
 use beacon_node_fallback::BeaconNodeFallback;
+use bls::PublicKeyBytes;
 use database::{ClusterMultiIndexMap, NetworkDatabase, UniqueIndex};
 use eth2::types::{StateId, ValidatorId};
 use slot_clock::SlotClock;
@@ -12,7 +13,6 @@ use tokio::{
     time::sleep,
 };
 use tracing::{debug, error, info, trace, warn};
-use types::PublicKeyBytes;
 
 pub type Tx = UnboundedSender<PublicKeyBytes>;
 

--- a/anchor/eth/src/sync.rs
+++ b/anchor/eth/src/sync.rs
@@ -129,7 +129,7 @@ impl SsvEventSyncer {
         debug!("Created rpc client");
 
         // Construct Websocket Provider
-        let ws = WsConnect::new(config.ws_url.full.as_str());
+        let ws = WsConnect::new(config.ws_url.expose_full().as_str());
         let ws_client = ProviderBuilder::default()
             .connect_ws(ws)
             .await
@@ -157,7 +157,7 @@ impl SsvEventSyncer {
         Ok(Self {
             rpc_client,
             ws_client,
-            ws_url: config.ws_url.full.into(),
+            ws_url: config.ws_url.expose_full().clone().into(),
             event_processor,
             network: config.network,
             is_synced: watch::channel(false).0,

--- a/anchor/eth/src/util.rs
+++ b/anchor/eth/src/util.rs
@@ -6,13 +6,14 @@ use alloy::{
     rpc::client::RpcClient,
     transports::{Transport, http::Http, layers::FallbackLayer},
 };
+use bls::{PublicKeyBytes, Signature};
 use database::NetworkState;
 use reqwest::Client;
 use sensitive_url::SensitiveUrl;
 use ssv_types::{ClusterId, ENCRYPTED_KEY_LENGTH, OperatorId, Share, ValidatorMetadata};
 use tower::ServiceBuilder;
 use tracing::{debug, trace};
-use types::{Graffiti, PublicKeyBytes, Signature};
+use types::Graffiti;
 
 use crate::{error::ExecutionError, sync::MAX_OPERATORS};
 
@@ -216,7 +217,7 @@ pub fn http_with_timeout_and_fallback(http_urls: &[SensitiveUrl]) -> RootProvide
 
     let http_transports: Vec<_> = http_urls
         .iter()
-        .map(|u| Http::with_client(base.clone(), u.full.to_owned()))
+        .map(|u| Http::with_client(base.clone(), u.expose_full().clone()))
         .collect();
 
     provider_from_transports(http_transports)

--- a/anchor/eth/src/voluntary_exit_processor.rs
+++ b/anchor/eth/src/voluntary_exit_processor.rs
@@ -2,6 +2,7 @@ use std::{sync::Arc, time::Duration};
 
 use anchor_validator_store::AnchorValidatorStore;
 use beacon_node_fallback::BeaconNodeFallback;
+use bls::PublicKeyBytes;
 use duties_tracker::voluntary_exit_tracker::{ExitDuty, VoluntaryExitTracker};
 use slot_clock::SlotClock;
 use ssv_types::ValidatorIndex;
@@ -11,7 +12,7 @@ use tokio::{
     time::sleep,
 };
 use tracing::{debug, error, info};
-use types::{EthSpec, PublicKeyBytes, voluntary_exit};
+use types::{EthSpec, VoluntaryExit};
 
 use crate::EXECUTION_EVENTS_PROCESSED;
 
@@ -204,7 +205,7 @@ async fn process_single_exit<E: EthSpec, T: SlotClock + 'static>(
 
     let epoch = target_slot.epoch(slots_per_epoch);
 
-    let voluntary_exit = voluntary_exit::VoluntaryExit {
+    let voluntary_exit = VoluntaryExit {
         epoch,
         validator_index: validator_index.0 as u64,
     };

--- a/anchor/eth/tests/common/mod.rs
+++ b/anchor/eth/tests/common/mod.rs
@@ -15,7 +15,7 @@ use alloy::{
     sol_types::SolEvent,
 };
 use base64::{Engine, engine::general_purpose::STANDARD as BASE64_STANDARD};
-use bls::{Hash256, SecretKey};
+use bls::{Hash256, PublicKeyBytes, SecretKey};
 pub use database::test_utils::InMemoryTestFixture;
 use database::{
     NetworkDatabase,
@@ -28,7 +28,6 @@ use eth::{
 };
 use ssv_types::{ENCRYPTED_KEY_LENGTH, *};
 use tokio::sync::mpsc::unbounded_channel;
-use types::PublicKeyBytes;
 
 /// Test cluster owner address used across integration tests
 pub const TEST_CLUSTER_OWNER: &str = "0x000000633b68f5d8d3a86593ebb815b4663bcbe0";

--- a/anchor/keysplit/Cargo.toml
+++ b/anchor/keysplit/Cargo.toml
@@ -7,6 +7,7 @@ authors = ["Sigma Prime <contact@sigmaprime.io>"]
 [dependencies]
 alloy = { workspace = true }
 base64 = { workspace = true }
+bls = { workspace = true }
 bls_lagrange = { workspace = true }
 chrono = { version = "0.4.39", features = ["serde"] }
 clap = { workspace = true }

--- a/anchor/keysplit/src/crypto.rs
+++ b/anchor/keysplit/src/crypto.rs
@@ -1,6 +1,6 @@
+use bls::SecretKey;
 use bls_lagrange::{KeyId, split};
 use openssl::{encrypt::Encrypter, pkey::PKey};
-use types::SecretKey;
 
 use crate::{EncryptedKeyShare, KeyShare, KeysplitError, cli::SharedKeygenOptions, split::Split};
 

--- a/anchor/keysplit/src/lib.rs
+++ b/anchor/keysplit/src/lib.rs
@@ -1,12 +1,12 @@
 use std::fs;
 
+use bls::{PublicKey, SecretKey};
 pub use cli::{KeygenSubcommands, Keysplit, Manual, Onchain};
 use error::KeysplitError;
 use global_config::GlobalConfig;
 use openssl::{pkey::Public, rsa::Rsa};
 use rayon::prelude::*;
 use tracing::info;
-use types::{PublicKey, SecretKey};
 
 use crate::{
     crypto::{encrypt_keyshares, split_key},

--- a/anchor/keysplit/src/output.rs
+++ b/anchor/keysplit/src/output.rs
@@ -1,8 +1,9 @@
 use alloy::primitives::Keccak256;
+use bls::{Keypair, PublicKey};
 use chrono::{DateTime, Utc};
 use openssl::{pkey::Public, rsa::Rsa};
 use serde::Serialize;
-use types::{Address, Keypair, PublicKey};
+use types::Address;
 
 use crate::{
     EncryptedKeyShare, cli::SharedKeygenOptions, error::KeysplitError, split::Split,

--- a/anchor/keysplit/src/split.rs
+++ b/anchor/keysplit/src/split.rs
@@ -1,11 +1,11 @@
 use std::{path::Path, sync::Arc};
 
+use bls::SecretKey;
 use database::NetworkDatabase;
 use eth::SsvEventSyncer;
 use global_config::GlobalConfig;
 use openssl::{pkey::Public, rsa::Rsa};
 use ssv_types::domain_type::DomainType;
-use types::SecretKey;
 
 use crate::{KeyShare, KeysplitError, Manual, Onchain, cli::SharedKeygenOptions, split_key};
 

--- a/anchor/message_validator/src/partial_signature.rs
+++ b/anchor/message_validator/src/partial_signature.rs
@@ -287,7 +287,7 @@ mod tests {
     };
     use slot_clock::{ManualSlotClock, SlotClock};
     use ssv_types::{
-        OperatorId, RSA_SIGNATURE_SIZE, ValidatorIndex,
+        OperatorId, RSA_SIGNATURE_SIZE, ValidatorIndex, VariableList,
         message::{MsgType, SSVMessage, SignedSSVMessage},
         partial_sig::PartialSignatureMessage,
     };
@@ -333,7 +333,7 @@ mod tests {
         let partial_sig_messages = PartialSignatureMessages {
             kind,
             slot: Slot::new(0),
-            messages: messages.into(),
+            messages: VariableList::new(messages).unwrap(),
         };
 
         let msg_id = create_message_id_for_test(role);
@@ -746,7 +746,7 @@ mod tests {
         let partial_sig_messages = PartialSignatureMessages {
             kind: PartialSignatureKind::PostConsensus,
             slot: Slot::new(0),
-            messages: messages.into(),
+            messages: VariableList::new(messages).unwrap(),
         };
 
         let msg_id = create_message_id_for_test(Role::SyncCommittee);
@@ -794,7 +794,7 @@ mod tests {
         let partial_sig_messages = PartialSignatureMessages {
             kind: PartialSignatureKind::PostConsensus,
             slot: Slot::new(0),
-            messages: messages.into(),
+            messages: VariableList::new(messages).unwrap(),
         };
 
         let msg_id = create_message_id_for_test(Role::Proposer); // Not committee role
@@ -899,7 +899,7 @@ mod tests {
         let partial_sig_messages = PartialSignatureMessages {
             kind: PartialSignatureKind::PostConsensus,
             slot: Slot::new(0),
-            messages: messages.into(),
+            messages: VariableList::new(messages).unwrap(),
         };
 
         let msg_id = create_message_id_for_test(Role::Committee);

--- a/anchor/network/Cargo.toml
+++ b/anchor/network/Cargo.toml
@@ -45,6 +45,7 @@ thiserror = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
 twox-hash = "2.1.2"
+typenum = { workspace = true }
 types = { workspace = true }
 version = { workspace = true }
 

--- a/anchor/network/src/discovery.rs
+++ b/anchor/network/src/discovery.rs
@@ -27,11 +27,12 @@ use libp2p::{
 use network_utils::enr_ext::{CombinedKeyExt, EnrExt, QUIC_ENR_KEY, QUIC6_ENR_KEY};
 use ssv_types::domain_type::DomainType;
 use ssz::{Decode, Encode};
+use ssz_types::BitVector;
 use subnet_service::SubnetId;
 use thiserror::Error;
 use tokio::sync::mpsc;
 use tracing::{debug, error, info, trace, warn};
-use types::{BitVector, typenum::U128};
+use typenum::U128;
 
 use crate::{
     Config,

--- a/anchor/operator_doppelganger/src/service.rs
+++ b/anchor/operator_doppelganger/src/service.rs
@@ -241,7 +241,7 @@ mod tests {
 
     use database::OwnOperatorId;
     use ssv_types::{
-        CommitteeId, OperatorId, RSA_SIGNATURE_SIZE,
+        CommitteeId, OperatorId, RSA_SIGNATURE_SIZE, VariableList,
         consensus::{QbftMessage, QbftMessageType},
         domain_type::DomainType,
         message::{MsgType, SSVMessage, SignedSSVMessage},
@@ -290,7 +290,7 @@ mod tests {
             qbft_message_type: QbftMessageType::Prepare,
             height,
             round,
-            identifier: message_id.as_ref().to_vec().into(),
+            identifier: VariableList::new(message_id.as_ref().to_vec()).unwrap(),
             root: Hash256::from([0u8; 32]),
             data_round: 0,
             round_change_justification: vec![].try_into().unwrap(),

--- a/anchor/processor/tests/processor_tests.rs
+++ b/anchor/processor/tests/processor_tests.rs
@@ -12,7 +12,7 @@ async fn test_max_workers() -> Result<(), Box<dyn Error>> {
     let handle = tokio::runtime::Handle::current();
     let (_signal, exit) = async_channel::bounded(1);
     let (shutdown_tx, _) = futures::channel::mpsc::channel(1);
-    let executor = TaskExecutor::new(handle, exit, shutdown_tx, "processor_test".into());
+    let executor = TaskExecutor::new(handle, exit, shutdown_tx);
 
     let config = processor::Config {
         max_workers: 3,

--- a/anchor/qbft_manager/Cargo.toml
+++ b/anchor/qbft_manager/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Sigma Prime <contact@sigmaprime.io"]
 edition = { workspace = true }
 
 [dependencies]
+bls = { workspace = true }
 dashmap = { workspace = true }
 database = { workspace = true }
 ethereum_ssz = { workspace = true }

--- a/anchor/qbft_manager/src/lib.rs
+++ b/anchor/qbft_manager/src/lib.rs
@@ -1,5 +1,6 @@
 use std::{fmt::Debug, hash::Hash, sync::Arc};
 
+use bls::PublicKeyBytes;
 use dashmap::DashMap;
 use database::OwnOperatorId;
 use message_sender::MessageSender;
@@ -26,7 +27,7 @@ use tokio::{
     time::{Instant, sleep},
 };
 use tracing::{Instrument, debug_span, error, warn};
-use types::{Hash256, PublicKeyBytes};
+use types::Hash256;
 
 use crate::instance::qbft_instance;
 

--- a/anchor/qbft_manager/src/tests.rs
+++ b/anchor/qbft_manager/src/tests.rs
@@ -661,7 +661,7 @@ mod manager_tests {
         let handle = tokio::runtime::Handle::current();
         let (signal, exit) = async_channel::bounded(1);
         let (shutdown, _) = futures::channel::mpsc::channel(1);
-        let executor = TaskExecutor::new(handle, exit, shutdown.clone(), "qbft_tests".into());
+        let executor = TaskExecutor::new(handle, exit, shutdown.clone());
 
         // setup the slot clock
         let slot_duration = Duration::from_secs(12);

--- a/anchor/signature_collector/Cargo.toml
+++ b/anchor/signature_collector/Cargo.toml
@@ -14,6 +14,7 @@ message_sender = { workspace = true }
 processor = { workspace = true }
 slot_clock = { workspace = true }
 ssv_types = { workspace = true }
+thiserror = { workspace = true }
 tokio = { workspace = true, features = ["sync"] }
 tracing = { workspace = true }
 types = { workspace = true }

--- a/anchor/signature_collector/Cargo.toml
+++ b/anchor/signature_collector/Cargo.toml
@@ -5,6 +5,7 @@ edition = { workspace = true }
 authors = ["Sigma Prime <contact@sigmaprime.io>"]
 
 [dependencies]
+bls = { workspace = true }
 bls_lagrange = { workspace = true }
 dashmap = { workspace = true }
 database = { workspace = true }

--- a/anchor/signature_collector/src/lib.rs
+++ b/anchor/signature_collector/src/lib.rs
@@ -4,6 +4,7 @@ use std::{
     sync::Arc,
 };
 
+use bls::{PublicKeyBytes, SecretKey, Signature};
 use bls_lagrange::KeyId;
 use dashmap::{DashMap, Entry};
 use database::OwnOperatorId;
@@ -29,7 +30,7 @@ use tokio::{
     time::sleep,
 };
 use tracing::{Instrument, debug_span, error, trace, warn};
-use types::{Hash256, PublicKeyBytes, SecretKey, Signature, Slot};
+use types::{Hash256, Slot};
 
 const COLLECTOR_NAME: &str = "signature_collector";
 const COLLECTOR_MESSAGE_NAME: &str = "signature_collector_message";
@@ -246,7 +247,8 @@ impl SignatureCollectorManager {
         let partial_sig_messages = PartialSignatureMessages {
             kind: metadata.kind,
             slot: metadata.slot,
-            messages: signatures.into(),
+            messages: ssv_types::VariableList::new(signatures)
+                .expect("number of signatures must be within bounds"),
         };
 
         UnsignedSSVMessage {

--- a/anchor/signature_collector/src/lib.rs
+++ b/anchor/signature_collector/src/lib.rs
@@ -11,15 +11,20 @@ use database::OwnOperatorId;
 use message_sender::MessageSender;
 use processor::{Error, Error::Queue, Senders, work::DropOnFinish};
 use slot_clock::SlotClock;
+use ssv_types::typenum::Unsigned;
 pub use ssv_types::{
     CommitteeId, OperatorId, ValidatorIndex,
     consensus::UnsignedSSVMessage,
     domain_type::DomainType,
-    message::{MsgType, SSVMessage},
+    message::{MsgType, SSVMessage, SSVMessageError},
     msgid::{DutyExecutor, MessageId, Role},
-    partial_sig::{PartialSignatureKind, PartialSignatureMessage, PartialSignatureMessages},
+    partial_sig::{
+        PartialSignatureKind, PartialSignatureMessage, PartialSignatureMessages,
+        PartialSignatureMessagesLen,
+    },
 };
 use ssz::Encode;
+use thiserror::Error;
 use tokio::{
     sync::{
         mpsc,
@@ -39,6 +44,15 @@ const SIGNER_NAME: &str = "partial_signer";
 
 /// number of slots to keep before the current slot
 const SIGNATURE_COLLECTOR_RETAIN_SLOTS: u64 = 1;
+
+/// Error type for creating partial signature messages.
+#[derive(Debug, Error)]
+enum CreateMessageError {
+    #[error("Too many partial signatures: {count} exceeds maximum {max}")]
+    TooManySignatures { count: usize, max: usize },
+    #[error("Failed to create SSV message: {0}")]
+    SSVMessage(#[from] SSVMessageError),
+}
 
 /// A handle to message the instance collecting a single specific signature
 struct SignatureCollector {
@@ -165,16 +179,24 @@ impl SignatureCollectorManager {
                     SignatureRequester::SingleValidator { pubkey } => {
                         // we do not have to wait for other partial signatures - send the message
                         // immediately.
-                        if let Err(err) = manager.message_sender.sign_and_send(
-                            manager.create_message(
-                                &metadata,
-                                vec![message.clone()],
-                                &DutyExecutor::Validator(pubkey),
-                            ),
-                            metadata.committee_id,
-                            None,
+                        let msg = match manager.create_message(
+                            &metadata,
+                            vec![message.clone()],
+                            &DutyExecutor::Validator(pubkey),
                         ) {
-                            error!(?err, "Error sending validator partial signature");
+                            Ok(msg) => msg,
+                            Err(err) => {
+                                error!(%err, "Failed to create validator partial signature message");
+                                return;
+                            }
+                        };
+
+                        if let Err(err) =
+                            manager
+                                .message_sender
+                                .sign_and_send(msg, metadata.committee_id, None)
+                        {
+                            error!(?err, "Failed to send validator partial signature");
                         }
                     }
                     SignatureRequester::Committee {
@@ -209,16 +231,24 @@ impl SignatureCollectorManager {
                         if collected_signatures.len() == num_signatures_to_collect {
                             let signatures = entry.remove().collected_signatures;
 
-                            if let Err(err) = manager.message_sender.sign_and_send(
-                                manager.create_message(
-                                    &metadata,
-                                    signatures,
-                                    &DutyExecutor::Committee(metadata.committee_id),
-                                ),
-                                metadata.committee_id,
-                                None,
+                            let msg = match manager.create_message(
+                                &metadata,
+                                signatures,
+                                &DutyExecutor::Committee(metadata.committee_id),
                             ) {
-                                error!(?err, "Error sending committee partial signatures");
+                                Ok(msg) => msg,
+                                Err(err) => {
+                                    error!(%err, "Failed to create committee partial signature message");
+                                    return;
+                                }
+                            };
+
+                            if let Err(err) =
+                                manager
+                                    .message_sender
+                                    .sign_and_send(msg, metadata.committee_id, None)
+                            {
+                                error!(?err, "Failed to send committee partial signatures");
                             }
                         }
                     }
@@ -243,23 +273,29 @@ impl SignatureCollectorManager {
         metadata: &SignatureMetadata,
         signatures: Vec<PartialSignatureMessage>,
         duty_executor: &DutyExecutor,
-    ) -> UnsignedSSVMessage {
+    ) -> Result<UnsignedSSVMessage, CreateMessageError> {
+        let count = signatures.len();
+        let messages = ssv_types::VariableList::new(signatures).map_err(|_| {
+            CreateMessageError::TooManySignatures {
+                count,
+                max: PartialSignatureMessagesLen::USIZE,
+            }
+        })?;
+
         let partial_sig_messages = PartialSignatureMessages {
             kind: metadata.kind,
             slot: metadata.slot,
-            messages: ssv_types::VariableList::new(signatures)
-                .expect("number of signatures must be within bounds"),
+            messages,
         };
 
-        UnsignedSSVMessage {
+        Ok(UnsignedSSVMessage {
             ssv_message: SSVMessage::new(
                 MsgType::SSVPartialSignatureMsgType,
                 MessageId::new(&self.domain, metadata.role, duty_executor),
                 partial_sig_messages.as_ssz_bytes(),
-            )
-            .expect("Creating a SSVMessage must succeed"),
+            )?,
             full_data: vec![],
-        }
+        })
     }
 
     pub fn receive_partial_signatures(

--- a/anchor/src/environment.rs
+++ b/anchor/src/environment.rs
@@ -72,7 +72,6 @@ impl Environment {
             Arc::downgrade(self.runtime()),
             self.exit.clone(),
             self.signal_tx.clone(),
-            "anchor".into(),
         )
     }
 

--- a/anchor/subnet_service/Cargo.toml
+++ b/anchor/subnet_service/Cargo.toml
@@ -15,4 +15,5 @@ ssv_types = { workspace = true }
 task_executor = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
+typenum = { workspace = true }
 types = { workspace = true }

--- a/anchor/subnet_service/src/message_rate.rs
+++ b/anchor/subnet_service/src/message_rate.rs
@@ -6,8 +6,9 @@
 
 use ssv_types::CommitteeInfo;
 use tracing::{debug, trace};
+use typenum::Unsigned;
 use types::{
-    ChainSpec, EthSpec, Unsigned,
+    ChainSpec, EthSpec,
     consts::altair::{SYNC_COMMITTEE_SUBNET_COUNT, TARGET_AGGREGATORS_PER_SYNC_SUBCOMMITTEE},
 };
 

--- a/anchor/validator_store/Cargo.toml
+++ b/anchor/validator_store/Cargo.toml
@@ -6,6 +6,7 @@ authors = ["Sigma Prime <contact@sigmaprime.io>"]
 
 [dependencies]
 beacon_node_fallback = { workspace = true }
+bls = { workspace = true }
 database = { workspace = true }
 eth2 = { workspace = true }
 ethereum_ssz = { workspace = true }

--- a/anchor/validator_store/src/lib.rs
+++ b/anchor/validator_store/src/lib.rs
@@ -12,6 +12,7 @@ use std::{
     time::Duration,
 };
 
+use bls::{PublicKeyBytes, SecretKey, Signature};
 use database::{NetworkDatabase, NonUniqueIndex, UniqueIndex};
 use eth2::types::{BlockContents, FullBlockContents, PublishBlockRequest};
 use lru::LruCache;
@@ -51,23 +52,13 @@ use tokio::{
 use tracing::{debug, error, info, warn};
 use types::{
     AbstractExecPayload, Address, AggregateAndProof, AggregateAndProofBase,
-    AggregateAndProofElectra, BeaconBlockRef, BlindedBeaconBlock, BlindedPayload, ChainSpec,
-    ContributionAndProof, Domain, EthSpec, ForkName, FullPayload, Hash256, PublicKeyBytes,
-    SecretKey, Signature, SignedBeaconBlock, SignedBlindedBeaconBlock, SignedRoot,
-    SignedVoluntaryExit, SyncAggregatorSelectionData, VoluntaryExit,
-    attestation::Attestation,
-    beacon_block::BeaconBlock,
-    graffiti::Graffiti,
-    selection_proof::SelectionProof,
-    signed_aggregate_and_proof::SignedAggregateAndProof,
-    signed_contribution_and_proof::SignedContributionAndProof,
-    slot_data::SlotData,
-    slot_epoch::{Epoch, Slot},
-    sync_committee_contribution::SyncCommitteeContribution,
-    sync_committee_message::SyncCommitteeMessage,
-    sync_selection_proof::SyncSelectionProof,
-    sync_subnet_id::SyncSubnetId,
-    validator_registration_data::{SignedValidatorRegistrationData, ValidatorRegistrationData},
+    AggregateAndProofElectra, Attestation, BeaconBlock, BeaconBlockRef, BlindedBeaconBlock,
+    BlindedPayload, ChainSpec, ContributionAndProof, Domain, Epoch, EthSpec, ForkName, FullPayload,
+    Graffiti, Hash256, SelectionProof, SignedAggregateAndProof, SignedBeaconBlock,
+    SignedBlindedBeaconBlock, SignedContributionAndProof, SignedRoot,
+    SignedValidatorRegistrationData, SignedVoluntaryExit, Slot, SlotData,
+    SyncAggregatorSelectionData, SyncCommitteeContribution, SyncCommitteeMessage,
+    SyncSelectionProof, SyncSubnetId, ValidatorRegistrationData, VoluntaryExit,
 };
 use validator_metrics::IntCounterVec;
 use validator_store::{

--- a/anchor/validator_store/src/registration_service.rs
+++ b/anchor/validator_store/src/registration_service.rs
@@ -15,15 +15,13 @@
 use std::sync::Arc;
 
 use beacon_node_fallback::BeaconNodeFallback;
+use bls::PublicKeyBytes;
 use futures::future::join_all;
 use slot_clock::SlotClock;
 use task_executor::TaskExecutor;
 use tokio::time::{Duration, sleep};
 use tracing::{debug, error, info, warn};
-use types::{
-    ChainSpec, EthSpec, PublicKeyBytes, SignedValidatorRegistrationData, Slot,
-    ValidatorRegistrationData,
-};
+use types::{ChainSpec, EthSpec, SignedValidatorRegistrationData, Slot, ValidatorRegistrationData};
 use validator_store::{DoppelgangerStatus, ValidatorStore};
 
 /// Number of epochs to wait before re-submitting validator registration.


### PR DESCRIPTION
## Issue Addressed

The agg committee feature is going to require a small update to lighthouse's validator client service, so this is a pre-requisite PR to update anchor to use latest lighthouse `unstable` commit and resolves conflicts that have emerged since the lighthouse commit that anchor is currently targeting.

## Proposed Changes

Update anchor's lighthouse packages to latest

## Additional Info

This PR is a dependency of https://github.com/sigp/anchor/issues/770
