### PR TITLE
refactor: decode proposerconsensusdata block helpers

### DIFF
--- a/anchor/common/ssv_types/src/consensus.rs
+++ b/anchor/common/ssv_types/src/consensus.rs
@@ -247,6 +247,20 @@ pub struct ProposerConsensusData {
     pub data_ssz: VariableList<u8, ProposerConsensusDataLen>,
 }
 
+impl ProposerConsensusData {
+    /// Decode the block data as a blinded beacon block.
+    pub fn decode_blinded_block<E: EthSpec>(&self) -> Result<BlindedBeaconBlock<E>, DecodeError> {
+        let fork = ForkName::from(self.version);
+        BlindedBeaconBlock::from_ssz_bytes_for_fork(&self.data_ssz, fork)
+    }
+
+    /// Decode the block data as full block contents (block + blobs).
+    pub fn decode_block_contents<E: EthSpec>(&self) -> Result<FullBlockContents<E>, DecodeError> {
+        let fork = ForkName::from(self.version);
+        FullBlockContents::from_ssz_bytes_for_fork(&self.data_ssz, fork)
+    }
+}
+
 impl QbftData for ProposerConsensusData {
     type Hash = Hash256;
 
@@ -365,14 +379,14 @@ impl<E: EthSpec> ProposerConsensusDataValidator<E> {
         &self,
         value: &ProposerConsensusData,
     ) -> Result<(), DataValidationError> {
-        let fork = ForkName::from(value.version);
-
         // Always do this check, even if we're not validating slashing. This is to ensure that we
         // have a decodable value.
-        let header = BlindedBeaconBlock::<E>::from_ssz_bytes_for_fork(&value.data_ssz, fork)
+        let header = value
+            .decode_blinded_block::<E>()
             .map(|block| block.block_header())
             .or_else(|_| {
-                FullBlockContents::<E>::from_ssz_bytes_for_fork(&value.data_ssz, fork)
+                value
+                    .decode_block_contents::<E>()
                     .map(|block| block.block().block_header())
             })
             .map_err(DataValidationError::DecodeError)?;

--- a/anchor/validator_store/src/lib.rs
+++ b/anchor/validator_store/src/lib.rs
@@ -59,9 +59,9 @@ use tracing::{debug, error, info, trace, warn};
 use types::{
     AbstractExecPayload, Address, AggregateAndProof, AggregateAndProofBase,
     AggregateAndProofElectra, Attestation, AttestationBase, AttestationElectra, BeaconBlock,
-    BeaconBlockRef, BlindedBeaconBlock, BlindedPayload, ChainSpec, ContributionAndProof, Domain,
-    Epoch, EthSpec, ExecutionPayloadEnvelope, ForkName, FullPayload, Graffiti, Hash256,
-    SelectionProof, SignedAggregateAndProof, SignedBeaconBlock, SignedBlindedBeaconBlock,
+    BeaconBlockRef, BlindedPayload, ChainSpec, ContributionAndProof, Domain, Epoch, EthSpec,
+    ExecutionPayloadEnvelope, ForkName, FullPayload, Graffiti, Hash256, SelectionProof,
+    SignedAggregateAndProof, SignedBeaconBlock, SignedBlindedBeaconBlock,
     SignedContributionAndProof, SignedExecutionPayloadEnvelope, SignedRoot,
     SignedValidatorRegistrationData, SignedVoluntaryExit, Slot, SlotData,
     SyncAggregatorSelectionData, SyncCommitteeContribution, SyncCommitteeMessage,
@@ -388,12 +388,12 @@ impl<T: SlotClock, E: EthSpec> AnchorValidatorStore<T, E> {
             Completed::Success(data) => data,
         };
 
-        let fork = ForkName::from(completed_data.version);
-
-        BlindedBeaconBlock::from_ssz_bytes_for_fork(&completed_data.data_ssz, fork)
+        completed_data
+            .decode_blinded_block()
             .map(UnsignedBlock::Blinded)
             .or_else(|_| {
-                FullBlockContents::from_ssz_bytes_for_fork(&completed_data.data_ssz, fork)
+                completed_data
+                    .decode_block_contents()
                     .map(UnsignedBlock::Full)
             })
             .map_err(|err| Error::SpecificError(SpecificError::InvalidQbftData(err)))


### PR DESCRIPTION
## Problem, Evidence, and Context (Required)

  - Block decoding from `ProposerConsensusData` (extract fork, SSZ decode as blinded or full) is duplicated identically in validate_block_proposal and validator_store.
  - PR #839 (spec tests) will also need the same decode logic, adding a third copy.

## Change Overview (Required)

  - Added `decode_blinded_block()` and `decode_block_contents()` methods to `ProposerConsensusData`, encapsulating the fork-extraction + SSZ decode pattern.
  - Updated both call sites (`ProposerConsensusDataValidator` and `AnchorValidatorStore`) to use the new methods.
  - No behavioral changes — same decode logic, same error handling, same fallback order (blinded first, then full).

## Risks, Trade-offs, and Mitigations (Required)

  - Pure refactor with no behavioral change. Risk is minimal.
  - Both existing call sites are updated; no orphaned code paths.

  Validation (Required)

  - Existing tests cover both decode paths. make test passes.

## Rollback (Required for behavior or runtime changes; optional otherwise)

  N/A — pure refactor, safe to revert.

## Blockers / Dependencies (Optional)

  - PR #839 depends on these new methods for spec test coverage.

## Additional Info / Next Steps (Optional)

  N/A