### PR TITLE
fix(ci): fix claude-pr-review failing on fork PRs

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -60,14 +60,12 @@ jobs:
                     exit 0
                   fi
 
-            - name: Checkout repository
-              if: steps.check.outputs.is_member == 'true'
-              uses: actions/checkout@v4
-              with:
-                  repository: ${{ github.event.pull_request.head.repo.full_name }}
-                  ref: ${{ github.event.pull_request.head.ref }}
-                  fetch-depth: 0
-
+            # Generate the app token before checkout so it can be used for
+            # git operations. claude-code-action calls setupBranch() (which
+            # fetches PR refs via `git fetch origin pull/N/head:...`) before
+            # configureGitAuth(), so the token embedded in origin by
+            # actions/checkout must already have permission to fetch fork
+            # PR refs.
             - name: Generate GitHub App token
               if: steps.check.outputs.is_member == 'true'
               id: app-token
@@ -75,6 +73,12 @@ jobs:
               with:
                   app-id: ${{ vars.APP_ID }}
                   private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+            - name: Checkout repository
+              if: steps.check.outputs.is_member == 'true'
+              uses: actions/checkout@v4
+              with:
+                  token: ${{ steps.app-token.outputs.token }}
 
             - name: Configure AWS Credentials (OIDC)
               if: steps.check.outputs.is_member == 'true'


### PR DESCRIPTION
## Issue Addressed

`claude-pr-review` fails on all fork PRs since Feb 11 with:
```
fatal: couldn't find remote ref pull/N/head
```

`pull_request_target` reads workflow files from the default branch (`stable`), so this fix must land here.

## Proposed Changes

- Remove fork-specific `repository`/`ref` overrides from checkout (origin must point to base repo where PR refs live)
- Generate the GitHub App token **before** checkout and pass it via `token:`

Root cause: `claude-code-action@v1` merged [anthropics/claude-code-action#851](https://github.com/anthropics/claude-code-action/pull/851) on Feb 10, changing branch fetch from `git fetch origin <branchName>` to `git fetch origin pull/N/head:<branchName>`. The action calls `setupBranch()` before `configureGitAuth()`, so it uses the token embedded by `actions/checkout`. The default `github.token` cannot fetch fork PR refs.

## Additional Info

- Same fix was merged to `unstable` via #827 and #828 but had no effect since `pull_request_target` reads from `stable`
- Same-repo runs (merge queue) are unaffected since `github.token` can access those refs