### PR TITLE
refactor: group Node CLI fields into logical option sub-structs

### DIFF
--- a/anchor/client/src/cli.rs
+++ b/anchor/client/src/cli.rs
@@ -465,14 +465,6 @@ pub struct NetworkOptions {
 
     #[clap(long, help = "Disables gossipsub topic scoring.", hide = true)]
     pub disable_gossipsub_topic_scoring: bool,
-
-    #[clap(
-        long,
-        help = "Disable the latency measurement service.",
-        display_order = 0,
-        help_heading = FLAG_HEADER
-    )]
-    pub disable_latency_measurement_service: bool,
 }
 
 #[derive(Parser, Clone, Debug)]
@@ -540,6 +532,14 @@ pub struct Node {
 
     #[clap(flatten)]
     pub payload_building_options: PayloadBuildingOptions,
+
+    #[clap(
+        long,
+        help = "Disable the latency measurement service.",
+        display_order = 0,
+        help_heading = FLAG_HEADER
+    )]
+    pub disable_latency_measurement_service: bool,
 
     #[clap(
         long,

--- a/anchor/client/src/cli.rs
+++ b/anchor/client/src/cli.rs
@@ -15,8 +15,7 @@ use logging::FileLoggingFlags;
 pub const FLAG_HEADER: &str = "Flags";
 
 #[derive(Parser, Clone, Debug)]
-#[clap(name = "node", about = "Start Anchor node")]
-pub struct Node {
+pub struct SecurityOptions {
     #[clap(
         long,
         global = true,
@@ -38,8 +37,10 @@ pub struct Node {
         display_order = 0
     )]
     pub password_file: Option<PathBuf>,
+}
 
-    // External APIs
+#[derive(Parser, Clone, Debug)]
+pub struct ExternalApis {
     #[clap(
         long,
         value_name = "NETWORK_ADDRESSES",
@@ -84,6 +85,18 @@ pub struct Node {
 
     #[clap(
         long,
+        value_name = "CERTIFICATE-FILES",
+        value_delimiter = ',',
+        help = "Comma-separated paths to custom TLS certificates to use when connecting \
+                to an execution node. These certificates must be in PEM format and are used \
+                in addition to the OS trust store. Commas must only be used as a \
+                delimiter, and must not be part of the certificate path",
+        display_order = 0
+    )]
+    pub execution_nodes_tls_certs: Option<Vec<PathBuf>>,
+
+    #[clap(
+        long,
         value_name = "API_TOPICS",
         value_delimiter = ',',
         help = "Comma-separated list of beacon API topics to broadcast to all beacon nodes. \
@@ -113,20 +126,10 @@ pub struct Node {
         help_heading = FLAG_HEADER
     )]
     pub beacon_nodes_sync_tolerances: Vec<u64>,
+}
 
-    #[clap(
-        long,
-        value_name = "CERTIFICATE-FILES",
-        value_delimiter = ',',
-        help = "Comma-separated paths to custom TLS certificates to use when connecting \
-                to an execution node. These certificates must be in PEM format and are used \
-                in addition to the OS trust store. Commas must only be used as a \
-                delimiter, and must not be part of the certificate path",
-        display_order = 0
-    )]
-    pub execution_nodes_tls_certs: Option<Vec<PathBuf>>,
-
-    // REST API related arguments
+#[derive(Parser, Clone, Debug)]
+pub struct HttpApiOptions {
     #[clap(
         long,
         help = "Enable the RESTful HTTP API server. Disabled by default.",
@@ -186,8 +189,64 @@ pub struct Node {
         requires = "http"
     )]
     pub http_allow_origin: Option<HeaderValue>,
+}
 
-    // Network related arguments
+#[derive(Parser, Clone, Debug)]
+pub struct MetricsOptions {
+    #[clap(
+        long,
+        help = "Enable the Prometheus metrics HTTP server. Disabled by default.",
+        display_order = 0,
+        help_heading = FLAG_HEADER,
+    )]
+    pub metrics: bool,
+
+    #[clap(
+        long,
+        value_name = "ADDRESS",
+        help = "Set the listen address for the Prometheus metrics HTTP server.",
+        default_value_if("metrics", ArgPredicate::IsPresent, "127.0.0.1"),
+        display_order = 0,
+        requires = "metrics"
+    )]
+    pub metrics_address: Option<IpAddr>,
+
+    #[clap(
+        long,
+        value_name = "PORT",
+        help = "Set the listen TCP port for the Prometheus metrics HTTP server.",
+        display_order = 0,
+        default_value_if("metrics", ArgPredicate::IsPresent, "5164"),
+        requires = "metrics"
+    )]
+    pub metrics_port: Option<u16>,
+
+    #[clap(
+        long,
+        help = "Enable per validator metrics for > 64 validators. \
+                Note: This flag is automatically enabled for <= 64 validators. \
+                Enabling this metric for higher validator counts will lead to higher volume \
+                of prometheus metrics being collected.",
+        display_order = 0,
+        help_heading = FLAG_HEADER
+    )]
+    pub enable_high_validator_count_metrics: bool,
+
+    #[clap(
+        long,
+        value_name = "ORIGIN",
+        help = "Set the value of the Access-Control-Allow-Origin response HTTP header \
+                for the metrics server. Use * to allow any origin (not recommended in production). \
+                If no value is supplied, the CORS allowed origin is set to the listen \
+                address of this server (e.g., http://localhost:5164).",
+        display_order = 0,
+        requires = "metrics"
+    )]
+    pub metrics_allow_origin: Option<HeaderValue>,
+}
+
+#[derive(Parser, Clone, Debug)]
+pub struct NetworkOptions {
     #[clap(
         long,
         value_name = "ADDRESS",
@@ -284,58 +343,6 @@ pub struct Node {
         action = ArgAction::Set,
     )]
     pub target_peers: Option<usize>,
-
-    // Prometheus metrics HTTP server related arguments
-    #[clap(
-        long,
-        help = "Enable the Prometheus metrics HTTP server. Disabled by default.",
-        display_order = 0,
-        help_heading = FLAG_HEADER,
-    )]
-    pub metrics: bool,
-
-    #[clap(
-        long,
-        value_name = "ADDRESS",
-        help = "Set the listen address for the Prometheus metrics HTTP server.",
-        default_value_if("metrics", ArgPredicate::IsPresent, "127.0.0.1"),
-        display_order = 0,
-        requires = "metrics"
-    )]
-    pub metrics_address: Option<IpAddr>,
-
-    #[clap(
-        long,
-        value_name = "PORT",
-        help = "Set the listen TCP port for the Prometheus metrics HTTP server.",
-        display_order = 0,
-        default_value_if("metrics", ArgPredicate::IsPresent, "5164"),
-        requires = "metrics"
-    )]
-    pub metrics_port: Option<u16>,
-
-    #[clap(
-        long,
-        help = "Enable per validator metrics for > 64 validators. \
-                Note: This flag is automatically enabled for <= 64 validators. \
-                Enabling this metric for higher validator counts will lead to higher volume \
-                of prometheus metrics being collected.",
-        display_order = 0,
-        help_heading = FLAG_HEADER
-    )]
-    pub enable_high_validator_count_metrics: bool,
-
-    #[clap(
-        long,
-        value_name = "ORIGIN",
-        help = "Set the value of the Access-Control-Allow-Origin response HTTP header \
-                for the metrics server. Use * to allow any origin (not recommended in production). \
-                If no value is supplied, the CORS allowed origin is set to the listen \
-                address of this server (e.g., http://localhost:5164).",
-        display_order = 0,
-        requires = "metrics"
-    )]
-    pub metrics_allow_origin: Option<HeaderValue>,
 
     #[clap(
         long,
@@ -450,38 +457,26 @@ pub struct Node {
 
     #[clap(
         long,
-        help = "Disable slashing protection for all validator clients. DO NOT ENABLE THIS UNLESS YOU HAVE A MORE THAN SUFFICIENT REASON TO",
-        hide = true,
-        display_order = 0
+        help = "Disables gossipsub peer scoring.",
+        display_order = 0,
+        help_heading = FLAG_HEADER
     )]
-    pub disable_slashing_protection: bool,
+    pub disable_gossipsub_peer_scoring: bool,
 
-    // debugging stuff
-    #[clap(
-        long,
-        hide = true,
-        help = "Act as if we were a certain operator, except for sending messages."
-    )]
-    pub impostor: Option<u64>,
-
-    // Performance options
-    #[clap(
-        long,
-        help = "The number of maximum concurrent workers. Defaults to logical cores.",
-        hide = true,
-        display_order = 0
-    )]
-    pub max_workers: Option<usize>,
+    #[clap(long, help = "Disables gossipsub topic scoring.", hide = true)]
+    pub disable_gossipsub_topic_scoring: bool,
 
     #[clap(
         long,
-        value_delimiter = ',',
-        help = "Override size for a specific queue. Needs to be of the format \"queue_name=42\".",
-        hide = true,
-        display_order = 0
+        help = "Disable the latency measurement service.",
+        display_order = 0,
+        help_heading = FLAG_HEADER
     )]
-    pub work_queue_size: Vec<String>,
+    pub disable_latency_measurement_service: bool,
+}
 
+#[derive(Parser, Clone, Debug)]
+pub struct PayloadBuildingOptions {
     #[clap(
         long,
         value_name = "INTEGER",
@@ -523,25 +518,62 @@ pub struct Node {
         help_heading = FLAG_HEADER
     )]
     pub prefer_builder_proposals: bool,
+}
+
+#[derive(Parser, Clone, Debug)]
+#[clap(name = "node", about = "Start Anchor node")]
+pub struct Node {
+    #[clap(flatten)]
+    pub security_options: SecurityOptions,
+
+    #[clap(flatten)]
+    pub external_apis: ExternalApis,
+
+    #[clap(flatten)]
+    pub http_api_options: HttpApiOptions,
+
+    #[clap(flatten)]
+    pub metrics_options: MetricsOptions,
+
+    #[clap(flatten)]
+    pub network_options: NetworkOptions,
+
+    #[clap(flatten)]
+    pub payload_building_options: PayloadBuildingOptions,
 
     #[clap(
         long,
-        help = "Disable the latency measurement service.",
-        display_order = 0,
-        help_heading = FLAG_HEADER
+        help = "Disable slashing protection for all validator clients. DO NOT ENABLE THIS UNLESS YOU HAVE A MORE THAN SUFFICIENT REASON TO",
+        hide = true,
+        display_order = 0
     )]
-    pub disable_latency_measurement_service: bool,
+    pub disable_slashing_protection: bool,
+
+    // debugging stuff
+    #[clap(
+        long,
+        hide = true,
+        help = "Act as if we were a certain operator, except for sending messages."
+    )]
+    pub impostor: Option<u64>,
+
+    // Performance options
+    #[clap(
+        long,
+        help = "The number of maximum concurrent workers. Defaults to logical cores.",
+        hide = true,
+        display_order = 0
+    )]
+    pub max_workers: Option<usize>,
 
     #[clap(
         long,
-        help = "Disables gossipsub peer scoring.",
-        display_order = 0,
-        help_heading = FLAG_HEADER
+        value_delimiter = ',',
+        help = "Override size for a specific queue. Needs to be of the format \"queue_name=42\".",
+        hide = true,
+        display_order = 0
     )]
-    pub disable_gossipsub_peer_scoring: bool,
-
-    #[clap(long, help = "Disables gossipsub topic scoring.", hide = true)]
-    pub disable_gossipsub_topic_scoring: bool,
+    pub work_queue_size: Vec<String>,
 
     // Operator Doppelgänger Protection
     #[clap(

--- a/anchor/client/src/config.rs
+++ b/anchor/client/src/config.rs
@@ -15,7 +15,7 @@ use ssv_types::OperatorId;
 use tower_http::cors::AllowOrigin;
 use tracing::{error, warn};
 
-use crate::cli::Node;
+use crate::cli::{NetworkOptions, Node};
 
 pub const DEFAULT_BEACON_NODE: &str = "http://localhost:5052/";
 pub const DEFAULT_EXECUTION_NODE: &str = "http://localhost:8545/";
@@ -138,16 +138,16 @@ impl Config {
 pub fn from_cli(mut cli_args: Node, global_config: GlobalConfig) -> Result<Config, String> {
     let mut config = Config::new(global_config);
 
-    config.key_file = cli_args.key_file.clone();
-    config.password_file = cli_args.password_file.clone();
+    config.key_file = cli_args.security_options.key_file.clone();
+    config.password_file = cli_args.security_options.password_file.clone();
 
-    if let Some(ref beacon_nodes) = cli_args.beacon_nodes {
+    if let Some(ref beacon_nodes) = cli_args.external_apis.beacon_nodes {
         parse_urls(&mut config.beacon_nodes, beacon_nodes, "beacon node")?;
     }
-    if let Some(ref execution_rpc) = cli_args.execution_rpc {
+    if let Some(ref execution_rpc) = cli_args.external_apis.execution_rpc {
         parse_urls(&mut config.execution_nodes, execution_rpc, "execution RPC")?;
     }
-    if let Some(ref execution_ws) = cli_args.execution_ws {
+    if let Some(ref execution_ws) = cli_args.external_apis.execution_ws {
         let ws =
             SensitiveUrl::parse(execution_ws).map_err(|e| format!("Unable to parse URL: {e:?}"))?;
         config.execution_nodes_websocket = ws;
@@ -157,9 +157,9 @@ pub fn from_cli(mut cli_args: Node, global_config: GlobalConfig) -> Result<Confi
     config.disable_slashing_protection = cli_args.disable_slashing_protection;
 
     // Network related
-    config.network.listen_addresses = parse_listening_addresses(&cli_args)?;
+    config.network.listen_addresses = parse_listening_addresses(&cli_args.network_options)?;
 
-    for addr in cli_args.boot_nodes.clone() {
+    for addr in cli_args.network_options.boot_nodes.clone() {
         match addr.parse() {
             Ok(enr) => config.network.boot_nodes_enr.push(enr),
             Err(_) => {
@@ -177,7 +177,7 @@ pub fn from_cli(mut cli_args: Node, global_config: GlobalConfig) -> Result<Confi
             }
         }
     }
-    if cli_args.boot_nodes.is_empty() {
+    if cli_args.network_options.boot_nodes.is_empty() {
         config.network.boot_nodes_enr = config
             .global_config
             .ssv_network
@@ -186,56 +186,62 @@ pub fn from_cli(mut cli_args: Node, global_config: GlobalConfig) -> Result<Confi
             .unwrap_or_default();
     }
 
-    config.network.enr_address = (cli_args.enr_address, cli_args.enr_address6);
-    config.network.disable_enr_auto_update = cli_args.disable_enr_auto_update;
-    config.network.enr_tcp4_port = cli_args.enr_tcp_port;
-    config.network.enr_udp4_port = cli_args.enr_udp_port;
-    config.network.enr_quic4_port = cli_args.enr_quic_port;
-    config.network.enr_tcp6_port = cli_args.enr_tcp6_port;
-    config.network.enr_udp6_port = cli_args.enr_udp6_port;
-    config.network.enr_quic6_port = cli_args.enr_quic6_port;
+    config.network.enr_address = (
+        cli_args.network_options.enr_address,
+        cli_args.network_options.enr_address6,
+    );
+    config.network.disable_enr_auto_update = cli_args.network_options.disable_enr_auto_update;
+    config.network.enr_tcp4_port = cli_args.network_options.enr_tcp_port;
+    config.network.enr_udp4_port = cli_args.network_options.enr_udp_port;
+    config.network.enr_quic4_port = cli_args.network_options.enr_quic_port;
+    config.network.enr_tcp6_port = cli_args.network_options.enr_tcp6_port;
+    config.network.enr_udp6_port = cli_args.network_options.enr_udp6_port;
+    config.network.enr_quic6_port = cli_args.network_options.enr_quic6_port;
 
-    config.network.subscribe_all_subnets = cli_args.subscribe_all_subnets;
+    config.network.subscribe_all_subnets = cli_args.network_options.subscribe_all_subnets;
 
     // If the flag was set (true), it means we disable upnp so upnp_enabled should be false
-    config.network.upnp_enabled = !cli_args.disable_upnp;
+    config.network.upnp_enabled = !cli_args.network_options.disable_upnp;
 
-    config.network.target_peers = cli_args.target_peers;
+    config.network.target_peers = cli_args.network_options.target_peers;
 
     // Network related - set peer scoring configuration
-    config.network.disable_gossipsub_peer_scoring = cli_args.disable_gossipsub_peer_scoring;
-    config.network.disable_gossipsub_topic_scoring = cli_args.disable_gossipsub_topic_scoring;
+    config.network.disable_gossipsub_peer_scoring =
+        cli_args.network_options.disable_gossipsub_peer_scoring;
+    config.network.disable_gossipsub_topic_scoring =
+        cli_args.network_options.disable_gossipsub_topic_scoring;
 
-    config.beacon_nodes_tls_certs = cli_args.beacon_nodes_tls_certs.clone();
-    config.execution_nodes_tls_certs = cli_args.execution_nodes_tls_certs.clone();
+    config.beacon_nodes_tls_certs = cli_args.external_apis.beacon_nodes_tls_certs.clone();
+    config.execution_nodes_tls_certs = cli_args.external_apis.execution_nodes_tls_certs.clone();
 
     // Beacon node fallback configuration
-    config.beacon_node_fallback.sync_tolerances =
-        BeaconNodeSyncDistanceTiers::from_vec(&cli_args.beacon_nodes_sync_tolerances)?;
+    config.beacon_node_fallback.sync_tolerances = BeaconNodeSyncDistanceTiers::from_vec(
+        &cli_args.external_apis.beacon_nodes_sync_tolerances,
+    )?;
 
-    if let Some(mut broadcast_topics) = cli_args.broadcast.clone() {
+    if let Some(mut broadcast_topics) = cli_args.external_apis.broadcast.clone() {
         broadcast_topics.retain(|topic| *topic != ApiTopic::None);
         config.broadcast_topics = broadcast_topics;
     }
 
     // MEV options
-    config.builder_boost_factor = cli_args.builder_boost_factor;
-    config.prefer_builder_proposals = cli_args.prefer_builder_proposals;
+    config.builder_boost_factor = cli_args.payload_building_options.builder_boost_factor;
+    config.prefer_builder_proposals = cli_args.payload_building_options.prefer_builder_proposals;
 
-    if cli_args.builder_proposals {
+    if cli_args.payload_building_options.builder_proposals {
         warn!(
             "The --builder-proposals flag is deprecated and ignored. Validator registrations are \
              now always created. This flag will be removed in a future release and will error then."
         );
     }
 
-    config.gas_limit = cli_args.gas_limit;
+    config.gas_limit = cli_args.payload_building_options.gas_limit;
 
     // Http API server
-    config.http_api.enabled = cli_args.http;
+    config.http_api.enabled = cli_args.http_api_options.http;
 
-    if let Some(address) = cli_args.http_address {
-        if cli_args.unencrypted_http_transport {
+    if let Some(address) = cli_args.http_api_options.http_address {
+        if cli_args.http_api_options.unencrypted_http_transport {
             config.http_api.listen_addr = address;
         } else {
             return Err(
@@ -245,36 +251,38 @@ pub fn from_cli(mut cli_args: Node, global_config: GlobalConfig) -> Result<Confi
         }
     }
 
-    if let Some(port) = cli_args.http_port {
+    if let Some(port) = cli_args.http_api_options.http_port {
         config.http_api.listen_port = port;
     }
 
-    if let Some(allow_origin) = cli_args.http_allow_origin.take() {
+    if let Some(allow_origin) = cli_args.http_api_options.http_allow_origin.take() {
         config.http_api.allow_origin = Some(AllowOrigin::exact(allow_origin));
     }
 
     // Prometheus metrics HTTP server
 
-    if cli_args.metrics {
+    if cli_args.metrics_options.metrics {
         config.http_metrics.enabled = true;
     }
 
-    if let Some(address) = cli_args.metrics_address {
+    if let Some(address) = cli_args.metrics_options.metrics_address {
         config.http_metrics.listen_addr = address;
     }
 
-    if let Some(port) = cli_args.metrics_port {
+    if let Some(port) = cli_args.metrics_options.metrics_port {
         config.http_metrics.listen_port = port;
     }
 
-    if let Some(allow_origin) = cli_args.metrics_allow_origin.take() {
+    if let Some(allow_origin) = cli_args.metrics_options.metrics_allow_origin.take() {
         config.http_metrics.allow_origin = Some(AllowOrigin::exact(allow_origin));
     }
 
-    config.enable_high_validator_count_metrics = cli_args.enable_high_validator_count_metrics;
+    config.enable_high_validator_count_metrics =
+        cli_args.metrics_options.enable_high_validator_count_metrics;
 
     config.impostor = cli_args.impostor.map(OperatorId);
-    config.disable_latency_measurement_service = cli_args.disable_latency_measurement_service;
+    config.disable_latency_measurement_service =
+        cli_args.network_options.disable_latency_measurement_service;
 
     // Operator doppelgänger protection
     config.operator_dg = cli_args.operator_dg;
@@ -315,11 +323,11 @@ fn parse_urls(dest: &mut Vec<SensitiveUrl>, src: &[String], kind: &str) -> Resul
 }
 
 /// Gets the listening_addresses for lighthouse based on the cli options.
-pub fn parse_listening_addresses(cli_args: &Node) -> Result<ListenAddress, String> {
+pub fn parse_listening_addresses(network: &NetworkOptions) -> Result<ListenAddress, String> {
     // parse the possible ips
     let mut maybe_ipv4 = None;
     let mut maybe_ipv6 = None;
-    for addr in cli_args.listen_addresses.iter() {
+    for addr in network.listen_addresses.iter() {
         match addr {
             IpAddr::V4(v4_addr) => match &maybe_ipv4 {
                 Some(first_ipv4_addr) => {
@@ -350,19 +358,19 @@ pub fn parse_listening_addresses(cli_args: &Node) -> Result<ListenAddress, Strin
         }
         (None, Some(ipv6)) => {
             // A single ipv6 address was provided. Set the ports
-            if cli_args.port6.is_some() {
+            if network.port6.is_some() {
                 warn!(
                     "When listening only over IPv6, use the --port flag. The value of --port6 will be ignored."
                 );
             }
 
-            if cli_args.discovery_port6.is_some() {
+            if network.discovery_port6.is_some() {
                 warn!(
                     "When listening only over IPv6, use the --discovery-port flag. The value of --discovery-port6 will be ignored."
                 )
             }
 
-            if cli_args.quic_port6.is_some() {
+            if network.quic_port6.is_some() {
                 warn!(
                     "When listening only over IPv6, use the --quic-port flag. The value of --quic-port6 will be ignored."
                 )
@@ -372,11 +380,11 @@ pub fn parse_listening_addresses(cli_args: &Node) -> Result<ListenAddress, Strin
             // 1. If use_zero_ports is set, use an unused TCP6 port.
             // 2. Else, if port is specified, use it.
             // 3. If none of the above are set, use the default TCP port (DEFAULT_TCP_PORT).
-            let tcp_port = cli_args
+            let tcp_port = network
                 .use_zero_ports
                 .then(unused_tcp6_port)
                 .transpose()?
-                .or(cli_args.port)
+                .or(network.port)
                 .unwrap_or(DEFAULT_TCP_PORT);
 
             // Select the discovery port in the following order of precedence:
@@ -384,23 +392,23 @@ pub fn parse_listening_addresses(cli_args: &Node) -> Result<ListenAddress, Strin
             // 2. Else, if discovery_port is specified in CLI args, use it.
             // 3. Else, if port is specified, use it as the fallback.
             // 4. If none of the above are set, use the default discovery port (DEFAULT_DISC_PORT).
-            let disc_port = cli_args
+            let disc_port = network
                 .use_zero_ports
                 .then(unused_udp6_port)
                 .transpose()?
-                .or(cli_args.discovery_port)
-                .or(cli_args.port)
+                .or(network.discovery_port)
+                .or(network.port)
                 .unwrap_or(DEFAULT_DISC_PORT);
 
             // Select the QUIC port in the following order of precedence:
             // 1. If use_zero_ports is set, use an unused UDP6 port.
             // 2. Else, if quic_port is specified, use it.
             // 3. If none of the above are set, use the selected TCP port + 1.
-            let quic_port = cli_args
+            let quic_port = network
                 .use_zero_ports
                 .then(unused_udp6_port)
                 .transpose()?
-                .or(cli_args.quic_port)
+                .or(network.quic_port)
                 .unwrap_or(if tcp_port == 0 { 0 } else { tcp_port + 1 });
 
             ListenAddress::V6(ListenAddr {
@@ -417,33 +425,33 @@ pub fn parse_listening_addresses(cli_args: &Node) -> Result<ListenAddress, Strin
             // 1. If use_zero_ports is set, use an unused TCP4 port.
             // 2. Else, if port is specified, use it.
             // 3. If none of the above are set, use the default TCP port (DEFAULT_TCP_PORT).
-            let tcp_port = cli_args
+            let tcp_port = network
                 .use_zero_ports
                 .then(unused_tcp4_port)
                 .transpose()?
-                .or(cli_args.port)
+                .or(network.port)
                 .unwrap_or(DEFAULT_TCP_PORT);
             // Select the discovery port in the following order of precedence:
             // 1. If use_zero_ports is set, use an unused UDP4 port.
             // 2. Else, if discovery_port is specified in CLI args, use it.
             // 3. Else, if port is specified, use it as the fallback.
             // 4. If none of the above are set, use the default discovery port (DEFAULT_DISC_PORT).
-            let disc_port = cli_args
+            let disc_port = network
                 .use_zero_ports
                 .then(unused_udp4_port)
                 .transpose()?
-                .or(cli_args.discovery_port)
-                .or(cli_args.port)
+                .or(network.discovery_port)
+                .or(network.port)
                 .unwrap_or(DEFAULT_DISC_PORT);
             // Select the QUIC port in the following order of precedence:
             // 1. If use_zero_ports is set, use an unused UDP4 port.
             // 2. Else, if quic_port is specified, use it.
             // 3. If none of the above are set, use the selected TCP port + 1.
-            let quic_port = cli_args
+            let quic_port = network
                 .use_zero_ports
                 .then(unused_udp4_port)
                 .transpose()?
-                .or(cli_args.quic_port)
+                .or(network.quic_port)
                 .unwrap_or(if tcp_port == 0 { 0 } else { tcp_port + 1 });
 
             ListenAddress::V4(ListenAddr {
@@ -454,47 +462,47 @@ pub fn parse_listening_addresses(cli_args: &Node) -> Result<ListenAddress, Strin
             })
         }
         (Some(ipv4), Some(ipv6)) => {
-            let ipv4_tcp_port = cli_args
+            let ipv4_tcp_port = network
                 .use_zero_ports
                 .then(unused_tcp4_port)
                 .transpose()?
-                .or(cli_args.port)
+                .or(network.port)
                 .unwrap_or(DEFAULT_TCP_PORT);
-            let ipv4_disc_port = cli_args
+            let ipv4_disc_port = network
                 .use_zero_ports
                 .then(unused_udp4_port)
                 .transpose()?
-                .or(cli_args.discovery_port)
-                .or(cli_args.port)
+                .or(network.discovery_port)
+                .or(network.port)
                 .unwrap_or(DEFAULT_DISC_PORT);
-            let ipv4_quic_port = cli_args
+            let ipv4_quic_port = network
                 .use_zero_ports
                 .then(unused_udp4_port)
                 .transpose()?
-                .or(cli_args.quic_port)
+                .or(network.quic_port)
                 .unwrap_or(if ipv4_tcp_port == 0 {
                     0
                 } else {
                     ipv4_tcp_port + 1
                 });
 
-            let ipv6_tcp_port = cli_args
+            let ipv6_tcp_port = network
                 .use_zero_ports
                 .then(unused_tcp6_port)
                 .transpose()?
-                .or(cli_args.port6)
+                .or(network.port6)
                 .unwrap_or(ipv4_tcp_port);
-            let ipv6_disc_port = cli_args
+            let ipv6_disc_port = network
                 .use_zero_ports
                 .then(unused_udp6_port)
                 .transpose()?
-                .or(cli_args.discovery_port6)
+                .or(network.discovery_port6)
                 .unwrap_or(ipv4_disc_port);
-            let ipv6_quic_port = cli_args
+            let ipv6_quic_port = network
                 .use_zero_ports
                 .then(unused_udp6_port)
                 .transpose()?
-                .or(cli_args.quic_port6)
+                .or(network.quic_port6)
                 .unwrap_or(if ipv6_tcp_port == 0 {
                     0
                 } else {

--- a/anchor/client/src/config.rs
+++ b/anchor/client/src/config.rs
@@ -281,8 +281,7 @@ pub fn from_cli(mut cli_args: Node, global_config: GlobalConfig) -> Result<Confi
         cli_args.metrics_options.enable_high_validator_count_metrics;
 
     config.impostor = cli_args.impostor.map(OperatorId);
-    config.disable_latency_measurement_service =
-        cli_args.network_options.disable_latency_measurement_service;
+    config.disable_latency_measurement_service = cli_args.disable_latency_measurement_service;
 
     // Operator doppelgänger protection
     config.operator_dg = cli_args.operator_dg;


### PR DESCRIPTION
## Issue Addressed

N/A — structural improvement to CLI organization, prerequisite for CLI doc auto-generation (#526).

## Proposed Changes

The `Node` struct has grown to 43 flat fields covering unrelated concerns (networking, metrics, HTTP API, security, MEV). This makes the struct hard to scan, and forces every function that touches CLI args to receive the entire `Node` even when it only needs a few fields.

**Mental model:** each sub-struct maps to one independent concern a node operator configures. Six `#[clap(flatten)]` sub-structs replace the flat layout:

| Sub-struct | Concern | Fields |
|---|---|---|
| `SecurityOptions` | Operator key & password | 2 |
| `ExternalApis` | Beacon/execution endpoints, TLS certs, broadcast, sync tolerances | 7 |
| `HttpApiOptions` | REST API server | 5 |
| `MetricsOptions` | Prometheus metrics server | 5 |
| `NetworkOptions` | P2P listen/port/ENR/discovery/gossipsub | 24 |
| `PayloadBuildingOptions` | Gas limit, builder boost, MEV preferences | 4 |

Fields that don't fit a clear group (slashing protection, impostor mode, performance tuning, doppelganger protection, majority fork protection) stay directly on `Node`.

**Reading order:** start with `cli.rs` (struct definitions move out of `Node` into sub-structs), then `config.rs` (field accesses get prefixed, e.g. `cli_args.http` → `cli_args.http_api_options.http`).

**What did NOT change:** CLI argument names, defaults, `requires`/`conflicts_with` relationships, and all runtime behavior are preserved. `main.rs` is untouched — it only accesses `node.logging_flags`, which was already a flatten.

**Bonus cleanup:** `parse_listening_addresses` was narrowed from `&Node` to `&NetworkOptions` since it only reads network fields — makes the dependency explicit and the function easier to test in isolation.

## Additional Info

- Purely mechanical refactor — the compiler catches any missed field access.
- Verified: `cargo build --release`, `make cargo-fmt`, `make lint`, `make test` all pass.
- This lays groundwork for a future CLI docgen PR that can iterate sub-structs to produce grouped documentation sections.