### PR TITLE
ci: add Dependabot policy to close dependency update gap

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,7 @@ version: 2
 updates:
   - package-ecosystem: "cargo"
     directory: "/"
+    target-branch: "unstable"
     schedule:
       interval: "weekly"
       day: "monday"
@@ -21,6 +22,7 @@ updates:
 
   - package-ecosystem: "github-actions"
     directory: "/"
+    target-branch: "unstable"
     schedule:
       interval: "weekly"
       day: "monday"
@@ -42,6 +44,7 @@ updates:
 
   - package-ecosystem: "npm"
     directory: "/docs"
+    target-branch: "unstable"
     schedule:
       interval: "weekly"
       day: "monday"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,60 @@
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "UTC"
+    open-pull-requests-limit: 3
+    labels:
+      - "dependencies"
+      - "rust"
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      cargo-patch-minor:
+        update-types:
+          - "patch"
+          - "minor"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:30"
+      timezone: "UTC"
+    open-pull-requests-limit: 2
+    labels:
+      - "dependencies"
+      - "ci"
+    commit-message:
+      prefix: "chore(ci)"
+    groups:
+      actions-patch-minor:
+        update-types:
+          - "patch"
+          - "minor"
+        patterns:
+          - "*"
+
+  - package-ecosystem: "npm"
+    directory: "/docs"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "07:00"
+      timezone: "UTC"
+    open-pull-requests-limit: 2
+    labels:
+      - "dependencies"
+      - "docs"
+    commit-message:
+      prefix: "chore(docs)"
+    groups:
+      docs-patch-minor:
+        update-types:
+          - "patch"
+          - "minor"


### PR DESCRIPTION
## Issue Addressed

N/A (critical reliability and supply-chain hardening gap)

## Proposed Changes

- Add `.github/dependabot.yml` to automate dependency update intake for:
  - Cargo workspace dependencies
  - GitHub Actions workflow dependencies
  - Docs npm dependencies (`/docs`)
- Configure low-noise cadence and batching:
  - Weekly schedule
  - Group patch/minor updates
  - Low open PR limits per ecosystem
- Add consistent dependency labels and conventional commit prefixes for easier triage.

## Additional Info

### Motivation
This closes a critical process gap: dependency updates currently rely on manual discovery and ad-hoc upgrades. That creates avoidable exposure to security advisories, CI drift, and delayed maintenance work that later lands as larger, riskier batches.

### Real Benefits
- Shorter vulnerability exposure window for dependency issues.
- Smaller, more reviewable update PRs instead of large catch-up upgrades.
- More stable CI over time by continuously updating Actions/tooling dependencies.
- Predictable maintenance cadence and lower operational surprise cost.

### Why this is safe
- This PR introduces no production runtime behavior changes.
- Noise is intentionally constrained via weekly scheduling, grouping, and strict PR limits.

### Risk
- Main risk is PR churn. Config limits are set conservatively to keep review load manageable.

### Testing
- No runtime tests required (configuration-only change).
- Verified the commit contains only `.github/dependabot.yml`.

### Rollback
- Revert this commit or remove `.github/dependabot.yml` to disable automation immediately.
