### PR TITLE
fix(ci): use app token for checkout in claude-pr-review

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -60,14 +60,12 @@ jobs:
                     exit 0
                   fi
 
-            # Do NOT set repository/ref here. claude-code-action fetches the
-            # PR branch itself via `git fetch origin pull/N/head:...`. Overriding
-            # origin to a fork repo breaks that fetch since PR refs only exist on
-            # the base repo.
-            - name: Checkout repository
-              if: steps.check.outputs.is_member == 'true'
-              uses: actions/checkout@v4
-
+            # Generate the app token before checkout so it can be used for
+            # git operations. claude-code-action calls setupBranch() (which
+            # fetches PR refs via `git fetch origin pull/N/head:...`) before
+            # configureGitAuth(), so the token embedded in origin by
+            # actions/checkout must already have permission to fetch fork
+            # PR refs.
             - name: Generate GitHub App token
               if: steps.check.outputs.is_member == 'true'
               id: app-token
@@ -75,6 +73,12 @@ jobs:
               with:
                   app-id: ${{ vars.APP_ID }}
                   private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+            - name: Checkout repository
+              if: steps.check.outputs.is_member == 'true'
+              uses: actions/checkout@v4
+              with:
+                  token: ${{ steps.app-token.outputs.token }}
 
             - name: Configure AWS Credentials (OIDC)
               if: steps.check.outputs.is_member == 'true'


### PR DESCRIPTION
## Issue Addressed

`claude-pr-review` fails on all fork PRs since Feb 11 with:
```
fatal: couldn't find remote ref pull/N/head
```

## Proposed Changes

Generate the GitHub App token **before** the checkout step and pass it via `token:`. 

Root cause: `claude-code-action@v1` merged [PR #851](https://github.com/anthropics/claude-code-action/pull/851) on Feb 10, changing branch fetch from `git fetch origin <branchName>` to `git fetch origin pull/N/head:<branchName>`. The action calls `setupBranch()` (which runs this fetch) **before** `configureGitAuth()`, so it uses whatever token `actions/checkout` embedded in `origin`. The default `github.token` cannot fetch fork PR refs, causing the failure.

## Additional Info

- The previous fix (#827) correctly removed the fork-specific `repository`/`ref` overrides but didn't address the token issue
- Fork PR runs succeeded on Feb 10 (before the `claude-code-action` update) and started failing on Feb 11
- Same-repo runs (merge queue) continue to succeed since `github.token` can access those refs