### PR TITLE
test: add spec_tests crate foundation with BeaconVote encoding test

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "anchor/spec_tests/ssv-spec"]
+	path = anchor/spec_tests/ssv-spec
+	url = https://github.com/ssvlabs/ssv-spec

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7194,6 +7194,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "spec_tests"
+version = "0.1.0"
+dependencies = [
+ "base64",
+ "ethereum_ssz",
+ "ethereum_ssz_derive",
+ "hex",
+ "serde",
+ "serde_json",
+ "ssv_types",
+ "tree_hash",
+ "types",
+]
+
+[[package]]
 name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ members = [
     "anchor/processor",
     "anchor/qbft_manager",
     "anchor/signature_collector",
+    "anchor/spec_tests",
     "anchor/subnet_service",
     "anchor/validator_store",
 ]

--- a/anchor/spec_tests/Cargo.toml
+++ b/anchor/spec_tests/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "spec_tests"
+version = "0.1.0"
+edition.workspace = true
+authors = ["Sigma Prime <contact@sigmaprime.io>"]
+
+[dependencies]
+base64 = { workspace = true }
+ethereum_ssz = { workspace = true }
+ethereum_ssz_derive = { workspace = true }
+hex = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+ssv_types = { workspace = true }
+tree_hash = { workspace = true }
+types = { workspace = true }

--- a/anchor/spec_tests/src/lib.rs
+++ b/anchor/spec_tests/src/lib.rs
@@ -1,0 +1,86 @@
+mod types;
+mod utils;
+
+use std::{fs, path::Path};
+
+use serde::de::DeserializeOwned;
+
+/// Core trait for spec tests. Mirrors Go's SpecTest interface.
+/// Each test type deserializes from JSON and runs assertions.
+trait SpecTest: DeserializeOwned {
+    /// Human-readable test name (from JSON "Name" field, if applicable)
+    fn name(&self) -> &str { "" }
+
+    /// Run the test. Returns Ok(()) on success, Err(description) on failure.
+    fn run(&self) -> Result<(), String>;
+}
+
+/// Generic test runner. Deserializes JSON into concrete type T, then runs the test.
+fn run_test<T: SpecTest>(path: &Path, contents: &str) -> Result<(), String> {
+    let test: T = serde_json::from_str(contents)
+        .map_err(|e| format!("Failed to parse {}: {e}", path.display()))?;
+    test.run()
+}
+
+/// Run all type spec tests from the fixture directory.
+/// Dispatches each JSON file to the correct test type based on exact prefix match.
+fn run_types_tests() {
+    let dir = Path::new("ssv-spec/types/spectest/generate/tests");
+    assert!(dir.exists(), "Fixture directory not found: {}", dir.display());
+
+    let mut failures = Vec::new();
+    let mut count = 0;
+
+    for entry in fs::read_dir(dir).expect("Failed to read fixture directory") {
+        let entry = entry.expect("Failed to read directory entry");
+        let path = entry.path();
+
+        if path.extension() != Some("json".as_ref()) {
+            continue;
+        }
+
+        let filename = path.file_name().unwrap().to_string_lossy().to_string();
+        let contents = fs::read_to_string(&path)
+            .unwrap_or_else(|e| panic!("Failed to read {}: {e}", path.display()));
+
+        // Extract exact type prefix — same as Go's strings.Split(name, "_")[0]
+        let prefix = filename.split('_').next().unwrap_or("");
+
+        let result = match prefix {
+            // Encoding tests (PR 1 - only BeaconVote for now)
+            "beaconvote.EncodingTest" => run_test::<types::BeaconVoteEncodingTest>(&path, &contents),
+
+            // Not yet implemented — skip during incremental development.
+            // This arm will be replaced with panic!() once all test types are added.
+            _ => {
+                eprintln!("SKIP (not yet implemented): {prefix}");
+                continue;
+            }
+        };
+
+        count += 1;
+        if let Err(e) = result {
+            failures.push(format!("  {filename}: {e}"));
+        }
+    }
+
+    assert!(count > 0, "No type spec test fixtures found in {}", dir.display());
+
+    if !failures.is_empty() {
+        panic!(
+            "\n{} of {count} type spec tests failed:\n{}",
+            failures.len(),
+            failures.join("\n")
+        );
+    }
+}
+
+#[cfg(test)]
+mod spec_tests {
+    use super::*;
+
+    #[test]
+    fn types_spec_tests() {
+        run_types_tests();
+    }
+}

--- a/anchor/spec_tests/src/lib.rs
+++ b/anchor/spec_tests/src/lib.rs
@@ -3,7 +3,10 @@
 mod types;
 mod utils;
 
-use std::{fs, path::Path};
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
 
 use serde::de::DeserializeOwned;
 
@@ -13,7 +16,7 @@ trait SpecTest: DeserializeOwned {
     fn run(&self) -> Result<(), String>;
 }
 
-/// Generic test runner. Deserializes JSON into concrete type T, then runs the test.
+/// Generic test runner. Deserializes JSON into concrete type `T`, then runs the test.
 fn run_test<T: SpecTest>(path: &Path, contents: &str) -> Result<(), String> {
     let test: T = serde_json::from_str(contents)
         .map_err(|e| format!("Failed to parse {}: {e}", path.display()))?;
@@ -23,13 +26,18 @@ fn run_test<T: SpecTest>(path: &Path, contents: &str) -> Result<(), String> {
 /// Run all type spec tests from the fixture directory.
 /// Dispatches each JSON file to the correct test type based on exact prefix match.
 fn run_types_tests() {
-    let dir = Path::new("ssv-spec/types/spectest/generate/tests");
-    assert!(dir.exists(), "Fixture directory not found: {}", dir.display());
+    let dir: PathBuf =
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("ssv-spec/types/spectest/generate/tests");
+    assert!(
+        dir.exists(),
+        "Fixture directory not found: {}",
+        dir.display()
+    );
 
     let mut failures = Vec::new();
     let mut count = 0;
 
-    for entry in fs::read_dir(dir).expect("Failed to read fixture directory") {
+    for entry in fs::read_dir(&dir).expect("Failed to read fixture directory") {
         let entry = entry.expect("Failed to read directory entry");
         let path = entry.path();
 
@@ -41,12 +49,14 @@ fn run_types_tests() {
         let contents = fs::read_to_string(&path)
             .unwrap_or_else(|e| panic!("Failed to read {}: {e}", path.display()));
 
-        // Extract exact type prefix — same as Go's strings.Split(name, "_")[0]
+        // Extract exact type prefix
         let prefix = filename.split('_').next().unwrap_or("");
 
         let result = match prefix {
-            // Encoding tests (PR 1 - only BeaconVote for now)
-            "beaconvote.EncodingTest" => run_test::<types::BeaconVoteEncodingTest>(&path, &contents),
+            // Encoding tests
+            "beaconvote.EncodingTest" => {
+                run_test::<types::BeaconVoteEncodingTest>(&path, &contents)
+            }
 
             // TODO(spec-tests): Add more test types here as they are implemented.
             // This arm will be replaced with panic!() once all test types are added.
@@ -62,7 +72,11 @@ fn run_types_tests() {
         }
     }
 
-    assert!(count > 0, "No type spec test fixtures found in {}", dir.display());
+    assert!(
+        count > 0,
+        "No type spec test fixtures found in {}",
+        dir.display()
+    );
 
     if !failures.is_empty() {
         panic!(

--- a/anchor/spec_tests/src/lib.rs
+++ b/anchor/spec_tests/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg(test)]
+
 mod types;
 mod utils;
 
@@ -5,13 +7,9 @@ use std::{fs, path::Path};
 
 use serde::de::DeserializeOwned;
 
-/// Core trait for spec tests. Mirrors Go's SpecTest interface.
+/// Core trait for spec tests.
 /// Each test type deserializes from JSON and runs assertions.
 trait SpecTest: DeserializeOwned {
-    /// Human-readable test name (from JSON "Name" field, if applicable)
-    fn name(&self) -> &str { "" }
-
-    /// Run the test. Returns Ok(()) on success, Err(description) on failure.
     fn run(&self) -> Result<(), String>;
 }
 
@@ -50,7 +48,7 @@ fn run_types_tests() {
             // Encoding tests (PR 1 - only BeaconVote for now)
             "beaconvote.EncodingTest" => run_test::<types::BeaconVoteEncodingTest>(&path, &contents),
 
-            // Not yet implemented — skip during incremental development.
+            // TODO(spec-tests): Add more test types here as they are implemented.
             // This arm will be replaced with panic!() once all test types are added.
             _ => {
                 eprintln!("SKIP (not yet implemented): {prefix}");

--- a/anchor/spec_tests/src/types/beacon_vote_encoding.rs
+++ b/anchor/spec_tests/src/types/beacon_vote_encoding.rs
@@ -1,0 +1,47 @@
+use crate::utils::deserializers::{deserialize_base64, deserialize_bytes_to_hash256};
+use crate::SpecTest;
+use ssz::{Decode, Encode};
+use serde::Deserialize;
+use tree_hash::TreeHash;
+use types::Hash256;
+
+/// Mirrors Go's `EncodingTest` for `BeaconVote`.
+///
+/// Validates SSZ encode/decode roundtrip and hash tree root.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct BeaconVoteEncodingTest {
+    #[serde(deserialize_with = "deserialize_base64")]
+    data: Vec<u8>,
+    #[serde(deserialize_with = "deserialize_bytes_to_hash256")]
+    expected_root: Hash256,
+}
+
+impl SpecTest for BeaconVoteEncodingTest {
+    fn run(&self) -> Result<(), String> {
+        // Decode BeaconVote from SSZ bytes
+        let decoded = ssv_types::consensus::BeaconVote::from_ssz_bytes(&self.data)
+            .map_err(|e| format!("SSZ decode failed: {e:?}"))?;
+
+        // Encode back and verify roundtrip
+        let encoded = decoded.as_ssz_bytes();
+        if encoded != self.data {
+            return Err(format!(
+                "SSZ roundtrip mismatch: encoded {} bytes, expected {} bytes",
+                encoded.len(),
+                self.data.len()
+            ));
+        }
+
+        // Verify hash tree root
+        let root = decoded.tree_hash_root();
+        if root != self.expected_root {
+            return Err(format!(
+                "Hash tree root mismatch: got {root:?}, expected {:?}",
+                self.expected_root
+            ));
+        }
+
+        Ok(())
+    }
+}

--- a/anchor/spec_tests/src/types/beacon_vote_encoding.rs
+++ b/anchor/spec_tests/src/types/beacon_vote_encoding.rs
@@ -1,9 +1,12 @@
-use crate::utils::deserializers::{deserialize_base64, deserialize_bytes_to_hash256};
-use crate::SpecTest;
-use ssz::{Decode, Encode};
 use serde::Deserialize;
+use ssz::{Decode, Encode};
 use tree_hash::TreeHash;
 use types::Hash256;
+
+use crate::{
+    SpecTest,
+    utils::deserializers::{deserialize_base64, deserialize_bytes_to_hash256},
+};
 
 /// Mirrors Go's `EncodingTest` for `BeaconVote`.
 ///

--- a/anchor/spec_tests/src/types/mod.rs
+++ b/anchor/spec_tests/src/types/mod.rs
@@ -1,0 +1,2 @@
+mod beacon_vote_encoding;
+pub use beacon_vote_encoding::*;

--- a/anchor/spec_tests/src/utils/deserializers.rs
+++ b/anchor/spec_tests/src/utils/deserializers.rs
@@ -1,0 +1,31 @@
+use base64::{engine::general_purpose::STANDARD, Engine};
+use serde::Deserialize;
+use types::Hash256;
+
+/// Deserializes a base64-encoded string into `Vec<u8>`.
+///
+/// Expects a JSON string field containing standard base64-encoded data.
+pub fn deserialize_base64<'de, D: serde::Deserializer<'de>>(
+    deserializer: D,
+) -> Result<Vec<u8>, D::Error> {
+    let s = String::deserialize(deserializer)?;
+    STANDARD
+        .decode(s)
+        .map_err(|e| serde::de::Error::custom(format!("Failed to decode base64: {e}")))
+}
+
+/// Deserializes a JSON byte array (array of 32 u8 values) into `Hash256`.
+///
+/// Expects a JSON array field containing exactly 32 unsigned integer values.
+pub fn deserialize_bytes_to_hash256<'de, D: serde::Deserializer<'de>>(
+    deserializer: D,
+) -> Result<Hash256, D::Error> {
+    let bytes = Vec::<u8>::deserialize(deserializer)?;
+    if bytes.len() != 32 {
+        return Err(serde::de::Error::custom(format!(
+            "expected 32 bytes for Hash256, got {}",
+            bytes.len()
+        )));
+    }
+    Ok(Hash256::from_slice(&bytes))
+}

--- a/anchor/spec_tests/src/utils/deserializers.rs
+++ b/anchor/spec_tests/src/utils/deserializers.rs
@@ -1,4 +1,4 @@
-use base64::{engine::general_purpose::STANDARD, Engine};
+use base64::{Engine, engine::general_purpose::STANDARD};
 use serde::Deserialize;
 use types::Hash256;
 

--- a/anchor/spec_tests/src/utils/mod.rs
+++ b/anchor/spec_tests/src/utils/mod.rs
@@ -1,0 +1,1 @@
+pub mod deserializers;


### PR DESCRIPTION
## Issue Addressed

Begins the work started in #581 to add [ssv-spec type spec tests](https://github.com/ssvlabs/ssv-spec/tree/main/types/spectest). This PR lays the foundation and includes one working test type as a proof of concept, with the goal of breaking the full implementation into smaller PRs for easier review.

## Proposed Changes

 - Add the [ssv-spec](https://github.com/ssvlabs/ssv-spec) repository as a git submodule, pinned at commit `4e2f944d` (101 JSON test fixtures)
   - Create the `spec_tests` workspace crate with a simple test runner that dispatches JSON fixtures to test implementations based on filename prefix matching
   - Implement `BeaconVoteEncodingTest` — SSZ decode, encode roundtrip, and tree hash root verification against the fixture's expected values
   - Add serde deserializer utilities for base64-encoded data and byte-array hashroots

Compared to #581, the orchestration is simplified: a single `match` on the exact filename prefix (mirroring the Go [run_test.go](https://github.com/ssvlabs/ssv-spec/blob/main/types/spectest/run_test.go) switch statement) replaces the enum registry, macro, and walkdir-based discovery. The test logic and adapters are largely the same.

## Additional Info

 This is the first in a series of PRs to build out the remaining type spec tests incrementally. Unimplemented prefixes are currently skipped with a warning during test execution.

Run with: `cargo test -p spec_tests --release -- types_spec_tests`
