### PR TITLE
ci: strengthen PR template with evidence, risk, and rollback prompts

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,9 +2,33 @@
 
 Which issue # does this PR address?
 
+## Motivation
+
+Why is this change needed now? What concrete gap or risk does it address?
+
 ## Proposed Changes
 
 Please list or describe the changes introduced by this PR.
+
+## Real Benefits
+
+What practical outcomes do we gain (e.g., risk reduction, reliability, performance, maintainability)?
+
+## Risk
+
+What could go wrong with this change? What is the expected blast radius if it fails?
+
+## Testing
+
+What verification was performed? Include relevant commands or evidence.
+
+## Rollback
+
+How can this change be reverted safely if needed?
+
+## Blockers / Dependencies
+
+What dependencies, prerequisite merges, external changes, or blockers are relevant?
 
 ## Additional Info
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,36 +1,38 @@
-## Issue Addressed
+Keep this concise. Use bullets where helpful. Write `N/A` if not applicable.
 
-Which issue # does this PR address?
+## Problem, Evidence, and Context (Required)
 
-## Motivation
+- What real problem does this solve, or what real value does it add now?
+- Why is this worth doing now?
+- What evidence supports that?
+- Relevant links: issue, discussion, spec, related PRs.
 
-Why is this change needed now? What concrete gap or risk does it address?
+## Change Overview (Required)
 
-## Proposed Changes
+- What changed at a high level?
+- How should the reviewer understand or read this diff?
+- What intentionally did not change?
 
-Please list or describe the changes introduced by this PR.
+## Risks, Trade-offs, and Mitigations (Required)
 
-## Real Benefits
+- What are the main risks or blast radius?
+- What trade-offs are being made?
+- How are those risks being mitigated?
 
-What practical outcomes do we gain (e.g., risk reduction, reliability, performance, maintainability)?
+## Validation (Required)
 
-## Risk
+- What proves the change does what it must do?
+- Examples: targeted tests, manual repro, benchmark/profiling result, before/after behavior, spec-parity check.
 
-What could go wrong with this change? What is the expected blast radius if it fails?
+## Rollback (Required for behavior or runtime changes; optional otherwise)
 
-## Testing
+- How can this be safely reverted?
+- Any config, data, or operational impact?
 
-What verification was performed? Include relevant commands or evidence.
+## Blockers / Dependencies (Optional)
 
-## Rollback
+- Anything that must happen before or after merge.
 
-How can this change be reverted safely if needed?
+## Additional Info / Next Steps (Optional)
 
-## Blockers / Dependencies
-
-What dependencies, prerequisite merges, external changes, or blockers are relevant?
-
-## Additional Info
-
-Please provide any additional information. For example, future considerations
-or information useful for reviewers.
+- Anything else reviewers should know.


### PR DESCRIPTION
## Problem, Evidence, and Context

The previous PR template was too verbose in some places and too thin in others. It did not consistently force authors to state the real problem being solved, the evidence that it exists, the risks being taken, or how the change can be rolled back. That weakens review quality in a repo where many changes can carry runtime or protocol risk.

Relevant context: Shane's feedback on this PR pointed out that some earlier sections overlapped, so this version simplifies the structure while keeping the important discipline.

## Change Overview

This change replaces the earlier section split with a shorter template built around six core review questions:
- what real problem or value justifies the change
- what changed at a high level
- what risks and trade-offs exist
- what validation proves the change works
- how it can be rolled back
- what blockers or dependencies matter

The template stays concise and explicitly allows `N/A` where appropriate.

## Risks, Trade-offs, and Mitigations

The main trade-off is adding a bit more structure to PR writing. The mitigation is keeping the prompts short and focused on the highest-value review context instead of expanding into a long checklist.

## Validation

- Reviewed the final template wording for overlap and unnecessary verbosity.
- Verified the branch changes only `.github/PULL_REQUEST_TEMPLATE.md`.

## Rollback

Revert this PR to restore the previous template.

## Blockers / Dependencies

N/A

## Additional Info / Next Steps

If this lands and proves useful in practice, we can later refine prompt wording based on actual reviewer friction instead of adding more sections up front.
