### PR TITLE
fix: partial sig message length increase

### DIFF
--- a/anchor/common/ssv_types/src/message.rs
+++ b/anchor/common/ssv_types/src/message.rs
@@ -45,9 +45,13 @@ const MAX_CONSENSUS_MSG_SIZE: usize = QBFT_MSG_TYPE_SIZE
     + (MAX_SIGNATURES * (PrepareJustificationLength::USIZE + ssz::BYTES_PER_LENGTH_OFFSET)
         + ssz::BYTES_PER_LENGTH_OFFSET);
 
+/// Size of each `PartialSignatureMessage` in bytes
 const PARTIAL_SIGNATURE_MSG_SIZE: usize =
     PARTIAL_SIGNATURE_SIZE + ROOT_SIZE + OPERATOR_ID_SIZE + VALIDATOR_INDEX_SIZE;
 
+/// Maximum size of `PartialSignatureMessages` structure in bytes
+/// Calculation: 8 (`Type`) + 8 (`Slot`) + 4 (offset) + (5048 × 144)
+/// where 144 = `PARTIAL_SIGNATURE_MSG_SIZE`
 const MAX_PARTIAL_SIGNATURE_MSGS_SIZE: usize = PARTIAL_SIG_MSG_TYPE_SIZE
     + SLOT_SIZE
     + MAX_PARTIAL_SIGNATURE_MESSAGES * PARTIAL_SIGNATURE_MSG_SIZE
@@ -57,7 +61,19 @@ const MAX_FULL_DATA_SIZE: usize = SSVMessageFullDataLen::USIZE;
 
 /// `SSVMessage.Data` max size: 726932
 /// `max(consensus_msg_max, partial_sig_max)` = `max(722412, 726932)` = 726932
-/// 726932 = 726 * 1000 + 932
+///
+/// Calculation breakdown for 726932:
+/// - 8 bytes: `Type` (`PartialSigMsgType`)
+/// - 8 bytes: `Slot`
+/// - 4 bytes: `Messages` list offset
+/// - 726912 bytes: 5048 messages × 144 bytes each
+///
+///   Total: 8 + 8 + 4 + (5048 × 144) = 726932
+///
+/// where 5048 = 3000 (max aggregators) + 2048 (512 sync committee × 4 subnets)
+/// and 144 = `PARTIAL_SIGNATURE_MSG_SIZE`
+///
+/// Expressed as: 726932 = 726 * 1000 + 932
 pub type SSVMessageDataLen = Sum<Prod<U726, U1000>, U932>;
 
 /// Defines the types of messages with explicit discriminant values.
@@ -1182,6 +1198,10 @@ mod tests {
 
     #[test]
     fn ensure_message_sizes_correct() {
+        // Verify individual constants match spec
+        assert_eq!(MAX_PARTIAL_SIGNATURE_MESSAGES, 5048);
+        assert_eq!(PARTIAL_SIGNATURE_MSG_SIZE, 144);
+
         let messages_vec = vec![
             PartialSignatureMessage {
                 partial_signature: Signature::empty(),

--- a/anchor/common/ssv_types/src/message.rs
+++ b/anchor/common/ssv_types/src/message.rs
@@ -9,7 +9,7 @@ use ssz_types::VariableList;
 use thiserror::Error;
 use tree_hash::{PackedEncoding, TreeHash, TreeHashType};
 use tree_hash_derive::TreeHash;
-use typenum::{Prod, Sum, U8, U13, U256, U388, U412, U722, U836, U1000, U1000000, Unsigned};
+use typenum::{Prod, Sum, U8, U13, U256, U388, U726, U836, U932, U1000, U1000000, Unsigned};
 use types::{Hash256, Slot};
 
 use crate::{
@@ -55,9 +55,10 @@ const MAX_PARTIAL_SIGNATURE_MSGS_SIZE: usize = PARTIAL_SIG_MSG_TYPE_SIZE
 
 const MAX_FULL_DATA_SIZE: usize = SSVMessageFullDataLen::USIZE;
 
-/// SSVMessage.Data max size: 722412 (from Go spec)
-/// 722412 = 722 * 1000 + 412 = 722000 + 412
-pub type SSVMessageDataLen = Sum<Prod<U722, U1000>, U412>;
+/// `SSVMessage.Data` max size: 726932
+/// `max(consensus_msg_max, partial_sig_max)` = `max(722412, 726932)` = 726932
+/// 726932 = 726 * 1000 + 932
+pub type SSVMessageDataLen = Sum<Prod<U726, U1000>, U932>;
 
 /// Defines the types of messages with explicit discriminant values.
 #[derive(Debug, Clone, PartialEq, Eq, Copy)]

--- a/anchor/common/ssv_types/src/message.rs
+++ b/anchor/common/ssv_types/src/message.rs
@@ -32,7 +32,7 @@ const OPERATOR_ID_SIZE: usize = 8;
 const VALIDATOR_INDEX_SIZE: usize = 8;
 const SLOT_SIZE: usize = 8;
 const PARTIAL_SIG_MSG_TYPE_SIZE: usize = 8;
-const MAX_PARTIAL_SIGNATURE_MESSAGES: usize = 1000;
+const MAX_PARTIAL_SIGNATURE_MESSAGES: usize = 5048;
 
 const MAX_CONSENSUS_MSG_SIZE: usize = QBFT_MSG_TYPE_SIZE
     + HEIGHT_SIZE
@@ -1189,7 +1189,7 @@ mod tests {
                 signer: Default::default(),
                 validator_index: Default::default(),
             };
-            1000
+            5048
         ];
         let partial_signature_messages = PartialSignatureMessages {
             kind: PartialSignatureKind::PostConsensus,

--- a/anchor/common/ssv_types/src/partial_sig.rs
+++ b/anchor/common/ssv_types/src/partial_sig.rs
@@ -4,14 +4,17 @@ use ssz_derive::{Decode, Encode};
 use ssz_types::VariableList;
 use tree_hash::{PackedEncoding, TreeHash, TreeHashType};
 use tree_hash_derive::TreeHash;
-use typenum::{Sum, U512, U1000};
+use typenum::{Prod, Sum, U3, U4, U512, U1000};
 use types::{Hash256, Slot};
 
 use crate::{OperatorId, ValidatorIndex};
 
-/// Maximum number of partial signature messages: 1512
-/// Calculated as 1000 + 512 = 1512
-pub type PartialSignatureMessagesLen = Sum<U1000, U512>;
+/// Maximum number of `PartialSignatureMessage`s: 5048
+/// Worst case scenario for a committee with 3000 validators:
+/// every validator has an aggregation duty (3000) +
+/// every validator is in sync committee and is a contributor to all 4 subnets (512 * 4 = 2048)
+/// Calculated as 3000 + 512 * 4 = 5048
+pub type PartialSignatureMessagesLen = Sum<Prod<U3, U1000>, Prod<U512, U4>>;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "arbitrary-fuzz", derive(arbitrary::Arbitrary))]


### PR DESCRIPTION
## Issue Addressed
- ssv parity

## Proposed Changes
  - Update SSZ max sizes to match spec: `PartialSignatureMessages` list max from 1512 to 5048 (3000  aggregators + 512×4 sync committee contributors), and `SSVMessage.Data` max from 722412 to 726932 (now bounded by partial sig messages rather than consensus messages) 

## Additional Info
N/A
