### PR TITLE
chore: add commit hash to docker build

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -61,6 +61,7 @@ jobs:
             - name: Build and push
               uses: docker/build-push-action@v6
               with:
+                context: .
                 platforms: linux/${{ matrix.target.docker-arch }}
                 labels: |
                     git.revision=${{ github.sha }}


### PR DESCRIPTION
## Issue Addressed
Docker images (`sigp/anchor:latest-unstable`, `sigp/anchor:latest`) report anchor v1.2.1 with no commit hash. Expected: `anchor v1.2.1-0e11d31` for current unstable for example. 

## Proposed Changes
Add `context: .` to `docker/build-push-action` so `BuildKit` uses the local checkout (which includes `.git`) instead of Git context (which strips `.git` by default). Without `.git`, the `git_version!` macro falls back to the version string with no commit hash.

## Additional Info
Lighthouse's `docker.yml` uses `context: .`. Verified locally by building the full docker image and confirming `anchor --version` outputs `v1.2.1-0e11d31`.
