### PR TITLE
chore: Less strict testnet in CI

### DIFF
--- a/.github/custom/local-testnet/params.yaml
+++ b/.github/custom/local-testnet/params.yaml
@@ -32,9 +32,10 @@ network:
     cl:
       enabled: true
 
+  # Assertoor can only load from URLs here (for some reason). The placeholder is replaced in the workflow.
   assertoor_params:
     tests:
-      - https://gist.githubusercontent.com/lmnzx/13c4135052bc0f13f3f785010b3197e7/raw/e3ee98c97c54bfaa692640c917d8c6f362d03a4b/check_anchor_proposal.yaml
+      - https://raw.githubusercontent.com/sigp/anchor/<<COMMIT>>/.github/custom/local-testnet/test_anchor_proposal.yaml
 
 
 monitor:

--- a/.github/custom/local-testnet/test_anchor_proposal.yaml
+++ b/.github/custom/local-testnet/test_anchor_proposal.yaml
@@ -1,6 +1,6 @@
 id: test_anchor_proposal
 name: "Check for Anchor Proposal"
-timeout: 30m
+timeout: 20m
 tasks:
   - name: sleep
     config:
@@ -15,9 +15,8 @@ tasks:
             minAttestationCount: 1
         - name: check_consensus_attestation_stats
           config:
-            minTargetPercent: 100
-            minHeadPercent: 100
-            minTotalPercent: 100
+            minTargetPercent: 98
+            minHeadPercent: 80
             failOnCheckMiss: true
             minCheckedEpochs: 2
   - name: check_consensus_finality

--- a/.github/custom/local-testnet/test_anchor_proposal.yaml
+++ b/.github/custom/local-testnet/test_anchor_proposal.yaml
@@ -15,6 +15,10 @@ tasks:
             minAttestationCount: 1
         - name: check_consensus_attestation_stats
           config:
+            # These values are taken from a similar config used in the ethereum-package.
+            # The minTargetPercent ensures that most attestations are included at some point.
+            # The minHeadPercent is more lenient as on shared CI, nodes might not have ideal performance.
+            # 80% is low enough to not cause false positives but high enough to catch consistent issues.
             minTargetPercent: 98
             minHeadPercent: 80
             failOnCheckMiss: true

--- a/.github/workflows/local-testnet.yml
+++ b/.github/workflows/local-testnet.yml
@@ -61,6 +61,9 @@ jobs:
       - name: Load Docker Image
         run: docker load -i anchor-docker.tar
 
+      - name: Replace Commit placeholder in params.yaml
+        run: sed -i 's/<<COMMIT>>/$(git rev-parse HEAD)/g' anchor/.github/custom/local-testnet/params.yaml
+
       - name: Start Local Testnet with Assertoor
         timeout-minutes: 30
         run: kurtosis run --verbosity DETAILED --enclave localnet ssv-mini --args-file anchor/.github/custom/local-testnet/params.yaml

--- a/.github/workflows/local-testnet.yml
+++ b/.github/workflows/local-testnet.yml
@@ -62,7 +62,7 @@ jobs:
         run: docker load -i anchor-docker.tar
 
       - name: Replace Commit placeholder in params.yaml
-        run: sed -i 's/<<COMMIT>>/$(git rev-parse HEAD)/g' anchor/.github/custom/local-testnet/params.yaml
+        run: sed -i "s/<<COMMIT>>/${{ github.sha }}/g" anchor/.github/custom/local-testnet/params.yaml
 
       - name: Start Local Testnet with Assertoor
         timeout-minutes: 30


### PR DESCRIPTION
## Issue Addressed

CI often fails due as the newly introduced local testnet is checked too strictly. 

## Proposed Changes

Replace the parameters with the less strict parameters found in `ethereum-package`

## Additional Info

Additionally, load the correct parameter file from the repo instead of a gist URL.
