### PR TITLE
refactor: rename ValidatorConsensusData to ProposerConsensusData

### DIFF
--- a/anchor/common/ssv_types/src/consensus.rs
+++ b/anchor/common/ssv_types/src/consensus.rs
@@ -337,9 +337,6 @@ impl<E: EthSpec> ProposerConsensusDataValidator<E> {
             });
         }
 
-        // TODO(post-boole): remove `BEACON_ROLE_AGGREGATOR` and
-        // `BEACON_ROLE_SYNC_COMMITTEE_CONTRIBUTION` branches. Post-Boole, `ProposerConsensusData`
-        // is only used for `Proposer`.
         match value.duty.r#type {
             BEACON_ROLE_AGGREGATOR => {
                 if value.version < DataVersion(ForkName::Electra) {

--- a/anchor/common/ssv_types/src/consensus.rs
+++ b/anchor/common/ssv_types/src/consensus.rs
@@ -35,7 +35,7 @@ use crate::{CommitteeId, ValidatorIndex, message::*, partial_sig::PartialSignatu
 //            |                                            |
 //          SSVMessage                                 FullData
 //     ---------------------                          ----------
-//     |                   |              ValidatorConsensusData/BeaconVote SSZ
+//     |                   |              ProposerConsensusData/BeaconVote SSZ
 //     |                   |
 //   MsgType            FullData
 //  ---------          -----------
@@ -60,10 +60,10 @@ impl<D: QbftData> QbftDataValidator<D> for NoDataValidation {
     }
 }
 
-/// ValidatorConsensusData.DataSSZ max size: 8388608 bytes (2^23)
-/// This is the maximum size that the validator consensus data may be
+/// ProposerConsensusData.DataSSZ max size: 8388608 bytes (2^23)
+/// This is the maximum size that the proposer consensus data may be
 /// Calculated as 2^23 = 8,388,608
-pub type ValidatorConsensusDataLen = <U2 as Pow<U23>>::Output;
+pub type ProposerConsensusDataLen = <U2 as Pow<U23>>::Output;
 
 // RoundChange max size: 51852
 // This is the maximum size that a round change justification may be
@@ -241,13 +241,13 @@ impl TreeHash for QbftMessageType {
 }
 
 #[derive(Clone, Debug, PartialEq, Encode, Decode, TreeHash)]
-pub struct ValidatorConsensusData {
+pub struct ProposerConsensusData {
     pub duty: ValidatorDuty,
     pub version: DataVersion,
-    pub data_ssz: VariableList<u8, ValidatorConsensusDataLen>,
+    pub data_ssz: VariableList<u8, ProposerConsensusDataLen>,
 }
 
-impl QbftData for ValidatorConsensusData {
+impl QbftData for ProposerConsensusData {
     type Hash = Hash256;
 
     fn hash(&self) -> Self::Hash {
@@ -260,7 +260,7 @@ impl QbftData for ValidatorConsensusData {
     }
 }
 
-pub struct ValidatorConsensusDataValidator<E: EthSpec> {
+pub struct ProposerConsensusDataValidator<E: EthSpec> {
     slashing_database: Arc<SlashingDatabase>,
     disable_slashing_protection: bool,
     spec: Arc<ChainSpec>,
@@ -269,19 +269,19 @@ pub struct ValidatorConsensusDataValidator<E: EthSpec> {
     _phantom: PhantomData<E>,
 }
 
-impl<E: EthSpec> QbftDataValidator<ValidatorConsensusData> for ValidatorConsensusDataValidator<E> {
-    fn validate(&self, value: &ValidatorConsensusData, our_value: &ValidatorConsensusData) -> bool {
+impl<E: EthSpec> QbftDataValidator<ProposerConsensusData> for ProposerConsensusDataValidator<E> {
+    fn validate(&self, value: &ProposerConsensusData, our_value: &ProposerConsensusData) -> bool {
         match self.do_validation(value, our_value) {
             Ok(_) => true,
             Err(err) => {
-                warn!(%err, "Operator proposed invalid validator consensus data");
+                warn!(%err, "Operator proposed invalid proposer consensus data");
                 false
             }
         }
     }
 }
 
-impl<E: EthSpec> ValidatorConsensusDataValidator<E> {
+impl<E: EthSpec> ProposerConsensusDataValidator<E> {
     pub fn new(
         slashing_database: Arc<SlashingDatabase>,
         disable_slashing_protection: bool,
@@ -301,8 +301,8 @@ impl<E: EthSpec> ValidatorConsensusDataValidator<E> {
 
     pub fn do_validation(
         &self,
-        value: &ValidatorConsensusData,
-        our_value: &ValidatorConsensusData,
+        value: &ProposerConsensusData,
+        our_value: &ProposerConsensusData,
     ) -> Result<(), DataValidationError> {
         // Check whether the slot matches
         if value.duty.slot != our_value.duty.slot {
@@ -337,6 +337,9 @@ impl<E: EthSpec> ValidatorConsensusDataValidator<E> {
             });
         }
 
+        // TODO(post-boole): remove `BEACON_ROLE_AGGREGATOR` and
+        // `BEACON_ROLE_SYNC_COMMITTEE_CONTRIBUTION` branches. Post-Boole, `ProposerConsensusData`
+        // is only used for `Proposer`.
         match value.duty.r#type {
             BEACON_ROLE_AGGREGATOR => {
                 if value.version < DataVersion(ForkName::Electra) {
@@ -360,7 +363,7 @@ impl<E: EthSpec> ValidatorConsensusDataValidator<E> {
 
     fn validate_block_proposal(
         &self,
-        value: &ValidatorConsensusData,
+        value: &ProposerConsensusData,
     ) -> Result<(), DataValidationError> {
         let fork = ForkName::from(value.version);
 
@@ -395,7 +398,7 @@ impl<E: EthSpec> ValidatorConsensusDataValidator<E> {
 
 #[derive(Error, Debug)]
 pub enum DataValidationError {
-    #[error("Unable to decode ssz in ValidatorConsensusData: {0:?}")]
+    #[error("Unable to decode ssz in ProposerConsensusData: {0:?}")]
     DecodeError(DecodeError),
     #[error("Invalid duty type for QBFT: {0:?}")]
     InvalidDutyType(BeaconRole),

--- a/anchor/qbft_manager/src/lib.rs
+++ b/anchor/qbft_manager/src/lib.rs
@@ -14,8 +14,8 @@ use slot_clock::SlotClock;
 use ssv_types::{
     Cluster, CommitteeId,
     consensus::{
-        AggregatorCommitteeConsensusData, BeaconVote, QbftData, QbftDataValidator,
-        ValidatorConsensusData,
+        AggregatorCommitteeConsensusData, BeaconVote, ProposerConsensusData, QbftData,
+        QbftDataValidator,
     },
     domain_type::DomainType,
     message::SignedSSVMessage,
@@ -72,15 +72,18 @@ pub struct AggregatorCommitteeInstanceId {
     pub instance_height: InstanceHeight,
 }
 
-// Unique Identifier for a validator instance
+// Unique Identifier for a proposer QBFT instance
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
-pub struct ValidatorInstanceId {
+pub struct ProposerInstanceId {
     pub validator: PublicKeyBytes,
+    // TODO(post-boole): remove `duty` field and `ValidatorDutyKind`. Post-boole,
+    // `Proposal` is the only validator specific duty
     pub duty: ValidatorDutyKind,
     pub instance_height: InstanceHeight,
 }
 
-// Type of validator duty that is being voted one
+// TODO(post-boole): remove this enum. Post-boole, `Proposal` is the only
+// validator specific duty kind.
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
 pub enum ValidatorDutyKind {
     Proposal,
@@ -130,8 +133,8 @@ pub struct QbftManager<E: EthSpec, S: SlotClock> {
     processor: Senders,
     // OperatorID
     operator_id: OwnOperatorId,
-    // All of the QBFT instances that are voting on validator consensus data
-    validator_consensus_data_instances: Map<ValidatorInstanceId, ValidatorConsensusData>,
+    // All of the QBFT instances that are voting on proposer consensus data
+    proposer_consensus_data_instances: Map<ProposerInstanceId, ProposerConsensusData>,
     // All of the QBFT instances that are voting on beacon data
     beacon_vote_instances: Map<CommitteeInstanceId, BeaconVote>,
     // QBFT instances for AggregatorCommitteeConsensusData
@@ -160,7 +163,7 @@ impl<E: EthSpec, S: SlotClock + Clone + 'static> QbftManager<E, S> {
         let manager = Arc::new(QbftManager {
             processor,
             operator_id,
-            validator_consensus_data_instances: DashMap::new(),
+            proposer_consensus_data_instances: DashMap::new(),
             beacon_vote_instances: DashMap::new(),
             aggregator_committee_instances: DashMap::new(),
             message_sender,
@@ -276,12 +279,12 @@ impl<E: EthSpec, S: SlotClock + Clone + 'static> QbftManager<E, S> {
                         return Err(QbftError::InconsistentMessageId);
                     }
                 };
-                let id = ValidatorInstanceId {
+                let id = ProposerInstanceId {
                     validator,
                     duty,
                     instance_height,
                 };
-                self.pass_to_instance::<ValidatorConsensusData>(
+                self.pass_to_instance::<ProposerConsensusData>(
                     id,
                     WrappedQbftMessage {
                         signed_message: full_message,
@@ -375,7 +378,7 @@ impl<E: EthSpec, S: SlotClock + Clone + 'static> QbftManager<E, S> {
             let cutoff = slot.saturating_sub(QBFT_RETAIN_SLOTS);
             self.beacon_vote_instances
                 .retain(|k, _| *k.instance_height >= cutoff.as_usize());
-            self.validator_consensus_data_instances
+            self.proposer_consensus_data_instances
                 .retain(|k, _| *k.instance_height >= cutoff.as_usize());
             self.aggregator_committee_instances
                 .retain(|k, _| *k.instance_height >= cutoff.as_usize());
@@ -416,10 +419,10 @@ pub trait QbftDecidable<E: EthSpec>: QbftData<Hash = Hash256> + Send + Sync + 's
     fn message_id(domain: &DomainType, id: &Self::Id) -> MessageId;
 }
 
-impl<E: EthSpec> QbftDecidable<E> for ValidatorConsensusData {
-    type Id = ValidatorInstanceId;
+impl<E: EthSpec> QbftDecidable<E> for ProposerConsensusData {
+    type Id = ProposerInstanceId;
     fn get_map<S: SlotClock>(manager: &QbftManager<E, S>) -> &Map<Self::Id, Self> {
-        &manager.validator_consensus_data_instances
+        &manager.proposer_consensus_data_instances
     }
 
     fn instance_height(&self, id: &Self::Id) -> InstanceHeight {

--- a/anchor/validator_store/src/lib.rs
+++ b/anchor/validator_store/src/lib.rs
@@ -24,8 +24,8 @@ use openssl::{
 use parking_lot::Mutex;
 use qbft::Completed;
 use qbft_manager::{
-    AggregatorCommitteeInstanceId, CommitteeInstanceId, QbftError, QbftManager, TimeoutMode,
-    ValidatorDutyKind, ValidatorInstanceId,
+    AggregatorCommitteeInstanceId, CommitteeInstanceId, ProposerInstanceId, QbftError, QbftManager,
+    TimeoutMode, ValidatorDutyKind,
 };
 use safe_arith::{ArithError, SafeArith};
 use signature_collector::{
@@ -40,7 +40,7 @@ use ssv_types::{
         AggregatorCommitteeConsensusData, AggregatorCommitteeDataValidator, BEACON_ROLE_AGGREGATOR,
         BEACON_ROLE_PROPOSER, BEACON_ROLE_SYNC_COMMITTEE_CONTRIBUTION, BeaconVote,
         BeaconVoteValidator, Contribution, ContributionWrapper, Contributions, DataVersion,
-        QbftData, SelectionProofBatchId, ValidatorConsensusData, ValidatorConsensusDataValidator,
+        ProposerConsensusData, ProposerConsensusDataValidator, QbftData, SelectionProofBatchId,
         ValidatorDuty,
     },
     msgid::Role,
@@ -323,8 +323,8 @@ impl<T: SlotClock, E: EthSpec> AnchorValidatorStore<T, E> {
             current_round_start_time: self.get_instant_in_slot(slot, Duration::ZERO)?,
         };
 
-        // Define the validator instance identity for QBFT consensus
-        let instance_id = ValidatorInstanceId {
+        // Define the proposer instance identity for QBFT consensus
+        let instance_id = ProposerInstanceId {
             validator: validator.public_key,
             duty: ValidatorDutyKind::Proposal,
             instance_height: slot.as_usize().into(),
@@ -350,7 +350,7 @@ impl<T: SlotClock, E: EthSpec> AnchorValidatorStore<T, E> {
         };
 
         // Package the consensus data
-        let consensus_data = ValidatorConsensusData {
+        let consensus_data = ProposerConsensusData {
             duty: validator_duty,
             version: block_version,
             data_ssz: try_to_variable_list(signable_block.as_ssz_bytes(), |provided, max| {
@@ -361,7 +361,7 @@ impl<T: SlotClock, E: EthSpec> AnchorValidatorStore<T, E> {
             })?,
         };
 
-        let data_validator = self.create_validator_consensus_data_validator(validator.public_key);
+        let data_validator = self.create_proposer_consensus_data_validator(validator.public_key);
 
         // Initiate QBFT consensus for this block proposal
         let completed = self
@@ -642,11 +642,11 @@ impl<T: SlotClock, E: EthSpec> AnchorValidatorStore<T, E> {
         Ok(signed_exit)
     }
 
-    fn create_validator_consensus_data_validator(
+    fn create_proposer_consensus_data_validator(
         &self,
         validator_pubkey: PublicKeyBytes,
-    ) -> Box<ValidatorConsensusDataValidator<E>> {
-        Box::new(ValidatorConsensusDataValidator::new(
+    ) -> Box<ProposerConsensusDataValidator<E>> {
+        Box::new(ProposerConsensusDataValidator::new(
             Arc::clone(&self.slashing_protection),
             self.disable_slashing_protection,
             self.spec.clone(),
@@ -905,12 +905,12 @@ impl<T: SlotClock, E: EthSpec> AnchorValidatorStore<T, E> {
         let completed = self
             .qbft_manager
             .decide_instance(
-                ValidatorInstanceId {
+                ProposerInstanceId {
                     validator: validator_pubkey,
                     duty: ValidatorDutyKind::Aggregator,
                     instance_height: message.aggregate().data().slot.as_usize().into(),
                 },
-                ValidatorConsensusData {
+                ProposerConsensusData {
                     duty: ValidatorDuty {
                         r#type: BEACON_ROLE_AGGREGATOR,
                         pub_key: validator_pubkey,
@@ -932,7 +932,7 @@ impl<T: SlotClock, E: EthSpec> AnchorValidatorStore<T, E> {
                         )))
                     })?,
                 },
-                self.create_validator_consensus_data_validator(validator_pubkey),
+                self.create_proposer_consensus_data_validator(validator_pubkey),
                 timeout_mode,
                 &cluster,
             )
@@ -1203,12 +1203,12 @@ impl<T: SlotClock, E: EthSpec> AnchorValidatorStore<T, E> {
         let completed = self
             .qbft_manager
             .decide_instance(
-                ValidatorInstanceId {
+                ProposerInstanceId {
                     validator: aggregator_pubkey,
                     duty: ValidatorDutyKind::SyncCommitteeAggregator,
                     instance_height: slot.as_usize().into(),
                 },
-                ValidatorConsensusData {
+                ProposerConsensusData {
                     duty: ValidatorDuty {
                         r#type: BEACON_ROLE_SYNC_COMMITTEE_CONTRIBUTION,
                         pub_key: aggregator_pubkey,
@@ -1228,7 +1228,7 @@ impl<T: SlotClock, E: EthSpec> AnchorValidatorStore<T, E> {
                         )))
                     })?,
                 },
-                self.create_validator_consensus_data_validator(aggregator_pubkey),
+                self.create_proposer_consensus_data_validator(aggregator_pubkey),
                 timeout_mode,
                 &cluster,
             )


### PR DESCRIPTION
  ## Issue Addressed                                                                                               
                                                            
  Spec alignment with SSV spec renaming PR [#596](https://github.com/ssvlabs/ssv-spec/pull/596) (commit [`e5171469`](https://github.com/ssvlabs/ssv-spec/commit/e5171469)) and SSV Go commit [`7b3f7a77f`](https://github.com/ssvlabs/ssv/commit/7b3f7a77f).

  ## Proposed Changes

  - Rename `ValidatorConsensusData` to `ProposerConsensusData` and related types (`ValidatorConsensusDataValidator`, `ValidatorConsensusDataLen`, `ValidatorInstanceId`) to align with the spec
  - Add `TODO(post-boole)` comments on pre-Boole code paths that will be removed when Aggregator and SyncCommittee post-fork

  ## Additional Info
  N/A