### PR TITLE
refactor: extract PartialSignatureMessages::validate() in ssv_types

### DIFF
--- a/anchor/common/ssv_types/src/partial_sig.rs
+++ b/anchor/common/ssv_types/src/partial_sig.rs
@@ -2,6 +2,7 @@ use bls::Signature;
 use ssz::{Decode, DecodeError, Encode};
 use ssz_derive::{Decode, Encode};
 use ssz_types::VariableList;
+use thiserror::Error;
 use tree_hash::{PackedEncoding, TreeHash, TreeHashType};
 use tree_hash_derive::TreeHash;
 use typenum::{Prod, Sum, U3, U4, U512, U1000};
@@ -130,6 +131,40 @@ pub struct PartialSignatureMessage {
     pub signing_root: Hash256,
     pub signer: OperatorId,
     pub validator_index: ValidatorIndex,
+}
+
+/// Errors from `PartialSignatureMessages::validate()`.
+#[derive(Debug, Error)]
+pub enum PartialSignatureMessagesError {
+    #[error("no partial signature messages")]
+    Empty,
+    #[error("inconsistent signers")]
+    InconsistentSigners,
+    #[error("signer ID 0 not allowed")]
+    ZeroSigner,
+}
+
+impl PartialSignatureMessages {
+    /// Validate that the messages list is non-empty, all signers are identical,
+    /// and the signer is non-zero. Returns the common signer on success.
+    pub fn validate(&self) -> Result<OperatorId, PartialSignatureMessagesError> {
+        let first = self
+            .messages
+            .first()
+            .ok_or(PartialSignatureMessagesError::Empty)?;
+
+        if first.signer == OperatorId(0) {
+            return Err(PartialSignatureMessagesError::ZeroSigner);
+        }
+
+        for m in self.messages.iter().skip(1) {
+            if m.signer != first.signer {
+                return Err(PartialSignatureMessagesError::InconsistentSigners);
+            }
+        }
+
+        Ok(first.signer)
+    }
 }
 
 #[cfg(test)]

--- a/anchor/message_validator/src/partial_signature.rs
+++ b/anchor/message_validator/src/partial_signature.rs
@@ -5,7 +5,7 @@ use slot_clock::SlotClock;
 use ssv_types::{
     OperatorId,
     msgid::Role,
-    partial_sig::{PartialSignatureKind, PartialSignatureMessages},
+    partial_sig::{PartialSignatureKind, PartialSignatureMessages, PartialSignatureMessagesError},
 };
 use ssz::Decode;
 use types::consts::altair::SYNC_COMMITTEE_SUBNET_COUNT;
@@ -105,18 +105,22 @@ fn validate_partial_signature_message_semantics(
         return Err(ValidationFailure::PartialSignatureTypeRoleMismatch);
     }
 
-    // Rule: Partial signature message must have at least one signature
-    if partial_signature_messages.messages.is_empty() {
-        return Err(ValidationFailure::NoPartialSignatureMessages);
+    // Structural validation: empty, internal signer consistency, zero signer.
+    let inner_signer = partial_signature_messages.validate().map_err(|e| match e {
+        PartialSignatureMessagesError::Empty => ValidationFailure::NoPartialSignatureMessages,
+        PartialSignatureMessagesError::InconsistentSigners => {
+            ValidationFailure::InconsistentSigners
+        }
+        PartialSignatureMessagesError::ZeroSigner => ValidationFailure::ZeroSigner,
+    })?;
+
+    // Rule: Partial signature signer must match the signed message's signer.
+    if inner_signer != signer {
+        return Err(ValidationFailure::InconsistentSigners);
     }
 
-    // Validate each individual message
+    // Validate validator indices for non-committee duties
     for message in &partial_signature_messages.messages {
-        // Rule: Partial signature signer must be consistent
-        if message.signer != signer {
-            return Err(ValidationFailure::InconsistentSigners);
-        }
-
         // Rule: (only for Validator duties) Validator index must match with validatorPK
         // For Committee duties (Committee and AggregatorCommittee), we don't assume that
         // operators are synced on the validators set, so we skip this check.


### PR DESCRIPTION
## Issue Addressed
Splits production changes out of #837 per review feedback.

## Proposed Changes
- Add `PartialSignatureMessages::validate()` method and `PartialSignatureMessagesError` to `ssv_types`, mirroring Go's `PartialSignatureMessages.Validate()`
  - Refactor `message_validator` to delegate structural validation (empty, inconsistent signers, zero signer) to the new method

## Additional Info
#837 depends on this PR for its spec tests.
