### PR TITLE
fix(ci): fix claude-pr-review checkout for fork PRs

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -60,13 +60,13 @@ jobs:
                     exit 0
                   fi
 
+            # Do NOT set repository/ref here. claude-code-action fetches the
+            # PR branch itself via `git fetch origin pull/N/head:...`. Overriding
+            # origin to a fork repo breaks that fetch since PR refs only exist on
+            # the base repo.
             - name: Checkout repository
               if: steps.check.outputs.is_member == 'true'
               uses: actions/checkout@v4
-              with:
-                  repository: ${{ github.event.pull_request.head.repo.full_name }}
-                  ref: ${{ github.event.pull_request.head.ref }}
-                  fetch-depth: 0
 
             - name: Generate GitHub App token
               if: steps.check.outputs.is_member == 'true'


### PR DESCRIPTION
## Issue Addressed

The `claude-pr-review` workflow fails on all fork PRs with:
```
fatal: couldn't find remote ref pull/N/head
```

## Proposed Changes

Remove the `repository` and `ref` overrides from the checkout step. The explicit `repository: head.repo.full_name` and `ref: head.ref` set `origin` to the fork repo, but `claude-code-action` internally runs `git fetch origin pull/N/head:...` expecting `origin` to be the base repo (`sigp/anchor`) where PR refs live. A plain `actions/checkout@v4` keeps `origin` as the base repo, and the action handles switching to the PR branch itself.

## Additional Info

Confirmed the same failure on multiple fork PRs (#824, shane-moore PRs) while merge-queue PRs from `sigp/anchor` succeed — consistent with `origin` pointing to the wrong repo after the fork-specific checkout.