### PR TITLE
chore: switch to ssv-mini fork for Boole testing

### DIFF
--- a/.github/custom/local-testnet/params.yaml
+++ b/.github/custom/local-testnet/params.yaml
@@ -46,6 +46,8 @@ nodes:
   anchor:
     count: 4
 
+boole_epoch: 3
+
 # Docker images configuration
 images:
   ssv: "ssv-node:v2.3.9"

--- a/.github/workflows/local-testnet.yml
+++ b/.github/workflows/local-testnet.yml
@@ -35,7 +35,7 @@ jobs:
       - uses: actions/checkout@v5
         with:
           repository: ssvlabs/ssv-mini
-          ref: 6ec110091a5ae7cccb0729b4b2541fe880dd8adb
+          ref: ae910a2da2aec8c3151bec0a7e5ea3be4c479a30
           path: ssv-mini
 
       - uses: actions/checkout@v5


### PR DESCRIPTION
## Issue Addressed

We need to test the Boole fork

## Proposed Changes

Switch to commit supporting Boole and configure epoch 3 to be the switch epoch

## Additional Information

Epoch 3 means that the preparation epoch is epoch 2. Nodes are expected to be online and stable by the start of epoch two (indicated by assertoor sleeping for 5 minutes, which is below 2 epochs (6.4 minutes))
