### PR TITLE
fix: guard fork phase channel handling

### DIFF
--- a/anchor/common/fork/src/monitor.rs
+++ b/anchor/common/fork/src/monitor.rs
@@ -19,7 +19,7 @@ use std::{ops::ControlFlow, sync::Arc, time::Duration};
 
 use slot_clock::SlotClock;
 use task_executor::TaskExecutor;
-use tracing::{info, warn};
+use tracing::{debug, info, warn};
 use types::{Epoch, Slot};
 
 use crate::{FORK_PREPARATION_EPOCHS, Fork, ForkConfig, ForkSchedule, SUBSEQUENT_WINDOW_SLOTS};
@@ -409,7 +409,7 @@ async fn broadcast_or_stop(
     phase: ForkPhase,
 ) -> ControlFlow<MonitorResult, ()> {
     if let Err(err) = phase_sender.broadcast_direct(phase).await {
-        warn!(?err, "Fork monitor: phase channel closed; stopping");
+        debug!(?err, "Fork monitor: phase channel closed; stopping");
         return ControlFlow::Break(MonitorResult::Completed);
     }
     ControlFlow::Continue(())

--- a/anchor/common/fork/src/monitor.rs
+++ b/anchor/common/fork/src/monitor.rs
@@ -403,17 +403,12 @@ async fn sleep_until_slot<S: SlotClock>(slot_clock: &S, target_slot: u64, second
     tokio::time::sleep(sleep_duration).await;
 }
 
-/// Broadcast a fork-phase event and stop the monitor if the channel is closed.
-///
-/// Returns `false` when the monitor should exit early.
-async fn broadcast_phase(phase_sender: &ForkPhaseSender, phase: ForkPhase) -> bool {
-    match phase_sender.broadcast_direct(phase).await {
-        Ok(_) => true,
-        Err(err) => {
-            warn!(?err, "Fork monitor: phase channel closed; stopping");
-            false
-        }
-    }
+/// Broadcast a fork-phase event.
+async fn broadcast_phase(
+    phase_sender: &ForkPhaseSender,
+    phase: ForkPhase,
+) -> Result<(), async_broadcast::SendError<ForkPhase>> {
+    phase_sender.broadcast_direct(phase).await.map(|_| ())
 }
 
 /// Run the fork monitor.
@@ -448,8 +443,9 @@ pub async fn run<S: SlotClock>(
     }
 
     if let Some(phase) = initial_phase
-        && !broadcast_phase(&phase_sender, phase).await
+        && let Err(err) = broadcast_phase(&phase_sender, phase).await
     {
+        warn!(?err, "Fork monitor: phase channel closed; stopping");
         return MonitorResult::Completed;
     }
 
@@ -474,7 +470,8 @@ pub async fn run<S: SlotClock>(
 
         let phases = state.check_slot(slot);
         for phase in phases {
-            if !broadcast_phase(&phase_sender, phase).await {
+            if let Err(err) = broadcast_phase(&phase_sender, phase).await {
+                warn!(?err, "Fork monitor: phase channel closed; stopping");
                 return MonitorResult::Completed;
             }
         }

--- a/anchor/common/fork/src/monitor.rs
+++ b/anchor/common/fork/src/monitor.rs
@@ -446,10 +446,10 @@ pub async fn run<S: SlotClock>(
         return MonitorResult::Completed;
     }
 
-    if let Some(phase) = initial_phase {
-        if let ControlFlow::Break(result) = broadcast_or_stop(&phase_sender, phase).await {
-            return result;
-        }
+    if let Some(phase) = initial_phase
+        && let ControlFlow::Break(result) = broadcast_or_stop(&phase_sender, phase).await
+    {
+        return result;
     }
 
     let mut last_slot = current_slot.as_u64();

--- a/anchor/common/fork/src/monitor.rs
+++ b/anchor/common/fork/src/monitor.rs
@@ -403,14 +403,6 @@ async fn sleep_until_slot<S: SlotClock>(slot_clock: &S, target_slot: u64, second
     tokio::time::sleep(sleep_duration).await;
 }
 
-/// Broadcast a fork-phase event.
-async fn broadcast_phase(
-    phase_sender: &ForkPhaseSender,
-    phase: ForkPhase,
-) -> Result<(), async_broadcast::SendError<ForkPhase>> {
-    phase_sender.broadcast_direct(phase).await.map(|_| ())
-}
-
 /// Run the fork monitor.
 ///
 /// This is the core async logic, separated from `spawn` for testability.
@@ -443,7 +435,7 @@ pub async fn run<S: SlotClock>(
     }
 
     if let Some(phase) = initial_phase
-        && let Err(err) = broadcast_phase(&phase_sender, phase).await
+        && let Err(err) = phase_sender.broadcast_direct(phase).await
     {
         warn!(?err, "Fork monitor: phase channel closed; stopping");
         return MonitorResult::Completed;
@@ -470,7 +462,7 @@ pub async fn run<S: SlotClock>(
 
         let phases = state.check_slot(slot);
         for phase in phases {
-            if let Err(err) = broadcast_phase(&phase_sender, phase).await {
+            if let Err(err) = phase_sender.broadcast_direct(phase).await {
                 warn!(?err, "Fork monitor: phase channel closed; stopping");
                 return MonitorResult::Completed;
             }

--- a/anchor/common/fork/src/monitor.rs
+++ b/anchor/common/fork/src/monitor.rs
@@ -403,6 +403,19 @@ async fn sleep_until_slot<S: SlotClock>(slot_clock: &S, target_slot: u64, second
     tokio::time::sleep(sleep_duration).await;
 }
 
+/// Broadcast a fork-phase event and stop the monitor if the channel is closed.
+///
+/// Returns `false` when the monitor should exit early.
+async fn broadcast_phase(phase_sender: &ForkPhaseSender, phase: ForkPhase) -> bool {
+    match phase_sender.broadcast_direct(phase).await {
+        Ok(_) => true,
+        Err(err) => {
+            warn!(?err, "Fork monitor: phase channel closed; stopping");
+            false
+        }
+    }
+}
+
 /// Run the fork monitor.
 ///
 /// This is the core async logic, separated from `spawn` for testability.
@@ -434,8 +447,10 @@ pub async fn run<S: SlotClock>(
         return MonitorResult::Completed;
     }
 
-    if let Some(phase) = initial_phase {
-        let _ = phase_sender.broadcast_direct(phase).await;
+    if let Some(phase) = initial_phase
+        && !broadcast_phase(&phase_sender, phase).await
+    {
+        return MonitorResult::Completed;
     }
 
     let mut last_slot = current_slot.as_u64();
@@ -459,7 +474,9 @@ pub async fn run<S: SlotClock>(
 
         let phases = state.check_slot(slot);
         for phase in phases {
-            let _ = phase_sender.broadcast_direct(phase).await;
+            if !broadcast_phase(&phase_sender, phase).await {
+                return MonitorResult::Completed;
+            }
         }
 
         if state.is_complete() {

--- a/anchor/common/fork/src/monitor.rs
+++ b/anchor/common/fork/src/monitor.rs
@@ -15,7 +15,7 @@
 //! activation) and sleeps directly until that time. This is more efficient
 //! and precise than periodic polling.
 
-use std::{sync::Arc, time::Duration};
+use std::{ops::ControlFlow, sync::Arc, time::Duration};
 
 use slot_clock::SlotClock;
 use task_executor::TaskExecutor;
@@ -403,6 +403,18 @@ async fn sleep_until_slot<S: SlotClock>(slot_clock: &S, target_slot: u64, second
     tokio::time::sleep(sleep_duration).await;
 }
 
+/// Broadcast a fork-phase event or signal early exit if the channel is closed.
+async fn broadcast_or_stop(
+    phase_sender: &ForkPhaseSender,
+    phase: ForkPhase,
+) -> ControlFlow<MonitorResult, ()> {
+    if let Err(err) = phase_sender.broadcast_direct(phase).await {
+        warn!(?err, "Fork monitor: phase channel closed; stopping");
+        return ControlFlow::Break(MonitorResult::Completed);
+    }
+    ControlFlow::Continue(())
+}
+
 /// Run the fork monitor.
 ///
 /// This is the core async logic, separated from `spawn` for testability.
@@ -434,11 +446,10 @@ pub async fn run<S: SlotClock>(
         return MonitorResult::Completed;
     }
 
-    if let Some(phase) = initial_phase
-        && let Err(err) = phase_sender.broadcast_direct(phase).await
-    {
-        warn!(?err, "Fork monitor: phase channel closed; stopping");
-        return MonitorResult::Completed;
+    if let Some(phase) = initial_phase {
+        if let ControlFlow::Break(result) = broadcast_or_stop(&phase_sender, phase).await {
+            return result;
+        }
     }
 
     let mut last_slot = current_slot.as_u64();
@@ -462,9 +473,8 @@ pub async fn run<S: SlotClock>(
 
         let phases = state.check_slot(slot);
         for phase in phases {
-            if let Err(err) = phase_sender.broadcast_direct(phase).await {
-                warn!(?err, "Fork monitor: phase channel closed; stopping");
-                return MonitorResult::Completed;
+            if let ControlFlow::Break(result) = broadcast_or_stop(&phase_sender, phase).await {
+                return result;
             }
         }
 

--- a/anchor/network/src/network.rs
+++ b/anchor/network/src/network.rs
@@ -77,6 +77,7 @@ enum LoopControl {
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum ForkPhaseRxState {
     Active,
+    /// Disable after closure to avoid repeatedly polling a closed receiver.
     Disabled,
 }
 

--- a/anchor/network/src/network.rs
+++ b/anchor/network/src/network.rs
@@ -6,6 +6,7 @@ use std::{
     time::Duration,
 };
 
+use async_broadcast::RecvError;
 use futures::StreamExt;
 use gossipsub::{IdentTopic, PublishError};
 use libp2p::{
@@ -65,6 +66,18 @@ pub enum NetworkError {
 
     #[error("DNS transport config error: {0}")]
     DnsTransport(std::io::Error),
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum LoopControl {
+    Continue,
+    Exit,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum ForkPhaseRxState {
+    Active,
+    Disabled,
 }
 
 pub struct Network<R: MessageReceiver> {
@@ -169,139 +182,12 @@ impl<R: MessageReceiver> Network<R> {
 
     /// Main loop for polling and handling swarm and channels.
     pub async fn run<E: EthSpec>(mut self) {
+        let mut fork_phase_rx_state = ForkPhaseRxState::Active;
+
         loop {
             tokio::select! {
                 swarm_message = self.swarm.select_next_some() => {
-                    match swarm_message {
-                        SwarmEvent::Behaviour(behaviour_event) => match behaviour_event {
-                            AnchorBehaviourEvent::Gossipsub(ge) => {
-                                match ge {
-                                    gossipsub::Event::Message {
-                                        propagation_source,
-                                        message_id,
-                                        message,
-                                    } => {
-                                        trace!(
-                                            source = ?propagation_source,
-                                            id = ?message_id,
-                                            "Received SignedSSVMessage"
-                                        );
-
-                                        // Build topic context for fork-aware validation.
-                                        // If we can't parse the topic, reject immediately - we only
-                                        // subscribe to topics we create, so parsing should always succeed.
-                                        let topic_context = match topic::parse_topic(&message.topic) {
-                                            Some(parsed) => TopicContext::Validate { parsed },
-                                            None => {
-                                                warn!(
-                                                    topic = ?message.topic,
-                                                    "Received message on unparseable topic - this is a bug"
-                                                );
-                                                continue;
-                                            }
-                                        };
-
-                                        if let Err(err) = self.message_receiver.receive(
-                                            propagation_source,
-                                            message_id,
-                                            message,
-                                            topic_context,
-                                        ) {
-                                            error!(?err, "Unable to pass message to message receiver");
-                                        }
-                                    }
-                                    gossipsub::Event::Subscribed { peer_id, topic } => {
-                                        if let Some(subnet) = topic::parse_subnet_id(&topic) {
-                                            self.peer_manager().set_peer_subscription(peer_id, subnet, true);
-                                        }
-                                    }
-                                    gossipsub::Event::Unsubscribed { peer_id, topic } => {
-                                        if let Some(subnet) = topic::parse_subnet_id(&topic) {
-                                            self.peer_manager().set_peer_subscription(peer_id, subnet, false);
-                                        }
-                                    }
-                                    _ => {
-                                        trace!(event = ?ge, "Unhandled gossipsub event");
-                                    }
-                                }
-                            },
-                            AnchorBehaviourEvent::Discovery(DiscoveredPeers { peers }) => {
-                                self.on_discovered_peers(peers);
-                            }
-                            AnchorBehaviourEvent::Handshake(event) => {
-                                self.handle_handshake_result(event);
-                            }
-                            AnchorBehaviourEvent::Upnp(upnp_event) => {
-                                self.on_upnp_event(upnp_event);
-                            }
-                            AnchorBehaviourEvent::PeerManager(peer_manager::Event::Heartbeat(heartbeat)) => {
-                                if let Some(actions) = heartbeat.connect_actions {
-                                    self.handle_connect_actions(actions);
-                                }
-
-                                if heartbeat.check_peer_scores {
-                                    self.check_block_and_prune_peers_by_score();
-                                }
-
-                                // Trigger periodic subnet-aware peer discovery if below target
-                                let connected_peers = self.swarm.behaviour().peer_manager.connected_peers();
-                                let target_peers = self.swarm.behaviour().peer_manager.target_peers();
-                                if connected_peers < target_peers {
-                                    let needed_subnets: Vec<_> = self.swarm.behaviour()
-                                        .peer_manager
-                                        .needed_subnets()
-                                        .iter()
-                                        .copied()
-                                        .collect();
-
-                                    if !needed_subnets.is_empty() {
-                                        debug!(
-                                            connected_peers,
-                                            target_peers,
-                                            subnets = ?needed_subnets,
-                                            "Below target peer count, triggering subnet-aware peer discovery"
-                                        );
-                                        self.swarm.behaviour_mut().discovery.start_subnet_query(needed_subnets);
-                                    }
-                                }
-
-                                if self.swarm.behaviour().peer_manager.active_subnet_count() > 0 {
-                                    // Disconnect peers that no longer subscribe to any needed subnets
-                                    let to_disconnect = self
-                                        .swarm
-                                        .behaviour()
-                                        .peer_manager
-                                        .peers_to_disconnect_due_to_subnets();
-
-                                    for peer_id in to_disconnect {
-                                        self.disconnect_peer(&peer_id, "No longer subscribed to any needed subnets");
-                                    }
-                                }
-                            }
-                            _ => {
-                                trace!(event = ?behaviour_event, "Unhandled behaviour event");
-                            }
-                        },
-                        SwarmEvent::NewListenAddr { listener_id, address } => {
-                            self.on_new_listen_addr(listener_id, address);
-                        },
-                        SwarmEvent::OutgoingConnectionError { peer_id, error, .. } => {
-                            debug!(?peer_id, ?error, "Outgoing connection error");
-                        },
-                        SwarmEvent::IncomingConnectionError { error, send_back_addr, .. } => {
-                            debug!(?send_back_addr, ?error, "Incoming connection error");
-                        },
-                        SwarmEvent::ConnectionClosed { peer_id, cause, .. } => {
-                            if cause.is_some() {
-                                debug!(?peer_id, ?cause, "Connection closed with error");
-                            } else {
-                                trace!(?peer_id, "Connection closed");
-                            }
-                        },
-                        _ => {
-                            trace!(event = ?swarm_message, "Unhandled swarm event");
-                        },
-                    }
+                    self.handle_swarm_event(swarm_message);
                 }
 
                 Some(event) = self.topic_event_receiver.recv() => {
@@ -309,42 +195,253 @@ impl<R: MessageReceiver> Network<R> {
                 }
 
                 event = self.message_rx.recv() => {
-                    match event {
-                        Some((topic_string, message)) => {
-                            // Topic is determined by message sender based on message slot (per SIP-43)
-                            let topic = IdentTopic::new(topic_string);
-                            if let Err(err) = self.gossipsub().publish(topic, message)
-                                && !matches!(err, PublishError::Duplicate)
-                            {
-                                error!(?err, "Failed to publish message");
-                            }
-                        }
-                        None => {
-                            error!("message queue was closed");
-                            return;
-                        }
+                    if self.handle_outbound_message(event) == LoopControl::Exit {
+                        return;
                     }
                 }
                 event = self.outcome_rx.recv() => {
-                    match event {
-                        Some(outcome) => {
-                            self.gossipsub()
-                                .report_message_validation_result(
-                                    &outcome.message_id,
-                                    &outcome.propagation_source,
-                                    outcome.action,
-                                );
-                        }
-                        None => {
-                            error!("message validator has quit");
-                            return;
-                        }
+                    if self.handle_validation_outcome(event) == LoopControl::Exit {
+                        return;
                     }
                 }
 
-                Ok(phase) = self.fork_phase_rx.recv() => {
-                    self.on_fork_phase(phase);
+                result = self.fork_phase_rx.recv(), if fork_phase_rx_state == ForkPhaseRxState::Active => {
+                    fork_phase_rx_state = self.handle_fork_phase_result(result);
                 }
+            }
+        }
+    }
+
+    /// Dispatch a libp2p swarm event to the appropriate handler.
+    ///
+    /// Keeps the main loop readable by isolating protocol-specific handling.
+    fn handle_swarm_event(&mut self, swarm_message: SwarmEvent<AnchorBehaviourEvent>) {
+        match swarm_message {
+            SwarmEvent::Behaviour(behaviour_event) => {
+                self.handle_behaviour_event(behaviour_event);
+            }
+            SwarmEvent::NewListenAddr {
+                listener_id,
+                address,
+            } => {
+                self.on_new_listen_addr(listener_id, address);
+            }
+            SwarmEvent::OutgoingConnectionError { peer_id, error, .. } => {
+                debug!(?peer_id, ?error, "Outgoing connection error");
+            }
+            SwarmEvent::IncomingConnectionError {
+                error,
+                send_back_addr,
+                ..
+            } => {
+                debug!(?send_back_addr, ?error, "Incoming connection error");
+            }
+            SwarmEvent::ConnectionClosed { peer_id, cause, .. } => {
+                if cause.is_some() {
+                    debug!(?peer_id, ?cause, "Connection closed with error");
+                } else {
+                    trace!(?peer_id, "Connection closed");
+                }
+            }
+            _ => {
+                trace!(event = ?swarm_message, "Unhandled swarm event");
+            }
+        }
+    }
+
+    /// Handle behaviour events emitted by the libp2p behaviour.
+    fn handle_behaviour_event(&mut self, behaviour_event: AnchorBehaviourEvent) {
+        match behaviour_event {
+            AnchorBehaviourEvent::Gossipsub(ge) => {
+                self.handle_gossipsub_event(ge);
+            }
+            AnchorBehaviourEvent::Discovery(DiscoveredPeers { peers }) => {
+                self.on_discovered_peers(peers);
+            }
+            AnchorBehaviourEvent::Handshake(event) => {
+                self.handle_handshake_result(event);
+            }
+            AnchorBehaviourEvent::Upnp(upnp_event) => {
+                self.on_upnp_event(upnp_event);
+            }
+            AnchorBehaviourEvent::PeerManager(peer_manager::Event::Heartbeat(heartbeat)) => {
+                self.handle_peer_manager_heartbeat(heartbeat);
+            }
+            _ => {
+                trace!(event = ?behaviour_event, "Unhandled behaviour event");
+            }
+        }
+    }
+
+    /// Handle gossipsub events (message flow and subscription changes).
+    fn handle_gossipsub_event(&mut self, event: gossipsub::Event) {
+        match event {
+            gossipsub::Event::Message {
+                propagation_source,
+                message_id,
+                message,
+            } => {
+                self.handle_gossipsub_message(propagation_source, message_id, message);
+            }
+            gossipsub::Event::Subscribed { peer_id, topic } => {
+                if let Some(subnet) = topic::parse_subnet_id(&topic) {
+                    self.peer_manager()
+                        .set_peer_subscription(peer_id, subnet, true);
+                }
+            }
+            gossipsub::Event::Unsubscribed { peer_id, topic } => {
+                if let Some(subnet) = topic::parse_subnet_id(&topic) {
+                    self.peer_manager()
+                        .set_peer_subscription(peer_id, subnet, false);
+                }
+            }
+            _ => {
+                trace!(event = ?event, "Unhandled gossipsub event");
+            }
+        }
+    }
+
+    /// Validate and forward an incoming gossipsub message to the receiver.
+    fn handle_gossipsub_message(
+        &mut self,
+        propagation_source: PeerId,
+        message_id: gossipsub::MessageId,
+        message: gossipsub::Message,
+    ) {
+        trace!(
+            source = ?propagation_source,
+            id = ?message_id,
+            "Received SignedSSVMessage"
+        );
+
+        // Build topic context for fork-aware validation.
+        // If we can't parse the topic, reject immediately - we only
+        // subscribe to topics we create, so parsing should always succeed.
+        let topic_context = match topic::parse_topic(&message.topic) {
+            Some(parsed) => TopicContext::Validate { parsed },
+            None => {
+                warn!(
+                    topic = ?message.topic,
+                    "Received message on unparseable topic - this is a bug"
+                );
+                return;
+            }
+        };
+
+        if let Err(err) =
+            self.message_receiver
+                .receive(propagation_source, message_id, message, topic_context)
+        {
+            error!(?err, "Unable to pass message to message receiver");
+        }
+    }
+
+    /// Process periodic peer-manager heartbeats (peer discovery, pruning, scoring).
+    fn handle_peer_manager_heartbeat(&mut self, heartbeat: peer_manager::heartbeat::Event) {
+        if let Some(actions) = heartbeat.connect_actions {
+            self.handle_connect_actions(actions);
+        }
+
+        if heartbeat.check_peer_scores {
+            self.check_block_and_prune_peers_by_score();
+        }
+
+        // Trigger periodic subnet-aware peer discovery if below target
+        let connected_peers = self.swarm.behaviour().peer_manager.connected_peers();
+        let target_peers = self.swarm.behaviour().peer_manager.target_peers();
+        if connected_peers < target_peers {
+            let needed_subnets: Vec<_> = self
+                .swarm
+                .behaviour()
+                .peer_manager
+                .needed_subnets()
+                .iter()
+                .copied()
+                .collect();
+
+            if !needed_subnets.is_empty() {
+                debug!(
+                    connected_peers,
+                    target_peers,
+                    subnets = ?needed_subnets,
+                    "Below target peer count, triggering subnet-aware peer discovery"
+                );
+                self.swarm
+                    .behaviour_mut()
+                    .discovery
+                    .start_subnet_query(needed_subnets);
+            }
+        }
+
+        if self.swarm.behaviour().peer_manager.active_subnet_count() > 0 {
+            // Disconnect peers that no longer subscribe to any needed subnets
+            let to_disconnect = self
+                .swarm
+                .behaviour()
+                .peer_manager
+                .peers_to_disconnect_due_to_subnets();
+
+            for peer_id in to_disconnect {
+                self.disconnect_peer(&peer_id, "No longer subscribed to any needed subnets");
+            }
+        }
+    }
+
+    /// Publish an outbound message or signal shutdown if the channel closed.
+    fn handle_outbound_message(&mut self, event: Option<(String, Vec<u8>)>) -> LoopControl {
+        match event {
+            Some((topic_string, message)) => {
+                // Topic is determined by message sender based on message slot (per SIP-43)
+                let topic = IdentTopic::new(topic_string);
+                if let Err(err) = self.gossipsub().publish(topic, message)
+                    && !matches!(err, PublishError::Duplicate)
+                {
+                    error!(?err, "Failed to publish message");
+                }
+                LoopControl::Continue
+            }
+            None => {
+                error!("message queue was closed");
+                LoopControl::Exit
+            }
+        }
+    }
+
+    /// Report validation outcomes to gossipsub or signal shutdown if the channel closed.
+    fn handle_validation_outcome(&mut self, event: Option<Outcome>) -> LoopControl {
+        match event {
+            Some(outcome) => {
+                self.gossipsub().report_message_validation_result(
+                    &outcome.message_id,
+                    &outcome.propagation_source,
+                    outcome.action,
+                );
+                LoopControl::Continue
+            }
+            None => {
+                error!("message validator has quit");
+                LoopControl::Exit
+            }
+        }
+    }
+
+    /// Process fork-phase events and handle receiver closure.
+    fn handle_fork_phase_result(
+        &mut self,
+        result: Result<ForkPhase, RecvError>,
+    ) -> ForkPhaseRxState {
+        match result {
+            Ok(phase) => {
+                self.on_fork_phase(phase);
+                ForkPhaseRxState::Active
+            }
+            Err(RecvError::Overflowed(missed)) => {
+                warn!(missed, "Fork phase channel overflowed");
+                ForkPhaseRxState::Active
+            }
+            Err(RecvError::Closed) => {
+                warn!("Fork phase channel closed; disabling receiver");
+                ForkPhaseRxState::Disabled
             }
         }
     }

--- a/anchor/network/src/network.rs
+++ b/anchor/network/src/network.rs
@@ -6,7 +6,6 @@ use std::{
     time::Duration,
 };
 
-use async_broadcast::RecvError;
 use futures::StreamExt;
 use gossipsub::{IdentTopic, PublishError};
 use libp2p::{
@@ -72,13 +71,6 @@ pub enum NetworkError {
 enum LoopControl {
     Continue,
     Exit,
-}
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-enum ForkPhaseRxState {
-    Active,
-    /// Disable after closure to avoid repeatedly polling a closed receiver.
-    Disabled,
 }
 
 pub struct Network<R: MessageReceiver> {
@@ -183,8 +175,6 @@ impl<R: MessageReceiver> Network<R> {
 
     /// Main loop for polling and handling swarm and channels.
     pub async fn run<E: EthSpec>(mut self) {
-        let mut fork_phase_rx_state = ForkPhaseRxState::Active;
-
         loop {
             tokio::select! {
                 swarm_message = self.swarm.select_next_some() => {
@@ -206,8 +196,8 @@ impl<R: MessageReceiver> Network<R> {
                     }
                 }
 
-                result = self.fork_phase_rx.recv(), if fork_phase_rx_state == ForkPhaseRxState::Active => {
-                    fork_phase_rx_state = self.handle_fork_phase_result(result);
+                Ok(phase) = self.fork_phase_rx.recv() => {
+                    self.on_fork_phase(phase);
                 }
             }
         }
@@ -422,27 +412,6 @@ impl<R: MessageReceiver> Network<R> {
             None => {
                 error!("message validator has quit");
                 LoopControl::Exit
-            }
-        }
-    }
-
-    /// Process fork-phase events and handle receiver closure.
-    fn handle_fork_phase_result(
-        &mut self,
-        result: Result<ForkPhase, RecvError>,
-    ) -> ForkPhaseRxState {
-        match result {
-            Ok(phase) => {
-                self.on_fork_phase(phase);
-                ForkPhaseRxState::Active
-            }
-            Err(RecvError::Overflowed(missed)) => {
-                warn!(missed, "Fork phase channel overflowed");
-                ForkPhaseRxState::Active
-            }
-            Err(RecvError::Closed) => {
-                warn!("Fork phase channel closed; disabling receiver");
-                ForkPhaseRxState::Disabled
             }
         }
     }


### PR DESCRIPTION
## Why

Fork-phase events are delivered via an async broadcast channel. Today, if the receiver closes, `recv()` can return errors immediately and repeatedly, which risks spinning the network loop or starving other branches. Fork monitor sends also silently drop errors, which can hide missed ENR domain updates.

## What

- Network loop now isolates event handling into helpers and explicitly handles fork-phase `recv()` errors.
  - On channel close, the fork-phase branch is disabled to prevent hot loops.
  - Overflow is logged once for visibility.
- Fork monitor now checks `broadcast_direct` results and exits early if the channel is closed.

## Notes

- No behavior change for normal operation; this only affects shutdown/edge conditions.
- Keeps ENR updates and fork-phase handling observable under failure.
