### PR TITLE
fix: anchor dappnode keys

### DIFF
--- a/anchor/client/src/key.rs
+++ b/anchor/client/src/key.rs
@@ -62,6 +62,18 @@ fn try_read(key_file: &Path, password_file: Option<&Path>) -> Option<Result<Rsa<
 fn generate_key(dir: &DataDir, password_file: Option<&Path>) -> Result<Rsa<Private>, String> {
     info!("Creating private key");
     let key = Rsa::generate(2048).map_err(|e| format!("Unable to generate key: {e}"))?;
+
+    // A key file may have been placed between our initial check and now (e.g. docker cp
+    // while the container is running). Prefer the externally-provided key if present.
+    let unencrypted_key_file = dir.unencrypted_private_key_file();
+    let encrypted_key_file = dir.encrypted_private_key_file();
+    if let Some(result) = try_read(&unencrypted_key_file, password_file)
+        .or_else(|| try_read(&encrypted_key_file, password_file))
+    {
+        info!("Key file appeared during generation, using externally-provided key");
+        return result;
+    }
+
     // Encrypt the fresh key if a password key file was provided. For interactive password
     // input, the user should use the keygen tool.
     let password = password_file


### PR DESCRIPTION
## Issue Addressed
https://github.com/dappnode/DAppNodePackage-anchor-generic/pull/1#issuecomment-3846021939

## Proposed Changes
DAppNode's `copyFileToDockerContainer` temporarily starts the container to `docker cp` a key file in. This races with Anchor's key generation -> `try_read` finds no file, `Rsa::generate` runs, then `docker cp` lands the file, and `File::create_new` fails with `EEXIST`.

Fix: re-check for key files after `Rsa::generate` before attempting to write. If one appeared, use it.

## Additional Info
The race window depends on how long `Rsa::generate(2048)` takes, which varies by hardware. Reproduced in Docker with an artificial sleep widening the window.
