### PR TITLE
chore: tweak minTargetPercent for testnet stability

### DIFF
--- a/.github/custom/local-testnet/test_anchor_proposal.yaml
+++ b/.github/custom/local-testnet/test_anchor_proposal.yaml
@@ -16,10 +16,10 @@ tasks:
         - name: check_consensus_attestation_stats
           config:
             # These values are taken from a similar config used in the ethereum-package.
-            # The minTargetPercent ensures that most attestations are included at some point.
+            # The minTargetPercent ensures that most attestations are included at some point (up to two missed atts).
             # The minHeadPercent is more lenient as on shared CI, nodes might not have ideal performance.
             # 80% is low enough to not cause false positives but high enough to catch consistent issues.
-            minTargetPercent: 98
+            minTargetPercent: 95
             minHeadPercent: 80
             failOnCheckMiss: true
             minCheckedEpochs: 2


### PR DESCRIPTION
## Issue Addressed

Intermittent CI testnet failures.

## Proposed Changes

The previous value of 98% was effectively 100%, as a single failing attestation of 40 was already 2.5%. 

Make this more lenient by reducing to 95%, allowing up to two failing attestations.
