### PR TITLE
refactor: validator store trait fns return streams

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -239,9 +239,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-eip7928"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3231de68d5d6e75332b7489cfcc7f4dfabeba94d990a10e4b923af0e6623540"
+checksum = "f8222b1d88f9a6d03be84b0f5e76bb60cd83991b43ad8ab6477f0e4a7809b98d"
 dependencies = [
  "alloy-primitives 1.5.7",
  "alloy-rlp",
@@ -393,7 +393,7 @@ dependencies = [
  "const-hex",
  "derive_more 2.1.1",
  "foldhash 0.2.0",
- "getrandom 0.4.1",
+ "getrandom 0.4.2",
  "hashbrown 0.16.1",
  "indexmap 2.13.0",
  "itoa",
@@ -1399,7 +1399,7 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 [[package]]
 name = "beacon_node_fallback"
 version = "0.1.0"
-source = "git+https://github.com/shane-moore/lighthouse?rev=a0a2a95#a0a2a950a7921baffde6e041bc4e5822c0aab766"
+source = "git+https://github.com/shane-moore/lighthouse?rev=66ff63a#66ff63a8d8d9fd75c5a842477f7789b93a996ee0"
 dependencies = [
  "bls",
  "clap",
@@ -1499,10 +1499,9 @@ dependencies = [
 [[package]]
 name = "bls"
 version = "0.2.0"
-source = "git+https://github.com/shane-moore/lighthouse?rev=a0a2a95#a0a2a950a7921baffde6e041bc4e5822c0aab766"
+source = "git+https://github.com/shane-moore/lighthouse?rev=66ff63a#66ff63a8d8d9fd75c5a842477f7789b93a996ee0"
 dependencies = [
  "alloy-primitives 1.5.7",
- "arbitrary",
  "blst",
  "ethereum_hashing 0.8.0",
  "ethereum_serde_utils 0.8.0",
@@ -1870,9 +1869,9 @@ dependencies = [
 
 [[package]]
 name = "const-hex"
-version = "1.18.0"
+version = "1.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af9a108e542ddf1de36743a6126e94d6659dccda38fc8a77e80b915102ac784a"
+checksum = "531185e432bb31db1ecda541e9e7ab21468d4d844ad7505e0546a49b4945d49b"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -2569,7 +2568,7 @@ dependencies = [
 [[package]]
 name = "eip_3076"
 version = "0.1.0"
-source = "git+https://github.com/shane-moore/lighthouse?rev=a0a2a95#a0a2a950a7921baffde6e041bc4e5822c0aab766"
+source = "git+https://github.com/shane-moore/lighthouse?rev=66ff63a#66ff63a8d8d9fd75c5a842477f7789b93a996ee0"
 dependencies = [
  "bls",
  "ethereum_serde_utils 0.8.0",
@@ -2804,7 +2803,7 @@ dependencies = [
 [[package]]
 name = "eth2"
 version = "0.1.0"
-source = "git+https://github.com/shane-moore/lighthouse?rev=a0a2a95#a0a2a950a7921baffde6e041bc4e5822c0aab766"
+source = "git+https://github.com/shane-moore/lighthouse?rev=66ff63a#66ff63a8d8d9fd75c5a842477f7789b93a996ee0"
 dependencies = [
  "bls",
  "context_deserialize",
@@ -2833,7 +2832,7 @@ dependencies = [
 [[package]]
 name = "eth2_config"
 version = "0.2.0"
-source = "git+https://github.com/shane-moore/lighthouse?rev=a0a2a95#a0a2a950a7921baffde6e041bc4e5822c0aab766"
+source = "git+https://github.com/shane-moore/lighthouse?rev=66ff63a#66ff63a8d8d9fd75c5a842477f7789b93a996ee0"
 dependencies = [
  "paste",
  "types",
@@ -2842,7 +2841,7 @@ dependencies = [
 [[package]]
 name = "eth2_interop_keypairs"
 version = "0.2.0"
-source = "git+https://github.com/shane-moore/lighthouse?rev=a0a2a95#a0a2a950a7921baffde6e041bc4e5822c0aab766"
+source = "git+https://github.com/shane-moore/lighthouse?rev=66ff63a#66ff63a8d8d9fd75c5a842477f7789b93a996ee0"
 dependencies = [
  "bls",
  "ethereum_hashing 0.8.0",
@@ -2855,7 +2854,7 @@ dependencies = [
 [[package]]
 name = "eth2_key_derivation"
 version = "0.1.0"
-source = "git+https://github.com/shane-moore/lighthouse?rev=a0a2a95#a0a2a950a7921baffde6e041bc4e5822c0aab766"
+source = "git+https://github.com/shane-moore/lighthouse?rev=66ff63a#66ff63a8d8d9fd75c5a842477f7789b93a996ee0"
 dependencies = [
  "bls",
  "num-bigint-dig",
@@ -2867,7 +2866,7 @@ dependencies = [
 [[package]]
 name = "eth2_keystore"
 version = "0.1.0"
-source = "git+https://github.com/shane-moore/lighthouse?rev=a0a2a95#a0a2a950a7921baffde6e041bc4e5822c0aab766"
+source = "git+https://github.com/shane-moore/lighthouse?rev=66ff63a#66ff63a8d8d9fd75c5a842477f7789b93a996ee0"
 dependencies = [
  "aes",
  "bls",
@@ -2884,14 +2883,14 @@ dependencies = [
  "serde_repr",
  "sha2",
  "unicode-normalization",
- "uuid 0.8.2",
+ "uuid",
  "zeroize",
 ]
 
 [[package]]
 name = "eth2_network_config"
 version = "0.2.0"
-source = "git+https://github.com/shane-moore/lighthouse?rev=a0a2a95#a0a2a950a7921baffde6e041bc4e5822c0aab766"
+source = "git+https://github.com/shane-moore/lighthouse?rev=66ff63a#66ff63a8d8d9fd75c5a842477f7789b93a996ee0"
 dependencies = [
  "bytes",
  "discv5",
@@ -3025,9 +3024,9 @@ dependencies = [
 
 [[package]]
 name = "fallible-iterator"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
 
 [[package]]
 name = "fallible-streaming-iterator"
@@ -3103,7 +3102,7 @@ dependencies = [
 [[package]]
 name = "filesystem"
 version = "0.1.0"
-source = "git+https://github.com/shane-moore/lighthouse?rev=a0a2a95#a0a2a950a7921baffde6e041bc4e5822c0aab766"
+source = "git+https://github.com/shane-moore/lighthouse?rev=66ff63a#66ff63a8d8d9fd75c5a842477f7789b93a996ee0"
 dependencies = [
  "winapi",
  "windows-acl",
@@ -3130,7 +3129,7 @@ dependencies = [
 [[package]]
 name = "fixed_bytes"
 version = "0.1.0"
-source = "git+https://github.com/shane-moore/lighthouse?rev=a0a2a95#a0a2a950a7921baffde6e041bc4e5822c0aab766"
+source = "git+https://github.com/shane-moore/lighthouse?rev=66ff63a#66ff63a8d8d9fd75c5a842477f7789b93a996ee0"
 dependencies = [
  "alloy-primitives 1.5.7",
  "safe_arith",
@@ -3381,20 +3380,20 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "139ef39800118c7683f2fd3c98c1b23c09ae076556b435f8e9064ae108aaeeec"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "wasip2",
  "wasip3",
 ]
@@ -3450,7 +3449,7 @@ dependencies = [
 [[package]]
 name = "graffiti_file"
 version = "0.1.0"
-source = "git+https://github.com/shane-moore/lighthouse?rev=a0a2a95#a0a2a950a7921baffde6e041bc4e5822c0aab766"
+source = "git+https://github.com/shane-moore/lighthouse?rev=66ff63a#66ff63a8d8d9fd75c5a842477f7789b93a996ee0"
 dependencies = [
  "bls",
  "serde",
@@ -3503,7 +3502,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
  "ahash",
- "allocator-api2",
 ]
 
 [[package]]
@@ -3533,15 +3531,6 @@ dependencies = [
 
 [[package]]
 name = "hashlink"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8094feaf31ff591f651a2664fb9cfd92bba7a60ce3197265e9482ebe753c8f7"
-dependencies = [
- "hashbrown 0.14.5",
-]
-
-[[package]]
-name = "hashlink"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
@@ -3559,9 +3548,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashlink"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea0b22561a9c04a7cb1a302c013e0259cd3b4bb619f145b32f72b8b4bcbed230"
+dependencies = [
+ "hashbrown 0.16.1",
+]
+
+[[package]]
 name = "health_metrics"
 version = "0.1.0"
-source = "git+https://github.com/shane-moore/lighthouse?rev=a0a2a95#a0a2a950a7921baffde6e041bc4e5822c0aab766"
+source = "git+https://github.com/shane-moore/lighthouse?rev=66ff63a#66ff63a8d8d9fd75c5a842477f7789b93a996ee0"
 dependencies = [
  "eth2",
  "metrics",
@@ -3829,7 +3827,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "socket2 0.6.2",
- "system-configuration 0.7.0",
+ "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
@@ -3848,7 +3846,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core",
 ]
 
 [[package]]
@@ -3976,19 +3974,19 @@ dependencies = [
 
 [[package]]
 name = "if-addrs"
-version = "0.10.2"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cabb0019d51a643781ff15c9c8a3e5dedc365c47211270f4e8f82812fedd8f0a"
+checksum = "c0a05c691e1fae256cf7013d99dad472dc52d5543322761f83ec8d47eab40d2b"
 dependencies = [
  "libc",
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "if-watch"
-version = "3.2.1"
+version = "3.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdf9d64cfcf380606e64f9a0bcf493616b65331199f984151a6fa11a7b3cde38"
+checksum = "71c02a5161c313f0cbdbadc511611893584a10a7b6153cb554bdf83ddce99ec2"
 dependencies = [
  "async-io",
  "core-foundation 0.9.4",
@@ -4002,7 +4000,7 @@ dependencies = [
  "netlink-proto",
  "netlink-sys",
  "rtnetlink",
- "system-configuration 0.6.1",
+ "system-configuration",
  "tokio",
  "windows",
 ]
@@ -4083,7 +4081,7 @@ dependencies = [
 [[package]]
 name = "int_to_bytes"
 version = "0.2.0"
-source = "git+https://github.com/shane-moore/lighthouse?rev=a0a2a95#a0a2a950a7921baffde6e041bc4e5822c0aab766"
+source = "git+https://github.com/shane-moore/lighthouse?rev=66ff63a#66ff63a8d8d9fd75c5a842477f7789b93a996ee0"
 dependencies = [
  "bytes",
 ]
@@ -4102,9 +4100,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.11.0"
+version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "iri-string"
@@ -4245,9 +4243,8 @@ dependencies = [
 [[package]]
 name = "kzg"
 version = "0.1.0"
-source = "git+https://github.com/shane-moore/lighthouse?rev=a0a2a95#a0a2a950a7921baffde6e041bc4e5822c0aab766"
+source = "git+https://github.com/shane-moore/lighthouse?rev=66ff63a#66ff63a8d8d9fd75c5a842477f7789b93a996ee0"
 dependencies = [
- "arbitrary",
  "c-kzg",
  "educe",
  "ethereum_hashing 0.8.0",
@@ -4715,19 +4712,18 @@ dependencies = [
 
 [[package]]
 name = "libredox"
-version = "0.1.12"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
+checksum = "1744e39d1d6a9948f4f388969627434e31128196de472883b39f148769bfe30a"
 dependencies = [
- "bitflags 2.11.0",
  "libc",
 ]
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.25.2"
+version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29f835d03d717946d28b1d1ed632eb6f0e24a299388ee623d0c23118d3e8a7fa"
+checksum = "95b4103cffefa72eb8428cb6b47d6627161e51c2739fc5e3b734584157bc642a"
 dependencies = [
  "cc",
  "pkg-config",
@@ -4781,7 +4777,7 @@ dependencies = [
 [[package]]
 name = "logging"
 version = "0.2.0"
-source = "git+https://github.com/shane-moore/lighthouse?rev=a0a2a95#a0a2a950a7921baffde6e041bc4e5822c0aab766"
+source = "git+https://github.com/shane-moore/lighthouse?rev=66ff63a#66ff63a8d8d9fd75c5a842477f7789b93a996ee0"
 dependencies = [
  "chrono",
  "logroller",
@@ -4836,7 +4832,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 [[package]]
 name = "lru_cache"
 version = "0.1.0"
-source = "git+https://github.com/shane-moore/lighthouse?rev=a0a2a95#a0a2a950a7921baffde6e041bc4e5822c0aab766"
+source = "git+https://github.com/shane-moore/lighthouse?rev=66ff63a#66ff63a8d8d9fd75c5a842477f7789b93a996ee0"
 dependencies = [
  "fnv",
 ]
@@ -4917,7 +4913,7 @@ dependencies = [
 [[package]]
 name = "merkle_proof"
 version = "0.2.0"
-source = "git+https://github.com/shane-moore/lighthouse?rev=a0a2a95#a0a2a950a7921baffde6e041bc4e5822c0aab766"
+source = "git+https://github.com/shane-moore/lighthouse?rev=66ff63a#66ff63a8d8d9fd75c5a842477f7789b93a996ee0"
 dependencies = [
  "alloy-primitives 1.5.7",
  "ethereum_hashing 0.8.0",
@@ -5016,7 +5012,7 @@ dependencies = [
 [[package]]
 name = "metrics"
 version = "0.2.0"
-source = "git+https://github.com/shane-moore/lighthouse?rev=a0a2a95#a0a2a950a7921baffde6e041bc4e5822c0aab766"
+source = "git+https://github.com/shane-moore/lighthouse?rev=66ff63a#66ff63a8d8d9fd75c5a842477f7789b93a996ee0"
 dependencies = [
  "prometheus",
 ]
@@ -5079,9 +5075,9 @@ dependencies = [
 
 [[package]]
 name = "moka"
-version = "0.12.13"
+version = "0.12.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ac832c50ced444ef6be0767a008b02c106a909ba79d1d830501e94b96f6b7e"
+checksum = "85f8024e1c8e71c778968af91d43700ce1d11b219d127d79fb2934153b82b42b"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-epoch",
@@ -5091,7 +5087,7 @@ dependencies = [
  "portable-atomic",
  "smallvec",
  "tagptr",
- "uuid 1.21.0",
+ "uuid",
 ]
 
 [[package]]
@@ -5174,46 +5170,30 @@ dependencies = [
 
 [[package]]
 name = "netlink-packet-core"
-version = "0.7.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72724faf704479d67b388da142b186f916188505e7e0b26719019c525882eda4"
+checksum = "3463cbb78394cb0141e2c926b93fc2197e473394b761986eca3b9da2c63ae0f4"
 dependencies = [
- "anyhow",
- "byteorder",
- "netlink-packet-utils",
+ "paste",
 ]
 
 [[package]]
 name = "netlink-packet-route"
-version = "0.17.1"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053998cea5a306971f88580d0829e90f270f940befd7cf928da179d4187a5a66"
+checksum = "4ce3636fa715e988114552619582b530481fd5ef176a1e5c1bf024077c2c9445"
 dependencies = [
- "anyhow",
- "bitflags 1.3.2",
- "byteorder",
+ "bitflags 2.11.0",
  "libc",
+ "log",
  "netlink-packet-core",
- "netlink-packet-utils",
-]
-
-[[package]]
-name = "netlink-packet-utils"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ede8a08c71ad5a95cdd0e4e52facd37190977039a4704eb82a283f713747d34"
-dependencies = [
- "anyhow",
- "byteorder",
- "paste",
- "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "netlink-proto"
-version = "0.11.5"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72452e012c2f8d612410d89eea01e2d9b56205274abb35d53f60200b2ec41d60"
+checksum = "b65d130ee111430e47eed7896ea43ca693c387f097dd97376bffafbf25812128"
 dependencies = [
  "bytes",
  "futures",
@@ -5276,7 +5256,7 @@ dependencies = [
 [[package]]
 name = "network_utils"
 version = "0.1.0"
-source = "git+https://github.com/shane-moore/lighthouse?rev=a0a2a95#a0a2a950a7921baffde6e041bc4e5822c0aab766"
+source = "git+https://github.com/shane-moore/lighthouse?rev=66ff63a#66ff63a8d8d9fd75c5a842477f7789b93a996ee0"
 dependencies = [
  "discv5",
  "libp2p-identity",
@@ -5301,12 +5281,13 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.26.4"
+version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.11.0",
  "cfg-if",
+ "cfg_aliases",
  "libc",
 ]
 
@@ -5513,6 +5494,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
+name = "openssl-src"
+version = "300.5.5+3.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f1787d533e03597a7934fd0a765f0d28e94ecc5fb7789f8053b1e699a56f709"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5520,6 +5510,7 @@ checksum = "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321"
 dependencies = [
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]
@@ -5830,7 +5821,7 @@ dependencies = [
 [[package]]
 name = "pretty_reqwest_error"
 version = "0.1.0"
-source = "git+https://github.com/shane-moore/lighthouse?rev=a0a2a95#a0a2a950a7921baffde6e041bc4e5822c0aab766"
+source = "git+https://github.com/shane-moore/lighthouse?rev=66ff63a#66ff63a8d8d9fd75c5a842477f7789b93a996ee0"
 dependencies = [
  "reqwest",
  "sensitive_url",
@@ -5859,9 +5850,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "3.4.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
  "toml_edit",
 ]
@@ -5991,7 +5982,7 @@ dependencies = [
 [[package]]
 name = "proto_array"
 version = "0.2.0"
-source = "git+https://github.com/shane-moore/lighthouse?rev=a0a2a95#a0a2a950a7921baffde6e041bc4e5822c0aab766"
+source = "git+https://github.com/shane-moore/lighthouse?rev=66ff63a#66ff63a8d8d9fd75c5a842477f7789b93a996ee0"
 dependencies = [
  "ethereum_ssz",
  "ethereum_ssz_derive",
@@ -6149,9 +6140,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.44"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
@@ -6161,6 +6152,12 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "r2d2"
@@ -6175,12 +6172,13 @@ dependencies = [
 
 [[package]]
 name = "r2d2_sqlite"
-version = "0.21.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4f5d0337e99cd5cacd91ffc326c6cc9d8078def459df560c4f9bf9ba4a51034"
+checksum = "a2ebd03c29250cdf191da93a35118b4567c2ef0eacab54f65e058d6f4c9965f6"
 dependencies = [
  "r2d2",
  "rusqlite",
+ "uuid",
 ]
 
 [[package]]
@@ -6505,19 +6503,29 @@ dependencies = [
 ]
 
 [[package]]
-name = "rtnetlink"
-version = "0.13.1"
+name = "rsqlite-vfs"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a552eb82d19f38c3beed3f786bd23aa434ceb9ac43ab44419ca6d67a7e186c0"
+checksum = "a8a1f2315036ef6b1fbacd1972e8ee7688030b0a2121edfc2a6550febd41574d"
 dependencies = [
- "futures",
+ "hashbrown 0.16.1",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "rtnetlink"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b960d5d873a75b5be9761b1e73b146f52dddcd27bac75263f40fba686d4d7b5"
+dependencies = [
+ "futures-channel",
+ "futures-util",
  "log",
  "netlink-packet-core",
  "netlink-packet-route",
- "netlink-packet-utils",
  "netlink-proto",
  "netlink-sys",
- "nix 0.26.4",
+ "nix 0.30.1",
  "thiserror 1.0.69",
  "tokio",
 ]
@@ -6568,16 +6576,17 @@ checksum = "48fd7bd8a6377e15ad9d42a8ec25371b94ddc67abe7c8b9127bec79bebaaae18"
 
 [[package]]
 name = "rusqlite"
-version = "0.28.0"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01e213bc3ecb39ac32e81e51ebe31fd888a940515173e3a18a35f8c6e896422a"
+checksum = "f1c93dd1c9683b438c392c492109cb702b8090b2bfc8fed6f6e4eb4523f17af3"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.11.0",
  "fallible-iterator",
  "fallible-streaming-iterator",
- "hashlink 0.8.4",
+ "hashlink 0.11.0",
  "libsqlite3-sys",
  "smallvec",
+ "sqlite-wasm-rs",
 ]
 
 [[package]]
@@ -7139,9 +7148,8 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 [[package]]
 name = "slashing_protection"
 version = "0.1.0"
-source = "git+https://github.com/shane-moore/lighthouse?rev=a0a2a95#a0a2a950a7921baffde6e041bc4e5822c0aab766"
+source = "git+https://github.com/shane-moore/lighthouse?rev=66ff63a#66ff63a8d8d9fd75c5a842477f7789b93a996ee0"
 dependencies = [
- "arbitrary",
  "bls",
  "eip_3076",
  "ethereum_serde_utils 0.8.0",
@@ -7160,7 +7168,7 @@ dependencies = [
 [[package]]
 name = "slot_clock"
 version = "0.2.0"
-source = "git+https://github.com/shane-moore/lighthouse?rev=a0a2a95#a0a2a950a7921baffde6e041bc4e5822c0aab766"
+source = "git+https://github.com/shane-moore/lighthouse?rev=66ff63a#66ff63a8d8d9fd75c5a842477f7789b93a996ee0"
 dependencies = [
  "metrics",
  "parking_lot",
@@ -7173,7 +7181,6 @@ version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 dependencies = [
- "arbitrary",
  "serde",
 ]
 
@@ -7247,6 +7254,18 @@ checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
  "der",
+]
+
+[[package]]
+name = "sqlite-wasm-rs"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4206ed3a67690b9c29b77d728f6acc3ce78f16bf846d83c94f76400320181b"
+dependencies = [
+ "cc",
+ "js-sys",
+ "rsqlite-vfs",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -7394,7 +7413,7 @@ dependencies = [
 [[package]]
 name = "swap_or_not_shuffle"
 version = "0.2.0"
-source = "git+https://github.com/shane-moore/lighthouse?rev=a0a2a95#a0a2a950a7921baffde6e041bc4e5822c0aab766"
+source = "git+https://github.com/shane-moore/lighthouse?rev=66ff63a#66ff63a8d8d9fd75c5a842477f7789b93a996ee0"
 dependencies = [
  "alloy-primitives 1.5.7",
  "ethereum_hashing 0.8.0",
@@ -7457,17 +7476,6 @@ dependencies = [
 
 [[package]]
 name = "system-configuration"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
-dependencies = [
- "bitflags 2.11.0",
- "core-foundation 0.9.4",
- "system-configuration-sys",
-]
-
-[[package]]
-name = "system-configuration"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
@@ -7508,7 +7516,7 @@ checksum = "c63f48baada5c52e65a29eef93ab4f8982681b67f9e8d29c7b05abcfec2b9ffe"
 [[package]]
 name = "task_executor"
 version = "0.1.0"
-source = "git+https://github.com/shane-moore/lighthouse?rev=a0a2a95#a0a2a950a7921baffde6e041bc4e5822c0aab766"
+source = "git+https://github.com/shane-moore/lighthouse?rev=66ff63a#66ff63a8d8d9fd75c5a842477f7789b93a996ee0"
 dependencies = [
  "async-channel 1.9.0",
  "futures",
@@ -7526,7 +7534,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82a72c767771b47409d2345987fda8628641887d5466101319899796367354a0"
 dependencies = [
  "fastrand",
- "getrandom 0.4.1",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -7551,7 +7559,7 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 [[package]]
 name = "test_random_derive"
 version = "0.2.0"
-source = "git+https://github.com/shane-moore/lighthouse?rev=a0a2a95#a0a2a950a7921baffde6e041bc4e5822c0aab766"
+source = "git+https://github.com/shane-moore/lighthouse?rev=66ff63a#66ff63a8d8d9fd75c5a842477f7789b93a996ee0"
 dependencies = [
  "quote",
  "syn 2.0.117",
@@ -7682,9 +7690,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.49.0"
+version = "1.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
+checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
 dependencies = [
  "bytes",
  "libc",
@@ -7698,9 +7706,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
+checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7771,18 +7779,18 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.7.5+spec-1.1.0"
+version = "1.0.0+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+checksum = "32c2555c699578a4f59f0cc68e5116c8d7cabbd45e1409b989d4be085b53f13e"
 dependencies = [
  "serde_core",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.23.10+spec-1.0.0"
+version = "0.25.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
+checksum = "a0a07913e63758bc95142d9863a5a45173b71515e68b690cad70cf99c3255ce1"
 dependencies = [
  "indexmap 2.13.0",
  "toml_datetime",
@@ -8010,7 +8018,7 @@ checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 [[package]]
 name = "types"
 version = "0.2.1"
-source = "git+https://github.com/shane-moore/lighthouse?rev=a0a2a95#a0a2a950a7921baffde6e041bc4e5822c0aab766"
+source = "git+https://github.com/shane-moore/lighthouse?rev=66ff63a#66ff63a8d8d9fd75c5a842477f7789b93a996ee0"
 dependencies = [
  "alloy-primitives 1.5.7",
  "alloy-rlp",
@@ -8191,29 +8199,21 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
-dependencies = [
- "getrandom 0.2.17",
- "serde",
-]
-
-[[package]]
-name = "uuid"
 version = "1.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b672338555252d43fd2240c714dc444b8c6fb0a5c5335e65a07bba7742735ddb"
 dependencies = [
- "getrandom 0.4.1",
+ "getrandom 0.4.2",
  "js-sys",
+ "rand 0.9.2",
+ "serde_core",
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "validator_metrics"
 version = "0.1.0"
-source = "git+https://github.com/shane-moore/lighthouse?rev=a0a2a95#a0a2a950a7921baffde6e041bc4e5822c0aab766"
+source = "git+https://github.com/shane-moore/lighthouse?rev=66ff63a#66ff63a8d8d9fd75c5a842477f7789b93a996ee0"
 dependencies = [
  "metrics",
 ]
@@ -8221,7 +8221,7 @@ dependencies = [
 [[package]]
 name = "validator_services"
 version = "0.1.0"
-source = "git+https://github.com/shane-moore/lighthouse?rev=a0a2a95#a0a2a950a7921baffde6e041bc4e5822c0aab766"
+source = "git+https://github.com/shane-moore/lighthouse?rev=66ff63a#66ff63a8d8d9fd75c5a842477f7789b93a996ee0"
 dependencies = [
  "beacon_node_fallback",
  "bls",
@@ -8246,7 +8246,7 @@ dependencies = [
 [[package]]
 name = "validator_store"
 version = "0.1.0"
-source = "git+https://github.com/shane-moore/lighthouse?rev=a0a2a95#a0a2a950a7921baffde6e041bc4e5822c0aab766"
+source = "git+https://github.com/shane-moore/lighthouse?rev=66ff63a#66ff63a8d8d9fd75c5a842477f7789b93a996ee0"
 dependencies = [
  "bls",
  "eth2",
@@ -8524,12 +8524,14 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
-version = "0.53.0"
+version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efc5cf48f83140dcaab716eeaea345f9e93d0018fb81162753a3f76c3397b538"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
 dependencies = [
- "windows-core 0.53.0",
- "windows-targets 0.52.6",
+ "windows-collections",
+ "windows-core",
+ "windows-future",
+ "windows-numerics",
 ]
 
 [[package]]
@@ -8545,13 +8547,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-core"
-version = "0.53.0"
+name = "windows-collections"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dcc5b895a6377f1ab9fa55acedab1fd5ac0db66ad1e6c7f47e28a22e446a5dd"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
 dependencies = [
- "windows-result 0.1.2",
- "windows-targets 0.52.6",
+ "windows-core",
 ]
 
 [[package]]
@@ -8563,8 +8564,19 @@ dependencies = [
  "windows-implement",
  "windows-interface",
  "windows-link",
- "windows-result 0.4.1",
+ "windows-result",
  "windows-strings",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core",
+ "windows-link",
+ "windows-threading",
 ]
 
 [[package]]
@@ -8596,23 +8608,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core",
+ "windows-link",
+]
+
+[[package]]
 name = "windows-registry"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
 dependencies = [
  "windows-link",
- "windows-result 0.4.1",
+ "windows-result",
  "windows-strings",
-]
-
-[[package]]
-name = "windows-result"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
-dependencies = [
- "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -8724,6 +8737,15 @@ dependencies = [
  "windows_x86_64_gnu 0.53.1",
  "windows_x86_64_gnullvm 0.53.1",
  "windows_x86_64_msvc 0.53.1",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
@@ -8974,7 +8996,7 @@ dependencies = [
 [[package]]
 name = "workspace_members"
 version = "0.1.0"
-source = "git+https://github.com/shane-moore/lighthouse?rev=a0a2a95#a0a2a950a7921baffde6e041bc4e5822c0aab766"
+source = "git+https://github.com/shane-moore/lighthouse?rev=66ff63a#66ff63a8d8d9fd75c5a842477f7789b93a996ee0"
 dependencies = [
  "cargo_metadata",
  "quote",
@@ -9231,9 +9253,9 @@ dependencies = [
 
 [[package]]
 name = "zlib-rs"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c745c48e1007337ed136dc99df34128b9faa6ed542d80a1c673cf55a6d7236c8"
+checksum = "3be3d40e40a133f9c916ee3f9f4fa2d9d63435b5fbe1bfc6d9dae0aa0ada1513"
 
 [[package]]
 name = "zmij"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -239,9 +239,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-eip7928"
-version = "0.3.3"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8222b1d88f9a6d03be84b0f5e76bb60cd83991b43ad8ab6477f0e4a7809b98d"
+checksum = "d3231de68d5d6e75332b7489cfcc7f4dfabeba94d990a10e4b923af0e6623540"
 dependencies = [
  "alloy-primitives 1.5.7",
  "alloy-rlp",
@@ -393,7 +393,7 @@ dependencies = [
  "const-hex",
  "derive_more 2.1.1",
  "foldhash 0.2.0",
- "getrandom 0.4.2",
+ "getrandom 0.4.1",
  "hashbrown 0.16.1",
  "indexmap 2.13.0",
  "itoa",
@@ -1399,7 +1399,7 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 [[package]]
 name = "beacon_node_fallback"
 version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?rev=f4b5b03#f4b5b033a227fcacdb8e8514bbca6cf6702f3a24"
+source = "git+https://github.com/shane-moore/lighthouse?rev=a0a2a95#a0a2a950a7921baffde6e041bc4e5822c0aab766"
 dependencies = [
  "bls",
  "clap",
@@ -1499,9 +1499,10 @@ dependencies = [
 [[package]]
 name = "bls"
 version = "0.2.0"
-source = "git+https://github.com/sigp/lighthouse?rev=f4b5b03#f4b5b033a227fcacdb8e8514bbca6cf6702f3a24"
+source = "git+https://github.com/shane-moore/lighthouse?rev=a0a2a95#a0a2a950a7921baffde6e041bc4e5822c0aab766"
 dependencies = [
  "alloy-primitives 1.5.7",
+ "arbitrary",
  "blst",
  "ethereum_hashing 0.8.0",
  "ethereum_serde_utils 0.8.0",
@@ -1869,9 +1870,9 @@ dependencies = [
 
 [[package]]
 name = "const-hex"
-version = "1.18.1"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "531185e432bb31db1ecda541e9e7ab21468d4d844ad7505e0546a49b4945d49b"
+checksum = "af9a108e542ddf1de36743a6126e94d6659dccda38fc8a77e80b915102ac784a"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -2568,7 +2569,7 @@ dependencies = [
 [[package]]
 name = "eip_3076"
 version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?rev=f4b5b03#f4b5b033a227fcacdb8e8514bbca6cf6702f3a24"
+source = "git+https://github.com/shane-moore/lighthouse?rev=a0a2a95#a0a2a950a7921baffde6e041bc4e5822c0aab766"
 dependencies = [
  "bls",
  "ethereum_serde_utils 0.8.0",
@@ -2803,7 +2804,7 @@ dependencies = [
 [[package]]
 name = "eth2"
 version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?rev=f4b5b03#f4b5b033a227fcacdb8e8514bbca6cf6702f3a24"
+source = "git+https://github.com/shane-moore/lighthouse?rev=a0a2a95#a0a2a950a7921baffde6e041bc4e5822c0aab766"
 dependencies = [
  "bls",
  "context_deserialize",
@@ -2832,7 +2833,7 @@ dependencies = [
 [[package]]
 name = "eth2_config"
 version = "0.2.0"
-source = "git+https://github.com/sigp/lighthouse?rev=f4b5b03#f4b5b033a227fcacdb8e8514bbca6cf6702f3a24"
+source = "git+https://github.com/shane-moore/lighthouse?rev=a0a2a95#a0a2a950a7921baffde6e041bc4e5822c0aab766"
 dependencies = [
  "paste",
  "types",
@@ -2841,7 +2842,7 @@ dependencies = [
 [[package]]
 name = "eth2_interop_keypairs"
 version = "0.2.0"
-source = "git+https://github.com/sigp/lighthouse?rev=f4b5b03#f4b5b033a227fcacdb8e8514bbca6cf6702f3a24"
+source = "git+https://github.com/shane-moore/lighthouse?rev=a0a2a95#a0a2a950a7921baffde6e041bc4e5822c0aab766"
 dependencies = [
  "bls",
  "ethereum_hashing 0.8.0",
@@ -2854,7 +2855,7 @@ dependencies = [
 [[package]]
 name = "eth2_key_derivation"
 version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?rev=f4b5b03#f4b5b033a227fcacdb8e8514bbca6cf6702f3a24"
+source = "git+https://github.com/shane-moore/lighthouse?rev=a0a2a95#a0a2a950a7921baffde6e041bc4e5822c0aab766"
 dependencies = [
  "bls",
  "num-bigint-dig",
@@ -2866,7 +2867,7 @@ dependencies = [
 [[package]]
 name = "eth2_keystore"
 version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?rev=f4b5b03#f4b5b033a227fcacdb8e8514bbca6cf6702f3a24"
+source = "git+https://github.com/shane-moore/lighthouse?rev=a0a2a95#a0a2a950a7921baffde6e041bc4e5822c0aab766"
 dependencies = [
  "aes",
  "bls",
@@ -2883,14 +2884,14 @@ dependencies = [
  "serde_repr",
  "sha2",
  "unicode-normalization",
- "uuid",
+ "uuid 0.8.2",
  "zeroize",
 ]
 
 [[package]]
 name = "eth2_network_config"
 version = "0.2.0"
-source = "git+https://github.com/sigp/lighthouse?rev=f4b5b03#f4b5b033a227fcacdb8e8514bbca6cf6702f3a24"
+source = "git+https://github.com/shane-moore/lighthouse?rev=a0a2a95#a0a2a950a7921baffde6e041bc4e5822c0aab766"
 dependencies = [
  "bytes",
  "discv5",
@@ -3024,9 +3025,9 @@ dependencies = [
 
 [[package]]
 name = "fallible-iterator"
-version = "0.3.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
 
 [[package]]
 name = "fallible-streaming-iterator"
@@ -3102,7 +3103,7 @@ dependencies = [
 [[package]]
 name = "filesystem"
 version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?rev=f4b5b03#f4b5b033a227fcacdb8e8514bbca6cf6702f3a24"
+source = "git+https://github.com/shane-moore/lighthouse?rev=a0a2a95#a0a2a950a7921baffde6e041bc4e5822c0aab766"
 dependencies = [
  "winapi",
  "windows-acl",
@@ -3129,7 +3130,7 @@ dependencies = [
 [[package]]
 name = "fixed_bytes"
 version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?rev=f4b5b03#f4b5b033a227fcacdb8e8514bbca6cf6702f3a24"
+source = "git+https://github.com/shane-moore/lighthouse?rev=a0a2a95#a0a2a950a7921baffde6e041bc4e5822c0aab766"
 dependencies = [
  "alloy-primitives 1.5.7",
  "safe_arith",
@@ -3380,20 +3381,20 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi 5.3.0",
+ "r-efi",
  "wasip2",
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.4.2"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+checksum = "139ef39800118c7683f2fd3c98c1b23c09ae076556b435f8e9064ae108aaeeec"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi 6.0.0",
+ "r-efi",
  "wasip2",
  "wasip3",
 ]
@@ -3449,7 +3450,7 @@ dependencies = [
 [[package]]
 name = "graffiti_file"
 version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?rev=f4b5b03#f4b5b033a227fcacdb8e8514bbca6cf6702f3a24"
+source = "git+https://github.com/shane-moore/lighthouse?rev=a0a2a95#a0a2a950a7921baffde6e041bc4e5822c0aab766"
 dependencies = [
  "bls",
  "serde",
@@ -3502,6 +3503,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
  "ahash",
+ "allocator-api2",
 ]
 
 [[package]]
@@ -3531,6 +3533,15 @@ dependencies = [
 
 [[package]]
 name = "hashlink"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8094feaf31ff591f651a2664fb9cfd92bba7a60ce3197265e9482ebe753c8f7"
+dependencies = [
+ "hashbrown 0.14.5",
+]
+
+[[package]]
+name = "hashlink"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
@@ -3548,18 +3559,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "hashlink"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea0b22561a9c04a7cb1a302c013e0259cd3b4bb619f145b32f72b8b4bcbed230"
-dependencies = [
- "hashbrown 0.16.1",
-]
-
-[[package]]
 name = "health_metrics"
 version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?rev=f4b5b03#f4b5b033a227fcacdb8e8514bbca6cf6702f3a24"
+source = "git+https://github.com/shane-moore/lighthouse?rev=a0a2a95#a0a2a950a7921baffde6e041bc4e5822c0aab766"
 dependencies = [
  "eth2",
  "metrics",
@@ -3827,7 +3829,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "socket2 0.6.2",
- "system-configuration",
+ "system-configuration 0.7.0",
  "tokio",
  "tower-service",
  "tracing",
@@ -3846,7 +3848,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -3974,19 +3976,19 @@ dependencies = [
 
 [[package]]
 name = "if-addrs"
-version = "0.15.0"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0a05c691e1fae256cf7013d99dad472dc52d5543322761f83ec8d47eab40d2b"
+checksum = "cabb0019d51a643781ff15c9c8a3e5dedc365c47211270f4e8f82812fedd8f0a"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
 name = "if-watch"
-version = "3.2.2"
+version = "3.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71c02a5161c313f0cbdbadc511611893584a10a7b6153cb554bdf83ddce99ec2"
+checksum = "cdf9d64cfcf380606e64f9a0bcf493616b65331199f984151a6fa11a7b3cde38"
 dependencies = [
  "async-io",
  "core-foundation 0.9.4",
@@ -4000,7 +4002,7 @@ dependencies = [
  "netlink-proto",
  "netlink-sys",
  "rtnetlink",
- "system-configuration",
+ "system-configuration 0.6.1",
  "tokio",
  "windows",
 ]
@@ -4081,7 +4083,7 @@ dependencies = [
 [[package]]
 name = "int_to_bytes"
 version = "0.2.0"
-source = "git+https://github.com/sigp/lighthouse?rev=f4b5b03#f4b5b033a227fcacdb8e8514bbca6cf6702f3a24"
+source = "git+https://github.com/shane-moore/lighthouse?rev=a0a2a95#a0a2a950a7921baffde6e041bc4e5822c0aab766"
 dependencies = [
  "bytes",
 ]
@@ -4100,9 +4102,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.12.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 
 [[package]]
 name = "iri-string"
@@ -4243,8 +4245,9 @@ dependencies = [
 [[package]]
 name = "kzg"
 version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?rev=f4b5b03#f4b5b033a227fcacdb8e8514bbca6cf6702f3a24"
+source = "git+https://github.com/shane-moore/lighthouse?rev=a0a2a95#a0a2a950a7921baffde6e041bc4e5822c0aab766"
 dependencies = [
+ "arbitrary",
  "c-kzg",
  "educe",
  "ethereum_hashing 0.8.0",
@@ -4712,18 +4715,19 @@ dependencies = [
 
 [[package]]
 name = "libredox"
-version = "0.1.14"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1744e39d1d6a9948f4f388969627434e31128196de472883b39f148769bfe30a"
+checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
 dependencies = [
+ "bitflags 2.11.0",
  "libc",
 ]
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.36.0"
+version = "0.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95b4103cffefa72eb8428cb6b47d6627161e51c2739fc5e3b734584157bc642a"
+checksum = "29f835d03d717946d28b1d1ed632eb6f0e24a299388ee623d0c23118d3e8a7fa"
 dependencies = [
  "cc",
  "pkg-config",
@@ -4777,7 +4781,7 @@ dependencies = [
 [[package]]
 name = "logging"
 version = "0.2.0"
-source = "git+https://github.com/sigp/lighthouse?rev=f4b5b03#f4b5b033a227fcacdb8e8514bbca6cf6702f3a24"
+source = "git+https://github.com/shane-moore/lighthouse?rev=a0a2a95#a0a2a950a7921baffde6e041bc4e5822c0aab766"
 dependencies = [
  "chrono",
  "logroller",
@@ -4832,7 +4836,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 [[package]]
 name = "lru_cache"
 version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?rev=f4b5b03#f4b5b033a227fcacdb8e8514bbca6cf6702f3a24"
+source = "git+https://github.com/shane-moore/lighthouse?rev=a0a2a95#a0a2a950a7921baffde6e041bc4e5822c0aab766"
 dependencies = [
  "fnv",
 ]
@@ -4913,7 +4917,7 @@ dependencies = [
 [[package]]
 name = "merkle_proof"
 version = "0.2.0"
-source = "git+https://github.com/sigp/lighthouse?rev=f4b5b03#f4b5b033a227fcacdb8e8514bbca6cf6702f3a24"
+source = "git+https://github.com/shane-moore/lighthouse?rev=a0a2a95#a0a2a950a7921baffde6e041bc4e5822c0aab766"
 dependencies = [
  "alloy-primitives 1.5.7",
  "ethereum_hashing 0.8.0",
@@ -5012,7 +5016,7 @@ dependencies = [
 [[package]]
 name = "metrics"
 version = "0.2.0"
-source = "git+https://github.com/sigp/lighthouse?rev=f4b5b03#f4b5b033a227fcacdb8e8514bbca6cf6702f3a24"
+source = "git+https://github.com/shane-moore/lighthouse?rev=a0a2a95#a0a2a950a7921baffde6e041bc4e5822c0aab766"
 dependencies = [
  "prometheus",
 ]
@@ -5075,9 +5079,9 @@ dependencies = [
 
 [[package]]
 name = "moka"
-version = "0.12.14"
+version = "0.12.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85f8024e1c8e71c778968af91d43700ce1d11b219d127d79fb2934153b82b42b"
+checksum = "b4ac832c50ced444ef6be0767a008b02c106a909ba79d1d830501e94b96f6b7e"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-epoch",
@@ -5087,7 +5091,7 @@ dependencies = [
  "portable-atomic",
  "smallvec",
  "tagptr",
- "uuid",
+ "uuid 1.21.0",
 ]
 
 [[package]]
@@ -5170,30 +5174,46 @@ dependencies = [
 
 [[package]]
 name = "netlink-packet-core"
-version = "0.8.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3463cbb78394cb0141e2c926b93fc2197e473394b761986eca3b9da2c63ae0f4"
+checksum = "72724faf704479d67b388da142b186f916188505e7e0b26719019c525882eda4"
 dependencies = [
- "paste",
+ "anyhow",
+ "byteorder",
+ "netlink-packet-utils",
 ]
 
 [[package]]
 name = "netlink-packet-route"
-version = "0.28.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ce3636fa715e988114552619582b530481fd5ef176a1e5c1bf024077c2c9445"
+checksum = "053998cea5a306971f88580d0829e90f270f940befd7cf928da179d4187a5a66"
 dependencies = [
- "bitflags 2.11.0",
+ "anyhow",
+ "bitflags 1.3.2",
+ "byteorder",
  "libc",
- "log",
  "netlink-packet-core",
+ "netlink-packet-utils",
+]
+
+[[package]]
+name = "netlink-packet-utils"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ede8a08c71ad5a95cdd0e4e52facd37190977039a4704eb82a283f713747d34"
+dependencies = [
+ "anyhow",
+ "byteorder",
+ "paste",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "netlink-proto"
-version = "0.12.0"
+version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b65d130ee111430e47eed7896ea43ca693c387f097dd97376bffafbf25812128"
+checksum = "72452e012c2f8d612410d89eea01e2d9b56205274abb35d53f60200b2ec41d60"
 dependencies = [
  "bytes",
  "futures",
@@ -5256,7 +5276,7 @@ dependencies = [
 [[package]]
 name = "network_utils"
 version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?rev=f4b5b03#f4b5b033a227fcacdb8e8514bbca6cf6702f3a24"
+source = "git+https://github.com/shane-moore/lighthouse?rev=a0a2a95#a0a2a950a7921baffde6e041bc4e5822c0aab766"
 dependencies = [
  "discv5",
  "libp2p-identity",
@@ -5281,13 +5301,12 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.30.1"
+version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 1.3.2",
  "cfg-if",
- "cfg_aliases",
  "libc",
 ]
 
@@ -5494,15 +5513,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
-name = "openssl-src"
-version = "300.5.5+3.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f1787d533e03597a7934fd0a765f0d28e94ecc5fb7789f8053b1e699a56f709"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "openssl-sys"
 version = "0.9.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5510,7 +5520,6 @@ checksum = "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321"
 dependencies = [
  "cc",
  "libc",
- "openssl-src",
  "pkg-config",
  "vcpkg",
 ]
@@ -5821,7 +5830,7 @@ dependencies = [
 [[package]]
 name = "pretty_reqwest_error"
 version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?rev=f4b5b03#f4b5b033a227fcacdb8e8514bbca6cf6702f3a24"
+source = "git+https://github.com/shane-moore/lighthouse?rev=a0a2a95#a0a2a950a7921baffde6e041bc4e5822c0aab766"
 dependencies = [
  "reqwest",
  "sensitive_url",
@@ -5982,7 +5991,7 @@ dependencies = [
 [[package]]
 name = "proto_array"
 version = "0.2.0"
-source = "git+https://github.com/sigp/lighthouse?rev=f4b5b03#f4b5b033a227fcacdb8e8514bbca6cf6702f3a24"
+source = "git+https://github.com/shane-moore/lighthouse?rev=a0a2a95#a0a2a950a7921baffde6e041bc4e5822c0aab766"
 dependencies = [
  "ethereum_ssz",
  "ethereum_ssz_derive",
@@ -6140,9 +6149,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
 dependencies = [
  "proc-macro2",
 ]
@@ -6152,12 +6161,6 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
-
-[[package]]
-name = "r-efi"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "r2d2"
@@ -6172,13 +6175,12 @@ dependencies = [
 
 [[package]]
 name = "r2d2_sqlite"
-version = "0.32.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2ebd03c29250cdf191da93a35118b4567c2ef0eacab54f65e058d6f4c9965f6"
+checksum = "b4f5d0337e99cd5cacd91ffc326c6cc9d8078def459df560c4f9bf9ba4a51034"
 dependencies = [
  "r2d2",
  "rusqlite",
- "uuid",
 ]
 
 [[package]]
@@ -6503,29 +6505,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "rsqlite-vfs"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8a1f2315036ef6b1fbacd1972e8ee7688030b0a2121edfc2a6550febd41574d"
-dependencies = [
- "hashbrown 0.16.1",
- "thiserror 2.0.18",
-]
-
-[[package]]
 name = "rtnetlink"
-version = "0.20.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b960d5d873a75b5be9761b1e73b146f52dddcd27bac75263f40fba686d4d7b5"
+checksum = "7a552eb82d19f38c3beed3f786bd23aa434ceb9ac43ab44419ca6d67a7e186c0"
 dependencies = [
- "futures-channel",
- "futures-util",
+ "futures",
  "log",
  "netlink-packet-core",
  "netlink-packet-route",
+ "netlink-packet-utils",
  "netlink-proto",
  "netlink-sys",
- "nix 0.30.1",
+ "nix 0.26.4",
  "thiserror 1.0.69",
  "tokio",
 ]
@@ -6576,17 +6568,16 @@ checksum = "48fd7bd8a6377e15ad9d42a8ec25371b94ddc67abe7c8b9127bec79bebaaae18"
 
 [[package]]
 name = "rusqlite"
-version = "0.38.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1c93dd1c9683b438c392c492109cb702b8090b2bfc8fed6f6e4eb4523f17af3"
+checksum = "01e213bc3ecb39ac32e81e51ebe31fd888a940515173e3a18a35f8c6e896422a"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 1.3.2",
  "fallible-iterator",
  "fallible-streaming-iterator",
- "hashlink 0.11.0",
+ "hashlink 0.8.4",
  "libsqlite3-sys",
  "smallvec",
- "sqlite-wasm-rs",
 ]
 
 [[package]]
@@ -7148,8 +7139,9 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 [[package]]
 name = "slashing_protection"
 version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?rev=f4b5b03#f4b5b033a227fcacdb8e8514bbca6cf6702f3a24"
+source = "git+https://github.com/shane-moore/lighthouse?rev=a0a2a95#a0a2a950a7921baffde6e041bc4e5822c0aab766"
 dependencies = [
+ "arbitrary",
  "bls",
  "eip_3076",
  "ethereum_serde_utils 0.8.0",
@@ -7168,7 +7160,7 @@ dependencies = [
 [[package]]
 name = "slot_clock"
 version = "0.2.0"
-source = "git+https://github.com/sigp/lighthouse?rev=f4b5b03#f4b5b033a227fcacdb8e8514bbca6cf6702f3a24"
+source = "git+https://github.com/shane-moore/lighthouse?rev=a0a2a95#a0a2a950a7921baffde6e041bc4e5822c0aab766"
 dependencies = [
  "metrics",
  "parking_lot",
@@ -7181,6 +7173,7 @@ version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 dependencies = [
+ "arbitrary",
  "serde",
 ]
 
@@ -7254,18 +7247,6 @@ checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
  "der",
-]
-
-[[package]]
-name = "sqlite-wasm-rs"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f4206ed3a67690b9c29b77d728f6acc3ce78f16bf846d83c94f76400320181b"
-dependencies = [
- "cc",
- "js-sys",
- "rsqlite-vfs",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -7413,7 +7394,7 @@ dependencies = [
 [[package]]
 name = "swap_or_not_shuffle"
 version = "0.2.0"
-source = "git+https://github.com/sigp/lighthouse?rev=f4b5b03#f4b5b033a227fcacdb8e8514bbca6cf6702f3a24"
+source = "git+https://github.com/shane-moore/lighthouse?rev=a0a2a95#a0a2a950a7921baffde6e041bc4e5822c0aab766"
 dependencies = [
  "alloy-primitives 1.5.7",
  "ethereum_hashing 0.8.0",
@@ -7476,6 +7457,17 @@ dependencies = [
 
 [[package]]
 name = "system-configuration"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
+dependencies = [
+ "bitflags 2.11.0",
+ "core-foundation 0.9.4",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
@@ -7516,7 +7508,7 @@ checksum = "c63f48baada5c52e65a29eef93ab4f8982681b67f9e8d29c7b05abcfec2b9ffe"
 [[package]]
 name = "task_executor"
 version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?rev=f4b5b03#f4b5b033a227fcacdb8e8514bbca6cf6702f3a24"
+source = "git+https://github.com/shane-moore/lighthouse?rev=a0a2a95#a0a2a950a7921baffde6e041bc4e5822c0aab766"
 dependencies = [
  "async-channel 1.9.0",
  "futures",
@@ -7534,7 +7526,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82a72c767771b47409d2345987fda8628641887d5466101319899796367354a0"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.4.1",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -7559,7 +7551,7 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 [[package]]
 name = "test_random_derive"
 version = "0.2.0"
-source = "git+https://github.com/sigp/lighthouse?rev=f4b5b03#f4b5b033a227fcacdb8e8514bbca6cf6702f3a24"
+source = "git+https://github.com/shane-moore/lighthouse?rev=a0a2a95#a0a2a950a7921baffde6e041bc4e5822c0aab766"
 dependencies = [
  "quote",
  "syn 2.0.117",
@@ -7690,9 +7682,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.50.0"
+version = "1.49.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
 dependencies = [
  "bytes",
  "libc",
@@ -7706,9 +7698,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.1"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8018,7 +8010,7 @@ checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 [[package]]
 name = "types"
 version = "0.2.1"
-source = "git+https://github.com/sigp/lighthouse?rev=f4b5b03#f4b5b033a227fcacdb8e8514bbca6cf6702f3a24"
+source = "git+https://github.com/shane-moore/lighthouse?rev=a0a2a95#a0a2a950a7921baffde6e041bc4e5822c0aab766"
 dependencies = [
  "alloy-primitives 1.5.7",
  "alloy-rlp",
@@ -8199,21 +8191,29 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
+dependencies = [
+ "getrandom 0.2.17",
+ "serde",
+]
+
+[[package]]
+name = "uuid"
 version = "1.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b672338555252d43fd2240c714dc444b8c6fb0a5c5335e65a07bba7742735ddb"
 dependencies = [
- "getrandom 0.4.2",
+ "getrandom 0.4.1",
  "js-sys",
- "rand 0.9.2",
- "serde_core",
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "validator_metrics"
 version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?rev=f4b5b03#f4b5b033a227fcacdb8e8514bbca6cf6702f3a24"
+source = "git+https://github.com/shane-moore/lighthouse?rev=a0a2a95#a0a2a950a7921baffde6e041bc4e5822c0aab766"
 dependencies = [
  "metrics",
 ]
@@ -8221,7 +8221,7 @@ dependencies = [
 [[package]]
 name = "validator_services"
 version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?rev=f4b5b03#f4b5b033a227fcacdb8e8514bbca6cf6702f3a24"
+source = "git+https://github.com/shane-moore/lighthouse?rev=a0a2a95#a0a2a950a7921baffde6e041bc4e5822c0aab766"
 dependencies = [
  "beacon_node_fallback",
  "bls",
@@ -8246,10 +8246,11 @@ dependencies = [
 [[package]]
 name = "validator_store"
 version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?rev=f4b5b03#f4b5b033a227fcacdb8e8514bbca6cf6702f3a24"
+source = "git+https://github.com/shane-moore/lighthouse?rev=a0a2a95#a0a2a950a7921baffde6e041bc4e5822c0aab766"
 dependencies = [
  "bls",
  "eth2",
+ "futures",
  "slashing_protection",
  "types",
 ]
@@ -8523,14 +8524,12 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
-version = "0.62.2"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+checksum = "efc5cf48f83140dcaab716eeaea345f9e93d0018fb81162753a3f76c3397b538"
 dependencies = [
- "windows-collections",
- "windows-core",
- "windows-future",
- "windows-numerics",
+ "windows-core 0.53.0",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -8546,12 +8545,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-collections"
-version = "0.3.2"
+name = "windows-core"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
+checksum = "9dcc5b895a6377f1ab9fa55acedab1fd5ac0db66ad1e6c7f47e28a22e446a5dd"
 dependencies = [
- "windows-core",
+ "windows-result 0.1.2",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -8563,19 +8563,8 @@ dependencies = [
  "windows-implement",
  "windows-interface",
  "windows-link",
- "windows-result",
+ "windows-result 0.4.1",
  "windows-strings",
-]
-
-[[package]]
-name = "windows-future"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
-dependencies = [
- "windows-core",
- "windows-link",
- "windows-threading",
 ]
 
 [[package]]
@@ -8607,24 +8596,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
-name = "windows-numerics"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
-dependencies = [
- "windows-core",
- "windows-link",
-]
-
-[[package]]
 name = "windows-registry"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
 dependencies = [
  "windows-link",
- "windows-result",
+ "windows-result 0.4.1",
  "windows-strings",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -8736,15 +8724,6 @@ dependencies = [
  "windows_x86_64_gnu 0.53.1",
  "windows_x86_64_gnullvm 0.53.1",
  "windows_x86_64_msvc 0.53.1",
-]
-
-[[package]]
-name = "windows-threading"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
-dependencies = [
- "windows-link",
 ]
 
 [[package]]
@@ -8995,7 +8974,7 @@ dependencies = [
 [[package]]
 name = "workspace_members"
 version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?rev=f4b5b03#f4b5b033a227fcacdb8e8514bbca6cf6702f3a24"
+source = "git+https://github.com/shane-moore/lighthouse?rev=a0a2a95#a0a2a950a7921baffde6e041bc4e5822c0aab766"
 dependencies = [
  "cargo_metadata",
  "quote",
@@ -9252,9 +9231,9 @@ dependencies = [
 
 [[package]]
 name = "zlib-rs"
-version = "0.6.3"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3be3d40e40a133f9c916ee3f9f4fa2d9d63435b5fbe1bfc6d9dae0aa0ada1513"
+checksum = "c745c48e1007337ed136dc99df34128b9faa6ed542d80a1c673cf55a6d7236c8"
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,23 +69,25 @@ ssv_types = { path = "anchor/common/ssv_types" }
 subnet_service = { path = "anchor/subnet_service" }
 version = { path = "anchor/common/version" }
 
-# Lighthouse version 8.1.0
-beacon_node_fallback = { git = "https://github.com/sigp/lighthouse", rev = "f4b5b03" }
-bls = { git = "https://github.com/sigp/lighthouse", rev = "f4b5b03" }
-eth2 = { git = "https://github.com/sigp/lighthouse", rev = "f4b5b03" }
-eth2_keystore = { git = "https://github.com/sigp/lighthouse", rev = "f4b5b03" }
-eth2_network_config = { git = "https://github.com/sigp/lighthouse", rev = "f4b5b03" }
-health_metrics = { git = "https://github.com/sigp/lighthouse", rev = "f4b5b03" }
-metrics = { git = "https://github.com/sigp/lighthouse", rev = "f4b5b03" }
-network_utils = { git = "https://github.com/sigp/lighthouse", rev = "f4b5b03" }
-slashing_protection = { git = "https://github.com/sigp/lighthouse", rev = "f4b5b03" }
-slot_clock = { git = "https://github.com/sigp/lighthouse", rev = "f4b5b03" }
-task_executor = { git = "https://github.com/sigp/lighthouse", rev = "f4b5b03" }
-types = { git = "https://github.com/sigp/lighthouse", rev = "f4b5b03" }
-validator_metrics = { git = "https://github.com/sigp/lighthouse", rev = "f4b5b03" }
-validator_services = { git = "https://github.com/sigp/lighthouse", rev = "f4b5b03" }
-validator_store = { git = "https://github.com/sigp/lighthouse", rev = "f4b5b03" }
-workspace_members = { git = "https://github.com/sigp/lighthouse", rev = "f4b5b03" }
+# Lighthouse version 8.1.0 (shane-moore/lighthouse fork with streaming ValidatorStore trait)
+# todo: Remove once streaming ValidatorStore PR is merged
+# https://github.com/sigp/lighthouse/pull/8880
+beacon_node_fallback = { git = "https://github.com/shane-moore/lighthouse", rev = "a0a2a95" }
+bls = { git = "https://github.com/shane-moore/lighthouse", rev = "a0a2a95" }
+eth2 = { git = "https://github.com/shane-moore/lighthouse", rev = "a0a2a95" }
+eth2_keystore = { git = "https://github.com/shane-moore/lighthouse", rev = "a0a2a95" }
+eth2_network_config = { git = "https://github.com/shane-moore/lighthouse", rev = "a0a2a95" }
+health_metrics = { git = "https://github.com/shane-moore/lighthouse", rev = "a0a2a95" }
+metrics = { git = "https://github.com/shane-moore/lighthouse", rev = "a0a2a95" }
+network_utils = { git = "https://github.com/shane-moore/lighthouse", rev = "a0a2a95" }
+slashing_protection = { git = "https://github.com/shane-moore/lighthouse", rev = "a0a2a95" }
+slot_clock = { git = "https://github.com/shane-moore/lighthouse", rev = "a0a2a95" }
+task_executor = { git = "https://github.com/shane-moore/lighthouse", rev = "a0a2a95" }
+types = { git = "https://github.com/shane-moore/lighthouse", rev = "a0a2a95" }
+validator_metrics = { git = "https://github.com/shane-moore/lighthouse", rev = "a0a2a95" }
+validator_services = { git = "https://github.com/shane-moore/lighthouse", rev = "a0a2a95" }
+validator_store = { git = "https://github.com/shane-moore/lighthouse", rev = "a0a2a95" }
+workspace_members = { git = "https://github.com/shane-moore/lighthouse", rev = "a0a2a95" }
 
 alloy = { version = "1.2.1", features = [
     "sol-types",
@@ -163,6 +165,26 @@ zeroize = "1.8.1"
 [patch.'https://github.com/libp2p/rust-libp2p.git']
 libp2p-core = "=0.43.2"
 libp2p-swarm = "=0.47.1"
+
+# todo: Remove once streaming ValidatorStore PR is merged
+# https://github.com/sigp/lighthouse/pull/8880
+[patch.'https://github.com/sigp/lighthouse']
+beacon_node_fallback = { git = "https://github.com/shane-moore/lighthouse", rev = "a0a2a95" }
+bls = { git = "https://github.com/shane-moore/lighthouse", rev = "a0a2a95" }
+eth2 = { git = "https://github.com/shane-moore/lighthouse", rev = "a0a2a95" }
+eth2_keystore = { git = "https://github.com/shane-moore/lighthouse", rev = "a0a2a95" }
+eth2_network_config = { git = "https://github.com/shane-moore/lighthouse", rev = "a0a2a95" }
+health_metrics = { git = "https://github.com/shane-moore/lighthouse", rev = "a0a2a95" }
+metrics = { git = "https://github.com/shane-moore/lighthouse", rev = "a0a2a95" }
+network_utils = { git = "https://github.com/shane-moore/lighthouse", rev = "a0a2a95" }
+slashing_protection = { git = "https://github.com/shane-moore/lighthouse", rev = "a0a2a95" }
+slot_clock = { git = "https://github.com/shane-moore/lighthouse", rev = "a0a2a95" }
+task_executor = { git = "https://github.com/shane-moore/lighthouse", rev = "a0a2a95" }
+types = { git = "https://github.com/shane-moore/lighthouse", rev = "a0a2a95" }
+validator_metrics = { git = "https://github.com/shane-moore/lighthouse", rev = "a0a2a95" }
+validator_services = { git = "https://github.com/shane-moore/lighthouse", rev = "a0a2a95" }
+validator_store = { git = "https://github.com/shane-moore/lighthouse", rev = "a0a2a95" }
+workspace_members = { git = "https://github.com/shane-moore/lighthouse", rev = "a0a2a95" }
 
 [patch.crates-io]
 yamux = { git = "https://github.com/sigp/rust-yamux", rev = "575b17c0f44f4253079a6bafaa2de74ca1d6dfaa" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,25 +69,24 @@ ssv_types = { path = "anchor/common/ssv_types" }
 subnet_service = { path = "anchor/subnet_service" }
 version = { path = "anchor/common/version" }
 
-# Lighthouse version 8.1.0 (shane-moore/lighthouse fork with streaming ValidatorStore trait)
-# todo: Remove once streaming ValidatorStore PR is merged
-# https://github.com/sigp/lighthouse/pull/8880
-beacon_node_fallback = { git = "https://github.com/shane-moore/lighthouse", rev = "a0a2a95" }
-bls = { git = "https://github.com/shane-moore/lighthouse", rev = "a0a2a95" }
-eth2 = { git = "https://github.com/shane-moore/lighthouse", rev = "a0a2a95" }
-eth2_keystore = { git = "https://github.com/shane-moore/lighthouse", rev = "a0a2a95" }
-eth2_network_config = { git = "https://github.com/shane-moore/lighthouse", rev = "a0a2a95" }
-health_metrics = { git = "https://github.com/shane-moore/lighthouse", rev = "a0a2a95" }
-metrics = { git = "https://github.com/shane-moore/lighthouse", rev = "a0a2a95" }
-network_utils = { git = "https://github.com/shane-moore/lighthouse", rev = "a0a2a95" }
-slashing_protection = { git = "https://github.com/shane-moore/lighthouse", rev = "a0a2a95" }
-slot_clock = { git = "https://github.com/shane-moore/lighthouse", rev = "a0a2a95" }
-task_executor = { git = "https://github.com/shane-moore/lighthouse", rev = "a0a2a95" }
-types = { git = "https://github.com/shane-moore/lighthouse", rev = "a0a2a95" }
-validator_metrics = { git = "https://github.com/shane-moore/lighthouse", rev = "a0a2a95" }
-validator_services = { git = "https://github.com/shane-moore/lighthouse", rev = "a0a2a95" }
-validator_store = { git = "https://github.com/shane-moore/lighthouse", rev = "a0a2a95" }
-workspace_members = { git = "https://github.com/shane-moore/lighthouse", rev = "a0a2a95" }
+# Lighthouse latest from unstable (d62054e)
+# todo: update after https://github.com/sigp/lighthouse/pull/8880 is merged
+beacon_node_fallback = { git = "https://github.com/sigp/lighthouse", rev = "f4b5b03" }
+bls = { git = "https://github.com/sigp/lighthouse", rev = "f4b5b03" }
+eth2 = { git = "https://github.com/sigp/lighthouse", rev = "f4b5b03" }
+eth2_keystore = { git = "https://github.com/sigp/lighthouse", rev = "f4b5b03" }
+eth2_network_config = { git = "https://github.com/sigp/lighthouse", rev = "f4b5b03" }
+health_metrics = { git = "https://github.com/sigp/lighthouse", rev = "f4b5b03" }
+metrics = { git = "https://github.com/sigp/lighthouse", rev = "f4b5b03" }
+network_utils = { git = "https://github.com/sigp/lighthouse", rev = "f4b5b03" }
+slashing_protection = { git = "https://github.com/sigp/lighthouse", rev = "f4b5b03" }
+slot_clock = { git = "https://github.com/sigp/lighthouse", rev = "f4b5b03" }
+task_executor = { git = "https://github.com/sigp/lighthouse", rev = "f4b5b03" }
+types = { git = "https://github.com/sigp/lighthouse", rev = "f4b5b03" }
+validator_metrics = { git = "https://github.com/sigp/lighthouse", rev = "f4b5b03" }
+validator_services = { git = "https://github.com/sigp/lighthouse", rev = "f4b5b03" }
+validator_store = { git = "https://github.com/sigp/lighthouse", rev = "f4b5b03" }
+workspace_members = { git = "https://github.com/sigp/lighthouse", rev = "f4b5b03" }
 
 alloy = { version = "1.2.1", features = [
     "sol-types",
@@ -169,22 +168,22 @@ libp2p-swarm = "=0.47.1"
 # todo: Remove once streaming ValidatorStore PR is merged
 # https://github.com/sigp/lighthouse/pull/8880
 [patch.'https://github.com/sigp/lighthouse']
-beacon_node_fallback = { git = "https://github.com/shane-moore/lighthouse", rev = "a0a2a95" }
-bls = { git = "https://github.com/shane-moore/lighthouse", rev = "a0a2a95" }
-eth2 = { git = "https://github.com/shane-moore/lighthouse", rev = "a0a2a95" }
-eth2_keystore = { git = "https://github.com/shane-moore/lighthouse", rev = "a0a2a95" }
-eth2_network_config = { git = "https://github.com/shane-moore/lighthouse", rev = "a0a2a95" }
-health_metrics = { git = "https://github.com/shane-moore/lighthouse", rev = "a0a2a95" }
-metrics = { git = "https://github.com/shane-moore/lighthouse", rev = "a0a2a95" }
-network_utils = { git = "https://github.com/shane-moore/lighthouse", rev = "a0a2a95" }
-slashing_protection = { git = "https://github.com/shane-moore/lighthouse", rev = "a0a2a95" }
-slot_clock = { git = "https://github.com/shane-moore/lighthouse", rev = "a0a2a95" }
-task_executor = { git = "https://github.com/shane-moore/lighthouse", rev = "a0a2a95" }
-types = { git = "https://github.com/shane-moore/lighthouse", rev = "a0a2a95" }
-validator_metrics = { git = "https://github.com/shane-moore/lighthouse", rev = "a0a2a95" }
-validator_services = { git = "https://github.com/shane-moore/lighthouse", rev = "a0a2a95" }
-validator_store = { git = "https://github.com/shane-moore/lighthouse", rev = "a0a2a95" }
-workspace_members = { git = "https://github.com/shane-moore/lighthouse", rev = "a0a2a95" }
+beacon_node_fallback = { git = "https://github.com/shane-moore/lighthouse", rev = "66ff63a" }
+bls = { git = "https://github.com/shane-moore/lighthouse", rev = "66ff63a" }
+eth2 = { git = "https://github.com/shane-moore/lighthouse", rev = "66ff63a" }
+eth2_keystore = { git = "https://github.com/shane-moore/lighthouse", rev = "66ff63a" }
+eth2_network_config = { git = "https://github.com/shane-moore/lighthouse", rev = "66ff63a" }
+health_metrics = { git = "https://github.com/shane-moore/lighthouse", rev = "66ff63a" }
+metrics = { git = "https://github.com/shane-moore/lighthouse", rev = "66ff63a" }
+network_utils = { git = "https://github.com/shane-moore/lighthouse", rev = "66ff63a" }
+slashing_protection = { git = "https://github.com/shane-moore/lighthouse", rev = "66ff63a" }
+slot_clock = { git = "https://github.com/shane-moore/lighthouse", rev = "66ff63a" }
+task_executor = { git = "https://github.com/shane-moore/lighthouse", rev = "66ff63a" }
+types = { git = "https://github.com/shane-moore/lighthouse", rev = "66ff63a" }
+validator_metrics = { git = "https://github.com/shane-moore/lighthouse", rev = "66ff63a" }
+validator_services = { git = "https://github.com/shane-moore/lighthouse", rev = "66ff63a" }
+validator_store = { git = "https://github.com/shane-moore/lighthouse", rev = "66ff63a" }
+workspace_members = { git = "https://github.com/shane-moore/lighthouse", rev = "66ff63a" }
 
 [patch.crates-io]
 yamux = { git = "https://github.com/sigp/rust-yamux", rev = "575b17c0f44f4253079a6bafaa2de74ca1d6dfaa" }

--- a/anchor/validator_store/src/lib.rs
+++ b/anchor/validator_store/src/lib.rs
@@ -1374,6 +1374,188 @@ impl<T: SlotClock, E: EthSpec> AnchorValidatorStore<T, E> {
         Ok(())
     }
 
+    /// Sign a single aggregate and proof, handling fork-aware production and metrics.
+    async fn sign_single_aggregate_and_proof(
+        self: &Arc<Self>,
+        aggregate: AggregateToSign<E>,
+    ) -> Result<SignedAggregateAndProof<E>, Error> {
+        let future = async {
+            let slot = aggregate.aggregate.data().slot;
+            let signing_epoch = aggregate.aggregate.data().target.epoch;
+            let (validator, cluster) = self.get_validator_and_cluster(aggregate.pubkey)?;
+            let committee_id = cluster.committee_id();
+
+            if self.fork_schedule.active_fork(signing_epoch) >= Fork::Boole {
+                self.produce_signed_aggregate_and_proof_boole(
+                    aggregate.pubkey,
+                    aggregate.aggregator_index,
+                    signing_epoch,
+                    slot,
+                    validator,
+                    cluster,
+                    committee_id,
+                )
+                .await
+            } else {
+                self.produce_signed_aggregate_and_proof_alan(
+                    aggregate.pubkey,
+                    aggregate.aggregator_index,
+                    aggregate.aggregate,
+                    aggregate.selection_proof,
+                    signing_epoch,
+                    validator,
+                    cluster,
+                )
+                .await
+            }
+        };
+        run_and_update_metrics(
+            AGGREGATE_LOG_NAME,
+            &validator_metrics::SIGNED_AGGREGATES_TOTAL,
+            future,
+        )
+        .await
+    }
+
+    /// Sign a single sync committee message, handling consensus and signature collection.
+    async fn sign_single_sync_committee_signature(
+        self: &Arc<Self>,
+        message: SyncMessageToSign,
+    ) -> Result<SyncCommitteeMessage, Error> {
+        let validator_pubkey = message.pubkey;
+        let future = async {
+            let epoch = message.slot.epoch(E::slots_per_epoch());
+            let (validator, cluster) = self.get_validator_and_cluster(validator_pubkey)?;
+            let metadata = self.get_voting_context(message.slot).await?;
+
+            let validator_attestation_committees =
+                self.get_attesting_validators_in_committee(&metadata, cluster.committee_id());
+
+            let timer =
+                metrics::start_timer_vec(&metrics::CONSENSUS_TIMES, &[metrics::BEACON_VOTE]);
+            let timeout_mode = TimeoutMode::SlotTime {
+                instance_start_time: self.get_instant_in_slot(
+                    message.slot,
+                    Duration::from_secs(self.spec.seconds_per_slot) / 3,
+                )?,
+            };
+            let completed = self
+                .qbft_manager
+                .decide_instance(
+                    CommitteeInstanceId {
+                        committee: cluster.committee_id(),
+                        instance_height: message.slot.as_usize().into(),
+                    },
+                    metadata.beacon_vote.clone(),
+                    self.create_beacon_vote_validator(
+                        message.slot,
+                        validator_attestation_committees,
+                    ),
+                    timeout_mode,
+                    &cluster,
+                )
+                .await
+                .map_err(SpecificError::from)?;
+            drop(timer);
+
+            let data = match completed {
+                Completed::TimedOut => {
+                    return Err(Error::SpecificError(SpecificError::Timeout));
+                }
+                Completed::Success(data) => data,
+            };
+
+            // Calculate signature count for post-consensus committee collection
+            let committee_validator_indices =
+                self.get_committee_validator_indices(&cluster.committee_id());
+
+            // Use `voting_message_count_for_committee` for post-consensus (flat counting)
+            let num_signatures_to_collect = metadata
+                .voting_assignments
+                .voting_message_count_for_committee(|idx| {
+                    committee_validator_indices.contains(idx)
+                });
+
+            let domain = self.get_domain(epoch, Domain::SyncCommittee);
+            let signing_root = data.block_root.signing_root(domain);
+            let signature = self
+                .collect_signature(
+                    PartialSignatureKind::PostConsensus,
+                    Role::Committee,
+                    CollectionMode::Committee {
+                        num_signatures_to_collect,
+                        base_hash: data.hash(),
+                    },
+                    &validator,
+                    &cluster,
+                    signing_root,
+                    message.slot,
+                )
+                .await?;
+
+            Ok(SyncCommitteeMessage {
+                slot: message.slot,
+                beacon_block_root: data.block_root,
+                validator_index: message.validator_index,
+                signature,
+            })
+        };
+        run_and_update_metrics(
+            SYNC_COMMITTEE_SIGNATURE_LOG_NAME,
+            &validator_metrics::SIGNED_SYNC_COMMITTEE_MESSAGES_TOTAL,
+            future,
+        )
+        .await
+    }
+
+    /// Sign a single sync committee contribution, handling fork-aware production and metrics.
+    async fn sign_single_sync_committee_contribution(
+        self: &Arc<Self>,
+        contribution: ContributionToSign<E>,
+    ) -> Result<SignedContributionAndProof<E>, Error> {
+        let future = async {
+            let slot = contribution.contribution.slot;
+            let epoch = slot.epoch(E::slots_per_epoch());
+            let (validator, cluster) =
+                self.get_validator_and_cluster(contribution.aggregator_pubkey)?;
+            let committee_id = cluster.committee_id();
+            let subcommittee_index = contribution.contribution.subcommittee_index;
+
+            if self.fork_schedule.active_fork(epoch) >= Fork::Boole {
+                self.produce_signed_contribution_and_proof_boole(
+                    contribution.aggregator_index,
+                    contribution.aggregator_pubkey,
+                    subcommittee_index,
+                    slot,
+                    epoch,
+                    validator,
+                    cluster,
+                    committee_id,
+                )
+                .await
+            } else {
+                self.produce_signed_contribution_and_proof_alan(
+                    contribution.aggregator_index,
+                    contribution.aggregator_pubkey,
+                    contribution.contribution,
+                    contribution.selection_proof,
+                    slot,
+                    epoch,
+                    subcommittee_index,
+                    validator,
+                    cluster,
+                )
+                .await
+            }
+        };
+        run_and_update_metrics(
+            SYNC_COMMITTEE_CONTRIBUTION_LOG_NAME,
+            &validator_metrics::SIGNED_SYNC_COMMITTEE_CONTRIBUTIONS_TOTAL,
+            future,
+        )
+        .await
+    }
+
     /// Provide slashing protection for attestations, safely updating the slashing protection DB.
     ///
     /// Returns a vec of safe attestations which have passed slashing protection. Unsafe
@@ -2083,46 +2265,7 @@ impl<T: SlotClock, E: EthSpec> ValidatorStore for AnchorValidatorStore<T, E> {
         stream::once(async move {
             let futures = aggregates.into_iter().map(|aggregate| {
                 let this = Arc::clone(&this);
-                async move {
-                    let future = async {
-                        let slot = aggregate.aggregate.data().slot;
-                        let signing_epoch = aggregate.aggregate.data().target.epoch;
-                        let (validator, cluster) =
-                            this.get_validator_and_cluster(aggregate.pubkey)?;
-                        let committee_id = cluster.committee_id();
-
-                        if this.fork_schedule.active_fork(signing_epoch) >= Fork::Boole {
-                            this.produce_signed_aggregate_and_proof_boole(
-                                aggregate.pubkey,
-                                aggregate.aggregator_index,
-                                signing_epoch,
-                                slot,
-                                validator,
-                                cluster,
-                                committee_id,
-                            )
-                            .await
-                        } else {
-                            this.produce_signed_aggregate_and_proof_alan(
-                                aggregate.pubkey,
-                                aggregate.aggregator_index,
-                                aggregate.aggregate,
-                                aggregate.selection_proof,
-                                signing_epoch,
-                                validator,
-                                cluster,
-                            )
-                            .await
-                        }
-                    };
-
-                    run_and_update_metrics(
-                        AGGREGATE_LOG_NAME,
-                        &validator_metrics::SIGNED_AGGREGATES_TOTAL,
-                        future,
-                    )
-                    .await
-                }
+                async move { this.sign_single_aggregate_and_proof(aggregate).await }
             });
 
             let results = join_all(futures).await;
@@ -2364,100 +2507,7 @@ impl<T: SlotClock, E: EthSpec> ValidatorStore for AnchorValidatorStore<T, E> {
         stream::once(async move {
             let futures = messages.into_iter().map(|message| {
                 let this = Arc::clone(&this);
-                async move {
-                    let validator_pubkey = message.pubkey;
-                    let future = async {
-                        let epoch = message.slot.epoch(E::slots_per_epoch());
-                        let (validator, cluster) =
-                            this.get_validator_and_cluster(validator_pubkey)?;
-                        let metadata = this.get_voting_context(message.slot).await?;
-
-                        let validator_attestation_committees = this
-                            .get_attesting_validators_in_committee(
-                                &metadata,
-                                cluster.committee_id(),
-                            );
-
-                        let timer = metrics::start_timer_vec(
-                            &metrics::CONSENSUS_TIMES,
-                            &[metrics::BEACON_VOTE],
-                        );
-                        let timeout_mode = TimeoutMode::SlotTime {
-                            instance_start_time: this.get_instant_in_slot(
-                                message.slot,
-                                Duration::from_secs(this.spec.seconds_per_slot) / 3,
-                            )?,
-                        };
-                        let completed = this
-                            .qbft_manager
-                            .decide_instance(
-                                CommitteeInstanceId {
-                                    committee: cluster.committee_id(),
-                                    instance_height: message.slot.as_usize().into(),
-                                },
-                                metadata.beacon_vote.clone(),
-                                this.create_beacon_vote_validator(
-                                    message.slot,
-                                    validator_attestation_committees,
-                                ),
-                                timeout_mode,
-                                &cluster,
-                            )
-                            .await
-                            .map_err(SpecificError::from)?;
-                        drop(timer);
-
-                        let data = match completed {
-                            Completed::TimedOut => {
-                                return Err(Error::SpecificError(SpecificError::Timeout));
-                            }
-                            Completed::Success(data) => data,
-                        };
-
-                        // Calculate signature count for post-consensus committee collection
-                        let committee_validator_indices =
-                            this.get_committee_validator_indices(&cluster.committee_id());
-
-                        // Use `voting_message_count_for_committee` for post-consensus (flat
-                        // counting)
-                        let num_signatures_to_collect = metadata
-                            .voting_assignments
-                            .voting_message_count_for_committee(|idx| {
-                                committee_validator_indices.contains(idx)
-                            });
-
-                        let domain = this.get_domain(epoch, Domain::SyncCommittee);
-                        let signing_root = data.block_root.signing_root(domain);
-                        let signature = this
-                            .collect_signature(
-                                PartialSignatureKind::PostConsensus,
-                                Role::Committee,
-                                CollectionMode::Committee {
-                                    num_signatures_to_collect,
-                                    base_hash: data.hash(),
-                                },
-                                &validator,
-                                &cluster,
-                                signing_root,
-                                message.slot,
-                            )
-                            .await?;
-
-                        Ok(SyncCommitteeMessage {
-                            slot: message.slot,
-                            beacon_block_root: data.block_root,
-                            validator_index: message.validator_index,
-                            signature,
-                        })
-                    };
-
-                    run_and_update_metrics(
-                        SYNC_COMMITTEE_SIGNATURE_LOG_NAME,
-                        &validator_metrics::SIGNED_SYNC_COMMITTEE_MESSAGES_TOTAL,
-                        future,
-                    )
-                    .await
-                }
+                async move { this.sign_single_sync_committee_signature(message).await }
             });
 
             let results = join_all(futures).await;
@@ -2477,47 +2527,8 @@ impl<T: SlotClock, E: EthSpec> ValidatorStore for AnchorValidatorStore<T, E> {
             let futures = contributions.into_iter().map(|contribution| {
                 let this = Arc::clone(&this);
                 async move {
-                    let future = async {
-                        let slot = contribution.contribution.slot;
-                        let epoch = slot.epoch(E::slots_per_epoch());
-                        let (validator, cluster) =
-                            this.get_validator_and_cluster(contribution.aggregator_pubkey)?;
-                        let committee_id = cluster.committee_id();
-                        let subcommittee_index = contribution.contribution.subcommittee_index;
-
-                        if this.fork_schedule.active_fork(epoch) >= Fork::Boole {
-                            this.produce_signed_contribution_and_proof_boole(
-                                contribution.aggregator_index,
-                                contribution.aggregator_pubkey,
-                                subcommittee_index,
-                                slot,
-                                epoch,
-                                validator,
-                                cluster,
-                                committee_id,
-                            )
-                            .await
-                        } else {
-                            this.produce_signed_contribution_and_proof_alan(
-                                contribution.aggregator_index,
-                                contribution.aggregator_pubkey,
-                                contribution.contribution,
-                                contribution.selection_proof,
-                                slot,
-                                epoch,
-                                subcommittee_index,
-                                validator,
-                                cluster,
-                            )
-                            .await
-                        }
-                    };
-                    run_and_update_metrics(
-                        SYNC_COMMITTEE_CONTRIBUTION_LOG_NAME,
-                        &validator_metrics::SIGNED_SYNC_COMMITTEE_CONTRIBUTIONS_TOTAL,
-                        future,
-                    )
-                    .await
+                    this.sign_single_sync_committee_contribution(contribution)
+                        .await
                 }
             });
 

--- a/anchor/validator_store/src/lib.rs
+++ b/anchor/validator_store/src/lib.rs
@@ -16,7 +16,7 @@ use bls::{PublicKeyBytes, SecretKey, Signature};
 use database::{NetworkDatabase, NonUniqueIndex, UniqueIndex};
 use eth2::types::{BlockContents, FullBlockContents, PublishBlockRequest};
 use fork::{Fork, ForkSchedule};
-use futures::future::join_all;
+use futures::{Stream, future::join_all, stream};
 use lru::LruCache;
 use openssl::{
     pkey::Private,
@@ -69,7 +69,8 @@ use types::{
 };
 use validator_metrics::IntCounterVec;
 use validator_store::{
-    DoppelgangerStatus, Error as ValidatorStoreError, ProposalData, SignedBlock, UnsignedBlock,
+    AggregateToSign, AttestationToSign, ContributionToSign, DoppelgangerStatus,
+    Error as ValidatorStoreError, ProposalData, SignedBlock, SyncMessageToSign, UnsignedBlock,
     ValidatorStore,
 };
 
@@ -2074,58 +2075,62 @@ impl<T: SlotClock, E: EthSpec> ValidatorStore for AnchorValidatorStore<T, E> {
         .await
     }
 
-    async fn sign_execution_payload_envelope(
-        &self,
-        _validator_pubkey: PublicKeyBytes,
-        _envelope: ExecutionPayloadEnvelope<E>,
-    ) -> Result<SignedExecutionPayloadEnvelope<E>, Error> {
-        Err(Error::SpecificError(SpecificError::Unsupported))
-    }
+    fn sign_aggregate_and_proofs(
+        self: &Arc<Self>,
+        aggregates: Vec<AggregateToSign<E>>,
+    ) -> impl Stream<Item = Result<Vec<SignedAggregateAndProof<E>>, Error>> + Send {
+        let this = Arc::clone(self);
+        stream::once(async move {
+            let futures = aggregates.into_iter().map(|aggregate| {
+                let this = Arc::clone(&this);
+                async move {
+                    let future = async {
+                        let slot = aggregate.aggregate.data().slot;
+                        let signing_epoch = aggregate.aggregate.data().target.epoch;
+                        let (validator, cluster) =
+                            this.get_validator_and_cluster(aggregate.pubkey)?;
+                        let committee_id = cluster.committee_id();
 
-    async fn produce_signed_aggregate_and_proof(
-        &self,
-        validator_pubkey: PublicKeyBytes,
-        aggregator_index: u64,
-        aggregate: Attestation<E>,
-        selection_proof: SelectionProof,
-    ) -> Result<SignedAggregateAndProof<E>, Error> {
-        let future = async {
-            let slot = aggregate.data().slot;
-            let signing_epoch = aggregate.data().target.epoch;
-            let (validator, cluster) = self.get_validator_and_cluster(validator_pubkey)?;
-            let committee_id = cluster.committee_id();
+                        if this.fork_schedule.active_fork(signing_epoch) >= Fork::Boole {
+                            this.produce_signed_aggregate_and_proof_boole(
+                                aggregate.pubkey,
+                                aggregate.aggregator_index,
+                                signing_epoch,
+                                slot,
+                                validator,
+                                cluster,
+                                committee_id,
+                            )
+                            .await
+                        } else {
+                            this.produce_signed_aggregate_and_proof_alan(
+                                aggregate.pubkey,
+                                aggregate.aggregator_index,
+                                aggregate.aggregate,
+                                aggregate.selection_proof,
+                                signing_epoch,
+                                validator,
+                                cluster,
+                            )
+                            .await
+                        }
+                    };
 
-            if self.fork_schedule.active_fork(signing_epoch) >= Fork::Boole {
-                self.produce_signed_aggregate_and_proof_boole(
-                    validator_pubkey,
-                    aggregator_index,
-                    signing_epoch,
-                    slot,
-                    validator,
-                    cluster,
-                    committee_id,
-                )
-                .await
-            } else {
-                self.produce_signed_aggregate_and_proof_alan(
-                    validator_pubkey,
-                    aggregator_index,
-                    aggregate,
-                    selection_proof,
-                    signing_epoch,
-                    validator,
-                    cluster,
-                )
-                .await
-            }
-        };
+                    run_and_update_metrics(
+                        AGGREGATE_LOG_NAME,
+                        &validator_metrics::SIGNED_AGGREGATES_TOTAL,
+                        future,
+                    )
+                    .await
+                }
+            });
 
-        run_and_update_metrics(
-            AGGREGATE_LOG_NAME,
-            &validator_metrics::SIGNED_AGGREGATES_TOTAL,
-            future,
-        )
-        .await
+            let results = join_all(futures).await;
+
+            let signed: Vec<_> = results.into_iter().filter_map(|r| r.ok()).collect();
+
+            Ok(signed)
+        })
     }
 
     async fn produce_selection_proof(
@@ -2351,141 +2356,177 @@ impl<T: SlotClock, E: EthSpec> ValidatorStore for AnchorValidatorStore<T, E> {
         .await
     }
 
-    async fn produce_sync_committee_signature(
-        &self,
-        slot: Slot,
-        _beacon_block_root: Hash256,
-        validator_index: u64,
-        validator_pubkey: &PublicKeyBytes,
-    ) -> Result<SyncCommitteeMessage, Error> {
-        let future = async {
-            let epoch = slot.epoch(E::slots_per_epoch());
-            let (validator, cluster) = self.get_validator_and_cluster(*validator_pubkey)?;
-            let metadata = self.get_voting_context(slot).await?;
+    fn sign_sync_committee_signatures(
+        self: &Arc<Self>,
+        messages: Vec<SyncMessageToSign>,
+    ) -> impl Stream<Item = Result<Vec<SyncCommitteeMessage>, Error>> + Send {
+        let this = Arc::clone(self);
+        stream::once(async move {
+            let futures = messages.into_iter().map(|message| {
+                let this = Arc::clone(&this);
+                async move {
+                    let validator_pubkey = message.pubkey;
+                    let future = async {
+                        let epoch = message.slot.epoch(E::slots_per_epoch());
+                        let (validator, cluster) =
+                            this.get_validator_and_cluster(validator_pubkey)?;
+                        let metadata = this.get_voting_context(message.slot).await?;
 
-            let validator_attestation_committees =
-                self.get_attesting_validators_in_committee(&metadata, cluster.committee_id());
+                        let validator_attestation_committees = this
+                            .get_attesting_validators_in_committee(
+                                &metadata,
+                                cluster.committee_id(),
+                            );
 
-            let timer =
-                metrics::start_timer_vec(&metrics::CONSENSUS_TIMES, &[metrics::BEACON_VOTE]);
-            let timeout_mode = TimeoutMode::SlotTime {
-                instance_start_time: self.get_instant_in_slot(
-                    slot,
-                    Duration::from_secs(self.spec.seconds_per_slot) / 3,
-                )?,
-            };
-            let completed = self
-                .qbft_manager
-                .decide_instance(
-                    CommitteeInstanceId {
-                        committee: cluster.committee_id(),
-                        instance_height: slot.as_usize().into(),
-                    },
-                    metadata.beacon_vote.clone(),
-                    self.create_beacon_vote_validator(slot, validator_attestation_committees),
-                    timeout_mode,
-                    &cluster,
-                )
-                .await
-                .map_err(SpecificError::from)?;
-            drop(timer);
+                        let timer = metrics::start_timer_vec(
+                            &metrics::CONSENSUS_TIMES,
+                            &[metrics::BEACON_VOTE],
+                        );
+                        let timeout_mode = TimeoutMode::SlotTime {
+                            instance_start_time: this.get_instant_in_slot(
+                                message.slot,
+                                Duration::from_secs(this.spec.seconds_per_slot) / 3,
+                            )?,
+                        };
+                        let completed = this
+                            .qbft_manager
+                            .decide_instance(
+                                CommitteeInstanceId {
+                                    committee: cluster.committee_id(),
+                                    instance_height: message.slot.as_usize().into(),
+                                },
+                                metadata.beacon_vote.clone(),
+                                this.create_beacon_vote_validator(
+                                    message.slot,
+                                    validator_attestation_committees,
+                                ),
+                                timeout_mode,
+                                &cluster,
+                            )
+                            .await
+                            .map_err(SpecificError::from)?;
+                        drop(timer);
 
-            let data = match completed {
-                Completed::TimedOut => return Err(Error::SpecificError(SpecificError::Timeout)),
-                Completed::Success(data) => data,
-            };
+                        let data = match completed {
+                            Completed::TimedOut => {
+                                return Err(Error::SpecificError(SpecificError::Timeout));
+                            }
+                            Completed::Success(data) => data,
+                        };
 
-            // Calculate signature count for post-consensus committee collection
-            let committee_validator_indices =
-                self.get_committee_validator_indices(&cluster.committee_id());
+                        // Calculate signature count for post-consensus committee collection
+                        let committee_validator_indices =
+                            this.get_committee_validator_indices(&cluster.committee_id());
 
-            // Use `voting_message_count_for_committee` for post-consensus (flat counting)
-            let num_signatures_to_collect = metadata
-                .voting_assignments
-                .voting_message_count_for_committee(|idx| {
-                    committee_validator_indices.contains(idx)
-                });
+                        // Use `voting_message_count_for_committee` for post-consensus (flat
+                        // counting)
+                        let num_signatures_to_collect = metadata
+                            .voting_assignments
+                            .voting_message_count_for_committee(|idx| {
+                                committee_validator_indices.contains(idx)
+                            });
 
-            let domain = self.get_domain(epoch, Domain::SyncCommittee);
-            let signing_root = data.block_root.signing_root(domain);
-            let signature = self
-                .collect_signature(
-                    PartialSignatureKind::PostConsensus,
-                    Role::Committee,
-                    CollectionMode::Committee {
-                        num_signatures_to_collect,
-                        base_hash: data.hash(),
-                    },
-                    &validator,
-                    &cluster,
-                    signing_root,
-                    slot,
-                )
-                .await?;
+                        let domain = this.get_domain(epoch, Domain::SyncCommittee);
+                        let signing_root = data.block_root.signing_root(domain);
+                        let signature = this
+                            .collect_signature(
+                                PartialSignatureKind::PostConsensus,
+                                Role::Committee,
+                                CollectionMode::Committee {
+                                    num_signatures_to_collect,
+                                    base_hash: data.hash(),
+                                },
+                                &validator,
+                                &cluster,
+                                signing_root,
+                                message.slot,
+                            )
+                            .await?;
 
-            Ok(SyncCommitteeMessage {
-                slot,
-                beacon_block_root: data.block_root,
-                validator_index,
-                signature,
-            })
-        };
+                        Ok(SyncCommitteeMessage {
+                            slot: message.slot,
+                            beacon_block_root: data.block_root,
+                            validator_index: message.validator_index,
+                            signature,
+                        })
+                    };
 
-        run_and_update_metrics(
-            SYNC_COMMITTEE_SIGNATURE_LOG_NAME,
-            &validator_metrics::SIGNED_SYNC_COMMITTEE_MESSAGES_TOTAL,
-            future,
-        )
-        .await
+                    run_and_update_metrics(
+                        SYNC_COMMITTEE_SIGNATURE_LOG_NAME,
+                        &validator_metrics::SIGNED_SYNC_COMMITTEE_MESSAGES_TOTAL,
+                        future,
+                    )
+                    .await
+                }
+            });
+
+            let results = join_all(futures).await;
+
+            let signed: Vec<_> = results.into_iter().filter_map(|r| r.ok()).collect();
+
+            Ok(signed)
+        })
     }
 
-    async fn produce_signed_contribution_and_proof(
-        &self,
-        aggregator_index: u64,
-        aggregator_pubkey: PublicKeyBytes,
-        contribution: SyncCommitteeContribution<E>,
-        selection_proof: SyncSelectionProof,
-    ) -> Result<SignedContributionAndProof<E>, Error> {
-        let future = async {
-            let slot = contribution.slot;
-            let epoch = slot.epoch(E::slots_per_epoch());
-            let (validator, cluster) = self.get_validator_and_cluster(aggregator_pubkey)?;
-            let committee_id = cluster.committee_id();
-            let subcommittee_index = contribution.subcommittee_index;
+    fn sign_sync_committee_contributions(
+        self: &Arc<Self>,
+        contributions: Vec<ContributionToSign<E>>,
+    ) -> impl Stream<Item = Result<Vec<SignedContributionAndProof<E>>, Error>> + Send {
+        let this = Arc::clone(self);
+        stream::once(async move {
+            let futures = contributions.into_iter().map(|contribution| {
+                let this = Arc::clone(&this);
+                async move {
+                    let future = async {
+                        let slot = contribution.contribution.slot;
+                        let epoch = slot.epoch(E::slots_per_epoch());
+                        let (validator, cluster) =
+                            this.get_validator_and_cluster(contribution.aggregator_pubkey)?;
+                        let committee_id = cluster.committee_id();
+                        let subcommittee_index = contribution.contribution.subcommittee_index;
 
-            if self.fork_schedule.active_fork(epoch) >= Fork::Boole {
-                self.produce_signed_contribution_and_proof_boole(
-                    aggregator_index,
-                    aggregator_pubkey,
-                    subcommittee_index,
-                    slot,
-                    epoch,
-                    validator,
-                    cluster,
-                    committee_id,
-                )
-                .await
-            } else {
-                self.produce_signed_contribution_and_proof_alan(
-                    aggregator_index,
-                    aggregator_pubkey,
-                    contribution,
-                    selection_proof,
-                    slot,
-                    epoch,
-                    subcommittee_index,
-                    validator,
-                    cluster,
-                )
-                .await
-            }
-        };
-        run_and_update_metrics(
-            SYNC_COMMITTEE_CONTRIBUTION_LOG_NAME,
-            &validator_metrics::SIGNED_SYNC_COMMITTEE_CONTRIBUTIONS_TOTAL,
-            future,
-        )
-        .await
+                        if this.fork_schedule.active_fork(epoch) >= Fork::Boole {
+                            this.produce_signed_contribution_and_proof_boole(
+                                contribution.aggregator_index,
+                                contribution.aggregator_pubkey,
+                                subcommittee_index,
+                                slot,
+                                epoch,
+                                validator,
+                                cluster,
+                                committee_id,
+                            )
+                            .await
+                        } else {
+                            this.produce_signed_contribution_and_proof_alan(
+                                contribution.aggregator_index,
+                                contribution.aggregator_pubkey,
+                                contribution.contribution,
+                                contribution.selection_proof,
+                                slot,
+                                epoch,
+                                subcommittee_index,
+                                validator,
+                                cluster,
+                            )
+                            .await
+                        }
+                    };
+                    run_and_update_metrics(
+                        SYNC_COMMITTEE_CONTRIBUTION_LOG_NAME,
+                        &validator_metrics::SIGNED_SYNC_COMMITTEE_CONTRIBUTIONS_TOTAL,
+                        future,
+                    )
+                    .await
+                }
+            });
+
+            let results = join_all(futures).await;
+
+            let signed: Vec<_> = results.into_iter().filter_map(|r| r.ok()).collect();
+
+            Ok(signed)
+        })
     }
 
     // stolen from lighthouse
@@ -2568,67 +2609,92 @@ impl<T: SlotClock, E: EthSpec> ValidatorStore for AnchorValidatorStore<T, E> {
         })
     }
 
-    async fn sign_attestations(
+    fn sign_attestations(
         self: &Arc<Self>,
-        mut attestations: Vec<(u64, PublicKeyBytes, usize, Attestation<E>)>,
-    ) -> Result<Vec<(u64, Attestation<E>)>, Error> {
-        if !*self.is_synced.borrow() {
-            return Err(Error::SpecificError(SpecificError::NotSynced));
-        }
+        attestations: Vec<AttestationToSign<E>>,
+    ) -> impl Stream<Item = Result<Vec<(u64, Attestation<E>)>, Error>> + Send {
+        let this = Arc::clone(self);
+        stream::once(async move {
+            if !*this.is_synced.borrow() {
+                return Err(Error::SpecificError(SpecificError::NotSynced));
+            }
 
-        let signing_futures = attestations.iter_mut().map(
-            |(_, pubkey, validator_committee_index, attestation)| async move {
-                self.sign_attestation(
-                    *pubkey,
-                    *validator_committee_index,
-                    attestation,
-                    attestation.data().target.epoch,
-                )
-                .await
-            },
-        );
+            // Convert `AttestationToSign` into the tuple format used internally
+            let mut attestation_tuples: Vec<(u64, PublicKeyBytes, usize, Attestation<E>)> =
+                attestations
+                    .into_iter()
+                    .map(|a| {
+                        (
+                            a.validator_index,
+                            a.pubkey,
+                            a.validator_committee_index,
+                            a.attestation,
+                        )
+                    })
+                    .collect();
 
-        let results = join_all(signing_futures).await;
+            let signing_futures = attestation_tuples.iter_mut().map(
+                |(_, pubkey, validator_committee_index, attestation)| async {
+                    this.sign_attestation(
+                        *pubkey,
+                        *validator_committee_index,
+                        attestation,
+                        attestation.data().target.epoch,
+                    )
+                    .await
+                },
+            );
 
-        let mut signed_attestations = Vec::with_capacity(results.len());
-        for (result, (validator_index, pubkey, _, attestation)) in
-            results.into_iter().zip(attestations.into_iter())
-        {
-            match result {
-                Ok(()) => {
-                    signed_attestations.push((validator_index, attestation, pubkey));
-                }
-                Err(ValidatorStoreError::UnknownPubkey(pubkey)) => {
-                    warn!(
-                        info = "a validator may have recently been removed from this VC",
-                        ?pubkey,
-                        "Missing pubkey for attestation"
-                    );
-                }
-                Err(e) => {
-                    error!(
-                        error = ?e,
-                        "Failed to sign attestation"
-                    );
+            let results = join_all(signing_futures).await;
+
+            let mut signed_attestations = Vec::with_capacity(results.len());
+            for (result, (validator_index, pubkey, _, attestation)) in
+                results.into_iter().zip(attestation_tuples.into_iter())
+            {
+                match result {
+                    Ok(()) => {
+                        signed_attestations.push((validator_index, attestation, pubkey));
+                    }
+                    Err(ValidatorStoreError::UnknownPubkey(pubkey)) => {
+                        warn!(
+                            info = "a validator may have recently been removed from this VC",
+                            ?pubkey,
+                            "Missing pubkey for attestation"
+                        );
+                    }
+                    Err(e) => {
+                        error!(
+                            error = ?e,
+                            "Failed to sign attestation"
+                        );
+                    }
                 }
             }
-        }
 
-        if signed_attestations.is_empty() {
-            return Ok(vec![]);
-        }
+            if signed_attestations.is_empty() {
+                return Ok(vec![]);
+            }
 
-        // Check slashing protection and insert into database. Use a dedicated blocking thread
-        // to avoid clogging the async executor with blocking database I/O.
-        let validator_store = self.clone();
-        self.task_executor
-            .spawn_blocking_handle(
-                move || validator_store.slashing_protection_attestations(signed_attestations),
-                "slashing_protect_attestations",
-            )
-            .ok_or(Error::ExecutorError)?
-            .await
-            .map_err(|_| Error::ExecutorError)?
+            // Check slashing protection and insert into database. Use a dedicated blocking
+            // thread to avoid clogging the async executor with blocking database I/O.
+            let validator_store = this.clone();
+            this.task_executor
+                .spawn_blocking_handle(
+                    move || validator_store.slashing_protection_attestations(signed_attestations),
+                    "slashing_protect_attestations",
+                )
+                .ok_or(Error::ExecutorError)?
+                .await
+                .map_err(|_| Error::ExecutorError)?
+        })
+    }
+
+    async fn sign_execution_payload_envelope(
+        &self,
+        _validator_pubkey: PublicKeyBytes,
+        _envelope: ExecutionPayloadEnvelope<E>,
+    ) -> Result<SignedExecutionPayloadEnvelope<E>, Error> {
+        Err(Error::SpecificError(SpecificError::Unsupported))
     }
 }
 


### PR DESCRIPTION
## Issue Addressed
  Prepares `unstable` for PR #834 (attestation batching optimization) by migrating to the updated lighthouse `ValidatorStore` trait

## Proposed Changes

 - Update Lighthouse dependency to `shane-moore/lighthouse` fork [PR](https://github.com/sigp/lighthouse/pull/8880) with streaming `ValidatorStore` trait fn return types. 
   - **Note** that [PR](https://github.com/sigp/lighthouse/pull/8880) must be merged on the lh side, and anchor updated to use `sigp/lighthouse` for dependencies, before we merge this code to our `stable` branch
 - Implement four streaming trait methods to replace existing fn's:
    - `sign_aggregate_and_proofs`,  `sign_sync_committee_signatures`,
  `sign_sync_committee_contributions`, and `sign_attestations`

The impl's now have naive stream wrappers, and the functionality is equivalent to the previous functions in `unstable`. The idea is that we can have separate PR's built on top of this base that will refactor these trait methods to stream committee based batched signing

## Additional Info
All new methods use `stream::once` to wrap existing logic, no behavioral changes. PR #834 should rebase on top and only needs to optimize `sign_attestations`