### PR TITLE
chore: Change lint `allow`s to `expect`s

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -131,7 +131,8 @@ test-full: cargo-fmt test-release test-debug
 # Clippy lints are opt-in per-crate for now. By default, everything is allowed except for performance and correctness lints.
 lint:
 	cargo clippy --workspace --tests $(EXTRA_CLIPPY_OPTS) --features "$(TEST_FEATURES)" -- \
-		-D warnings
+		-D warnings \
+		-D clippy::allow_attributes
 
 # Lints the code using Clippy and automatically fix some simple compiler warnings.
 lint-fix:

--- a/anchor/common/qbft/src/tests.rs
+++ b/anchor/common/qbft/src/tests.rs
@@ -91,7 +91,6 @@ impl Default for TestQBFTCommitteeBuilder {
     }
 }
 
-#[allow(dead_code)]
 impl TestQBFTCommitteeBuilder {
     /// Consumes self and runs a test scenario. This returns a [`TestQBFTCommittee`] which
     /// represents a running quorum.
@@ -105,7 +104,6 @@ impl TestQBFTCommitteeBuilder {
 }
 
 /// A testing structure representing a committee of running instances
-#[allow(clippy::type_complexity)]
 struct TestQBFTCommittee<D: QbftData<Hash = Hash256>, S: FnMut(UnsignedWrappedQbftMessage)> {
     msg_queue: Rc<RefCell<VecDeque<(OperatorId, UnsignedWrappedQbftMessage)>>>,
     instances: HashMap<OperatorId, Qbft<DefaultLeaderFunction, D, S>>,

--- a/anchor/common/version/src/lib.rs
+++ b/anchor/common/version/src/lib.rs
@@ -25,7 +25,6 @@ pub const VERSION: &str = git_version!(
 ///
 /// No indication is given if the tree is dirty. This is part of the standard
 /// for reporting the client version to the execution engine.
-#[allow(dead_code)]
 pub const COMMIT_PREFIX: &str = git_version!(
     args = [
         "--always",

--- a/anchor/duties_tracker/src/duties_tracker.rs
+++ b/anchor/duties_tracker/src/duties_tracker.rs
@@ -22,7 +22,7 @@ pub enum Error {
     #[error("Unable to read the slot clock")]
     UnableToReadSlotClock,
     #[error("Arithmetic error")]
-    Arith(#[allow(dead_code)] ArithError),
+    Arith(ArithError),
     #[error("Failed to poll proposers: {0}")]
     FailedToPollProposers(String),
 }

--- a/anchor/message_receiver/src/manager.rs
+++ b/anchor/message_receiver/src/manager.rs
@@ -38,7 +38,7 @@ pub struct NetworkMessageReceiver<E: types::EthSpec, S: SlotClock, D: DutiesProv
 }
 
 impl<E: types::EthSpec, S: SlotClock + 'static, D: DutiesProvider> NetworkMessageReceiver<E, S, D> {
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     pub fn new(
         processor: processor::Senders,
         qbft_manager: Arc<QbftManager<E, S>>,

--- a/anchor/message_validator/src/consensus_message.rs
+++ b/anchor/message_validator/src/consensus_message.rs
@@ -228,7 +228,6 @@ fn validate_justification_list<N: Unsigned>(
     })
 }
 
-#[allow(clippy::comparison_chain)]
 pub(crate) fn validate_qbft_logic(
     validation_context: &ValidationContext<impl SlotClock>,
     consensus_message: &QbftMessage,

--- a/anchor/message_validator/src/lib.rs
+++ b/anchor/message_validator/src/lib.rs
@@ -329,9 +329,8 @@ pub struct Validator<S: SlotClock, D: DutiesProvider> {
     fork_schedule: Arc<ForkSchedule>,
 }
 
-#[allow(clippy::too_many_arguments)]
 impl<S: SlotClock + 'static, D: DutiesProvider> Validator<S, D> {
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     pub fn new(
         network_state_rx: Receiver<NetworkState>,
         slots_per_epoch: u64,

--- a/anchor/network/src/discovery.rs
+++ b/anchor/network/src/discovery.rs
@@ -579,7 +579,6 @@ impl NetworkBehaviour for Discovery {
     ) {
     }
 
-    #[allow(clippy::single_match)]
     fn poll(
         &mut self,
         cx: &mut Context<'_>,

--- a/anchor/network/src/handshake/envelope/generated/message/pb.rs
+++ b/anchor/network/src/handshake/envelope/generated/message/pb.rs
@@ -12,7 +12,7 @@ use quick_protobuf::{MessageInfo, MessageRead, MessageWrite, BytesReader, Writer
 use quick_protobuf::sizeofs::*;
 use super::*;
 
-#[allow(clippy::derive_partial_eq_without_eq)]
+#[expect(clippy::derive_partial_eq_without_eq)]
 #[derive(Debug, Default, PartialEq, Clone)]
 pub struct Envelope {
     pub public_key: Vec<u8>,

--- a/anchor/network/src/network.rs
+++ b/anchor/network/src/network.rs
@@ -89,7 +89,7 @@ pub struct Network<R: MessageReceiver> {
 impl<R: MessageReceiver> Network<R> {
     // Creates an instance of the Network struct to start sending and receiving information on the
     // p2p network.
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     pub async fn try_new<E: EthSpec>(
         config: &Config,
         topic_event_receiver: mpsc::Receiver<TopicEvent>,

--- a/anchor/network/src/peer_manager/connection.rs
+++ b/anchor/network/src/peer_manager/connection.rs
@@ -489,7 +489,7 @@ impl ConnectionManager {
     }
 
     /// Handle established outbound connection with priority peer logic
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     pub fn handle_established_outbound_connection(
         &mut self,
         connection_id: ConnectionId,

--- a/anchor/subnet_service/src/service.rs
+++ b/anchor/subnet_service/src/service.rs
@@ -54,7 +54,7 @@ pub struct SubnetService<S: SlotClock> {
 
 impl<S: SlotClock> SubnetService<S> {
     /// Create a new subnet service.
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     fn new(
         tx: mpsc::Sender<TopicEvent>,
         db: watch::Receiver<NetworkState>,
@@ -145,7 +145,7 @@ impl<S: SlotClock> SubnetService<S> {
 
 /// Spawn the subnet service task and return both the service (for subnet queries)
 /// and the receiver for topic events.
-#[allow(clippy::too_many_arguments)]
+#[expect(clippy::too_many_arguments)]
 pub fn start_subnet_service<S: SlotClock + 'static, E: EthSpec>(
     db: watch::Receiver<NetworkState>,
     subscribe_all_subnets: bool,

--- a/anchor/validator_store/src/lib.rs
+++ b/anchor/validator_store/src/lib.rs
@@ -118,7 +118,7 @@ pub struct AnchorValidatorStore<T: SlotClock + 'static, E: EthSpec> {
 }
 
 impl<T: SlotClock, E: EthSpec> AnchorValidatorStore<T, E> {
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     pub fn new(
         database: Arc<NetworkDatabase>,
         signature_collector: Arc<SignatureCollectorManager<T>>,
@@ -236,7 +236,7 @@ impl<T: SlotClock, E: EthSpec> AnchorValidatorStore<T, E> {
         .signing_root(domain)
     }
 
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     async fn collect_signature(
         &self,
         signature_kind: PartialSignatureKind,
@@ -704,7 +704,7 @@ impl<T: SlotClock, E: EthSpec> AnchorValidatorStore<T, E> {
 
     /// Boole+ path for `produce_signed_aggregate_and_proof`: committee-based consensus using
     /// `AggregatorCommitteeConsensusData`.
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     async fn produce_signed_aggregate_and_proof_boole(
         &self,
         validator_pubkey: PublicKeyBytes,
@@ -877,7 +877,7 @@ impl<T: SlotClock, E: EthSpec> AnchorValidatorStore<T, E> {
     }
 
     /// Pre-Boole path for `produce_signed_aggregate_and_proof`: per-validator consensus.
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     async fn produce_signed_aggregate_and_proof_alan(
         &self,
         validator_pubkey: PublicKeyBytes,
@@ -991,7 +991,7 @@ impl<T: SlotClock, E: EthSpec> AnchorValidatorStore<T, E> {
 
     /// Boole+ path for `produce_signed_contribution_and_proof`: committee-based consensus using
     /// `AggregatorCommitteeConsensusData`.
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     async fn produce_signed_contribution_and_proof_boole(
         &self,
         aggregator_index: u64,
@@ -1142,7 +1142,7 @@ impl<T: SlotClock, E: EthSpec> AnchorValidatorStore<T, E> {
     }
 
     /// Pre-Boole path for `produce_signed_contribution_and_proof`: per-validator consensus.
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     async fn produce_signed_contribution_and_proof_alan(
         &self,
         aggregator_index: u64,


### PR DESCRIPTION
## Issue Addressed

`#[allow(lint)]` suppresses a certain lint or compiler warning. While this is useful in some cases, these attributes tend to remain for forever, even if a lint or warning no longer occurs. This is bad as e.g. `#[allow(dead_code)]` can be misleading, or lints like `#[allow(clippy::too_many_arguments)]` that may cause developer to reconsider their design are suppressed.

## Proposed Changes

Use `expect` instead. This fails if the lint is actually not suppressed, so we are forced to remove stale attributes. Also, ban `allow` in the future through the `clippy::allow_attributes` lint.

## Additional Info

Especially forbidding `allow` completely is up for discussion :)
