### PR TITLE
feat: reject deprecated roles after Boole fork

### DIFF
--- a/anchor/common/ssv_types/src/consensus.rs
+++ b/anchor/common/ssv_types/src/consensus.rs
@@ -337,6 +337,9 @@ impl<E: EthSpec> ProposerConsensusDataValidator<E> {
             });
         }
 
+        // TODO(post-boole): remove `BEACON_ROLE_AGGREGATOR` and
+        // `BEACON_ROLE_SYNC_COMMITTEE_CONTRIBUTION` branches. Post-Boole, `ProposerConsensusData`
+        // is only used for `Proposer`.
         match value.duty.r#type {
             BEACON_ROLE_AGGREGATOR => {
                 if value.version < DataVersion(ForkName::Electra) {

--- a/anchor/message_validator/src/consensus_message.rs
+++ b/anchor/message_validator/src/consensus_message.rs
@@ -46,6 +46,21 @@ pub(crate) fn validate_consensus_message(
         }
     }
 
+    // Reject deprecated roles after Boole fork
+    if matches!(
+        validation_context.role,
+        Role::Aggregator | Role::SyncCommittee
+    ) {
+        let epoch = slot.epoch(validation_context.slots_per_epoch);
+        if validation_context.fork_schedule.active_fork(epoch) >= Fork::Boole {
+            return Err(ValidationFailure::RoleNotActiveAfterFork {
+                role: validation_context.role,
+                current_fork: validation_context.fork_schedule.active_fork(epoch),
+                deprecated_since_fork: Fork::Boole,
+            });
+        }
+    }
+
     // Call the existing semantic validation
     validate_consensus_message_semantics(
         validation_context.signed_ssv_message,
@@ -1724,5 +1739,72 @@ mod tests {
         let result = duty_limit(&validation_context, slot, &[], mock_duties_provider);
 
         assert_eq!(result, Ok(Some(expected_duty_count)));
+    }
+
+    #[test]
+    fn test_aggregator_consensus_message_rejected_after_boole() {
+        let committee_info = create_committee_info(FOUR_NODE_COMMITTEE);
+        let (private_key, public_key) = generate_test_key_pair();
+        let map =
+            create_operator_pub_keys(committee_info.committee_members.clone(), vec![public_key]);
+
+        let qbft_message =
+            QbftMessageBuilder::new(Role::Aggregator, QbftMessageType::Prepare).build();
+        let signed_msg = create_signed_consensus_message(
+            qbft_message.clone(),
+            vec![OperatorId(1)],
+            vec![],
+            vec![private_key],
+        );
+
+        let now = SystemTime::now();
+        let slot_duration = Duration::from_secs(12);
+        let slot_clock = ManualSlotClock::new(
+            Slot::new(0),
+            now.duration_since(UNIX_EPOCH).unwrap(),
+            slot_duration,
+        );
+        slot_clock.advance_slot();
+        slot_clock.advance_time(slot_duration);
+
+        let validation_context = ValidationContext {
+            signed_ssv_message: &signed_msg,
+            committee_info: &committee_info,
+            role: Role::Aggregator,
+            received_at: now + slot_duration,
+            slots_per_epoch: 32,
+            epochs_per_sync_committee_period: 256,
+            sync_committee_size: 512,
+            slot_clock,
+            operator_pub_keys: &map,
+            fork_schedule: Arc::new(ForkSchedule::new(
+                Fork::Boole,
+                DomainType::default(),
+                "testing",
+            )),
+        };
+
+        let result = validate_ssv_message(
+            validation_context,
+            &mut DutyState::new(64),
+            Arc::new(MockDutiesProvider {
+                voluntary_exit_duty_count: 0,
+            }),
+        );
+
+        assert_validation_error(
+            result,
+            |failure| {
+                matches!(
+                    failure,
+                    ValidationFailure::RoleNotActiveAfterFork {
+                        role: Role::Aggregator,
+                        deprecated_since_fork: Fork::Boole,
+                        ..
+                    }
+                )
+            },
+            "RoleNotActiveAfterFork for Aggregator",
+        );
     }
 }

--- a/anchor/message_validator/src/consensus_message.rs
+++ b/anchor/message_validator/src/consensus_message.rs
@@ -17,7 +17,7 @@ use types::Epoch;
 use crate::{
     FIRST_ROUND, ValidatedSSVMessage, ValidationContext, ValidationFailure, compute_quorum_size,
     duty_state::DutyState, hash_data, slot_start_time, validate_beacon_duty, validate_duty_count,
-    validate_slot_time, verify_message_signatures,
+    validate_role_for_fork, validate_slot_time, verify_message_signatures,
 };
 
 pub(crate) fn validate_consensus_message(
@@ -33,33 +33,9 @@ pub(crate) fn validate_consensus_message(
         Err(err) => return Err(ValidationFailure::UndecodableMessageData(err)),
     };
 
-    // Reject AggregatorCommittee before Boole fork (safety net)
+    // Validate role is allowed for the fork active at this slot
     let slot = Slot::new(consensus_message.height);
-    if validation_context.role == Role::AggregatorCommittee {
-        let epoch = slot.epoch(validation_context.slots_per_epoch);
-        if validation_context.fork_schedule.active_fork(epoch) < Fork::Boole {
-            return Err(ValidationFailure::RoleNotActiveBeforeFork {
-                role: validation_context.role,
-                current_fork: validation_context.fork_schedule.active_fork(epoch),
-                minimum_fork: Fork::Boole,
-            });
-        }
-    }
-
-    // Reject deprecated roles after Boole fork
-    if matches!(
-        validation_context.role,
-        Role::Aggregator | Role::SyncCommittee
-    ) {
-        let epoch = slot.epoch(validation_context.slots_per_epoch);
-        if validation_context.fork_schedule.active_fork(epoch) >= Fork::Boole {
-            return Err(ValidationFailure::RoleNotActiveAfterFork {
-                role: validation_context.role,
-                current_fork: validation_context.fork_schedule.active_fork(epoch),
-                deprecated_since_fork: Fork::Boole,
-            });
-        }
-    }
+    validate_role_for_fork(slot, &validation_context)?;
 
     // Call the existing semantic validation
     validate_consensus_message_semantics(

--- a/anchor/message_validator/src/consensus_message.rs
+++ b/anchor/message_validator/src/consensus_message.rs
@@ -523,6 +523,17 @@ mod tests {
         }
     }
 
+    fn assert_qbft_message_accepted(
+        result: Result<ValidatedSSVMessage, ValidationFailure>,
+        context: &str,
+    ) {
+        match result {
+            Ok(ValidatedSSVMessage::QbftMessage(_)) => {} // success
+            Err(e) => panic!("{context}: Expected QbftMessage to be accepted, got error: {e:?}"),
+            Ok(other) => panic!("{context}: Expected QbftMessage variant, got: {other:?}"),
+        }
+    }
+
     // Extract common key generation into a helper
     fn generate_test_key_pair() -> (Rsa<Private>, Rsa<Public>) {
         let private_key = Rsa::generate(2048).expect("Failed to generate RSA key");
@@ -598,18 +609,7 @@ mod tests {
             }),
         );
 
-        match result {
-            Ok(ValidatedSSVMessage::QbftMessage(_)) => {} // success
-            Err(e) => panic!("Expected successful validation, got: {e:?}"),
-            _ => {}
-        }
-
-        assert!(result.is_ok(), "Expected successful validation");
-
-        match result.unwrap() {
-            ValidatedSSVMessage::QbftMessage(_) => {} // success
-            _ => panic!("Expected QbftMessage variant"),
-        }
+        assert_qbft_message_accepted(result, "Expected successful validation");
     }
 
     #[test]
@@ -1717,15 +1717,19 @@ mod tests {
         assert_eq!(result, Ok(Some(expected_duty_count)));
     }
 
-    #[test]
-    fn test_aggregator_consensus_message_rejected_after_boole() {
+    /// Helper function for testing role validation against fork schedules.
+    ///
+    /// Tests whether a consensus message for a given role is properly accepted or rejected
+    /// based on the fork schedule. Used to verify that deprecated roles (Aggregator and
+    /// SyncCommittee) are rejected after the Boole fork but accepted before it.
+    fn test_role_fork_validation(role: Role, is_after_boole: bool, should_be_rejected: bool) {
+        // Arrange: Set up test data and validation context
         let committee_info = create_committee_info(FOUR_NODE_COMMITTEE);
         let (private_key, public_key) = generate_test_key_pair();
         let map =
             create_operator_pub_keys(committee_info.committee_members.clone(), vec![public_key]);
 
-        let qbft_message =
-            QbftMessageBuilder::new(Role::Aggregator, QbftMessageType::Prepare).build();
+        let qbft_message = QbftMessageBuilder::new(role, QbftMessageType::Prepare).build();
         let signed_msg = create_signed_consensus_message(
             qbft_message.clone(),
             vec![OperatorId(1)],
@@ -1743,23 +1747,30 @@ mod tests {
         slot_clock.advance_slot();
         slot_clock.advance_time(slot_duration);
 
+        let fork_schedule = if is_after_boole {
+            Arc::new(ForkSchedule::new(
+                Fork::Boole,
+                DomainType::default(),
+                "testing",
+            ))
+        } else {
+            generate_fork_schedule()
+        };
+
         let validation_context = ValidationContext {
             signed_ssv_message: &signed_msg,
             committee_info: &committee_info,
-            role: Role::Aggregator,
+            role,
             received_at: now + slot_duration,
             slots_per_epoch: 32,
             epochs_per_sync_committee_period: 256,
             sync_committee_size: 512,
             slot_clock,
             operator_pub_keys: &map,
-            fork_schedule: Arc::new(ForkSchedule::new(
-                Fork::Boole,
-                DomainType::default(),
-                "testing",
-            )),
+            fork_schedule,
         };
 
+        // Act: Validate the message
         let result = validate_ssv_message(
             validation_context,
             &mut DutyState::new(64),
@@ -1768,198 +1779,47 @@ mod tests {
             }),
         );
 
-        assert_validation_error(
-            result,
-            |failure| {
-                matches!(
-                    failure,
-                    ValidationFailure::RoleNotActiveAfterFork {
-                        role: Role::Aggregator,
-                        deprecated_since_fork: Fork::Boole,
-                        ..
-                    }
-                )
-            },
-            "RoleNotActiveAfterFork for Aggregator",
-        );
+        // Assert: Verify the expected outcome
+        if should_be_rejected {
+            assert_validation_error(
+                result,
+                |failure| {
+                    matches!(
+                        failure,
+                        ValidationFailure::RoleNotActiveAfterFork {
+                            role: r,
+                            deprecated_since_fork: Fork::Boole,
+                            ..
+                        } if *r == role
+                    )
+                },
+                &format!("RoleNotActiveAfterFork for {role:?}"),
+            );
+        } else {
+            assert_qbft_message_accepted(
+                result,
+                &format!("Expected {role:?} to be accepted before Boole fork"),
+            );
+        }
+    }
+
+    #[test]
+    fn test_aggregator_consensus_message_rejected_after_boole() {
+        test_role_fork_validation(Role::Aggregator, true, true);
     }
 
     #[test]
     fn test_aggregator_consensus_message_accepted_before_boole() {
-        let committee_info = create_committee_info(FOUR_NODE_COMMITTEE);
-        let (private_key, public_key) = generate_test_key_pair();
-        let map =
-            create_operator_pub_keys(committee_info.committee_members.clone(), vec![public_key]);
-
-        let qbft_message =
-            QbftMessageBuilder::new(Role::Aggregator, QbftMessageType::Prepare).build();
-        let signed_msg = create_signed_consensus_message(
-            qbft_message.clone(),
-            vec![OperatorId(1)],
-            vec![],
-            vec![private_key],
-        );
-
-        let now = SystemTime::now();
-        let slot_duration = Duration::from_secs(12);
-        let slot_clock = ManualSlotClock::new(
-            Slot::new(0),
-            now.duration_since(UNIX_EPOCH).unwrap(),
-            slot_duration,
-        );
-        slot_clock.advance_slot();
-        slot_clock.advance_time(slot_duration);
-
-        let validation_context = ValidationContext {
-            signed_ssv_message: &signed_msg,
-            committee_info: &committee_info,
-            role: Role::Aggregator,
-            received_at: now + slot_duration,
-            slots_per_epoch: 32,
-            epochs_per_sync_committee_period: 256,
-            sync_committee_size: 512,
-            slot_clock,
-            operator_pub_keys: &map,
-            fork_schedule: generate_fork_schedule(),
-        };
-
-        let result = validate_ssv_message(
-            validation_context,
-            &mut DutyState::new(64),
-            Arc::new(MockDutiesProvider {
-                voluntary_exit_duty_count: 0,
-            }),
-        );
-
-        match result {
-            Ok(ValidatedSSVMessage::QbftMessage(_)) => {}
-            Err(e) => {
-                panic!("Expected Role::Aggregator to be accepted before Boole fork, got: {e:?}")
-            }
-            _ => panic!("Expected QbftMessage variant"),
-        }
+        test_role_fork_validation(Role::Aggregator, false, false);
     }
 
     #[test]
     fn test_sync_committee_consensus_message_accepted_before_boole() {
-        let committee_info = create_committee_info(FOUR_NODE_COMMITTEE);
-        let (private_key, public_key) = generate_test_key_pair();
-        let map =
-            create_operator_pub_keys(committee_info.committee_members.clone(), vec![public_key]);
-
-        let qbft_message =
-            QbftMessageBuilder::new(Role::SyncCommittee, QbftMessageType::Prepare).build();
-        let signed_msg = create_signed_consensus_message(
-            qbft_message.clone(),
-            vec![OperatorId(1)],
-            vec![],
-            vec![private_key],
-        );
-
-        let now = SystemTime::now();
-        let slot_duration = Duration::from_secs(12);
-        let slot_clock = ManualSlotClock::new(
-            Slot::new(0),
-            now.duration_since(UNIX_EPOCH).unwrap(),
-            slot_duration,
-        );
-        slot_clock.advance_slot();
-        slot_clock.advance_time(slot_duration);
-
-        let validation_context = ValidationContext {
-            signed_ssv_message: &signed_msg,
-            committee_info: &committee_info,
-            role: Role::SyncCommittee,
-            received_at: now + slot_duration,
-            slots_per_epoch: 32,
-            epochs_per_sync_committee_period: 256,
-            sync_committee_size: 512,
-            slot_clock,
-            operator_pub_keys: &map,
-            fork_schedule: generate_fork_schedule(),
-        };
-
-        let result = validate_ssv_message(
-            validation_context,
-            &mut DutyState::new(64),
-            Arc::new(MockDutiesProvider {
-                voluntary_exit_duty_count: 0,
-            }),
-        );
-
-        match result {
-            Ok(ValidatedSSVMessage::QbftMessage(_)) => {}
-            Err(e) => {
-                panic!("Expected Role::SyncCommittee to be accepted before Boole fork, got: {e:?}")
-            }
-            _ => panic!("Expected QbftMessage variant"),
-        }
+        test_role_fork_validation(Role::SyncCommittee, false, false);
     }
 
     #[test]
     fn test_sync_committee_consensus_message_rejected_after_boole() {
-        let committee_info = create_committee_info(FOUR_NODE_COMMITTEE);
-        let (private_key, public_key) = generate_test_key_pair();
-        let map =
-            create_operator_pub_keys(committee_info.committee_members.clone(), vec![public_key]);
-
-        let qbft_message =
-            QbftMessageBuilder::new(Role::SyncCommittee, QbftMessageType::Prepare).build();
-        let signed_msg = create_signed_consensus_message(
-            qbft_message.clone(),
-            vec![OperatorId(1)],
-            vec![],
-            vec![private_key],
-        );
-
-        let now = SystemTime::now();
-        let slot_duration = Duration::from_secs(12);
-        let slot_clock = ManualSlotClock::new(
-            Slot::new(0),
-            now.duration_since(UNIX_EPOCH).unwrap(),
-            slot_duration,
-        );
-        slot_clock.advance_slot();
-        slot_clock.advance_time(slot_duration);
-
-        let validation_context = ValidationContext {
-            signed_ssv_message: &signed_msg,
-            committee_info: &committee_info,
-            role: Role::SyncCommittee,
-            received_at: now + slot_duration,
-            slots_per_epoch: 32,
-            epochs_per_sync_committee_period: 256,
-            sync_committee_size: 512,
-            slot_clock,
-            operator_pub_keys: &map,
-            fork_schedule: Arc::new(ForkSchedule::new(
-                Fork::Boole,
-                DomainType::default(),
-                "testing",
-            )),
-        };
-
-        let result = validate_ssv_message(
-            validation_context,
-            &mut DutyState::new(64),
-            Arc::new(MockDutiesProvider {
-                voluntary_exit_duty_count: 0,
-            }),
-        );
-
-        assert_validation_error(
-            result,
-            |failure| {
-                matches!(
-                    failure,
-                    ValidationFailure::RoleNotActiveAfterFork {
-                        role: Role::SyncCommittee,
-                        deprecated_since_fork: Fork::Boole,
-                        ..
-                    }
-                )
-            },
-            "RoleNotActiveAfterFork for SyncCommittee",
-        );
+        test_role_fork_validation(Role::SyncCommittee, true, true);
     }
 }

--- a/anchor/message_validator/src/consensus_message.rs
+++ b/anchor/message_validator/src/consensus_message.rs
@@ -1783,4 +1783,183 @@ mod tests {
             "RoleNotActiveAfterFork for Aggregator",
         );
     }
+
+    #[test]
+    fn test_aggregator_consensus_message_accepted_before_boole() {
+        let committee_info = create_committee_info(FOUR_NODE_COMMITTEE);
+        let (private_key, public_key) = generate_test_key_pair();
+        let map =
+            create_operator_pub_keys(committee_info.committee_members.clone(), vec![public_key]);
+
+        let qbft_message =
+            QbftMessageBuilder::new(Role::Aggregator, QbftMessageType::Prepare).build();
+        let signed_msg = create_signed_consensus_message(
+            qbft_message.clone(),
+            vec![OperatorId(1)],
+            vec![],
+            vec![private_key],
+        );
+
+        let now = SystemTime::now();
+        let slot_duration = Duration::from_secs(12);
+        let slot_clock = ManualSlotClock::new(
+            Slot::new(0),
+            now.duration_since(UNIX_EPOCH).unwrap(),
+            slot_duration,
+        );
+        slot_clock.advance_slot();
+        slot_clock.advance_time(slot_duration);
+
+        let validation_context = ValidationContext {
+            signed_ssv_message: &signed_msg,
+            committee_info: &committee_info,
+            role: Role::Aggregator,
+            received_at: now + slot_duration,
+            slots_per_epoch: 32,
+            epochs_per_sync_committee_period: 256,
+            sync_committee_size: 512,
+            slot_clock,
+            operator_pub_keys: &map,
+            fork_schedule: generate_fork_schedule(),
+        };
+
+        let result = validate_ssv_message(
+            validation_context,
+            &mut DutyState::new(64),
+            Arc::new(MockDutiesProvider {
+                voluntary_exit_duty_count: 0,
+            }),
+        );
+
+        match result {
+            Ok(ValidatedSSVMessage::QbftMessage(_)) => {}
+            Err(e) => {
+                panic!("Expected Role::Aggregator to be accepted before Boole fork, got: {e:?}")
+            }
+            _ => panic!("Expected QbftMessage variant"),
+        }
+    }
+
+    #[test]
+    fn test_sync_committee_consensus_message_accepted_before_boole() {
+        let committee_info = create_committee_info(FOUR_NODE_COMMITTEE);
+        let (private_key, public_key) = generate_test_key_pair();
+        let map =
+            create_operator_pub_keys(committee_info.committee_members.clone(), vec![public_key]);
+
+        let qbft_message =
+            QbftMessageBuilder::new(Role::SyncCommittee, QbftMessageType::Prepare).build();
+        let signed_msg = create_signed_consensus_message(
+            qbft_message.clone(),
+            vec![OperatorId(1)],
+            vec![],
+            vec![private_key],
+        );
+
+        let now = SystemTime::now();
+        let slot_duration = Duration::from_secs(12);
+        let slot_clock = ManualSlotClock::new(
+            Slot::new(0),
+            now.duration_since(UNIX_EPOCH).unwrap(),
+            slot_duration,
+        );
+        slot_clock.advance_slot();
+        slot_clock.advance_time(slot_duration);
+
+        let validation_context = ValidationContext {
+            signed_ssv_message: &signed_msg,
+            committee_info: &committee_info,
+            role: Role::SyncCommittee,
+            received_at: now + slot_duration,
+            slots_per_epoch: 32,
+            epochs_per_sync_committee_period: 256,
+            sync_committee_size: 512,
+            slot_clock,
+            operator_pub_keys: &map,
+            fork_schedule: generate_fork_schedule(),
+        };
+
+        let result = validate_ssv_message(
+            validation_context,
+            &mut DutyState::new(64),
+            Arc::new(MockDutiesProvider {
+                voluntary_exit_duty_count: 0,
+            }),
+        );
+
+        match result {
+            Ok(ValidatedSSVMessage::QbftMessage(_)) => {}
+            Err(e) => {
+                panic!("Expected Role::SyncCommittee to be accepted before Boole fork, got: {e:?}")
+            }
+            _ => panic!("Expected QbftMessage variant"),
+        }
+    }
+
+    #[test]
+    fn test_sync_committee_consensus_message_rejected_after_boole() {
+        let committee_info = create_committee_info(FOUR_NODE_COMMITTEE);
+        let (private_key, public_key) = generate_test_key_pair();
+        let map =
+            create_operator_pub_keys(committee_info.committee_members.clone(), vec![public_key]);
+
+        let qbft_message =
+            QbftMessageBuilder::new(Role::SyncCommittee, QbftMessageType::Prepare).build();
+        let signed_msg = create_signed_consensus_message(
+            qbft_message.clone(),
+            vec![OperatorId(1)],
+            vec![],
+            vec![private_key],
+        );
+
+        let now = SystemTime::now();
+        let slot_duration = Duration::from_secs(12);
+        let slot_clock = ManualSlotClock::new(
+            Slot::new(0),
+            now.duration_since(UNIX_EPOCH).unwrap(),
+            slot_duration,
+        );
+        slot_clock.advance_slot();
+        slot_clock.advance_time(slot_duration);
+
+        let validation_context = ValidationContext {
+            signed_ssv_message: &signed_msg,
+            committee_info: &committee_info,
+            role: Role::SyncCommittee,
+            received_at: now + slot_duration,
+            slots_per_epoch: 32,
+            epochs_per_sync_committee_period: 256,
+            sync_committee_size: 512,
+            slot_clock,
+            operator_pub_keys: &map,
+            fork_schedule: Arc::new(ForkSchedule::new(
+                Fork::Boole,
+                DomainType::default(),
+                "testing",
+            )),
+        };
+
+        let result = validate_ssv_message(
+            validation_context,
+            &mut DutyState::new(64),
+            Arc::new(MockDutiesProvider {
+                voluntary_exit_duty_count: 0,
+            }),
+        );
+
+        assert_validation_error(
+            result,
+            |failure| {
+                matches!(
+                    failure,
+                    ValidationFailure::RoleNotActiveAfterFork {
+                        role: Role::SyncCommittee,
+                        deprecated_since_fork: Fork::Boole,
+                        ..
+                    }
+                )
+            },
+            "RoleNotActiveAfterFork for SyncCommittee",
+        );
+    }
 }

--- a/anchor/message_validator/src/lib.rs
+++ b/anchor/message_validator/src/lib.rs
@@ -217,6 +217,11 @@ pub enum ValidationFailure {
         current_fork: fork::Fork,
         minimum_fork: fork::Fork,
     },
+    RoleNotActiveAfterFork {
+        role: Role,
+        current_fork: fork::Fork,
+        deprecated_since_fork: fork::Fork,
+    },
 }
 
 impl From<&ValidationFailure> for MessageAcceptance {

--- a/anchor/message_validator/src/lib.rs
+++ b/anchor/message_validator/src/lib.rs
@@ -797,25 +797,22 @@ pub(crate) fn validate_role_for_fork(
 ) -> Result<(), ValidationFailure> {
     let role = validation_context.role;
     let epoch = slot.epoch(validation_context.slots_per_epoch);
+    let active_fork = validation_context.fork_schedule.active_fork(epoch);
 
     // Reject AggregatorCommittee before Boole fork (safety net)
-    if role == Role::AggregatorCommittee
-        && validation_context.fork_schedule.active_fork(epoch) < Fork::Boole
-    {
+    if role == Role::AggregatorCommittee && active_fork < Fork::Boole {
         return Err(ValidationFailure::RoleNotActiveBeforeFork {
             role,
-            current_fork: validation_context.fork_schedule.active_fork(epoch),
+            current_fork: active_fork,
             minimum_fork: Fork::Boole,
         });
     }
 
     // Reject deprecated roles after Boole fork
-    if matches!(role, Role::Aggregator | Role::SyncCommittee)
-        && validation_context.fork_schedule.active_fork(epoch) >= Fork::Boole
-    {
+    if matches!(role, Role::Aggregator | Role::SyncCommittee) && active_fork >= Fork::Boole {
         return Err(ValidationFailure::RoleNotActiveAfterFork {
             role,
-            current_fork: validation_context.fork_schedule.active_fork(epoch),
+            current_fork: active_fork,
             deprecated_since_fork: Fork::Boole,
         });
     }

--- a/anchor/message_validator/src/lib.rs
+++ b/anchor/message_validator/src/lib.rs
@@ -12,7 +12,7 @@ use std::{
 use dashmap::{DashMap, mapref::one::RefMut};
 use database::NetworkState;
 pub use duties_tracker::DutiesProvider;
-use fork::ForkSchedule;
+use fork::{Fork, ForkSchedule};
 pub use gossipsub::MessageAcceptance;
 use openssl::{
     hash::MessageDigest,
@@ -781,6 +781,43 @@ pub(crate) fn validate_beacon_duty(
         if !duty_provider.is_validator_in_sync_committee(period, validator_index) {
             return Err(ValidationFailure::NoDuty);
         }
+    }
+
+    Ok(())
+}
+
+/// Validates that a role is allowed for the fork active at the given slot.
+///
+/// Rejects:
+/// - AggregatorCommittee before Boole fork (not yet active)
+/// - Aggregator and SyncCommittee after Boole fork (deprecated)
+pub(crate) fn validate_role_for_fork(
+    slot: Slot,
+    validation_context: &ValidationContext<impl SlotClock>,
+) -> Result<(), ValidationFailure> {
+    let role = validation_context.role;
+    let epoch = slot.epoch(validation_context.slots_per_epoch);
+
+    // Reject AggregatorCommittee before Boole fork (safety net)
+    if role == Role::AggregatorCommittee
+        && validation_context.fork_schedule.active_fork(epoch) < Fork::Boole
+    {
+        return Err(ValidationFailure::RoleNotActiveBeforeFork {
+            role,
+            current_fork: validation_context.fork_schedule.active_fork(epoch),
+            minimum_fork: Fork::Boole,
+        });
+    }
+
+    // Reject deprecated roles after Boole fork
+    if matches!(role, Role::Aggregator | Role::SyncCommittee)
+        && validation_context.fork_schedule.active_fork(epoch) >= Fork::Boole
+    {
+        return Err(ValidationFailure::RoleNotActiveAfterFork {
+            role,
+            current_fork: validation_context.fork_schedule.active_fork(epoch),
+            deprecated_since_fork: Fork::Boole,
+        });
     }
 
     Ok(())

--- a/anchor/message_validator/src/partial_signature.rs
+++ b/anchor/message_validator/src/partial_signature.rs
@@ -1,7 +1,6 @@
 use std::{collections::HashMap, sync::Arc};
 
 use duties_tracker::DutiesProvider;
-use fork::Fork;
 use slot_clock::SlotClock;
 use ssv_types::{
     OperatorId,
@@ -13,7 +12,8 @@ use types::consts::altair::SYNC_COMMITTEE_SUBNET_COUNT;
 
 use crate::{
     ValidatedSSVMessage, ValidationContext, ValidationFailure, duty_state::DutyState,
-    validate_beacon_duty, validate_duty_count, validate_slot_time, verify_message_signature,
+    validate_beacon_duty, validate_duty_count, validate_role_for_fork, validate_slot_time,
+    verify_message_signature,
 };
 
 // Constants for validation rules
@@ -32,32 +32,8 @@ pub(crate) fn validate_partial_signature_message(
         Err(err) => return Err(ValidationFailure::UndecodableMessageData(err)),
     };
 
-    // Reject AggregatorCommittee before Boole fork (safety net)
-    if validation_context.role == Role::AggregatorCommittee {
-        let epoch = messages.slot.epoch(validation_context.slots_per_epoch);
-        if validation_context.fork_schedule.active_fork(epoch) < Fork::Boole {
-            return Err(ValidationFailure::RoleNotActiveBeforeFork {
-                role: validation_context.role,
-                current_fork: validation_context.fork_schedule.active_fork(epoch),
-                minimum_fork: Fork::Boole,
-            });
-        }
-    }
-
-    // Reject deprecated roles after Boole fork
-    if matches!(
-        validation_context.role,
-        Role::Aggregator | Role::SyncCommittee
-    ) {
-        let epoch = messages.slot.epoch(validation_context.slots_per_epoch);
-        if validation_context.fork_schedule.active_fork(epoch) >= Fork::Boole {
-            return Err(ValidationFailure::RoleNotActiveAfterFork {
-                role: validation_context.role,
-                current_fork: validation_context.fork_schedule.active_fork(epoch),
-                deprecated_since_fork: Fork::Boole,
-            });
-        }
-    }
+    // Validate role is allowed for the fork active at this slot
+    validate_role_for_fork(messages.slot, &validation_context)?;
 
     // Validate basic semantics
     let signer = validate_partial_signature_message_semantics(&validation_context, &messages)?;
@@ -353,7 +329,7 @@ mod tests {
     use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
     use bls::{Hash256, Signature};
-    use fork::ForkSchedule;
+    use fork::{Fork, ForkSchedule};
     use openssl::{
         hash::MessageDigest,
         pkey::{PKey, Private, Public},

--- a/anchor/message_validator/src/partial_signature.rs
+++ b/anchor/message_validator/src/partial_signature.rs
@@ -44,6 +44,21 @@ pub(crate) fn validate_partial_signature_message(
         }
     }
 
+    // Reject deprecated roles after Boole fork
+    if matches!(
+        validation_context.role,
+        Role::Aggregator | Role::SyncCommittee
+    ) {
+        let epoch = messages.slot.epoch(validation_context.slots_per_epoch);
+        if validation_context.fork_schedule.active_fork(epoch) >= Fork::Boole {
+            return Err(ValidationFailure::RoleNotActiveAfterFork {
+                role: validation_context.role,
+                current_fork: validation_context.fork_schedule.active_fork(epoch),
+                deprecated_since_fork: Fork::Boole,
+            });
+        }
+    }
+
     // Validate basic semantics
     let signer = validate_partial_signature_message_semantics(&validation_context, &messages)?;
 
@@ -1675,6 +1690,57 @@ mod tests {
             result,
             |failure| matches!(failure, ValidationFailure::LateSlotMessage { .. }),
             "LateSlotMessage",
+        );
+    }
+
+    #[test]
+    fn test_aggregator_partial_sig_rejected_after_boole() {
+        // Arrange
+        let committee_info = create_committee_info(FOUR_NODE_COMMITTEE);
+        let (private_key, public_key) = generate_test_key_pair();
+        let map =
+            create_operator_pub_keys(committee_info.committee_members.clone(), vec![public_key]);
+
+        let (_, signed_msg) = create_test_partial_signature(
+            Role::Aggregator,
+            PartialSignatureKind::SelectionProofPartialSig,
+            OperatorId(1),
+            PartialSigTestOptions::default(),
+            Some(private_key),
+        );
+
+        // Create validation context with Boole fork (Boole is active)
+        let validation_context = create_test_validation_context_with_fork(
+            &signed_msg,
+            &committee_info,
+            Role::Aggregator,
+            &map,
+            Some(generate_fork_schedule(Fork::Boole)),
+        );
+
+        // Act
+        let result = validate_partial_signature_message(
+            validation_context,
+            &mut DutyState::new(64),
+            Arc::new(MockDutiesProvider {
+                voluntary_exit_duty_count: 0,
+            }),
+        );
+
+        // Assert - Should be rejected after Boole
+        assert_validation_error(
+            result,
+            |failure| {
+                matches!(
+                    failure,
+                    ValidationFailure::RoleNotActiveAfterFork {
+                        role: Role::Aggregator,
+                        deprecated_since_fork: Fork::Boole,
+                        ..
+                    }
+                )
+            },
+            "RoleNotActiveAfterFork for Aggregator",
         );
     }
 }


### PR DESCRIPTION
## Issue Addressed
Feature parity with ssv-go, catching up with their recent commits. This PR supports https://github.com/sigp/anchor/issues/770.

## Proposed Changes
Reject deprecated `Role::Aggregator` and `Role::SyncCommittee` messages after the Boole fork activates. SSV-Go's 
  `validRoleAtSlot()` rejects these roles post-Boole, so Anchor must do the same for P2P compatibility.            
                                                                                                                   
  - Add `RoleNotActiveAfterFork` validation error                                                                  
  - Add fork-aware validation in consensus message and partial signature handlers    

## Additional Info
N/A
