### PR TITLE
fix: prompt file needs to be read from stable branch

### DIFF
--- a/.github/workflows/claude-mentions.yml
+++ b/.github/workflows/claude-mentions.yml
@@ -80,6 +80,7 @@ jobs:
               id: review-prompt
               # Always load the prompt from the default branch (trusted source),
               # independent of whichever PR/fork ref was checked out above.
+              # Keep this block in sync with .github/workflows/claude-pr-review.yml.
               run: |
                   {
                     echo "content<<PROMPT_EOF"

--- a/.github/workflows/claude-mentions.yml
+++ b/.github/workflows/claude-mentions.yml
@@ -78,10 +78,12 @@ jobs:
             - name: Read review prompt
               if: steps.check.outputs.is_member == 'true'
               id: review-prompt
+              # Always load the prompt from the default branch (trusted source),
+              # independent of whichever PR/fork ref was checked out above.
               run: |
                   {
                     echo "content<<PROMPT_EOF"
-                    git fetch https://github.com/${{ github.repository }}.git stable --depth=1
+                    git fetch https://github.com/${{ github.repository }}.git ${{ github.event.repository.default_branch }} --depth=1
                     git show FETCH_HEAD:.github/prompts/review.md
                     echo "PROMPT_EOF"
                   } >> "$GITHUB_OUTPUT"

--- a/.github/workflows/claude-mentions.yml
+++ b/.github/workflows/claude-mentions.yml
@@ -81,8 +81,8 @@ jobs:
               run: |
                   {
                     echo "content<<PROMPT_EOF"
-                    git fetch origin stable --depth=1
-                    git show origin/stable:.github/prompts/review.md
+                    git fetch https://github.com/${{ github.repository }}.git stable --depth=1
+                    git show FETCH_HEAD:.github/prompts/review.md
                     echo "PROMPT_EOF"
                   } >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/claude-mentions.yml
+++ b/.github/workflows/claude-mentions.yml
@@ -81,7 +81,8 @@ jobs:
               run: |
                   {
                     echo "content<<PROMPT_EOF"
-                    cat .github/prompts/review.md
+                    git fetch origin stable --depth=1
+                    git show origin/stable:.github/prompts/review.md
                     echo "PROMPT_EOF"
                   } >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -93,7 +93,7 @@ jobs:
               run: |
                   {
                     echo "content<<PROMPT_EOF"
-                    git fetch https://github.com/${{ github.repository }}.git stable --depth=1
+                    git fetch https://github.com/${{ github.repository }}.git ${{ github.event.repository.default_branch }} --depth=1
                     git show FETCH_HEAD:.github/prompts/review.md
                     echo "PROMPT_EOF"
                   } >> "$GITHUB_OUTPUT"

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -93,8 +93,8 @@ jobs:
               run: |
                   {
                     echo "content<<PROMPT_EOF"
-                    git fetch origin stable --depth=1
-                    git show origin/stable:.github/prompts/review.md
+                    git fetch https://github.com/${{ github.repository }}.git stable --depth=1
+                    git show FETCH_HEAD:.github/prompts/review.md
                     echo "PROMPT_EOF"
                   } >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -93,7 +93,8 @@ jobs:
               run: |
                   {
                     echo "content<<PROMPT_EOF"
-                    cat .github/prompts/review.md
+                    git fetch origin stable --depth=1
+                    git show origin/stable:.github/prompts/review.md
                     echo "PROMPT_EOF"
                   } >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -90,6 +90,9 @@ jobs:
             - name: Read review prompt
               if: steps.check.outputs.is_member == 'true'
               id: review-prompt
+              # Always load the prompt from the default branch (trusted source),
+              # independent of whichever PR/fork ref was checked out above.
+              # Keep this block in sync with .github/workflows/claude-mentions.yml.
               run: |
                   {
                     echo "content<<PROMPT_EOF"


### PR DESCRIPTION
## Issue Addressed
`@claude` mentions fail with `cat: .github/prompts/review.md`: No such file or directory on PRs branched before #844, which added the shared prompt file. 

The workflow YAML runs from stable but reads the file from the PR's head branch, which may not have it.

## Proposed Changes

Read the shared review prompt from stable instead of the checked out PR branch so it's always available regardless of when the PR was branched.

## Additional Info
N/A