### PR TITLE
chore: add worktree-isolated task list script for parallel development

### DIFF
--- a/.github/wordlist.txt
+++ b/.github/wordlist.txt
@@ -31,6 +31,7 @@ libp
 linter
 localhost
 MacOS
+macOS
 md
 mdBook
 middleware

--- a/.github/wordlist.txt
+++ b/.github/wordlist.txt
@@ -130,3 +130,7 @@ Callouts
 nav
 dev
 reviewable
+worktree
+worktrees
+Worktrees
+anthropics

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -463,6 +463,43 @@ Effective code reviews question "why" architectural decisions exist:
 - Follow test-driven development principles when possible
 - Use debugging tools like `tracing` and metrics to understand system behavior
 
+## Parallel Development with Git Worktrees
+
+Git worktrees allow running multiple Claude Code sessions in parallel on different branches of the same repo. However, worktrees share the same `.git` directory, which causes Claude Code's task list (`TaskCreate`/`TodoWrite`) to leak across sessions (see [anthropics/claude-code#24754](https://github.com/anthropics/claude-code/issues/24754)).
+
+### Setup
+
+Use the provided wrapper script to launch Claude Code with worktree-isolated task lists:
+
+```bash
+# Instead of running `claude` directly in a worktree:
+./scripts/claude-worktree.sh
+
+# Or with arguments:
+./scripts/claude-worktree.sh --resume
+```
+
+The script auto-detects the worktree name and sets `CLAUDE_CODE_TASK_LIST_ID` so each worktree gets its own task list.
+
+### Creating Worktrees
+
+```bash
+# Create a worktree for a new feature branch based on upstream/unstable
+git fetch upstream unstable
+git worktree add ../anchor-my-feature -b feat/my-feature FETCH_HEAD
+
+# Launch Claude Code in the new worktree
+cd ../anchor-my-feature
+../anchor/scripts/claude-worktree.sh
+```
+
+### Cleanup
+
+```bash
+# Remove a worktree when done
+git worktree remove ../anchor-my-feature
+```
+
 ## Session Learning Updates
 
 After successful Claude Code sessions where the user is satisfied with results, update both CLAUDE.md and relevant specialized agents with general principles learned:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -467,36 +467,33 @@ Effective code reviews question "why" architectural decisions exist:
 
 Git worktrees allow running multiple Claude Code sessions in parallel on different branches of the same repo. However, worktrees share the same `.git` directory, which causes Claude Code's task list (`TaskCreate`/`TodoWrite`) to leak across sessions (see [anthropics/claude-code#24754](https://github.com/anthropics/claude-code/issues/24754)).
 
-### Setup
+### Creating a New Worktree
 
-Use the provided wrapper script to launch Claude Code with worktree-isolated task lists:
+The script handles worktree creation, fetching, and launching in one command:
 
 ```bash
-# Instead of running `claude` directly in a worktree:
-./scripts/claude-worktree.sh
+# Create worktree from upstream/unstable (default) and launch
+./scripts/claude-worktree.sh new feat/my-feature
 
-# Or with arguments:
-./scripts/claude-worktree.sh --resume
+# Create worktree from a specific base
+./scripts/claude-worktree.sh new fix/bug-123 origin/stable
 ```
 
-The script auto-detects the worktree name and sets `CLAUDE_CODE_TASK_LIST_ID` so each worktree gets its own task list.
+This creates `../anchor-my-feature/`, fetches the base ref, creates the branch, and launches Claude Code with an isolated task list.
 
-**Note**: Examples below use `upstream` as the remote pointing to `sigp/anchor` and `origin` as your fork, following the standard fork contribution workflow. Set up with:
+**Note**: Examples use `upstream` as the remote pointing to `sigp/anchor` and `origin` as your fork. Set up with:
 
 ```bash
 git remote add upstream https://github.com/sigp/anchor.git
 ```
 
-### Creating Worktrees
+### Launching in an Existing Worktree
+
+From within any worktree, run the script instead of `claude` directly:
 
 ```bash
-# Create a worktree for a new feature branch based on upstream/unstable
-git fetch upstream unstable
-git worktree add ../anchor-my-feature -b feat/my-feature FETCH_HEAD
-
-# Launch Claude Code in the new worktree
-cd ../anchor-my-feature
-../anchor/scripts/claude-worktree.sh
+./scripts/claude-worktree.sh              # interactive session
+./scripts/claude-worktree.sh --resume     # with claude args
 ```
 
 ### Cleanup

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -502,6 +502,14 @@ cd ../anchor-my-feature
 git worktree remove ../anchor-my-feature
 ```
 
+### Troubleshooting
+
+**Script not executable**: Run `chmod +x scripts/claude-worktree.sh`
+
+**Hash command not found**: The script requires `sha256sum` (Linux) or `shasum` (macOS). Install the appropriate tool for your platform.
+
+**Task lists still shared**: Ensure you're launching through the script, not directly via the `claude` command.
+
 ## Session Learning Updates
 
 After successful Claude Code sessions where the user is satisfied with results, update both CLAUDE.md and relevant specialized agents with general principles learned:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -481,6 +481,8 @@ Use the provided wrapper script to launch Claude Code with worktree-isolated tas
 
 The script auto-detects the worktree name and sets `CLAUDE_CODE_TASK_LIST_ID` so each worktree gets its own task list.
 
+**Note**: Examples below use `upstream` as the remote pointing to `sigp/anchor` and `origin` as your fork, following the standard fork contribution workflow.
+
 ### Creating Worktrees
 
 ```bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -481,7 +481,11 @@ Use the provided wrapper script to launch Claude Code with worktree-isolated tas
 
 The script auto-detects the worktree name and sets `CLAUDE_CODE_TASK_LIST_ID` so each worktree gets its own task list.
 
-**Note**: Examples below use `upstream` as the remote pointing to `sigp/anchor` and `origin` as your fork, following the standard fork contribution workflow.
+**Note**: Examples below use `upstream` as the remote pointing to `sigp/anchor` and `origin` as your fork, following the standard fork contribution workflow. Set up with:
+
+```bash
+git remote add upstream https://github.com/sigp/anchor.git
+```
 
 ### Creating Worktrees
 
@@ -509,6 +513,8 @@ git worktree remove ../anchor-my-feature
 **Hash command not found**: The script requires `sha256sum` (Linux) or `shasum` (macOS). Install the appropriate tool for your platform.
 
 **Task lists still shared**: Ensure you're launching through the script, not directly via the `claude` command.
+
+**Different task list after moving a worktree**: The task list ID includes a hash of the absolute path. Moving the worktree directory changes the hash, resulting in a new task list.
 
 ## Session Learning Updates
 

--- a/scripts/claude-worktree.sh
+++ b/scripts/claude-worktree.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Wrapper script to launch Claude Code with worktree-isolated task lists.
+#
+# Git worktrees share the same .git directory, which causes Claude Code's
+# task list (TaskCreate/TodoWrite) to leak across concurrent sessions.
+# This script sets CLAUDE_CODE_TASK_LIST_ID based on the worktree directory
+# name so each worktree gets its own task list.
+#
+# Workaround for: https://github.com/anthropics/claude-code/issues/24754
+#
+# Usage:
+#   ./scripts/claude-worktree.sh [claude args...]
+
+set -euo pipefail
+
+# Derive a unique task list ID from the worktree directory name.
+# For the main worktree (e.g., "anchor"), this still works — each directory
+# gets a consistent, unique ID regardless of whether it's a worktree or not.
+WORKTREE_DIR="$(basename "$(git rev-parse --show-toplevel 2>/dev/null || pwd)")"
+
+export CLAUDE_CODE_TASK_LIST_ID="${WORKTREE_DIR}"
+
+echo "Task list isolated to: ${CLAUDE_CODE_TASK_LIST_ID}"
+exec claude "$@"

--- a/scripts/claude-worktree.sh
+++ b/scripts/claude-worktree.sh
@@ -17,7 +17,14 @@ set -euo pipefail
 # Using a hash ensures different directories with the same basename get unique IDs.
 WORKTREE_PATH="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
 WORKTREE_DIR="$(basename "${WORKTREE_PATH}")"
-PATH_HASH="$(echo "${WORKTREE_PATH}" | shasum -a 256 | cut -c1-8)"
+if command -v sha256sum >/dev/null 2>&1; then
+    PATH_HASH="$(echo "${WORKTREE_PATH}" | sha256sum | cut -c1-8)"
+elif command -v shasum >/dev/null 2>&1; then
+    PATH_HASH="$(echo "${WORKTREE_PATH}" | shasum -a 256 | cut -c1-8)"
+else
+    echo "Error: Neither sha256sum nor shasum found in PATH" >&2
+    exit 1
+fi
 
 export CLAUDE_CODE_TASK_LIST_ID="${WORKTREE_DIR}-${PATH_HASH}"
 

--- a/scripts/claude-worktree.sh
+++ b/scripts/claude-worktree.sh
@@ -4,7 +4,7 @@
 # Git worktrees share the same .git directory, which causes Claude Code's
 # task list (TaskCreate/TodoWrite) to leak across concurrent sessions.
 # This script sets CLAUDE_CODE_TASK_LIST_ID based on the worktree directory
-# name so each worktree gets its own task list.
+# so each worktree gets its own task list.
 #
 # Workaround for: https://github.com/anthropics/claude-code/issues/24754
 #
@@ -13,12 +13,20 @@
 
 set -euo pipefail
 
-# Derive a unique task list ID from the worktree directory name.
-# For the main worktree (e.g., "anchor"), this still works — each directory
-# gets a consistent, unique ID regardless of whether it's a worktree or not.
-WORKTREE_DIR="$(basename "$(git rev-parse --show-toplevel 2>/dev/null || pwd)")"
+# Derive a unique task list ID from the full worktree path.
+# Using a hash ensures different directories with the same basename get unique IDs.
+WORKTREE_PATH="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+WORKTREE_DIR="$(basename "${WORKTREE_PATH}")"
+PATH_HASH="$(echo "${WORKTREE_PATH}" | shasum -a 256 | cut -c1-8)"
 
-export CLAUDE_CODE_TASK_LIST_ID="${WORKTREE_DIR}"
+export CLAUDE_CODE_TASK_LIST_ID="${WORKTREE_DIR}-${PATH_HASH}"
+
+# Validate that claude command exists
+command -v claude >/dev/null 2>&1 || {
+    echo "Error: 'claude' command not found in PATH" >&2
+    echo "Please install Claude Code or add it to your PATH" >&2
+    exit 1
+}
 
 echo "Task list isolated to: ${CLAUDE_CODE_TASK_LIST_ID}"
 exec claude "$@"

--- a/scripts/claude-worktree.sh
+++ b/scripts/claude-worktree.sh
@@ -1,47 +1,98 @@
 #!/usr/bin/env bash
-# Wrapper script to launch Claude Code with worktree-isolated task lists.
+# Launch Claude Code with worktree-isolated task lists.
 #
-# Git worktrees share the same .git directory, which causes Claude Code's
-# task list (TaskCreate/TodoWrite) to leak across concurrent sessions.
-# This script sets CLAUDE_CODE_TASK_LIST_ID based on the worktree directory
-# so each worktree gets its own task list.
+# Creates a new git worktree (if needed) and launches Claude Code with
+# CLAUDE_CODE_TASK_LIST_ID set so each worktree gets its own task list.
 #
 # Workaround for: https://github.com/anthropics/claude-code/issues/24754
 #
 # Usage:
-#   ./scripts/claude-worktree.sh [claude args...]
+#   ./scripts/claude-worktree.sh new <branch> [base]  Create worktree and launch
+#   ./scripts/claude-worktree.sh [claude args...]      Launch in current directory
+#
+# Examples:
+#   ./scripts/claude-worktree.sh new feat/my-feature                  # from upstream/unstable
+#   ./scripts/claude-worktree.sh new fix/bug-123 origin/stable        # from specific base
+#   ./scripts/claude-worktree.sh                                      # in existing worktree
+#   ./scripts/claude-worktree.sh --resume                             # with claude args
 
 set -euo pipefail
 
-# Derive a unique task list ID from the full worktree path.
-# Using a hash ensures different directories with the same basename get unique IDs.
-WORKTREE_PATH="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+# --- Helper functions ---
 
-if [ -z "${WORKTREE_PATH}" ]; then
-    echo "Error: Unable to determine working directory" >&2
-    exit 1
-fi
-
-WORKTREE_DIR="$(basename "${WORKTREE_PATH}")"
-
-# Use printf to avoid trailing newline differences across platforms.
-if command -v sha256sum >/dev/null 2>&1; then
-    PATH_HASH="$(printf '%s' "${WORKTREE_PATH}" | sha256sum | cut -c1-8)"
-elif command -v shasum >/dev/null 2>&1; then
-    PATH_HASH="$(printf '%s' "${WORKTREE_PATH}" | shasum -a 256 | cut -c1-8)"
-else
-    echo "Error: Neither sha256sum nor shasum found in PATH" >&2
-    exit 1
-fi
-
-export CLAUDE_CODE_TASK_LIST_ID="${WORKTREE_DIR}-${PATH_HASH}"
-
-# Validate that claude command exists
-command -v claude >/dev/null 2>&1 || {
-    echo "Error: 'claude' command not found in PATH" >&2
-    echo "Please install Claude Code or add it to your PATH" >&2
-    exit 1
+hash_path() {
+    local path="$1"
+    if command -v sha256sum >/dev/null 2>&1; then
+        printf '%s' "${path}" | sha256sum | cut -c1-8
+    elif command -v shasum >/dev/null 2>&1; then
+        printf '%s' "${path}" | shasum -a 256 | cut -c1-8
+    else
+        echo "Error: Neither sha256sum nor shasum found in PATH" >&2
+        exit 1
+    fi
 }
 
-echo "Task list isolated to: ${CLAUDE_CODE_TASK_LIST_ID}"
-exec claude "$@"
+launch_claude() {
+    local worktree_path="$1"
+    shift
+
+    if [ -z "${worktree_path}" ]; then
+        echo "Error: Unable to determine working directory" >&2
+        exit 1
+    fi
+
+    local worktree_dir
+    worktree_dir="$(basename "${worktree_path}")"
+    local path_hash
+    path_hash="$(hash_path "${worktree_path}")"
+
+    export CLAUDE_CODE_TASK_LIST_ID="${worktree_dir}-${path_hash}"
+
+    command -v claude >/dev/null 2>&1 || {
+        echo "Error: 'claude' command not found in PATH" >&2
+        echo "Please install Claude Code or add it to your PATH" >&2
+        exit 1
+    }
+
+    echo "Task list isolated to: ${CLAUDE_CODE_TASK_LIST_ID}"
+    exec claude "$@"
+}
+
+# --- Main ---
+
+if [ "${1:-}" = "new" ]; then
+    shift
+
+    if [ $# -lt 1 ]; then
+        echo "Usage: $0 new <branch-name> [base-ref]" >&2
+        echo "  base-ref defaults to upstream/unstable (fetched automatically)" >&2
+        exit 1
+    fi
+
+    BRANCH="$1"
+    BASE="${2:-upstream/unstable}"
+
+    # Derive worktree directory name from branch (e.g., feat/my-feature -> anchor-my-feature)
+    REPO_NAME="$(basename "$(git rev-parse --show-toplevel)")"
+    DIR_SUFFIX="$(basename "${BRANCH}")"
+    WORKTREE_DIR="../${REPO_NAME}-${DIR_SUFFIX}"
+
+    # Fetch if base looks like a remote ref
+    if [[ "${BASE}" == */* ]]; then
+        REMOTE="${BASE%%/*}"
+        REF="${BASE#*/}"
+        echo "Fetching ${REF} from ${REMOTE}..."
+        git fetch "${REMOTE}" "${REF}" 2>&1
+    fi
+
+    echo "Creating worktree at ${WORKTREE_DIR} on branch ${BRANCH}..."
+    git worktree add "${WORKTREE_DIR}" -b "${BRANCH}" "${BASE}"
+
+    WORKTREE_PATH="$(cd "${WORKTREE_DIR}" && pwd)"
+    cd "${WORKTREE_PATH}"
+    launch_claude "${WORKTREE_PATH}"
+else
+    # Launch in current directory
+    WORKTREE_PATH="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+    launch_claude "${WORKTREE_PATH}" "$@"
+fi

--- a/scripts/claude-worktree.sh
+++ b/scripts/claude-worktree.sh
@@ -16,11 +16,19 @@ set -euo pipefail
 # Derive a unique task list ID from the full worktree path.
 # Using a hash ensures different directories with the same basename get unique IDs.
 WORKTREE_PATH="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+
+if [ -z "${WORKTREE_PATH}" ]; then
+    echo "Error: Unable to determine working directory" >&2
+    exit 1
+fi
+
 WORKTREE_DIR="$(basename "${WORKTREE_PATH}")"
+
+# Use printf to avoid trailing newline differences across platforms.
 if command -v sha256sum >/dev/null 2>&1; then
-    PATH_HASH="$(echo "${WORKTREE_PATH}" | sha256sum | cut -c1-8)"
+    PATH_HASH="$(printf '%s' "${WORKTREE_PATH}" | sha256sum | cut -c1-8)"
 elif command -v shasum >/dev/null 2>&1; then
-    PATH_HASH="$(echo "${WORKTREE_PATH}" | shasum -a 256 | cut -c1-8)"
+    PATH_HASH="$(printf '%s' "${WORKTREE_PATH}" | shasum -a 256 | cut -c1-8)"
 else
     echo "Error: Neither sha256sum nor shasum found in PATH" >&2
     exit 1


### PR DESCRIPTION
## Issue Addressed

Workaround for [anthropics/claude-code#24754](https://github.com/anthropics/claude-code/issues/24754) — Claude Code's task list (`TaskCreate`/`TodoWrite`) leaks across git worktrees because worktrees share the same `.git` directory.

## Proposed Changes

- Added `scripts/claude-worktree.sh`, a script that creates worktrees and launches Claude Code with isolated task lists in one command
- Documented the parallel development workflow in `CLAUDE.md`, including usage, cleanup, and troubleshooting

### Usage

Create a new worktree and launch:
```bash
./scripts/claude-worktree.sh new feat/my-feature                  # from upstream/unstable
./scripts/claude-worktree.sh new fix/bug-123 origin/stable        # from specific base
```

Launch in an existing worktree:
```bash
./scripts/claude-worktree.sh              # interactive session
./scripts/claude-worktree.sh --resume     # with claude args
```

The script sets `CLAUDE_CODE_TASK_LIST_ID` to a unique value derived from the worktree directory name and a hash of its absolute path, ensuring each worktree gets its own task list. Works on both Linux (`sha256sum`) and macOS (`shasum`).

## Additional Info

This is a lightweight workaround until Claude Code provides native worktree-level task isolation. The script requires no configuration and produces human-readable IDs with guaranteed uniqueness.