### PR TITLE
test: add encryption spec test

### DIFF
--- a/anchor/spec_tests/src/runner/types_dispatcher.rs
+++ b/anchor/spec_tests/src/runner/types_dispatcher.rs
@@ -55,6 +55,11 @@ fn dispatch_fixture_by_prefix(prefix: &str, path: &Path, contents: &str) -> Disp
             DispatchOutcome::Executed(run_test::<types::PartialSigMsgSpecTest>(path, contents))
         }
 
+        // Encryption tests
+        "encryption.EncryptionSpecTest" => {
+            DispatchOutcome::Executed(run_test::<types::EncryptionSpecTest>(path, contents))
+        }
+
         // TODO(spec-tests): Add more test types here as they are implemented.
         // This arm will be replaced with panic!() once all test types are added.
         _ => {

--- a/anchor/spec_tests/src/types/encryption.rs
+++ b/anchor/spec_tests/src/types/encryption.rs
@@ -1,15 +1,16 @@
 use base64::prelude::*;
-use operator_key::{encrypted::EncryptedKey, public, unencrypted};
+use openssl::{encrypt::Encrypter, pkey::PKey, rsa::Padding};
+use operator_key::{public, unencrypted};
 use serde::Deserialize;
 
 use crate::{SpecTest, utils::deserializers::deserialize_base64};
 
-/// Anchor-specific coverage using Go's `EncryptionSpecTest` fixtures.
+/// Mirrors Go's `EncryptionSpecTest.Run()`: parse RSA key pair from PEM,
+/// verify SK/PK consistency, then RSA-PKCS1v15 encrypt/decrypt roundtrip.
 ///
-/// Go tests RSA-PKCS1v15 encrypt/decrypt of arbitrary data. Anchor doesn't use
-/// RSA-PKCS1v15; operator keys are protected via EIP-2335 keystores instead.
-/// This test exercises that production path: parse the fixture's RSA key,
-/// verify the SK/PK pair, then roundtrip the key through EIP-2335 encrypt/decrypt.
+/// Uses the same RSA-PKCS1v15 primitives that `keysplit` and `validator_store`
+/// use in production for keyshare encryption/decryption, but calls `openssl`
+/// directly rather than going through those higher-level wrappers.
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "PascalCase")]
 pub struct EncryptionSpecTest {
@@ -23,16 +24,13 @@ pub struct EncryptionSpecTest {
 
 impl SpecTest for EncryptionSpecTest {
     fn run(&self) -> Result<(), String> {
-        if self.plain_text.is_empty() {
-            return Err("Fixture plain_text is empty — expected non-empty data".to_string());
-        }
-
-        // `from_base64` expects base64-encoded PEM, so re-encode the raw PEM bytes.
+        // Parse private key from PEM.
         let sk_b64 = BASE64_STANDARD.encode(&self.sk_pem);
         let private_key = unencrypted::from_base64(sk_b64.as_bytes())
             .map_err(|e| format!("Failed to parse private key: {e}"))?;
 
         // Verify derived public key matches fixture.
+        // Go compares raw PEM bytes; we compare base64-encoded PEM (equivalent).
         let derived_pk_b64 = public::to_base64(&private_key)
             .map_err(|e| format!("Failed to derive public key: {e}"))?;
         let expected_pk_b64 = BASE64_STANDARD.encode(&self.pk_pem);
@@ -42,29 +40,41 @@ impl SpecTest for EncryptionSpecTest {
             );
         }
 
-        // Use plaintext as password; fall back to base64 if not valid UTF-8.
-        // `into_bytes()` recovers the original Vec<u8> from the FromUtf8Error.
-        let password = String::from_utf8(self.plain_text.clone())
-            .unwrap_or_else(|e| BASE64_STANDARD.encode(e.into_bytes()));
+        // Parse public key from fixture PEM.
+        let public_key = public::from_base64(expected_pk_b64.as_bytes())
+            .map_err(|e| format!("Failed to parse public key: {e}"))?;
 
-        let encrypted = EncryptedKey::encrypt(&private_key, &password)
+        // RSA-PKCS1v15 encrypt plaintext with public key.
+        let pkey = PKey::from_rsa(public_key)
+            .map_err(|e| format!("Failed to create PKey from RSA public key: {e}"))?;
+        let mut encrypter =
+            Encrypter::new(&pkey).map_err(|e| format!("Failed to create encrypter: {e}"))?;
+        encrypter
+            .set_rsa_padding(Padding::PKCS1)
+            .map_err(|e| format!("Failed to set padding: {e}"))?;
+        let buffer_len = encrypter
+            .encrypt_len(&self.plain_text)
+            .map_err(|e| format!("Failed to get encrypt length: {e}"))?;
+        let mut ciphertext = vec![0u8; buffer_len];
+        let encrypted_len = encrypter
+            .encrypt(&self.plain_text, &mut ciphertext)
             .map_err(|e| format!("Encryption failed: {e}"))?;
+        ciphertext.truncate(encrypted_len);
 
-        let decrypted = encrypted
-            .decrypt(&password)
+        // RSA-PKCS1v15 decrypt with private key.
+        let mut decrypted = vec![0u8; private_key.size() as usize];
+        let decrypted_len = private_key
+            .private_decrypt(&ciphertext, &mut decrypted, Padding::PKCS1)
             .map_err(|e| format!("Decryption failed: {e}"))?;
+        decrypted.truncate(decrypted_len);
 
-        // Compare full DER-encoded keys (all components: n, e, d, p, q, dp, dq, qinv).
-        // Note: Go compares RSA-encrypted plaintext; we compare the key itself after EIP-2335
-        // roundtrip.
-        let original_der = private_key
-            .private_key_to_der()
-            .map_err(|e| format!("Failed to encode original key to DER: {e}"))?;
-        let decrypted_der = decrypted
-            .private_key_to_der()
-            .map_err(|e| format!("Failed to encode decrypted key to DER: {e}"))?;
-        if original_der != decrypted_der {
-            return Err("Roundtrip failed: decrypted key does not match original".to_string());
+        // Compare decrypted bytes to original plaintext.
+        if decrypted != self.plain_text {
+            return Err(format!(
+                "Roundtrip failed: decrypted {} bytes, expected {} bytes",
+                decrypted.len(),
+                self.plain_text.len(),
+            ));
         }
 
         Ok(())

--- a/anchor/spec_tests/src/types/encryption.rs
+++ b/anchor/spec_tests/src/types/encryption.rs
@@ -53,7 +53,8 @@ impl SpecTest for EncryptionSpecTest {
             .map_err(|e| format!("Decryption failed: {e}"))?;
 
         // Compare full DER-encoded keys (all components: n, e, d, p, q, dp, dq, qinv).
-        // Analogous to Go's byte-for-byte `require.EqualValues(t, test.PlainText, plain)`.
+        // Note: Go compares RSA-encrypted plaintext; we compare the key itself after EIP-2335
+        // roundtrip.
         let original_der = private_key
             .private_key_to_der()
             .map_err(|e| format!("Failed to encode original key to DER: {e}"))?;

--- a/anchor/spec_tests/src/types/encryption.rs
+++ b/anchor/spec_tests/src/types/encryption.rs
@@ -1,0 +1,69 @@
+use base64::prelude::*;
+use operator_key::{encrypted::EncryptedKey, public, unencrypted};
+use serde::Deserialize;
+
+use crate::{SpecTest, utils::deserializers::deserialize_base64};
+
+/// Tests RSA key encryption/decryption roundtrip via Anchor's `operator_key` crate.
+///
+/// Go tests raw RSA encrypt/decrypt; Anchor uses EIP-2335 key encryption instead,
+/// so we test that path using the fixture's plaintext as the password.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct EncryptionSpecTest {
+    #[serde(rename = "SKPem", deserialize_with = "deserialize_base64")]
+    sk_pem: Vec<u8>,
+    #[serde(rename = "PKPem", deserialize_with = "deserialize_base64")]
+    pk_pem: Vec<u8>,
+    #[serde(deserialize_with = "deserialize_base64")]
+    plain_text: Vec<u8>,
+}
+
+impl SpecTest for EncryptionSpecTest {
+    fn run(&self) -> Result<(), String> {
+        if self.plain_text.is_empty() {
+            return Err("Fixture plain_text is empty — expected non-empty data".to_string());
+        }
+
+        // `from_base64` expects base64-encoded PEM, so re-encode the raw PEM bytes.
+        let sk_b64 = BASE64_STANDARD.encode(&self.sk_pem);
+        let private_key = unencrypted::from_base64(sk_b64.as_bytes())
+            .map_err(|e| format!("Failed to parse private key: {e}"))?;
+
+        // Verify derived public key matches fixture.
+        let derived_pk_b64 = public::to_base64(&private_key)
+            .map_err(|e| format!("Failed to derive public key: {e}"))?;
+        let expected_pk_b64 = BASE64_STANDARD.encode(&self.pk_pem);
+        if derived_pk_b64 != expected_pk_b64 {
+            return Err(
+                "Public key derived from private key does not match fixture PKPem".to_string(),
+            );
+        }
+
+        // Use plaintext as password; fall back to base64 if not valid UTF-8.
+        // `into_bytes()` recovers the original Vec<u8> from the FromUtf8Error.
+        let password = String::from_utf8(self.plain_text.clone())
+            .unwrap_or_else(|e| BASE64_STANDARD.encode(e.into_bytes()));
+
+        let encrypted = EncryptedKey::encrypt(&private_key, &password)
+            .map_err(|e| format!("Encryption failed: {e}"))?;
+
+        let decrypted = encrypted
+            .decrypt(&password)
+            .map_err(|e| format!("Decryption failed: {e}"))?;
+
+        // Compare full DER-encoded keys (all components: n, e, d, p, q, dp, dq, qinv).
+        // Analogous to Go's byte-for-byte `require.EqualValues(t, test.PlainText, plain)`.
+        let original_der = private_key
+            .private_key_to_der()
+            .map_err(|e| format!("Failed to encode original key to DER: {e}"))?;
+        let decrypted_der = decrypted
+            .private_key_to_der()
+            .map_err(|e| format!("Failed to encode decrypted key to DER: {e}"))?;
+        if original_der != decrypted_der {
+            return Err("Roundtrip failed: decrypted key does not match original".to_string());
+        }
+
+        Ok(())
+    }
+}

--- a/anchor/spec_tests/src/types/encryption.rs
+++ b/anchor/spec_tests/src/types/encryption.rs
@@ -4,10 +4,12 @@ use serde::Deserialize;
 
 use crate::{SpecTest, utils::deserializers::deserialize_base64};
 
-/// Tests RSA key encryption/decryption roundtrip via Anchor's `operator_key` crate.
+/// Anchor-specific coverage using Go's `EncryptionSpecTest` fixtures.
 ///
-/// Go tests raw RSA encrypt/decrypt; Anchor uses EIP-2335 key encryption instead,
-/// so we test that path using the fixture's plaintext as the password.
+/// Go tests RSA-PKCS1v15 encrypt/decrypt of arbitrary data. Anchor doesn't use
+/// RSA-PKCS1v15; operator keys are protected via EIP-2335 keystores instead.
+/// This test exercises that production path: parse the fixture's RSA key,
+/// verify the SK/PK pair, then roundtrip the key through EIP-2335 encrypt/decrypt.
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "PascalCase")]
 pub struct EncryptionSpecTest {

--- a/anchor/spec_tests/src/types/encryption.rs
+++ b/anchor/spec_tests/src/types/encryption.rs
@@ -8,9 +8,9 @@ use crate::{SpecTest, utils::deserializers::deserialize_base64};
 /// Mirrors Go's `EncryptionSpecTest.Run()`: parse RSA key pair from PEM,
 /// verify SK/PK consistency, then RSA-PKCS1v15 encrypt/decrypt roundtrip.
 ///
-/// Uses the same RSA-PKCS1v15 primitives that `keysplit` and `validator_store`
-/// use in production for keyshare encryption/decryption, but calls `openssl`
-/// directly rather than going through those higher-level wrappers.
+/// Uses the same RSA-PKCS1v15 primitives that `validator_store` uses in
+/// production for keyshare decryption, but calls `openssl` directly rather
+/// than going through the higher-level wrapper.
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "PascalCase")]
 pub struct EncryptionSpecTest {

--- a/anchor/spec_tests/src/types/mod.rs
+++ b/anchor/spec_tests/src/types/mod.rs
@@ -1,5 +1,6 @@
 mod aggregator_committee_consensus_data_encoding;
 mod beacon_vote_encoding;
+mod encryption;
 mod partial_sig_message;
 mod partial_sig_message_encoding;
 mod proposer_consensus_data_encoding;
@@ -10,6 +11,7 @@ mod ssv_msg;
 
 pub use aggregator_committee_consensus_data_encoding::*;
 pub use beacon_vote_encoding::*;
+pub use encryption::*;
 pub use partial_sig_message::*;
 pub use partial_sig_message_encoding::*;
 pub use proposer_consensus_data_encoding::*;


### PR DESCRIPTION
## Problem, Evidence, and Context

- Anchor's spec test suite lacks coverage for the Go ssv-spec `EncryptionSpecTest` type.
- Maintains spec parity as the test matrix grows. Continuation of the spec test effort from PR #837.
- Proposer consensus data tests extracted to a separate PR per [review feedback](https://github.com/sigp/anchor/pull/839#issuecomment-4215024532). Tracked in #941.

## Change Overview

**`EncryptionSpecTest`**: Mirrors Go's `EncryptionSpecTest.Run()` step-by-step:
1. Parse RSA private key from fixture PEM
2. Derive public key and verify it matches fixture PEM
3. RSA-PKCS1v15 encrypt plaintext with public key
4. RSA-PKCS1v15 decrypt ciphertext with private key
5. Verify decrypted output matches original plaintext

This tests the same RSA-PKCS1v15 invariant that Go tests, and the same primitives that `validator_store` uses in production for keyshare decryption. The test calls `openssl` directly rather than going through the higher-level wrapper.

One minor divergence: Go compares raw PEM bytes for SK/PK consistency; we compare base64-encoded PEM (equivalent check, different encoding).

Changes:
- New `EncryptionSpecTest` type in `spec_tests/src/types/encryption.rs`
- Dispatcher wiring and module registration

## Risks, Trade-offs, and Mitigations

- **Uses `openssl` directly instead of production wrapper**: The test validates the same RSA-PKCS1v15 primitives but doesn't exercise the `validator_store` wrapper itself. The wrapper adds BLS-specific encoding logic that doesn't apply to the spec test's arbitrary plaintext fixture.

## Validation

- `cargo test -p spec_tests`: all fixtures pass
- `cargo clippy` and `cargo fmt` clean
- Audited against [Go source](https://github.com/ssvlabs/ssv-spec/blob/main/types/spectest/tests/encryption/test.go) for invariant parity

## Blockers / Dependencies

- Depends on PR #837 for CI (branch chain). Local builds/tests pass independently.
- Proposer consensus data tests will follow in a separate PR (#941).