### PR TITLE
refactor: remove `DutyState` to use `OperatorState` for better parallelism

### DIFF
--- a/anchor/message_validator/src/consensus_message.rs
+++ b/anchor/message_validator/src/consensus_message.rs
@@ -16,13 +16,13 @@ use types::Epoch;
 
 use crate::{
     FIRST_ROUND, ValidatedSSVMessage, ValidationContext, ValidationFailure, compute_quorum_size,
-    duty_state::DutyState, hash_data, slot_start_time, validate_beacon_duty, validate_duty_count,
-    validate_slot_time, verify_message_signatures,
+    duty_state::OperatorState, hash_data, slot_start_time, validate_beacon_duty,
+    validate_duty_count, validate_slot_time, verify_message_signatures,
 };
 
 pub(crate) fn validate_consensus_message(
     validation_context: ValidationContext<impl SlotClock>,
-    duty_state: &mut DutyState,
+    operator_state: &mut OperatorState,
     duty_provider: Arc<impl DutiesProvider>,
 ) -> Result<ValidatedSSVMessage, ValidationFailure> {
     // Decode message to QbftMessage
@@ -54,12 +54,12 @@ pub(crate) fn validate_consensus_message(
         validation_context.operator_pub_keys,
     )?;
 
-    validate_qbft_logic(&validation_context, &consensus_message, duty_state)?;
+    validate_qbft_logic(&validation_context, &consensus_message, operator_state)?;
 
     validate_qbft_message_by_duty_logic(
         &validation_context,
         &consensus_message,
-        duty_state,
+        operator_state,
         duty_provider,
     )?;
 
@@ -68,10 +68,13 @@ pub(crate) fn validate_consensus_message(
         validation_context.operator_pub_keys,
     )?;
 
-    duty_state.update_for_consensus_message(
+    let msg_slot = Slot::from(consensus_message.height);
+    let msg_epoch = msg_slot.epoch(validation_context.slots_per_epoch);
+    operator_state.update(
         validation_context.signed_ssv_message,
         &consensus_message,
-        validation_context.slots_per_epoch,
+        &msg_slot,
+        &msg_epoch,
     );
 
     // Return the validated message
@@ -232,7 +235,7 @@ fn validate_justification_list<N: Unsigned>(
 pub(crate) fn validate_qbft_logic(
     validation_context: &ValidationContext<impl SlotClock>,
     consensus_message: &QbftMessage,
-    duty_state: &mut DutyState,
+    operator_state: &mut OperatorState,
 ) -> Result<(), ValidationFailure> {
     let signed_ssv_message = validation_context.signed_ssv_message;
 
@@ -260,55 +263,49 @@ pub(crate) fn validate_qbft_logic(
     // Create slot from height
     let msg_slot = Slot::new(consensus_message.height);
 
-    // Check validation rules for each signer
-    for signer in signers {
-        // Get or create the operator state first, then check if there's a signer state
-        let Some(signer_state) = duty_state
-            .get_or_create_operator(signer)
-            .get_signer_state(&msg_slot)
-        else {
-            continue;
-        };
+    // Get or create the operator state first, then check if there's a signer state
+    let Some(signer_state) = operator_state.get_signer_state(&msg_slot) else {
+        return Ok(());
+    };
 
-        if signers.len() == 1 {
-            // Single-signer validation rules (non-decided messages)
+    if signers.len() == 1 {
+        // Single-signer validation rules (non-decided messages)
 
-            // Rule: Ignore if peer already advanced to a later round
-            if consensus_message.round < signer_state.round {
-                // Signers aren't allowed to decrease their round.
-                // If they've sent a future message due to clock error,
-                // they'd have to wait for the next slot/round to be accepted.
-                return Err(ValidationFailure::RoundAlreadyAdvanced {
-                    got: consensus_message.round,
-                    want: signer_state.round,
-                });
+        // Rule: Ignore if peer already advanced to a later round
+        if consensus_message.round < signer_state.round {
+            // Signers aren't allowed to decrease their round.
+            // If they've sent a future message due to clock error,
+            // they'd have to wait for the next slot/round to be accepted.
+            return Err(ValidationFailure::RoundAlreadyAdvanced {
+                got: consensus_message.round,
+                want: signer_state.round,
+            });
+        }
+
+        if consensus_message.round == signer_state.round {
+            // Rule: Peer must not send two proposals with different data.
+            // We separately verify that the root in the message matches the data.
+            if !signed_ssv_message.full_data().is_empty()
+                && signer_state
+                    .proposal_hash
+                    .as_ref()
+                    .is_some_and(|hash| hash != consensus_message.root)
+            {
+                return Err(ValidationFailure::DifferentProposalData);
             }
 
-            if consensus_message.round == signer_state.round {
-                // Rule: Peer must not send two proposals with different data.
-                // We separately verify that the root in the message matches the data.
-                if !signed_ssv_message.full_data().is_empty()
-                    && signer_state
-                        .proposal_hash
-                        .as_ref()
-                        .is_some_and(|hash| hash != consensus_message.root)
-                {
-                    return Err(ValidationFailure::DifferentProposalData);
-                }
-
-                signer_state
-                    .message_counts
-                    .validate_consensus_message_limits(
-                        signed_ssv_message,
-                        consensus_message.qbft_message_type,
-                    )?;
-            }
-        } else if signers.len() > 1 {
-            // Rule: Decided msg can't have the same signers as previously sent before for the same
-            // duty
-            if signer_state.has_seen_signers(signers) {
-                return Err(ValidationFailure::DecidedWithSameSigners);
-            }
+            signer_state
+                .message_counts
+                .validate_consensus_message_limits(
+                    signed_ssv_message,
+                    consensus_message.qbft_message_type,
+                )?;
+        }
+    } else if signers.len() > 1 {
+        // Rule: Decided msg can't have the same signers as previously sent before for the same
+        // duty
+        if signer_state.has_seen_signers(signers) {
+            return Err(ValidationFailure::DecidedWithSameSigners);
         }
     }
 
@@ -435,24 +432,20 @@ fn current_estimated_round(since_slot_start: Duration) -> Round {
 pub(crate) fn validate_qbft_message_by_duty_logic(
     validation_context: &ValidationContext<impl SlotClock>,
     consensus_message: &QbftMessage,
-    duty_state: &mut DutyState,
+    operator_state: &mut OperatorState,
     duty_provider: Arc<impl DutiesProvider>,
 ) -> Result<(), ValidationFailure> {
     let role = validation_context.role;
-    let signed_ssv_message = validation_context.signed_ssv_message;
 
     // Rule: Height must not be "old". I.e., signer must not have already advanced to a later slot.
     // Skip for committee roles
     if !role.is_committee_role() {
-        for &signer in signed_ssv_message.operator_ids() {
-            let signer_state = duty_state.get_or_create_operator(&signer);
-            let max_slot = signer_state.max_slot();
-            if max_slot > consensus_message.height {
-                return Err(ValidationFailure::SlotAlreadyAdvanced {
-                    got: consensus_message.height,
-                    want: max_slot.as_u64(),
-                });
-            }
+        let max_slot = operator_state.max_slot();
+        if max_slot > consensus_message.height {
+            return Err(ValidationFailure::SlotAlreadyAdvanced {
+                got: consensus_message.height,
+                want: max_slot.as_u64(),
+            });
         }
     }
 
@@ -472,15 +465,12 @@ pub(crate) fn validate_qbft_message_by_duty_logic(
     validate_slot_time(msg_slot, validation_context)?;
 
     // Rule: valid number of duties per epoch
-    for &signer in signed_ssv_message.operator_ids() {
-        let signer_state = duty_state.get_or_create_operator(&signer);
-        validate_duty_count(
-            validation_context,
-            msg_slot,
-            signer_state,
-            duty_provider.clone(),
-        )?;
-    }
+    validate_duty_count(
+        validation_context,
+        msg_slot,
+        operator_state,
+        duty_provider.clone(),
+    )?;
 
     Ok(())
 }
@@ -601,7 +591,7 @@ mod tests {
         let expected_duty_count = 5;
         let result = validate_ssv_message(
             validation_context,
-            &mut DutyState::new(2),
+            &mut OperatorState::new(2),
             Arc::new(MockDutiesProvider {
                 voluntary_exit_duty_count: expected_duty_count,
             }),
@@ -660,7 +650,7 @@ mod tests {
 
         let result = validate_ssv_message(
             validation_context,
-            &mut DutyState::new(2),
+            &mut OperatorState::new(2),
             Arc::new(MockDutiesProvider {
                 voluntary_exit_duty_count: 0,
             }),
@@ -715,7 +705,7 @@ mod tests {
 
         let result = validate_ssv_message(
             validation_context,
-            &mut DutyState::new(2),
+            &mut OperatorState::new(2),
             Arc::new(MockDutiesProvider {
                 voluntary_exit_duty_count: 0,
             }),
@@ -767,7 +757,7 @@ mod tests {
 
         let result = validate_ssv_message(
             validation_context,
-            &mut DutyState::new(2),
+            &mut OperatorState::new(2),
             Arc::new(MockDutiesProvider {
                 voluntary_exit_duty_count: 0,
             }),
@@ -1600,7 +1590,7 @@ mod tests {
         };
 
         // Create a duty state where the operator has already advanced to slot 10
-        let mut duty_state = DutyState::new(64);
+        let mut operator_state = OperatorState::new(64);
         // Process a dummy consensus message for slot 10 to advance the operator's max_slot
         let mut dummy_qbft =
             QbftMessageBuilder::new(Role::AggregatorCommittee, QbftMessageType::Prepare).build();
@@ -1611,13 +1601,20 @@ mod tests {
             vec![],
             vec![],
         );
-        duty_state.update_for_consensus_message(&dummy_signed_msg, &dummy_qbft, 32);
+        let msg_slot = Slot::from(dummy_qbft.height);
+        let estimated_msg_epoch = Epoch::new(msg_slot.as_u64() / 32);
+        operator_state.update(
+            &dummy_signed_msg,
+            &dummy_qbft,
+            &msg_slot,
+            &estimated_msg_epoch,
+        );
 
         // Now validate a consensus message for height 1 (which is "old")
         let result = validate_qbft_message_by_duty_logic(
             &validation_context,
             &qbft_message,
-            &mut duty_state,
+            &mut operator_state,
             Arc::new(MockDutiesProvider {
                 voluntary_exit_duty_count: 0,
             }),
@@ -1647,7 +1644,7 @@ mod tests {
         let result = validate_qbft_message_by_duty_logic(
             &validation_context_proposer,
             &qbft_message,
-            &mut duty_state,
+            &mut operator_state,
             Arc::new(MockDutiesProvider {
                 voluntary_exit_duty_count: 0,
             }),

--- a/anchor/message_validator/src/consensus_message.rs
+++ b/anchor/message_validator/src/consensus_message.rs
@@ -1,5 +1,6 @@
 use std::{collections::HashMap, convert::Into, sync::Arc, time::Duration};
 
+use dashmap::DashMap;
 use duties_tracker::DutiesProvider;
 use fork::{Fork, ForkSchedule};
 use openssl::{pkey::Public, rsa::Rsa};
@@ -8,7 +9,7 @@ use ssv_types::{
     CommitteeInfo, IndexSet, OperatorId, Round, Slot, VariableList,
     consensus::{QbftMessage, QbftMessageType},
     message::SignedSSVMessage,
-    msgid::Role,
+    msgid::{MessageId, Role},
 };
 use ssz::Decode;
 use typenum::{U13, Unsigned};
@@ -24,6 +25,8 @@ pub(crate) fn validate_consensus_message(
     validation_context: ValidationContext<impl SlotClock>,
     operator_state: &mut OperatorState,
     duty_provider: Arc<impl DutiesProvider>,
+    duty_state_map: &DashMap<(MessageId, OperatorId), OperatorState>,
+    message_id: &MessageId,
 ) -> Result<ValidatedSSVMessage, ValidationFailure> {
     // Decode message to QbftMessage
     let consensus_message = match QbftMessage::from_ssz_bytes(
@@ -59,8 +62,10 @@ pub(crate) fn validate_consensus_message(
     validate_qbft_message_by_duty_logic(
         &validation_context,
         &consensus_message,
-        operator_state,
-        duty_provider,
+        duty_provider.clone(),
+        duty_state_map,
+        message_id,
+        validation_context.slots_per_epoch,
     )?;
 
     verify_message_signatures(
@@ -263,6 +268,11 @@ pub(crate) fn validate_qbft_logic(
     // Create slot from height
     let msg_slot = Slot::new(consensus_message.height);
 
+    // Rule: Round must be within allowed spread from current time
+    if signers.len() == 1 {
+        validate_round_in_allowed_spread(consensus_message, validation_context)?;
+    }
+
     // Get or create the operator state first, then check if there's a signer state
     let Some(signer_state) = operator_state.get_signer_state(&msg_slot) else {
         return Ok(());
@@ -307,11 +317,6 @@ pub(crate) fn validate_qbft_logic(
         if signer_state.has_seen_signers(signers) {
             return Err(ValidationFailure::DecidedWithSameSigners);
         }
-    }
-
-    // Rule: Round must be within allowed spread from current time
-    if signers.len() == 1 {
-        validate_round_in_allowed_spread(consensus_message, validation_context)?;
     }
 
     Ok(())
@@ -432,20 +437,29 @@ fn current_estimated_round(since_slot_start: Duration) -> Round {
 pub(crate) fn validate_qbft_message_by_duty_logic(
     validation_context: &ValidationContext<impl SlotClock>,
     consensus_message: &QbftMessage,
-    operator_state: &mut OperatorState,
     duty_provider: Arc<impl DutiesProvider>,
+    duty_state_map: &DashMap<(MessageId, OperatorId), OperatorState>,
+    message_id: &MessageId,
+    slots_per_epoch: u64,
 ) -> Result<(), ValidationFailure> {
     let role = validation_context.role;
+    let signed_ssv_message = validation_context.signed_ssv_message;
+    let stored_slot_count = (slots_per_epoch * 2) as usize;
 
     // Rule: Height must not be "old". I.e., signer must not have already advanced to a later slot.
     // Skip for committee roles
     if !role.is_committee_role() {
-        let max_slot = operator_state.max_slot();
-        if max_slot > consensus_message.height {
-            return Err(ValidationFailure::SlotAlreadyAdvanced {
-                got: consensus_message.height,
-                want: max_slot.as_u64(),
-            });
+        for &signer in signed_ssv_message.operator_ids() {
+            let signer_state = duty_state_map
+                .entry((message_id.clone(), signer))
+                .or_insert_with(|| OperatorState::new(stored_slot_count));
+            let max_slot = signer_state.max_slot();
+            if max_slot > consensus_message.height {
+                return Err(ValidationFailure::SlotAlreadyAdvanced {
+                    got: consensus_message.height,
+                    want: max_slot.as_u64(),
+                });
+            }
         }
     }
 
@@ -464,13 +478,18 @@ pub(crate) fn validate_qbft_message_by_duty_logic(
     // - duty's starting slot + 3 (other types)
     validate_slot_time(msg_slot, validation_context)?;
 
-    // Rule: valid number of duties per epoch
-    validate_duty_count(
-        validation_context,
-        msg_slot,
-        operator_state,
-        duty_provider.clone(),
-    )?;
+    // Rule: valid number of duties per epoch - validate for ALL signers
+    for &signer in signed_ssv_message.operator_ids() {
+        let mut signer_state = duty_state_map
+            .entry((message_id.clone(), signer))
+            .or_insert_with(|| OperatorState::new(stored_slot_count));
+        validate_duty_count(
+            validation_context,
+            msg_slot,
+            signer_state.value_mut(),
+            duty_provider.clone(),
+        )?;
+    }
 
     Ok(())
 }
@@ -589,12 +608,16 @@ mod tests {
         };
 
         let expected_duty_count = 5;
+        let duty_state_map = DashMap::new();
+        let message_id = signed_msg.ssv_message().msg_id();
         let result = validate_ssv_message(
             validation_context,
             &mut OperatorState::new(2),
             Arc::new(MockDutiesProvider {
                 voluntary_exit_duty_count: expected_duty_count,
             }),
+            &duty_state_map,
+            message_id,
         );
 
         match result {
@@ -648,12 +671,16 @@ mod tests {
             fork_schedule: generate_fork_schedule(),
         };
 
+        let duty_state_map = DashMap::new();
+        let message_id = signed_msg.ssv_message().msg_id();
         let result = validate_ssv_message(
             validation_context,
             &mut OperatorState::new(2),
             Arc::new(MockDutiesProvider {
                 voluntary_exit_duty_count: 0,
             }),
+            &duty_state_map,
+            message_id,
         );
 
         assert_validation_error(
@@ -703,12 +730,16 @@ mod tests {
             fork_schedule: generate_fork_schedule(),
         };
 
+        let duty_state_map = DashMap::new();
+        let message_id = signed_msg.ssv_message().msg_id();
         let result = validate_ssv_message(
             validation_context,
             &mut OperatorState::new(2),
             Arc::new(MockDutiesProvider {
                 voluntary_exit_duty_count: 0,
             }),
+            &duty_state_map,
+            message_id,
         );
 
         assert_validation_error(
@@ -755,12 +786,16 @@ mod tests {
             fork_schedule: generate_fork_schedule(),
         };
 
+        let duty_state_map = DashMap::new();
+        let message_id = signed_msg.ssv_message().msg_id();
         let result = validate_ssv_message(
             validation_context,
             &mut OperatorState::new(2),
             Arc::new(MockDutiesProvider {
                 voluntary_exit_duty_count: 0,
             }),
+            &duty_state_map,
+            message_id,
         );
 
         assert_validation_error(
@@ -1611,13 +1646,20 @@ mod tests {
         );
 
         // Now validate a consensus message for height 1 (which is "old")
+        let duty_state_map: DashMap<(MessageId, OperatorId), OperatorState> = DashMap::new();
+        // Pre-populate the duty state map with the operator's advanced state
+        let message_id = signed_msg.ssv_message().msg_id();
+        duty_state_map.insert((message_id.clone(), OperatorId(1)), operator_state.clone());
+
         let result = validate_qbft_message_by_duty_logic(
             &validation_context,
             &qbft_message,
-            &mut operator_state,
             Arc::new(MockDutiesProvider {
                 voluntary_exit_duty_count: 0,
             }),
+            &duty_state_map,
+            message_id,
+            32, // slots_per_epoch
         );
 
         // Should succeed because AggregatorCommittee skips the height advancement check
@@ -1644,10 +1686,12 @@ mod tests {
         let result = validate_qbft_message_by_duty_logic(
             &validation_context_proposer,
             &qbft_message,
-            &mut operator_state,
             Arc::new(MockDutiesProvider {
                 voluntary_exit_duty_count: 0,
             }),
+            &duty_state_map,
+            message_id,
+            32, // slots_per_epoch
         );
 
         // Should fail for non-committee roles

--- a/anchor/message_validator/src/duty_state.rs
+++ b/anchor/message_validator/src/duty_state.rs
@@ -1,7 +1,4 @@
-use std::{
-    cmp::Ordering,
-    collections::{HashMap, HashSet},
-};
+use std::{cmp::Ordering, collections::HashSet};
 
 use ssv_types::{
     CommitteeId, Epoch, OperatorId, Slot,
@@ -11,112 +8,6 @@ use ssv_types::{
 };
 
 use crate::{FIRST_ROUND, ValidationFailure, message_counts::MessageCounts};
-// duty_state.rs
-//
-// This file defines structures that help track and validate the consensus process.
-// The main components are:
-//  - DutyState: The top-level state tracker across operators and slots.
-//  - OperatorState: The state for a specific operator over a range of slots.
-//  - SignerState: The state of a signer at a particular slot, including message counts and proposal
-//    data.
-
-/// DutyState manages the state for duty validation across operators and slots
-pub(crate) struct DutyState {
-    /// Tracks the duty state for an operator
-    operators: HashMap<OperatorId, OperatorState>,
-    /// The number of slots for which state is stored (defines the size of the circular buffer)
-    stored_slot_count: usize,
-}
-
-impl DutyState {
-    /// Creates a new DutyState with the specified storage capacity
-    pub(crate) fn new(stored_slot_count: usize) -> Self {
-        Self {
-            operators: HashMap::new(),
-            stored_slot_count,
-        }
-    }
-
-    /// Retrieves an existing OperatorState for the given signer or creates one if it doesn't exist.
-    /// This ensures that every operator has an associated state tracking its consensus messages.
-    pub(crate) fn get_or_create_operator(&mut self, signer: &OperatorId) -> &mut OperatorState {
-        self.operators
-            .entry(*signer)
-            .or_insert_with(|| OperatorState::new(self.stored_slot_count))
-    }
-
-    /// Updates the duty state with new incoming messages.
-    ///
-    /// For each operator involved in the signed message, this method:
-    /// - Determines the corresponding slot and estimated epoch,
-    /// - Retrieves or creates the operator's state,
-    /// - And delegates the update to the operator's state.
-    pub(crate) fn update_for_consensus_message(
-        &mut self,
-        signed_ssv_message: &SignedSSVMessage,
-        consensus_message: &QbftMessage,
-        slots_per_epoch: u64,
-    ) {
-        let msg_slot = Slot::from(consensus_message.height);
-        let estimated_msg_epoch = Epoch::new(msg_slot.as_u64() / slots_per_epoch);
-
-        for signer in signed_ssv_message.operator_ids() {
-            let operator_state = self.get_or_create_operator(signer);
-            operator_state.update(
-                signed_ssv_message,
-                consensus_message,
-                &msg_slot,
-                &estimated_msg_epoch,
-            );
-        }
-    }
-
-    /// Updates the duty state with information about a partial signature message.
-    /// This records the message type in the message counts for the signer at the given slot.
-    pub(crate) fn update_for_partial_signature(
-        &mut self,
-        partial_signature_messages: &PartialSignatureMessages,
-        signer: &OperatorId,
-        slots_per_epoch: u64,
-    ) -> Result<(), ValidationFailure> {
-        let operator_state = self.get_or_create_operator(signer);
-        let message_slot = partial_signature_messages.slot;
-        let message_epoch = Epoch::new(message_slot.as_u64() / slots_per_epoch);
-
-        // Get or create a signer state for this slot
-        let signer_state = match operator_state.get_signer_state_mut(&message_slot) {
-            Some(existing_state) => existing_state,
-            _ => {
-                // Create a new signer state
-                let new_signer_state = SignerState::new(message_slot, FIRST_ROUND);
-                operator_state.set_signer_state_for_first_round(
-                    &message_slot,
-                    &message_epoch,
-                    new_signer_state,
-                )
-            }
-        };
-
-        // Record the partial signature (only once)
-        signer_state
-            .message_counts
-            .record_partial_signature(partial_signature_messages.kind);
-
-        Ok(())
-    }
-
-    /// Returns true if all operators within the map have a `max_slot` lower than `now -
-    /// stored_slot_count`. This indicates that there has been no relevant activity for this duty
-    /// recently and no relevant information is lost if this is dropped.
-    pub(crate) fn outdated(&self, current_slot: Slot) -> bool {
-        let earliest_relevant_slot =
-            current_slot.saturating_sub(Slot::from(self.stored_slot_count));
-        self.operators
-            .values()
-            .all(|operator_state| operator_state.max_slot < earliest_relevant_slot)
-    }
-}
-
 /// Tracks the state for a specific operator across multiple slots.
 ///
 /// This structure uses a fixed-size vector as a circular buffer to store the state
@@ -137,7 +28,7 @@ pub struct OperatorState {
 
 impl OperatorState {
     /// Initializes a new OperatorState with a circular buffer sized according to stored_slot_count.
-    fn new(stored_slot_count: usize) -> Self {
+    pub fn new(stored_slot_count: usize) -> Self {
         Self {
             state: vec![None; stored_slot_count],
             max_slot: Slot::new(0),
@@ -197,7 +88,7 @@ impl OperatorState {
     /// If a state already exists and the incoming consensus round is higher,
     /// it replaces the state with a new one. Otherwise, it creates a new state
     /// if none exists for that slot.
-    fn update(
+    pub fn update(
         &mut self,
         signed_ssv_message: &SignedSSVMessage,
         consensus_message: &QbftMessage,
@@ -257,6 +148,46 @@ impl OperatorState {
             }
         }
         self.state[index].as_mut().unwrap()
+    }
+
+    /// Returns true if an operator has a `max_slot` lower than `now -
+    /// stored_slot_count`. This indicates that there has been no relevant activity for this duty
+    /// recently and no relevant information is lost if this is dropped.
+    pub(crate) fn outdated(&self, current_slot: Slot, stored_slot_count: usize) -> bool {
+        let earliest_relevant_slot = current_slot.saturating_sub(Slot::from(stored_slot_count));
+        self.max_slot < earliest_relevant_slot
+    }
+
+    /// Updates the operator state with information about a partial signature message.
+    /// This records the message type in the message counts for the signer at the given slot.
+    pub(crate) fn update_for_partial_signature(
+        &mut self,
+        partial_signature_messages: &PartialSignatureMessages,
+        slots_per_epoch: u64,
+    ) -> Result<(), ValidationFailure> {
+        let message_slot = partial_signature_messages.slot;
+        let message_epoch = Epoch::new(message_slot.as_u64() / slots_per_epoch);
+
+        // Get or create a signer state for this slot
+        let signer_state = match self.get_signer_state_mut(&message_slot) {
+            Some(existing_state) => existing_state,
+            _ => {
+                // Create a new signer state
+                let new_signer_state = SignerState::new(message_slot, FIRST_ROUND);
+                self.set_signer_state_for_first_round(
+                    &message_slot,
+                    &message_epoch,
+                    new_signer_state,
+                )
+            }
+        };
+
+        // Record the partial signature (only once)
+        signer_state
+            .message_counts
+            .record_partial_signature(partial_signature_messages.kind);
+
+        Ok(())
     }
 }
 
@@ -334,8 +265,8 @@ mod tests {
     };
 
     #[test]
-    fn test_duty_state_update() {
-        let mut duty_state = DutyState::new(10);
+    fn test_operator_state_update() {
+        let mut operator_state = OperatorState::new(10);
 
         let mut qbft_message =
             QbftMessageBuilder::new(Role::Committee, QbftMessageType::Proposal).build();
@@ -350,13 +281,11 @@ mod tests {
             full_data.clone(),
             vec![],
         );
-
-        // Update the duty state
-        duty_state.update_for_consensus_message(&signed_ssv_message, &qbft_message, 32);
-
-        // Retrieve the operator state
-        let operator_state = duty_state.get_or_create_operator(&operator_id);
         let slot = Slot::from(qbft_message.height);
+        let msg_epoch = Epoch::new(slot.as_u64() / 32);
+
+        // Update the operator state
+        operator_state.update(&signed_ssv_message, &qbft_message, &slot, &msg_epoch);
 
         // Get the signer state for the slot
         if let Some(signer_state) = operator_state.get_signer_state(&slot) {
@@ -379,7 +308,7 @@ mod tests {
 
     #[test]
     fn test_decided_message_not_counted() {
-        let mut duty_state = DutyState::new(10);
+        let mut operator_state = OperatorState::new(10);
 
         // Create a commit message with a single signer (should be counted)
         let single_signer_commit =
@@ -393,9 +322,10 @@ mod tests {
             vec![],
             vec![],
         );
-
-        // Update duty state with single-signer commit
-        duty_state.update_for_consensus_message(&signed_single_signer, &single_signer_commit, 32);
+        let slot = Slot::from(single_signer_commit.height);
+        let epoch = Epoch::new(slot.as_u64() / 32);
+        // Update operator state with single-signer commit
+        operator_state.update(&signed_single_signer, &single_signer_commit, &slot, &epoch);
 
         // Create a commit message with multiple signers (decided message, should NOT be counted)
         let multi_signer_commit =
@@ -408,12 +338,8 @@ mod tests {
             vec![],
         );
 
-        // Update duty state with multi-signer commit
-        duty_state.update_for_consensus_message(&signed_multi_signer, &multi_signer_commit, 32);
-
-        // Retrieve the operator state
-        let operator_state = duty_state.get_or_create_operator(&operator_id);
-        let slot = Slot::from(single_signer_commit.height);
+        // Update operator state with multi-signer commit
+        operator_state.update(&signed_multi_signer, &multi_signer_commit, &slot, &epoch);
 
         // Get the signer state for the slot
         if let Some(signer_state) = operator_state.get_signer_state(&slot) {

--- a/anchor/message_validator/src/lib.rs
+++ b/anchor/message_validator/src/lib.rs
@@ -38,8 +38,7 @@ use tracing::{debug, trace};
 use types::{Epoch, Slot};
 
 use crate::{
-    consensus_message::validate_consensus_message,
-    duty_state::{DutyState, OperatorState},
+    consensus_message::validate_consensus_message, duty_state::OperatorState,
     partial_signature::validate_partial_signature_message,
 };
 
@@ -319,7 +318,7 @@ struct ValidationContext<'a, S> {
 
 pub struct Validator<S: SlotClock, D: DutiesProvider> {
     network_state_rx: Receiver<NetworkState>,
-    duty_state_map: DashMap<MessageId, DutyState>,
+    duty_state_map: DashMap<(MessageId, OperatorId), OperatorState>,
     slots_per_epoch: u64,
     epochs_per_sync_committee_period: u64,
     sync_committee_size: usize,
@@ -438,10 +437,14 @@ impl<S: SlotClock + 'static, D: DutiesProvider> Validator<S, D> {
 
         let operator_pub_keys =
             &get_operator_pub_keys(&network_state, &committee_info.committee_members);
-
+        let operator_id = *signed_ssv_message
+            .operator_ids()
+            .first()
+            .expect("Should have an OperatorId");
         drop(network_state);
 
-        let mut duty_state = self.get_duty_state(ssv_message.msg_id(), self.slots_per_epoch);
+        let mut operator_state =
+            self.get_duty_state(ssv_message.msg_id(), operator_id, self.slots_per_epoch);
 
         let validation_context = ValidationContext {
             signed_ssv_message,
@@ -458,7 +461,7 @@ impl<S: SlotClock + 'static, D: DutiesProvider> Validator<S, D> {
 
         validate_ssv_message(
             validation_context,
-            duty_state.value_mut(),
+            operator_state.value_mut(),
             self.duties_provider.clone(),
         )
         .map(|validated| ValidatedMessage::new(signed_ssv_message.clone(), validated))
@@ -468,14 +471,15 @@ impl<S: SlotClock + 'static, D: DutiesProvider> Validator<S, D> {
     fn get_duty_state(
         &self,
         message_id: &MessageId,
+        operator_id: OperatorId,
         slots_per_epoch: u64,
-    ) -> RefMut<'_, MessageId, DutyState> {
+    ) -> RefMut<'_, (MessageId, OperatorId), OperatorState> {
         self.duty_state_map
-            .entry(message_id.clone())
+            .entry((message_id.clone(), operator_id))
             .or_insert_with(|| {
                 let stored_slot_count = slots_per_epoch * 2; // Store last two epochs
 
-                DutyState::new(stored_slot_count as usize)
+                OperatorState::new(stored_slot_count as usize)
             })
     }
 
@@ -507,9 +511,9 @@ impl<S: SlotClock + 'static, D: DutiesProvider> Validator<S, D> {
                 continue;
             };
 
-            validator
-                .duty_state_map
-                .retain(|_, duty_state| !duty_state.outdated(now));
+            validator.duty_state_map.retain(|_, operator_state| {
+                !operator_state.outdated(now, (slots_per_epoch * 2) as usize)
+            });
         }
     }
 
@@ -633,17 +637,17 @@ impl<S: SlotClock + 'static, D: DutiesProvider> Validator<S, D> {
 
 fn validate_ssv_message(
     validation_context: ValidationContext<impl SlotClock>,
-    duty_state: &mut DutyState,
+    operator_state: &mut OperatorState,
     duty_provider: Arc<impl DutiesProvider>,
 ) -> Result<ValidatedSSVMessage, ValidationFailure> {
     let ssv_message = validation_context.signed_ssv_message.ssv_message();
 
     match ssv_message.msg_type() {
         MsgType::SSVConsensusMsgType => {
-            validate_consensus_message(validation_context, duty_state, duty_provider)
+            validate_consensus_message(validation_context, operator_state, duty_provider)
         }
         MsgType::SSVPartialSignatureMsgType => {
-            validate_partial_signature_message(validation_context, duty_state, duty_provider)
+            validate_partial_signature_message(validation_context, operator_state, duty_provider)
         }
     }
 }

--- a/anchor/message_validator/src/lib.rs
+++ b/anchor/message_validator/src/lib.rs
@@ -440,7 +440,7 @@ impl<S: SlotClock + 'static, D: DutiesProvider> Validator<S, D> {
         let operator_id = *signed_ssv_message
             .operator_ids()
             .first()
-            .expect("Should have an OperatorId");
+            .ok_or(ValidationFailure::NoSigners)?;
         drop(network_state);
 
         let mut operator_state =
@@ -459,10 +459,13 @@ impl<S: SlotClock + 'static, D: DutiesProvider> Validator<S, D> {
             fork_schedule: Arc::clone(&self.fork_schedule),
         };
 
+        let message_id = ssv_message.msg_id();
         validate_ssv_message(
             validation_context,
             operator_state.value_mut(),
             self.duties_provider.clone(),
+            &self.duty_state_map,
+            message_id,
         )
         .map(|validated| ValidatedMessage::new(signed_ssv_message.clone(), validated))
     }
@@ -639,12 +642,14 @@ fn validate_ssv_message(
     validation_context: ValidationContext<impl SlotClock>,
     operator_state: &mut OperatorState,
     duty_provider: Arc<impl DutiesProvider>,
+    duty_state_map: &DashMap<(MessageId, OperatorId), OperatorState>,
+    message_id: &MessageId,
 ) -> Result<ValidatedSSVMessage, ValidationFailure> {
     let ssv_message = validation_context.signed_ssv_message.ssv_message();
 
     match ssv_message.msg_type() {
         MsgType::SSVConsensusMsgType => {
-            validate_consensus_message(validation_context, operator_state, duty_provider)
+            validate_consensus_message(validation_context, operator_state, duty_provider, duty_state_map, message_id)
         }
         MsgType::SSVPartialSignatureMsgType => {
             validate_partial_signature_message(validation_context, operator_state, duty_provider)

--- a/anchor/message_validator/src/partial_signature.rs
+++ b/anchor/message_validator/src/partial_signature.rs
@@ -12,7 +12,7 @@ use ssz::Decode;
 use types::consts::altair::SYNC_COMMITTEE_SUBNET_COUNT;
 
 use crate::{
-    ValidatedSSVMessage, ValidationContext, ValidationFailure, duty_state::DutyState,
+    ValidatedSSVMessage, ValidationContext, ValidationFailure, duty_state::OperatorState,
     validate_beacon_duty, validate_duty_count, validate_slot_time, verify_message_signature,
 };
 
@@ -21,7 +21,7 @@ const MAX_SIGNATURES_IN_SYNC_COMMITTEE: usize = 13;
 
 pub(crate) fn validate_partial_signature_message(
     validation_context: ValidationContext<impl SlotClock>,
-    duty_state: &mut DutyState,
+    operator_state: &mut OperatorState,
     duty_provider: Arc<impl DutiesProvider>,
 ) -> Result<ValidatedSSVMessage, ValidationFailure> {
     // Decode message directly to PartialSignatureMessages
@@ -51,7 +51,7 @@ pub(crate) fn validate_partial_signature_message(
     validate_partial_sig_messages_by_duty_logic(
         &validation_context,
         &messages,
-        duty_state,
+        operator_state,
         duty_provider,
     )?;
 
@@ -73,18 +73,7 @@ pub(crate) fn validate_partial_signature_message(
         signature,
     )?;
 
-    // Update the duty state with information about this partial signature message
-    let signer = validation_context
-        .signed_ssv_message
-        .operator_ids()
-        .first()
-        .ok_or(ValidationFailure::NoSigners)?;
-
-    duty_state.update_for_partial_signature(
-        &messages,
-        signer,
-        validation_context.slots_per_epoch,
-    )?;
+    operator_state.update_for_partial_signature(&messages, validation_context.slots_per_epoch)?;
 
     Ok(ValidatedSSVMessage::PartialSignatureMessages(messages))
 }
@@ -175,21 +164,11 @@ fn partial_signature_type_matches_role(kind: PartialSignatureKind, role: Role) -
 fn validate_partial_sig_messages_by_duty_logic(
     validation_context: &ValidationContext<impl SlotClock>,
     partial_signature_messages: &PartialSignatureMessages,
-    duty_state: &mut DutyState,
+    operator_state: &mut OperatorState,
     duty_provider: Arc<impl DutiesProvider>,
 ) -> Result<(), ValidationFailure> {
     let role = validation_context.role;
     let message_slot = partial_signature_messages.slot;
-    let signed_message = validation_context.signed_ssv_message;
-
-    // Get the operator ID (signer)
-    let signer = signed_message
-        .operator_ids()
-        .first()
-        .ok_or(ValidationFailure::NoSigners)?;
-
-    // Get duty state for this signer
-    let operator_state = duty_state.get_or_create_operator(signer);
 
     // Rule: Slot must not be "old" - signer must not have already advanced to a later slot
     // Skip for committee roles (Committee and AggregatorCommittee)
@@ -580,7 +559,7 @@ mod tests {
 
         let result = validate_partial_signature_message(
             validation_context,
-            &mut DutyState::new(2),
+            &mut OperatorState::new(2),
             Arc::new(MockDutiesProvider {
                 voluntary_exit_duty_count: 0,
             }),
@@ -632,7 +611,7 @@ mod tests {
 
         let result = validate_partial_signature_message(
             validation_context,
-            &mut DutyState::new(2),
+            &mut OperatorState::new(2),
             Arc::new(MockDutiesProvider {
                 voluntary_exit_duty_count: 0,
             }),
@@ -674,7 +653,7 @@ mod tests {
 
         let result = validate_partial_signature_message(
             validation_context,
-            &mut DutyState::new(2),
+            &mut OperatorState::new(2),
             Arc::new(MockDutiesProvider {
                 voluntary_exit_duty_count: 0,
             }),
@@ -716,7 +695,7 @@ mod tests {
 
         let result = validate_partial_signature_message(
             validation_context,
-            &mut DutyState::new(2),
+            &mut OperatorState::new(2),
             Arc::new(MockDutiesProvider {
                 voluntary_exit_duty_count: 0,
             }),
@@ -758,7 +737,7 @@ mod tests {
 
         let result = validate_partial_signature_message(
             validation_context,
-            &mut DutyState::new(2),
+            &mut OperatorState::new(2),
             Arc::new(MockDutiesProvider {
                 voluntary_exit_duty_count: 0,
             }),
@@ -799,7 +778,7 @@ mod tests {
 
         let result = validate_partial_signature_message(
             validation_context,
-            &mut DutyState::new(2),
+            &mut OperatorState::new(2),
             Arc::new(MockDutiesProvider {
                 voluntary_exit_duty_count: 0,
             }),
@@ -851,7 +830,7 @@ mod tests {
 
         let result = validate_partial_signature_message(
             validation_context,
-            &mut DutyState::new(2),
+            &mut OperatorState::new(2),
             Arc::new(MockDutiesProvider {
                 voluntary_exit_duty_count: 0,
             }),
@@ -899,7 +878,7 @@ mod tests {
 
         let result = validate_partial_signature_message(
             validation_context,
-            &mut DutyState::new(2),
+            &mut OperatorState::new(2),
             Arc::new(MockDutiesProvider {
                 voluntary_exit_duty_count: 0,
             }),
@@ -950,7 +929,7 @@ mod tests {
 
         let result = validate_partial_signature_message(
             validation_context,
-            &mut DutyState::new(2),
+            &mut OperatorState::new(2),
             Arc::new(MockDutiesProvider {
                 voluntary_exit_duty_count: 0,
             }),
@@ -1027,7 +1006,7 @@ mod tests {
 
         validate_partial_signature_message(
             validation_context,
-            &mut DutyState::new(2),
+            &mut OperatorState::new(2),
             Arc::new(MockDutiesProvider {
                 voluntary_exit_duty_count: 0,
             }),
@@ -1074,7 +1053,7 @@ mod tests {
 
         let result = validate_partial_signature_message(
             validation_context,
-            &mut DutyState::new(2),
+            &mut OperatorState::new(2),
             Arc::new(MockDutiesProvider {
                 voluntary_exit_duty_count: 0,
             }),
@@ -1185,7 +1164,7 @@ mod tests {
 
         let result = validate_partial_signature_message(
             validation_context,
-            &mut DutyState::new(2),
+            &mut OperatorState::new(2),
             Arc::new(MockDutiesProvider {
                 voluntary_exit_duty_count: 0,
             }),
@@ -1299,7 +1278,7 @@ mod tests {
         // Execute
         let result = validate_partial_signature_message(
             validation_context,
-            &mut DutyState::new(64),
+            &mut OperatorState::new(64),
             Arc::new(MockDutiesProvider {
                 voluntary_exit_duty_count: 0,
             }),
@@ -1336,7 +1315,7 @@ mod tests {
         // Execute
         let result = validate_partial_signature_message(
             validation_context,
-            &mut DutyState::new(64),
+            &mut OperatorState::new(64),
             Arc::new(MockDutiesProvider {
                 voluntary_exit_duty_count: 0,
             }),
@@ -1377,7 +1356,7 @@ mod tests {
         // Execute
         let result = validate_partial_signature_message(
             validation_context,
-            &mut DutyState::new(64),
+            &mut OperatorState::new(64),
             Arc::new(MockDutiesProvider {
                 voluntary_exit_duty_count: 1,
             }),
@@ -1448,7 +1427,7 @@ mod tests {
         };
 
         // Create a duty state where the operator has already advanced to slot 10
-        let mut duty_state = DutyState::new(64);
+        let mut operator_state = OperatorState::new(64);
         // Process a dummy message for slot 10 to advance the operator's max_slot
         let dummy_messages = PartialSignatureMessages {
             kind: PartialSignatureKind::AggregatorCommitteePartialSig,
@@ -1461,14 +1440,14 @@ mod tests {
             }])
             .unwrap(),
         };
-        duty_state
-            .update_for_partial_signature(&dummy_messages, &signer_id, 32)
+        operator_state
+            .update_for_partial_signature(&dummy_messages, 32)
             .unwrap();
 
         // Now validate a message for slot 1 (which is "old")
         let result = validate_partial_signature_message(
             validation_context,
-            &mut duty_state,
+            &mut operator_state,
             Arc::new(MockDutiesProvider {
                 voluntary_exit_duty_count: 0,
             }),
@@ -1552,7 +1531,7 @@ mod tests {
         // Should succeed with 5 occurrences
         let result = validate_partial_signature_message(
             validation_context,
-            &mut DutyState::new(2),
+            &mut OperatorState::new(2),
             Arc::new(MockDutiesProvider {
                 voluntary_exit_duty_count: 0,
             }),
@@ -1619,7 +1598,7 @@ mod tests {
         // Should fail with 6 occurrences
         let result = validate_partial_signature_message(
             validation_context,
-            &mut DutyState::new(2),
+            &mut OperatorState::new(2),
             Arc::new(MockDutiesProvider {
                 voluntary_exit_duty_count: 0,
             }),
@@ -1664,7 +1643,7 @@ mod tests {
         // Execute
         let result = validate_partial_signature_message(
             validation_context,
-            &mut DutyState::new(64),
+            &mut OperatorState::new(64),
             Arc::new(MockDutiesProvider {
                 voluntary_exit_duty_count: 1,
             }),


### PR DESCRIPTION
## Issue Addressed

Fixes #745 

## Proposed Changes

- Changed `duty_state_map` from `DashMap<MessageId, DutyState>` to `DashMap<(MessageId, OperatorId), OperatorState>` to enable parallel processing of messages
- Removed `DutyState` wrapper struct.
- Updated validation functions