### PR TITLE
chore: restructure CLAUDE.md into modular rules

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -1,0 +1,26 @@
+## Architecture and design
+
+Anchor is a modular Rust workspace with service-oriented architecture. Preserve crate boundaries and typed interfaces.
+
+### Crate structure
+- Each major component is its own crate with a minimal, well-documented public API
+- Crates should only depend on what they need
+- Each crate has clear responsibility and ownership
+
+### Dependency flow
+- Common types and utilities live in `common/` subdirectories
+- Higher-level services depend on lower-level ones, not vice versa
+- Config flows down from client to components; events flow up to coordinators
+
+### Inter-component communication
+- Components communicate via typed message channels
+- System-wide events use the EventBus pattern
+- Components interact through trait interfaces, not concrete implementations
+- Errors are properly typed and propagated up the stack
+
+### Design principles
+1. **Question intermediaries**: If data flows A -> B with no transformation, question why an intermediate layer exists. Each layer must provide clear value (logging, transformation, validation, etc.)
+2. **Separation through interfaces, not layers**: Clean boundaries come from well-defined APIs, not intermediary components
+3. **Simplification is always valid**: Refactoring working code for simplicity is encouraged. Fewer lines and fewer components often indicates better design
+4. **Challenge complexity**: Every abstraction must justify its existence. "We might need it later" is not sufficient. Complexity must solve specific, current problems
+5. **Prefer direct communication**: Unless an intermediary adds clear value (validation, transformation, isolation, or observability), components should communicate directly

--- a/.claude/rules/commands.md
+++ b/.claude/rules/commands.md
@@ -1,0 +1,29 @@
+## Command catalog
+
+Use project Make targets by default.
+
+**Build/install:**
+- `cargo build --release` - build in release mode
+- `make install` - install to path
+- `make build-x86_64` / `make build-aarch64` - cross-compile
+- `make build-release-tarballs` - create release archives
+
+**Testing:**
+- `make test` - all tests, release mode (standard)
+- `make test-debug` - all tests, debug mode
+- `make nextest-release` / `make nextest-debug` - nextest runner
+- `cargo test -p <crate>` - specific crate
+- `make check-benches` - compile benchmarks without running
+
+**Format & lint:**
+- `make cargo-fmt` - format code
+- `make cargo-fmt-check` - check formatting
+- `make lint` - run clippy
+- `make lint-fix` - auto-fix lint issues
+
+**Quality:**
+- `make udeps` - unused dependencies
+- `make sort` - dependency sort order
+- `make audit` - security audit
+- `make mdlint` - markdown lint
+- `make cli-local` - update CLI docs

--- a/.claude/rules/dependency-api.md
+++ b/.claude/rules/dependency-api.md
@@ -1,0 +1,22 @@
+---
+paths:
+  - "**/Cargo.toml"
+  - "**/*.rs"
+---
+
+## Dependency and API management
+
+**Critical:** Never suggest functionality that doesn't exist in dependencies.
+
+- Check `Cargo.toml` for exact versions before suggesting any dependency APIs
+- Verify methods exist in the specific versions used — never assume latest documentation applies
+- Read dependency public APIs carefully before recommending features or methods
+- Search existing codebase for established patterns, but prioritize best practices over bad existing patterns
+- Don't assume capabilities — external dependencies may have architectural constraints
+- If you don't see a method in the public API, don't suggest creating or using it
+- When uncertain, check dependency source code or ask instead of guessing
+- Don't extrapolate — don't assume dependencies support common patterns if they have different design requirements
+- For dependency upgrades, verify feature-gated API changes before refactors
+- Prefer checked boundary conversions over unchecked casts
+- Keep dependencies minimal and up to date
+- Prefer well-maintained crates; pin versions appropriately

--- a/.claude/rules/dev-workflow.md
+++ b/.claude/rules/dev-workflow.md
@@ -1,0 +1,30 @@
+## Development workflow
+
+### Branches
+- Base contributions on `unstable` unless explicitly told otherwise
+- `stable`: latest release; `unstable`: development and PR base
+
+### Development sequence
+1. Plan scope
+2. Implement following project style guidelines
+3. Test — add tests that cover changes
+4. Document when needed
+5. Submit with clean PR metadata
+
+### Pre-commit checks (required)
+
+```bash
+make cargo-fmt
+make cargo-fmt-check
+make lint
+make test
+```
+
+### Commit messages
+- Use present tense ("Add feature", not "Added feature")
+- First line is a summary (50 chars or less)
+- Include component prefix (e.g., `network:`, `consensus:`)
+- Reference issues or tickets when applicable
+- Explain why the change was made
+- Use Conventional Commits style for PR titles
+- Follow `.github/PULL_REQUEST_TEMPLATE.md`

--- a/.claude/rules/pr-workflow.md
+++ b/.claude/rules/pr-workflow.md
@@ -1,0 +1,33 @@
+## Pull request workflow
+
+### PR title
+Must follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format (enforced by CI):
+- `feat:`, `fix:`, `docs:`, `test:`, `chore:`, `perf:`, `refactor:`, `ci:`, `revert:`
+- Use `!` for breaking changes (e.g., `feat!: changed the API`)
+
+### PR description
+**ALWAYS read `.github/PULL_REQUEST_TEMPLATE.md` first**, then follow the template:
+- **Issue Addressed:** Which issue # does this PR address?
+- **Proposed Changes:** List or describe the changes introduced
+- **Additional Info:** Future considerations or information for reviewers
+
+### Description best practices
+- Keep "Proposed Changes" section high-level — focus on what components changed and why
+- Avoid line-by-line documentation; use component-level summaries
+- Emphasize principles being applied and operational impact
+- Focus on the "why", not the mechanics
+- Don't mention implementation details (exact files, line numbers, function names)
+- Don't state the obvious or repeat information from the title
+
+### Code review culture
+Question "why" architectural decisions exist:
+- "Why does this intermediary layer exist?"
+- "What problem does this abstraction solve?"
+- "Could components communicate directly?"
+- Working code can still be improved; test passing != design complete
+- Question complexity, but respect existing patterns that solve real problems
+
+### PR shaping
+- Keep each PR independently reviewable
+- Avoid mixing refactor and behavior change unless unavoidable
+- Include explicit sections for: Motivation, Scope, Risk, Testing, Rollback

--- a/.claude/rules/production-safety.md
+++ b/.claude/rules/production-safety.md
@@ -1,0 +1,14 @@
+---
+paths:
+  - "**/*.rs"
+---
+
+## Production safety
+
+- Never use `.unwrap()` or `.expect()` in production paths without explicit safety justification
+- Always use proper `Result`/`Option` handling
+- Validate user inputs and handle invalid states with typed errors
+- Never log secrets or sensitive payloads
+- Keep error messages actionable and include context without leaking sensitive data
+- Favor memory-safe patterns; avoid `unsafe` unless there is clear necessity and justification
+- Leverage Rust's ownership system for memory safety

--- a/.claude/rules/rust-style.md
+++ b/.claude/rules/rust-style.md
@@ -1,0 +1,49 @@
+---
+paths:
+  - "**/*.rs"
+---
+
+## Rust style
+
+### General
+- Use idiomatic `Option`/`Result` and typed errors; avoid stringly-typed designs
+- Avoid nested control-flow result shapes like `Option<Result<T, E>>` when a dedicated outcome enum is clearer
+- Use clear, descriptive names following Rust conventions (snake_case for functions/variables, CamelCase for types)
+- Keep functions/modules focused and small
+- Prefer simple solutions first; avoid abstractions without clear current value
+- Document public APIs with `///` when introducing or changing public behavior
+- Use the type system to prevent errors
+- Check requirements first: read existing templates, guidelines, and patterns before implementing
+
+### Async code
+- Use `async`/`.await` properly with Tokio
+- Handle cancellation correctly
+- Avoid blocking the runtime with CPU-intensive work
+
+### Error types
+- Create domain-specific error types using `thiserror`
+- Include context in errors
+- Make error messages user-friendly and actionable
+
+### DRY
+- Avoid duplicating logic, validation, or transformation in multiple places
+- When the same pattern appears more than once, extract it into a shared function or method
+
+### Single source of truth
+- Each piece of domain logic should have one authoritative location, owned by the type or module closest to the data it operates on
+
+### Function readability
+- Flag functions that are hard to follow due to deep nesting, excessive length, or mixed abstraction levels
+- When a function body exceeds ~50 lines or has more than 2 levels of nesting, extract inner logic into named helper methods
+- Prefer flat, linear control flow over deeply indented structures
+
+### Control-flow clarity
+- Keep dispatch/selection helpers pure whenever possible (select outcome, do not mutate counters via `&mut`)
+- Return explicit outcome enums for multi-branch behavior (`Executed`, `SkippedKnown`, `SkippedUnknown`, etc.)
+- Update metrics/counters/logging in the caller, where control flow is easier to read and audit
+
+### Comments
+- Comment "why", not "what"
+- Use doc comments (`///`) for public API documentation
+- Add `TODO`, `FIXME`, or `NOTE` markers as needed
+- Use backticks around identifiers in comments: function names (`validate()`), types (`VariableList<u8, U256>`), constants (`RSA_SIGNATURE_SIZE`), field names (`operator_ids`)

--- a/.claude/rules/session-learning.md
+++ b/.claude/rules/session-learning.md
@@ -1,0 +1,9 @@
+## Session learning updates
+
+After successful Claude Code sessions:
+- Update CLAUDE.md and relevant specialized agents with general principles learned
+- Add universal principles that apply across all development contexts
+- Update agents with context-specific lessons in their domain
+- Focus on underlying reasoning and approach, not implementation details
+- Generalize lessons for application to similar future problems
+- Keep updates concise and applicable across similar tasks

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -1,0 +1,18 @@
+---
+paths:
+  - "**/*.rs"
+---
+
+## Testing
+
+**MANDATORY:** Always use the `tester-subagent` via the Task tool before creating or modifying any tests. Do not write test code directly.
+
+### Patterns
+- Prefer AAA (Arrange-Act-Assert) structure and clear test naming
+- For bug fixes, add a failing repro test before the fix when feasible
+- Complex, important, or non-trivial production code must have test coverage
+- During review, flag new production functions that lack tests — especially state transitions, side-effect-producing logic, and data-destructive operations
+
+### Database fixtures
+- **InMemoryTestFixture**: Fast unit/integration tests using SQLite in-memory databases (`:memory:`). No file I/O overhead; data lost when connection closes.
+- **FileTestFixture**: Tests requiring persistence, restart simulation, migrations, or cross-process scenarios. Uses temporary files, automatically cleaned up.

--- a/.claude/rules/verification.md
+++ b/.claude/rules/verification.md
@@ -1,0 +1,22 @@
+## Verification recipe (mandatory)
+
+Every completion must include:
+- Formatting check
+- Lint check
+- Tests (or an explicit reason tests were not run)
+- Evidence for behavior claims (command output, reproduction, or source reference)
+
+If behavior is not verified, label it as a hypothesis instead of a fact.
+
+### Default commands
+
+```bash
+make cargo-fmt && make cargo-fmt-check
+make lint
+make test
+```
+
+### Additional quality checks
+- Consider performance implications
+- Ensure backwards compatibility when applicable
+- Run `make audit` when dependencies change

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,473 +1,91 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+Guidance for Claude Code when working with this repository. Detailed standards live in `.claude/rules/`.
 
 ## About Anchor
 
-Anchor is an open-source implementation of the Secret Shared Validator (SSV) protocol, written in Rust and maintained by Sigma Prime. It serves as a validator client for Ethereum's proof-of-stake consensus mechanism using secret sharing techniques.
+Anchor is an open-source SSV protocol implementation in Rust, maintained by Sigma Prime. It serves as an Ethereum proof-of-stake validator client using secret sharing techniques.
 
 ## Common Commands
 
-### Build and Install
-
 ```bash
-# Build the project in release mode
+# Build
 cargo build --release
-
-# Install Anchor to your path
 make install
 
-# Build for specific architectures
-make build-x86_64      # Build for x86_64 Linux (requires cross)
-make build-aarch64     # Build for aarch64 Linux (requires cross)
+# Test
+make test                    # release mode (standard)
+make test-debug              # debug mode
+make nextest-release         # nextest (faster)
+cargo test -p <crate>        # specific crate
 
-# Create release tarballs
-make build-release-tarballs
-```
+# Format & Lint
+make cargo-fmt               # format
+make cargo-fmt-check         # check format
+make lint                    # clippy
+make lint-fix                # auto-fix
 
-### Testing
-
-```bash
-# Run all tests in release mode (standard)
-make test
-# or
-cargo test --release --features "$(TEST_FEATURES)"
-
-# Run all tests in debug mode
-make test-debug
-# or
-cargo test --workspace --features "$(TEST_FEATURES)"
-
-# Run tests with nextest (faster)
-make nextest-release
-make nextest-debug
-
-# Test a specific crate
-cd anchor/common/qbft
-cargo test
-
-# Check benchmark code (without running benchmarks)
-make check-benches
-```
-
-### Linting and Formatting
-
-```bash
-# Format code
-make cargo-fmt
-# or
-cargo +nightly fmt --all
-
-# Check formatting
-make cargo-fmt-check
-
-# Run linter
-make lint
-# or
-cargo clippy --workspace --tests --features "$(TEST_FEATURES)" -- -D warnings
-
-# Fix linting issues automatically
-make lint-fix
-
-# Check for unused dependencies
-make udeps
-# or
-cargo +nightly udeps --tests --all-targets --release --features "$(TEST_FEATURES)"
-
-# Check if dependencies are sorted correctly
-make sort
-```
-
-### Other Useful Commands
-
-```bash
-# Run dependency audit for security issues
-make audit
-
-# Update CLI documentation in the book
-make cli-local
-
-# Check for markdown issues
-make mdlint
+# Quality
+make check-benches           # benchmark compilation
+make udeps                   # unused dependencies
+make sort                    # dependency ordering
+make audit                   # security audit
 ```
 
 ## Architecture Overview
 
-Anchor is a multi-threaded client with several core components organized as a modular Rust workspace. The architecture follows a service-oriented approach with well-defined boundaries between components.
+Multi-threaded, service-oriented Rust workspace built on Tokio.
 
-### Core Design Principles
+**Services:** Core Client, HTTP API, Metrics, Execution Service, Duties Service, Network (libp2p), Processor, QBFT Manager
 
-1. **Modularity**: Components are separated into their own crates with clear boundaries
-2. **Error Handling**: Comprehensive error types specific to each module
-3. **Asynchronous Design**: Built on Tokio for non-blocking operations
-4. **Thread Safety**: Uses Arc, Mutex, RwLock appropriately for shared state
-5. **Message Passing**: Communication between components via channels
+**Event flow:** Duties Service identifies duty -> Processor creates QBFT instance -> Network exchanges messages -> consensus reached -> signed message published on P2P network
 
-### Thread Model
-
-Anchor consists of multiple long-standing tasks that are spawned during initialization:
-
-1. **Core Client**: The main control flow
-2. **HTTP API**: Endpoint for reading data and modifying components
-3. **Metrics**: Prometheus-compatible metrics endpoint
-4. **Execution Service**: Syncs SSV information from execution layer nodes
-5. **Duties Service**: Watches the beacon chain for validator duties for known SSV validator shares
-6. **Network**: P2P network stack (libp2p) for communication on the SSV network
-7. **Processor**: Middleware that handles CPU-intensive tasks and prioritizes client workload
-8. **QBFT**: Manages QBFT instances to reach consensus in SSV committees
-
-### Key Components In Detail
-
-#### Consensus (QBFT)
-
-The QBFT module implements the Quorum Byzantine Fault Tolerance consensus algorithm:
-- Located in `anchor/common/qbft`
-- State machine-based implementation
-- Supports pluggable network and validation layers
-- Thread-safe for concurrent operation
-- Includes comprehensive testing for consensus edge cases
-
-#### Signature Collection
-
-The Signature Collector manages distributed validator signatures:
-- Located in `anchor/signature_collector`
-- Collects partial signatures from distributed validator operators
-- Uses threshold signature schemes with Lagrange interpolation
-- Handles timeouts and failure modes
-- Reconstructs full signatures when threshold is reached
-
-#### Network Layer
-
-The network component handles P2P communication:
-- Based on libp2p
-- Supports encrypted communications
-- Handles peer discovery and connection management
-- Routes messages to appropriate internal components
-
-### General Event Flow
-
-1. The Duties Service identifies a validator duty
-2. The duty is sent to the Processor
-3. The Processor creates a QBFT instance
-4. The Network receives messages until the QBFT instance completes
-5. The required consensus message is signed
-6. The message is published on the P2P network
+**Design principles:**
+- Modularity with clear crate boundaries
+- Typed error handling per module
+- Async-first with Tokio
+- Thread safety via Arc/Mutex/RwLock
+- Inter-component message passing via channels
 
 ## Code Organization
 
-The codebase is organized as a Rust workspace with multiple crates, each with a specific responsibility:
-
-- `anchor/`: Main crate with several submodules:
-    - `client/`: CLI and client interface
-    - `common/`: Shared types and utilities
-        - `api_types/`: API data structures
-        - `bls_lagrange/`: BLS cryptography implementations
-        - `global_config/`: Global configuration
-        - `operator_key/`: Key management
-        - `qbft/`: QBFT consensus implementation
-        - `ssv_network_config/`: Network configuration
-        - `ssv_types/`: Core SSV data types
-        - `version/`: Version information
-    - `database/`: Database operations and storage
-    - `duties_tracker/`: Validator duty tracking
-    - `eth/`: Ethereum connectivity
-    - `http_api/`: HTTP API implementation
-    - `http_metrics/`: Metrics API
-    - `keygen/`: Key generation
-    - `keysplit/`: Key splitting for SSV
-    - `logging/`: Logging infrastructure
-    - `message_receiver/`: Message reception
-    - `message_sender/`: Message sending
-    - `message_validator/`: Message validation
-    - `network/`: P2P networking
-    - `processor/`: Task processing
-    - `qbft_manager/`: QBFT instance management
-    - `signature_collector/`: Signature aggregation
-    - `subnet_service/`: Subnet operations
-    - `validator_store/`: Validator data storage
-
-## Modular Project Structure and Boundaries
-
-Anchor follows a modular design with clear boundaries between components, emphasizing the following principles:
-
-### Crate Structure
-
-1. **Independent Crates**: Each major component is its own crate with a clearly defined API
-2. **Minimal Dependencies**: Crates should only depend on what they need
-3. **Public API Surface**: APIs between crates should be well-documented and minimal
-4. **Clear Ownership**: Each crate has a clear responsibility and ownership model
-
-### Dependency Flow
-
-- **Common Libraries**: Core types and utilities are in `common/` subdirectories
-- **Service Dependencies**: Higher-level services depend on lower-level ones, not vice versa
-- **Configuration Flow**: Config flows down from the client to individual components
-- **Event Flow**: Events flow up from components to central coordinators
-
-### Inter-Component Communication
-
-1. **Message Passing**: Components communicate via typed message channels
-2. **Event Bus**: System-wide events use the EventBus pattern
-3. **Trait Boundaries**: Components interact through trait interfaces, not concrete implementations
-4. **Error Propagation**: Errors are properly typed and propagated up the stack
-
-## Code Style and Best Practices
-
-When contributing to Anchor, follow these Rust best practices:
-
-### General Principles
-
-1. **Follow Rust Idioms**: Use idiomatic Rust patterns (e.g., `Option`, `Result`, iterators)
-2. **Error Handling**: Use proper error types and the `?` operator; avoid `unwrap()`/`expect()` in production code
-3. **Memory Safety**: Leverage Rust's ownership system; avoid unsafe code when possible
-4. **Documentation**: All public APIs should be documented with examples
-5. **Type Safety**: Use the type system to prevent errors; avoid stringly-typed interfaces
-6. **Simplicity First**: Always choose the simplest solution that elegantly solves the problem, follows existing patterns, maintains performance, and uses basic constructs over complex data structures
-7. **Check Requirements First**: Before implementing or creating anything (PRs, commits, code), always read and follow existing templates, guidelines, and requirements in the codebase
-
-### Architecture and Design
-
-1. **Question Intermediaries**: If data flows A → B with no transformation, question why A → intermediate → B exists. Each layer should provide clear value (logging, transformation, validation, etc.). Ask: "What problem does this solve that direct communication doesn't?"
-
-2. **Separation Through Interfaces, Not Layers**: Clean boundaries come from well-defined APIs, not intermediary components. A component receiving a `Sender<Event>` achieves separation without needing forwarding tasks or wrapper channels.
-
-3. **Simplification is Always Valid**: Refactoring working code for simplicity is encouraged. Question architectural decisions even after tests pass. Fewer lines and fewer components often indicates better design.
-
-4. **Challenge Complexity**: Every abstraction should justify its existence. "We might need it later" or "it provides separation" aren't sufficient reasons. Complexity must solve specific, current problems.
-
-### Specific Guidelines
-
-1. **Naming**:
-    - Use clear, descriptive names
-    - Follow Rust naming conventions (snake_case for functions/variables, CamelCase for types)
-    - Prefer explicit names over abbreviations
-
-2. **Code Organization**:
-    - Organize code into logical modules
-    - Keep functions small and focused
-    - Use the module system to control visibility
-
-3. **Error Types**:
-    - Create domain-specific error types using `thiserror`
-    - Include context in errors
-    - Make error messages user-friendly
-
-4. **Comments**:
-    - Comment "why", not "what"
-    - Use doc comments (`///`) for public API documentation
-    - Add `TODO`, `FIXME`, or `NOTE` markers as needed for future work
-
-5. **Async Code**:
-    - Use `async`/`.await` properly with Tokio
-    - Handle cancellation correctly
-    - Avoid blocking the runtime with CPU-intensive work
-
-6. **Dependencies**:
-    - Keep dependencies minimal and up to date
-    - Prefer well-maintained crates from the ecosystem
-    - Pin dependency versions appropriately
-
-## Testing
-
-**MANDATORY: Always use the `tester-subagent` via the Task tool when creating or modifying tests.** Do not write tests directly - spawn the agent first. This ensures proper AAA structure, naming conventions, and avoids common mistakes.
-
-### Database Testing Patterns
-
-Anchor uses two types of test fixtures for database testing:
-
-1. **InMemoryTestFixture**: Fast tests using SQLite in-memory databases (`:memory:`)
-   - Use for unit tests and fast integration tests
-   - No file I/O overhead
-   - Data is lost when connection closes
-
-2. **FileTestFixture**: Tests requiring persistence or restart simulation
-   - Use for testing database migrations, restarts, or cross-process scenarios
-   - Uses temporary files that are automatically cleaned up
-   - Data persists until TempDir is dropped
-
-## Universal Code Quality Principles
-
-All agents and contributors must follow these fundamental principles:
-
-### Evidence and Verification
-- **Behavioral claims require evidence**: before asserting language/runtime behavior or performance implications, check authoritative docs/source or run a minimal reproduction; if not verified, label it as a hypothesis or ask.
-
-### Production Safety Requirements 
-- **Never use `.unwrap()` or `.expect()` without clear safety justification** - always use proper Result/Option handling
-- **Validate all user inputs** and handle potential failure cases gracefully
-- **No secrets or sensitive data** in logs, error messages, or debug output
-- **Memory safety first** - leverage Rust's ownership system, avoid unsafe code without justification
-
-### API and Dependency Management
-
-**Critical Principle**: Never suggest functionality that doesn't exist in dependencies.
-
-- **Check `Cargo.toml` for exact versions** before suggesting any dependency APIs
-- **Verify methods exist** in the specific versions used - never assume latest documentation applies
-- **Read dependency public APIs carefully** before recommending features or methods
-- **Search existing codebase** for established patterns, but prioritize best practices over bad existing patterns
-- **Don't assume capabilities** - external dependencies may have architectural constraints that prevent certain patterns
-- **Check implementation details** - if you don't see a method in the public API, don't suggest creating or using it
-- **When uncertain, verify** - check the dependency's source code or ask the user before suggesting
-- **Don't extrapolate** - don't assume dependencies support common patterns if they have different design requirements
-
-### Incremental Improvement Strategy
-- **Fix bad practices in code being modified** - if you're touching it, improve it
-- **Use best practices for all new code** - never add to technical debt
-- **Create GitHub issues for technical debt found elsewhere** - don't fix unrelated code in current PR
-- **Prioritize safety fixes** over performance optimizations over style improvements
-
-### Agent Usage Requirements  
-- **Use specialized agents immediately** when their expertise applies - don't wait for users to ask
-- **Follow the principle hierarchy**: Safety → Best Practices → Existing Patterns → Consistency
-- **Validate suggestions** before implementing - agents should verify their recommendations work
+Rust workspace under `anchor/`:
+- `client/` - CLI and client interface
+- `common/` - Shared types: `api_types/`, `bls_lagrange/`, `global_config/`, `operator_key/`, `qbft/`, `ssv_network_config/`, `ssv_types/`, `version/`
+- `database/` - Storage operations
+- `duties_tracker/` - Validator duty tracking
+- `eth/` - Ethereum connectivity
+- `http_api/` - HTTP API
+- `http_metrics/` - Metrics endpoint
+- `keygen/`, `keysplit/` - Key generation and splitting
+- `logging/` - Logging infrastructure
+- `message_receiver/`, `message_sender/`, `message_validator/` - Message handling
+- `network/` - P2P networking
+- `processor/` - Task processing
+- `qbft_manager/` - QBFT instance management
+- `signature_collector/` - Signature aggregation
+- `subnet_service/` - Subnet operations
+- `validator_store/` - Validator data storage
 
 ## Specialized Agents
 
-Use these agents proactively to prevent errors and enforce quality standards:
-
-- **tester-subagent**: **MANDATORY - Spawn via Task tool before creating or modifying ANY tests.** Do not write test code directly. Expert in AAA structure, naming conventions, and Anchor-specific testing patterns.
-
-- **code-reviewer-subagent**: **Use immediately after writing or modifying Rust code.** Reviews for safety, memory management, idiomatic patterns, and performance.
-
-- **logging-subagent**: **Use for any logging/tracing task.** Improves structured logging, reduces noise, and enforces performance patterns in Anchor's tracing infrastructure.
-
-- **qbft-subagent**: **Use for QBFT specification questions.** Expert on EEA QBFT v1 Dafny L1 specification, predicates, events, and invariants.
-
-Proactive agent usage prevents compilation errors from incorrect APIs, catches safety issues like `.unwrap()` before production, and saves debugging time by catching problems early.
-
-## Contribution Workflow
-
-When contributing to Anchor, follow these steps to ensure high-quality code that meets project standards:
-
-### Pull Request Requirements
-
-**PR Title:** Must follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format as enforced by `.github/workflows/pr-checks.yml`:
-- `feat: add new user login`
-- `fix: correct button size`
-- `docs: update README`
-- `test: add QBFT consensus tests`
-- `chore: update dependencies`
-- `perf: optimize message processing`
-- `refactor: simplify validation logic`
-- `ci: update workflow configuration`
-- `revert: undo previous change`
-
-**Breaking Changes:** Use `!` for breaking changes (e.g., `feat!: changed the API`)
-
-**PR Description:** **ALWAYS read `.github/PULL_REQUEST_TEMPLATE.md` first**, then follow the template format exactly:
-- **Issue Addressed:** Which issue # does this PR address?
-- **Proposed Changes:** List or describe the changes introduced
-- **Additional Info:** Future considerations or information for reviewers
-
-### Step 1: Plan Your Changes
-
-- Start with a clear understanding of the problem or feature
-- Break down complex tasks into smaller, manageable steps
-- Consider how your change affects the overall architecture
-- Discuss significant changes with the team before implementing
-
-### Step 2: Development Process
-
-1. **Branch**: Create a feature branch from the `unstable` branch
-2. **Implement**: Write code following project style guidelines
-3. **Test**: Add tests that cover your changes
-4. **Document**: Update documentation as needed
-5. **Refactor**: Clean up code before submission
-
-### Step 3: Pre-Commit Quality Checks
-
-**MANDATORY:** Before committing any code changes, run:
-
-```bash
-# Format code (required)
-make cargo-fmt
-# or
-cargo +nightly fmt --all
-
-# Check formatting
-make cargo-fmt-check
-
-# Run linter (required) 
-make lint
-# or
-cargo clippy --workspace --tests --features "$(TEST_FEATURES)" -- -D warnings
-
-# Run tests
-make test
-```
-
-**Additional Quality Checks:**
-- **Check Performance**: Consider performance implications
-- **Ensure Backwards Compatibility**: When applicable
-- **Run Audit**: `make audit` for security issues (when dependencies change)
-
-### Step 4: Submit Changes
-
-1. **Commit**: Use clear commit messages that explain the change
-2. **Push**: Push your branch to your fork
-3. **PR**: Open a pull request against the `unstable` branch
-4. **Review**: Address review feedback promptly
-5. **CI**: Ensure all CI checks pass
-
-### Commit Message Guidelines
-
-- Use present tense ("Add feature", not "Added feature")
-- First line is a summary (50 chars or less)
-- Include component prefix (e.g., `network:`, `consensus:`)
-- Reference issues or tickets when applicable
-- Include context on why the change was made
-
-### PR Description Best Practices
-
-When writing PR descriptions, follow these guidelines for maintainable and reviewable documentation:
-
-- **Keep "Proposed Changes" section high-level** - focus on what components were changed and why
-- **Avoid line-by-line documentation** - reviewers can see specific changes in the diff
-- **Use component-level summaries** rather than file-by-file breakdowns
-- **Emphasize the principles** being applied and operational impact
-- **Be concise but complete** - provide context without overwhelming detail
-- **Don't mention implementation details** - avoid specifying exact files, line numbers, or function names
-- **Don't state the obvious** - don't mention that tests pass (CI will verify this)
-- **Avoid redundancy** - don't repeat information already in the title or commit message
-- **Focus on the "why"** - explain the motivation and impact, not the mechanics
-
-### Code Review Culture
-
-Effective code reviews question "why" architectural decisions exist:
-
-**Questions to Ask:**
-- "Why does this intermediary layer exist?"
-- "What problem does this abstraction solve?"
-- "Could components communicate directly?"
-- "Is this complexity providing clear value?"
-
-**Encourage Simplification:**
-- Working code can still be improved
-- Refactoring for clarity is valuable
-- Fewer components usually means better architecture
-- Test passing ≠ design complete
-
-**Balance:**
-- Question complexity, but respect existing patterns that solve real problems
-- Not every layer is unnecessary - some provide genuine value
-- Focus on "why" over "what"
+Use these agents proactively:
+- **tester-subagent**: MANDATORY before creating/modifying any tests
+- **code-reviewer-subagent**: Use after writing/modifying Rust code
+- **logging-subagent**: Use for any logging/tracing task
+- **qbft-subagent**: Use for QBFT specification questions
 
 ## Development Tips
 
-- This is a Rust project that follows standard Rust development practices
-- Sigma Prime maintains two permanent branches:
-    - `stable`: Always points to the latest stable release, ideal for most users
-    - `unstable`: Used for development, contains the latest PRs, base branch for contributions
-- When implementing new features, focus on modular design with clear boundaries
-- Follow test-driven development principles when possible
-- Use debugging tools like `tracing` and metrics to understand system behavior
+- Two permanent branches: `stable` (latest release), `unstable` (development, PR base)
+- Priority order: Safety > Correctness > Simplicity > Performance > Style
+- Use specialized agents immediately when their expertise applies
+- Validate suggestions before implementing
+- Follow the principle hierarchy: Safety > Best Practices > Existing Patterns > Consistency
 
-## Session Learning Updates
+## Quality Principles
 
-After successful Claude Code sessions where the user is satisfied with results, update both CLAUDE.md and relevant specialized agents with general principles learned:
-
-- **CLAUDE.md**: Add universal principles that apply across all development contexts
-- **Specialized Agents**: Update each agent with context-specific lessons learned in their domain
-- **Focus on Principles**: Capture the underlying reasoning and approach, not implementation details
-- **Generalize Lessons**: Extract principles that can be applied to similar future problems
+- Behavioral claims require evidence; label unverified claims as hypotheses
+- Fix bad practices in code being modified; use best practices for all new code
+- Create issues for tech debt found elsewhere; don't fix unrelated code in current PR
+- Prioritize: safety fixes > performance > style improvements


### PR DESCRIPTION
## Issue Addressed

N/A — improves AI-assisted development workflow by restructuring project instructions.

## Proposed Changes

The monolithic `CLAUDE.md` (474 lines) was well beyond the recommended size for effective context loading. This PR splits it into a concise core file (~90 lines) plus 10 modular rule files under `.claude/rules/`.

The core `CLAUDE.md` retains only essential project context: description, commands, architecture overview, code organization, specialized agents, and development tips. Detailed standards are extracted into dedicated rule files:

- **Rust-specific rules** (`rust-style.md`, `production-safety.md`, `testing.md`, `dependency-api.md`) use `paths` frontmatter so they load only when relevant files are touched
- **Workflow rules** (`verification.md`, `pr-workflow.md`, `dev-workflow.md`, `commands.md`, `session-learning.md`) and **architecture rules** (`architecture.md`) load always

**What did NOT change:** No code changes. All existing guidance content is preserved — it's reorganized, not removed. The rule files merge and deduplicate content that was previously split across `CLAUDE.md` and local rule files.

**Reading order:** Start with `CLAUDE.md` (the trimmed core), then scan any rule file of interest.

## Additional Info

- Rule files with `paths` frontmatter are conditionally loaded, reducing token overhead for unrelated tasks
- Verified: `make cargo-fmt-check`, `make lint`, `make sort` all pass (pre-commit hooks ran successfully)