### PR TITLE
chore: Edition in rustfmt.toml

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -8,3 +8,5 @@ wrap_comments = true
 comment_width = 100
 normalize_comments = true
 format_code_in_doc_comments = true
+
+edition = "2024"


### PR DESCRIPTION
## Issue Addressed

Invoking `rustfmt` directly requires edition information to be noted in the `rustfmt.toml`. Some workflows prefer this over calling `cargo fmt`.

