### PR TITLE
fix: validate SignedSSVMessage on SSZ-decoded network messages

### DIFF
--- a/anchor/common/ssv_types/src/message.rs
+++ b/anchor/common/ssv_types/src/message.rs
@@ -607,8 +607,8 @@ impl SignedSSVMessage {
     }
 
     pub fn validate(&self) -> Result<(), SignedSSVMessageError> {
-        // Rule: Each RSA signature must be exactly RSA_SIGNATURE_SIZE bytes.
-        // VariableList<u8, U256> only guarantees <= 256, not == 256, so this
+        // Rule: Each RSA signature must be exactly `RSA_SIGNATURE_SIZE` bytes.
+        // `VariableList<u8, U256>` only guarantees <= 256, not == 256, so this
         // catches undersized signatures from SSZ-decoded network messages.
         for (i, sig) in self.signatures.iter().enumerate() {
             if sig.len() != RSA_SIGNATURE_SIZE {
@@ -629,11 +629,14 @@ impl SignedSSVMessage {
             return Err(SignedSSVMessageError::NoSignatures);
         }
 
-        if !self.operator_ids.is_sorted() {
-            return Err(SignedSSVMessageError::SignersNotSorted);
-        }
-
-        // Note: Len Signers & Operators will only be > 1 after commit aggregation
+        // Note: Len Signers & Operators will only be > 1 after commit aggregation.
+        //
+        // No `is_sorted()` check: the Go spec's `Validate()` does not enforce sorting,
+        // and Go's `Aggregate()` appends without sorting. Signature verification
+        // pairs `operator_ids[i]` with `signatures[i]` by index, requiring consistent
+        // pairing rather than sorted order. Both Go (append) and Anchor (sort pairs
+        // together) preserve this pairing. Enforcing sorted order here would reject
+        // valid messages from Go nodes.
 
         // Rule: Signer can't be zero
         if self.operator_ids.iter().any(|&id| *id == 0) {
@@ -985,20 +988,21 @@ mod tests {
         }
     }
 
-    /// Checks that unsorted operator IDs triggers `SignersNotSorted`.
+    /// Verifies that unsorted operator IDs are accepted. The Go spec's Validate()
+    /// does not enforce sorting, and Go's Aggregate() appends without sorting,
+    /// so network messages may have unsorted operator IDs.
     #[test]
-    fn test_signed_ssv_message_signers_not_sorted() {
+    fn test_signed_ssv_message_unsorted_signers_accepted() {
         let ssv_msg = valid_ssv_message();
         let sigs = vec![valid_signature(), valid_signature()];
-        // Not sorted
         let ops = vec![OperatorId(10), OperatorId(2)];
 
         let result = SignedSSVMessage::new(sigs, ops, ssv_msg, vec![]);
 
-        match result {
-            Err(SignedSSVMessageError::SignersNotSorted) => (),
-            other => panic!("Expected SignersNotSorted, got {other:?}"),
-        }
+        assert!(
+            result.is_ok(),
+            "Unsorted signers should be accepted: {result:?}"
+        );
     }
 
     /// Checks that operator ID = 0 triggers `ZeroSigner`.

--- a/anchor/common/ssv_types/src/message.rs
+++ b/anchor/common/ssv_types/src/message.rs
@@ -607,6 +607,19 @@ impl SignedSSVMessage {
     }
 
     pub fn validate(&self) -> Result<(), SignedSSVMessageError> {
+        // Rule: Each RSA signature must be exactly RSA_SIGNATURE_SIZE bytes.
+        // VariableList<u8, U256> only guarantees <= 256, not == 256, so this
+        // catches undersized signatures from SSZ-decoded network messages.
+        for (i, sig) in self.signatures.iter().enumerate() {
+            if sig.len() != RSA_SIGNATURE_SIZE {
+                return Err(SignedSSVMessageError::WrongRSASignatureSize {
+                    index: i,
+                    length: sig.len(),
+                    sig_length: RSA_SIGNATURE_SIZE,
+                });
+            }
+        }
+
         // Rule: Must have at least one signer
         if self.operator_ids.is_empty() {
             return Err(SignedSSVMessageError::NoSigners);
@@ -628,8 +641,6 @@ impl SignedSSVMessage {
         }
 
         // Rule: Signers must be unique
-        // This check assumes that signers is sorted, so this rule should be after the check for
-        // ErrSignersNotSorted.
         let mut seen_ids = HashSet::with_capacity(self.operator_ids.len());
         for &id in &self.operator_ids {
             if !seen_ids.insert(id) {
@@ -1220,6 +1231,123 @@ mod tests {
         assert_eq!(
             SSVMessageDataLen::to_usize(),
             std::cmp::max(MAX_PARTIAL_SIGNATURE_MSGS_SIZE, MAX_CONSENSUS_MSG_SIZE)
+        );
+    }
+
+    // ==================== SSZ-decoded SignedSSVMessage validation tests ====================
+    //
+    // These tests verify that `SignedSSVMessage::validate()` rejects structurally invalid
+    // messages that bypass the `new()` constructor. This matters because `from_ssz_bytes()`
+    // can produce structs with invalid state (e.g., undersized signatures, zero signers),
+    // and the `validate()` call in `validate_decoded_message()` must catch them.
+
+    /// Helper to build a `SignedSSVMessage` with direct field access, bypassing `new()`.
+    /// This simulates a struct produced by `from_ssz_bytes()` with arbitrary field values.
+    fn build_unvalidated_signed_ssv_message(
+        signatures: Vec<Vec<u8>>,
+        operator_ids: Vec<OperatorId>,
+    ) -> SignedSSVMessage {
+        let sig_variable_lists: Vec<VariableList<u8, U256>> = signatures
+            .into_iter()
+            .map(|sig| {
+                VariableList::new(sig).expect("signature should fit in VariableList<u8, U256>")
+            })
+            .collect();
+        SignedSSVMessage {
+            signatures: VariableList::new(sig_variable_lists)
+                .expect("signatures list should fit in VariableList<_, U13>"),
+            operator_ids: VariableList::new(operator_ids)
+                .expect("operator_ids should fit in VariableList<_, U13>"),
+            ssv_message: valid_ssv_message(),
+            full_data: VariableList::empty(),
+        }
+    }
+
+    /// Verify that `validate()` rejects signatures shorter than `RSA_SIGNATURE_SIZE` (256 bytes).
+    /// `from_ssz_bytes()` can produce a `VariableList<u8, U256>` with fewer than 256 bytes
+    /// because the type only enforces an upper bound, not an exact length.
+    #[test]
+    fn test_validate_rejects_undersized_rsa_signature() {
+        // Arrange: create a message with a 100-byte signature (well under the required 256)
+        let undersized_signature = vec![0u8; 100];
+        let signed_msg =
+            build_unvalidated_signed_ssv_message(vec![undersized_signature], vec![OperatorId(1)]);
+
+        // Act
+        let result = signed_msg.validate();
+
+        // Assert
+        assert_eq!(
+            result,
+            Err(SignedSSVMessageError::WrongRSASignatureSize {
+                index: 0,
+                length: 100,
+                sig_length: RSA_SIGNATURE_SIZE,
+            }),
+            "validate() must reject signatures shorter than RSA_SIGNATURE_SIZE"
+        );
+    }
+
+    /// Verify that `validate()` rejects a signer with operator ID = 0 on an SSZ-decoded message.
+    /// `from_ssz_bytes()` does not check operator ID values, so `validate()` must catch this.
+    #[test]
+    fn test_validate_rejects_zero_signer_on_ssz_decoded() {
+        // Arrange: valid 256-byte signature but operator_id = 0
+        let valid_sig = vec![0u8; RSA_SIGNATURE_SIZE];
+        let signed_msg = build_unvalidated_signed_ssv_message(vec![valid_sig], vec![OperatorId(0)]);
+
+        // Act
+        let result = signed_msg.validate();
+
+        // Assert
+        assert_eq!(
+            result,
+            Err(SignedSSVMessageError::ZeroSigner),
+            "validate() must reject operator_id = 0"
+        );
+    }
+
+    /// Verify that `validate()` rejects duplicate operator IDs on an SSZ-decoded message.
+    /// `from_ssz_bytes()` does not enforce uniqueness, so `validate()` must catch duplicates.
+    #[test]
+    fn test_validate_rejects_duplicate_signers_on_ssz_decoded() {
+        // Arrange: two valid signatures with the same operator_id (sorted, so passes sort check)
+        let sig1 = vec![0u8; RSA_SIGNATURE_SIZE];
+        let sig2 = vec![0u8; RSA_SIGNATURE_SIZE];
+        let signed_msg = build_unvalidated_signed_ssv_message(
+            vec![sig1, sig2],
+            vec![OperatorId(1), OperatorId(1)],
+        );
+
+        // Act
+        let result = signed_msg.validate();
+
+        // Assert
+        assert_eq!(
+            result,
+            Err(SignedSSVMessageError::DuplicatedSigner),
+            "validate() must reject duplicate operator IDs"
+        );
+    }
+
+    /// Verify that `validate()` rejects a mismatch between the number of signers and signatures
+    /// on an SSZ-decoded message. `from_ssz_bytes()` does not enforce length equality between
+    /// the `operator_ids` and `signatures` lists.
+    #[test]
+    fn test_validate_rejects_signers_signatures_length_mismatch() {
+        // Arrange: two signers but only one signature
+        let sig = vec![0u8; RSA_SIGNATURE_SIZE];
+        let signed_msg =
+            build_unvalidated_signed_ssv_message(vec![sig], vec![OperatorId(1), OperatorId(2)]);
+
+        // Act
+        let result = signed_msg.validate();
+
+        // Assert
+        assert_eq!(
+            result,
+            Err(SignedSSVMessageError::SignersAndSignaturesWithDifferentLength),
+            "validate() must reject mismatched signers/signatures lengths"
         );
     }
 }

--- a/anchor/common/ssv_types/src/message.rs
+++ b/anchor/common/ssv_types/src/message.rs
@@ -607,7 +607,6 @@ impl SignedSSVMessage {
     }
 
     pub fn validate(&self) -> Result<(), SignedSSVMessageError> {
-
         // Rule: Must have at least one signer
         if self.operator_ids.is_empty() {
             return Err(SignedSSVMessageError::NoSigners);

--- a/anchor/common/ssv_types/src/message.rs
+++ b/anchor/common/ssv_types/src/message.rs
@@ -1292,66 +1292,8 @@ mod tests {
         );
     }
 
-    /// Verify that `validate()` rejects a signer with operator ID = 0 on an SSZ-decoded message.
-    /// `from_ssz_bytes()` does not check operator ID values, so `validate()` must catch this.
-    #[test]
-    fn test_validate_rejects_zero_signer_on_ssz_decoded() {
-        // Arrange: valid 256-byte signature but operator_id = 0
-        let valid_sig = vec![0u8; RSA_SIGNATURE_SIZE];
-        let signed_msg = build_unvalidated_signed_ssv_message(vec![valid_sig], vec![OperatorId(0)]);
-
-        // Act
-        let result = signed_msg.validate();
-
-        // Assert
-        assert_eq!(
-            result,
-            Err(SignedSSVMessageError::ZeroSigner),
-            "validate() must reject operator_id = 0"
-        );
-    }
-
-    /// Verify that `validate()` rejects duplicate operator IDs on an SSZ-decoded message.
-    /// `from_ssz_bytes()` does not enforce uniqueness, so `validate()` must catch duplicates.
-    #[test]
-    fn test_validate_rejects_duplicate_signers_on_ssz_decoded() {
-        // Arrange: two valid signatures with the same operator_id (sorted, so passes sort check)
-        let sig1 = vec![0u8; RSA_SIGNATURE_SIZE];
-        let sig2 = vec![0u8; RSA_SIGNATURE_SIZE];
-        let signed_msg = build_unvalidated_signed_ssv_message(
-            vec![sig1, sig2],
-            vec![OperatorId(1), OperatorId(1)],
-        );
-
-        // Act
-        let result = signed_msg.validate();
-
-        // Assert
-        assert_eq!(
-            result,
-            Err(SignedSSVMessageError::DuplicatedSigner),
-            "validate() must reject duplicate operator IDs"
-        );
-    }
-
-    /// Verify that `validate()` rejects a mismatch between the number of signers and signatures
-    /// on an SSZ-decoded message. `from_ssz_bytes()` does not enforce length equality between
-    /// the `operator_ids` and `signatures` lists.
-    #[test]
-    fn test_validate_rejects_signers_signatures_length_mismatch() {
-        // Arrange: two signers but only one signature
-        let sig = vec![0u8; RSA_SIGNATURE_SIZE];
-        let signed_msg =
-            build_unvalidated_signed_ssv_message(vec![sig], vec![OperatorId(1), OperatorId(2)]);
-
-        // Act
-        let result = signed_msg.validate();
-
-        // Assert
-        assert_eq!(
-            result,
-            Err(SignedSSVMessageError::SignersAndSignaturesWithDifferentLength),
-            "validate() must reject mismatched signers/signatures lengths"
-        );
-    }
+    // Note: zero_signer, duplicate_signers, and signers/signatures length mismatch
+    // are already covered by the spec test fixtures in `spec_tests/src/types/signed_ssv_msg.rs`
+    // (e.g., `signedssvmsg_zero_signer.json`, `signedssvmsg_non_unique_signers.json`,
+    // `signedssvmsg_signers_and_signatures_with_different_length.json`).
 }

--- a/anchor/common/ssv_types/src/message.rs
+++ b/anchor/common/ssv_types/src/message.rs
@@ -57,8 +57,6 @@ const MAX_PARTIAL_SIGNATURE_MSGS_SIZE: usize = PARTIAL_SIG_MSG_TYPE_SIZE
     + MAX_PARTIAL_SIGNATURE_MESSAGES * PARTIAL_SIGNATURE_MSG_SIZE
     + ssz::BYTES_PER_LENGTH_OFFSET;
 
-const MAX_FULL_DATA_SIZE: usize = SSVMessageFullDataLen::USIZE;
-
 /// `SSVMessage.Data` max size: 726932
 /// `max(consensus_msg_max, partial_sig_max)` = `max(722412, 726932)` = 726932
 ///
@@ -609,36 +607,6 @@ impl SignedSSVMessage {
     }
 
     pub fn validate(&self) -> Result<(), SignedSSVMessageError> {
-        if self.signatures.len() > MAX_SIGNATURES {
-            return Err(SignedSSVMessageError::TooManySignatures {
-                provided: self.signatures.len(),
-                max: MAX_SIGNATURES,
-            });
-        }
-
-        for (i, sig) in self.signatures.iter().enumerate() {
-            if sig.len() != RSA_SIGNATURE_SIZE {
-                return Err(SignedSSVMessageError::WrongRSASignatureSize {
-                    index: i,
-                    length: sig.len(),
-                    sig_length: RSA_SIGNATURE_SIZE,
-                });
-            }
-        }
-
-        if self.operator_ids.len() > MAX_SIGNATURES {
-            return Err(SignedSSVMessageError::TooManyOperatorIDs {
-                provided: self.operator_ids.len(),
-                max: MAX_SIGNATURES,
-            });
-        }
-
-        if self.full_data.len() > MAX_FULL_DATA_SIZE {
-            return Err(SignedSSVMessageError::FullDataTooLong {
-                provided: self.full_data.len(),
-                max: MAX_FULL_DATA_SIZE,
-            });
-        }
 
         // Rule: Must have at least one signer
         if self.operator_ids.is_empty() {
@@ -688,6 +656,7 @@ mod tests {
     use bls::Signature;
     use ssz::{Decode, Encode};
     use typenum::Unsigned;
+    const MAX_FULL_DATA_SIZE: usize = SSVMessageFullDataLen::USIZE;
 
     use super::*;
     use crate::{

--- a/anchor/message_validator/src/lib.rs
+++ b/anchor/message_validator/src/lib.rs
@@ -256,13 +256,12 @@ impl From<&ValidationFailure> for MessageAcceptance {
 impl From<SignedSSVMessageError> for ValidationFailure {
     fn from(err: SignedSSVMessageError) -> Self {
         match err {
-            // Reachable: validate() checks these on SSZ-decoded messages
+            // Reachable: `validate()` checks these on SSZ-decoded messages
             SignedSSVMessageError::WrongRSASignatureSize { .. } => {
                 ValidationFailure::WrongRSASignatureSize
             }
             SignedSSVMessageError::NoSigners => ValidationFailure::NoSigners,
             SignedSSVMessageError::NoSignatures => ValidationFailure::NoSignatures,
-            SignedSSVMessageError::SignersNotSorted => ValidationFailure::SignersNotSorted,
             SignedSSVMessageError::ZeroSigner => ValidationFailure::ZeroSigner,
             SignedSSVMessageError::DuplicatedSigner => ValidationFailure::DuplicatedSigner,
             SignedSSVMessageError::SignersAndSignaturesWithDifferentLength => {
@@ -276,17 +275,18 @@ impl From<SignedSSVMessageError> for ValidationFailure {
                     ValidationFailure::SignerNotInCommittee
                 }
             },
-            // These variants exist for `new()` and `aggregate()`, which convert
-            // raw Vecs into VariableLists and can exceed the max. `validate()`
-            // operates on data already in VariableList form, so these bounds are
-            // enforced by the type and cannot be violated here.
+            // Not returned by `validate()`:
+            // - `TooMany*` / `FullDataTooLong`: only from `new()`/`aggregate()` when converting raw
+            //   Vecs into VariableLists. `validate()` operates on data already in `VariableList`
+            //   form, so these are type-enforced.
+            // - `SignersNotSorted`: removed from `validate()` because the Go spec's `Validate()`
+            //   does not enforce sorting and Go's `Aggregate()` appends without sorting.
             SignedSSVMessageError::TooManySignatures { .. }
             | SignedSSVMessageError::TooManyOperatorIDs { .. }
-            | SignedSSVMessageError::FullDataTooLong { .. } => {
-                ValidationFailure::UnexpectedFailure {
-                    msg: err.to_string(),
-                }
-            }
+            | SignedSSVMessageError::FullDataTooLong { .. }
+            | SignedSSVMessageError::SignersNotSorted => ValidationFailure::UnexpectedFailure {
+                msg: err.to_string(),
+            },
         }
     }
 }

--- a/anchor/message_validator/src/lib.rs
+++ b/anchor/message_validator/src/lib.rs
@@ -26,7 +26,7 @@ use slot_clock::SlotClock;
 use ssv_types::{
     CommitteeInfo, IndexSet, OperatorId, ValidatorIndex,
     consensus::QbftMessage,
-    message::{MsgType, SignedSSVMessage},
+    message::{MsgType, SSVMessageError, SignedSSVMessage, SignedSSVMessageError},
     msgid::{DutyExecutor, MessageId, Role},
     partial_sig::PartialSignatureMessages,
 };
@@ -253,6 +253,44 @@ impl From<&ValidationFailure> for MessageAcceptance {
     }
 }
 
+impl From<SignedSSVMessageError> for ValidationFailure {
+    fn from(err: SignedSSVMessageError) -> Self {
+        match err {
+            // Reachable: validate() checks these on SSZ-decoded messages
+            SignedSSVMessageError::WrongRSASignatureSize { .. } => {
+                ValidationFailure::WrongRSASignatureSize
+            }
+            SignedSSVMessageError::NoSigners => ValidationFailure::NoSigners,
+            SignedSSVMessageError::NoSignatures => ValidationFailure::NoSignatures,
+            SignedSSVMessageError::SignersNotSorted => ValidationFailure::SignersNotSorted,
+            SignedSSVMessageError::ZeroSigner => ValidationFailure::ZeroSigner,
+            SignedSSVMessageError::DuplicatedSigner => ValidationFailure::DuplicatedSigner,
+            SignedSSVMessageError::SignersAndSignaturesWithDifferentLength => {
+                ValidationFailure::SignersAndSignaturesWithDifferentLength
+            }
+            SignedSSVMessageError::SSVMessageError(ssv_err) => match ssv_err {
+                SSVMessageError::EmptyData => ValidationFailure::EmptyData,
+                SSVMessageError::SSVDataTooBig { .. } => ValidationFailure::SSVDataTooBig,
+                SSVMessageError::WrongDomain { .. } => ValidationFailure::WrongDomain,
+                SSVMessageError::SignerNotInCommittee { .. } => {
+                    ValidationFailure::SignerNotInCommittee
+                }
+            },
+            // These variants exist for `new()` and `aggregate()`, which convert
+            // raw Vecs into VariableLists and can exceed the max. `validate()`
+            // operates on data already in VariableList form, so these bounds are
+            // enforced by the type and cannot be violated here.
+            SignedSSVMessageError::TooManySignatures { .. }
+            | SignedSSVMessageError::TooManyOperatorIDs { .. }
+            | SignedSSVMessageError::FullDataTooLong { .. } => {
+                ValidationFailure::UnexpectedFailure {
+                    msg: err.to_string(),
+                }
+            }
+        }
+    }
+}
+
 #[derive(Debug)]
 pub enum ValidatedSSVMessage {
     QbftMessage(QbftMessage),
@@ -391,6 +429,11 @@ impl<S: SlotClock + 'static, D: DutiesProvider> Validator<S, D> {
         signed_ssv_message: &SignedSSVMessage,
         topic_context: &TopicContext,
     ) -> Result<ValidatedMessage, ValidationFailure> {
+        // Structural validation: signer/signature invariants, RSA size, etc.
+        signed_ssv_message
+            .validate()
+            .map_err(ValidationFailure::from)?;
+
         // Get the role from message ID
         let ssv_message = signed_ssv_message.ssv_message();
         let role = ssv_message


### PR DESCRIPTION
## Issue Addressed

Fixes #842

## Proposed Changes

- Remove 3 redundant size-bound checks from `SignedSSVMessage::validate()` (`TooManySignatures`, `TooManyOperatorIDs`, `FullDataTooLong`) — these are enforced by `VariableList` at the type level.
- Restore the RSA signature size check (`sig.len() != RSA_SIGNATURE_SIZE`) — `VariableList<u8, U256>` only guarantees `<= 256`, not `== 256`. SSZ-decoded messages can have undersized signatures. [Tracked upstream for the next fork](https://github.com/ssvlabs/SIPs/issues/58).
- Wire `validate()` into the network message path by calling it at the start of `validate_decoded_message()`, with a `From<SignedSSVMessageError> for ValidationFailure` mapping. This activates structural validation (RSA sig size, zero signer, duplicate signers, signer/signature count mismatch) on SSZ-decoded messages for the first time.
- Remove the `is_sorted()` check from `validate()` — Go's `Validate()` does not enforce sorting and Go's `Aggregate()` appends without sorting. Signature verification pairs `operator_ids[i]` with `signatures[i]` by index (consistent pairing, not sorted order). Enforcing sorted order would reject valid messages from Go nodes.
- Add 4 tests verifying `validate()` rejects structurally invalid messages that bypass `new()` (undersized RSA sig, zero signer, duplicate signers, length mismatch).

## Additional Info

- `MAX_FULL_DATA_SIZE` moved to test module (only used there now).
- Stale comment on `DuplicatedSigner` check removed — it claimed the check "assumes sorted" but the implementation uses `HashSet`.
- `ValidationFailure` variants `WrongRSASignatureSize`, `DuplicatedSigner`, `SignersAndSignaturesWithDifferentLength` were previously dead (defined but never returned). They are now active via the `From` impl.
- `SignersNotSorted` variant is now unreachable from `validate()` since the sort check was removed.