### PR TITLE
chore: bump lh crates to latest from unstable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1399,7 +1399,7 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 [[package]]
 name = "beacon_node_fallback"
 version = "0.1.0"
-source = "git+https://github.com/shane-moore/lighthouse?rev=66ff63a#66ff63a8d8d9fd75c5a842477f7789b93a996ee0"
+source = "git+https://github.com/sigp/lighthouse?rev=4b3a9d3#4b3a9d3d10a6181a1a1588880de133457eb90816"
 dependencies = [
  "bls",
  "clap",
@@ -1499,7 +1499,7 @@ dependencies = [
 [[package]]
 name = "bls"
 version = "0.2.0"
-source = "git+https://github.com/shane-moore/lighthouse?rev=66ff63a#66ff63a8d8d9fd75c5a842477f7789b93a996ee0"
+source = "git+https://github.com/sigp/lighthouse?rev=4b3a9d3#4b3a9d3d10a6181a1a1588880de133457eb90816"
 dependencies = [
  "alloy-primitives 1.5.7",
  "blst",
@@ -2588,7 +2588,7 @@ dependencies = [
 [[package]]
 name = "eip_3076"
 version = "0.1.0"
-source = "git+https://github.com/shane-moore/lighthouse?rev=66ff63a#66ff63a8d8d9fd75c5a842477f7789b93a996ee0"
+source = "git+https://github.com/sigp/lighthouse?rev=4b3a9d3#4b3a9d3d10a6181a1a1588880de133457eb90816"
 dependencies = [
  "bls",
  "ethereum_serde_utils 0.8.0",
@@ -2823,7 +2823,7 @@ dependencies = [
 [[package]]
 name = "eth2"
 version = "0.1.0"
-source = "git+https://github.com/shane-moore/lighthouse?rev=66ff63a#66ff63a8d8d9fd75c5a842477f7789b93a996ee0"
+source = "git+https://github.com/sigp/lighthouse?rev=4b3a9d3#4b3a9d3d10a6181a1a1588880de133457eb90816"
 dependencies = [
  "bls",
  "context_deserialize",
@@ -2852,7 +2852,7 @@ dependencies = [
 [[package]]
 name = "eth2_config"
 version = "0.2.0"
-source = "git+https://github.com/shane-moore/lighthouse?rev=66ff63a#66ff63a8d8d9fd75c5a842477f7789b93a996ee0"
+source = "git+https://github.com/sigp/lighthouse?rev=4b3a9d3#4b3a9d3d10a6181a1a1588880de133457eb90816"
 dependencies = [
  "paste",
  "types",
@@ -2861,7 +2861,7 @@ dependencies = [
 [[package]]
 name = "eth2_interop_keypairs"
 version = "0.2.0"
-source = "git+https://github.com/shane-moore/lighthouse?rev=66ff63a#66ff63a8d8d9fd75c5a842477f7789b93a996ee0"
+source = "git+https://github.com/sigp/lighthouse?rev=4b3a9d3#4b3a9d3d10a6181a1a1588880de133457eb90816"
 dependencies = [
  "bls",
  "ethereum_hashing 0.8.0",
@@ -2874,7 +2874,7 @@ dependencies = [
 [[package]]
 name = "eth2_key_derivation"
 version = "0.1.0"
-source = "git+https://github.com/shane-moore/lighthouse?rev=66ff63a#66ff63a8d8d9fd75c5a842477f7789b93a996ee0"
+source = "git+https://github.com/sigp/lighthouse?rev=4b3a9d3#4b3a9d3d10a6181a1a1588880de133457eb90816"
 dependencies = [
  "bls",
  "num-bigint-dig",
@@ -2886,7 +2886,7 @@ dependencies = [
 [[package]]
 name = "eth2_keystore"
 version = "0.1.0"
-source = "git+https://github.com/shane-moore/lighthouse?rev=66ff63a#66ff63a8d8d9fd75c5a842477f7789b93a996ee0"
+source = "git+https://github.com/sigp/lighthouse?rev=4b3a9d3#4b3a9d3d10a6181a1a1588880de133457eb90816"
 dependencies = [
  "aes",
  "bls",
@@ -2910,7 +2910,7 @@ dependencies = [
 [[package]]
 name = "eth2_network_config"
 version = "0.2.0"
-source = "git+https://github.com/shane-moore/lighthouse?rev=66ff63a#66ff63a8d8d9fd75c5a842477f7789b93a996ee0"
+source = "git+https://github.com/sigp/lighthouse?rev=4b3a9d3#4b3a9d3d10a6181a1a1588880de133457eb90816"
 dependencies = [
  "bytes",
  "discv5",
@@ -3122,7 +3122,7 @@ dependencies = [
 [[package]]
 name = "filesystem"
 version = "0.1.0"
-source = "git+https://github.com/shane-moore/lighthouse?rev=66ff63a#66ff63a8d8d9fd75c5a842477f7789b93a996ee0"
+source = "git+https://github.com/sigp/lighthouse?rev=4b3a9d3#4b3a9d3d10a6181a1a1588880de133457eb90816"
 dependencies = [
  "winapi",
  "windows-acl",
@@ -3149,7 +3149,7 @@ dependencies = [
 [[package]]
 name = "fixed_bytes"
 version = "0.1.0"
-source = "git+https://github.com/shane-moore/lighthouse?rev=66ff63a#66ff63a8d8d9fd75c5a842477f7789b93a996ee0"
+source = "git+https://github.com/sigp/lighthouse?rev=4b3a9d3#4b3a9d3d10a6181a1a1588880de133457eb90816"
 dependencies = [
  "alloy-primitives 1.5.7",
  "safe_arith",
@@ -3470,7 +3470,7 @@ dependencies = [
 [[package]]
 name = "graffiti_file"
 version = "0.1.0"
-source = "git+https://github.com/shane-moore/lighthouse?rev=66ff63a#66ff63a8d8d9fd75c5a842477f7789b93a996ee0"
+source = "git+https://github.com/sigp/lighthouse?rev=4b3a9d3#4b3a9d3d10a6181a1a1588880de133457eb90816"
 dependencies = [
  "bls",
  "serde",
@@ -3571,7 +3571,7 @@ dependencies = [
 [[package]]
 name = "health_metrics"
 version = "0.1.0"
-source = "git+https://github.com/shane-moore/lighthouse?rev=66ff63a#66ff63a8d8d9fd75c5a842477f7789b93a996ee0"
+source = "git+https://github.com/sigp/lighthouse?rev=4b3a9d3#4b3a9d3d10a6181a1a1588880de133457eb90816"
 dependencies = [
  "eth2",
  "metrics",
@@ -4093,7 +4093,7 @@ dependencies = [
 [[package]]
 name = "int_to_bytes"
 version = "0.2.0"
-source = "git+https://github.com/shane-moore/lighthouse?rev=66ff63a#66ff63a8d8d9fd75c5a842477f7789b93a996ee0"
+source = "git+https://github.com/sigp/lighthouse?rev=4b3a9d3#4b3a9d3d10a6181a1a1588880de133457eb90816"
 dependencies = [
  "bytes",
 ]
@@ -4255,9 +4255,8 @@ dependencies = [
 [[package]]
 name = "kzg"
 version = "0.1.0"
-source = "git+https://github.com/shane-moore/lighthouse?rev=66ff63a#66ff63a8d8d9fd75c5a842477f7789b93a996ee0"
+source = "git+https://github.com/sigp/lighthouse?rev=4b3a9d3#4b3a9d3d10a6181a1a1588880de133457eb90816"
 dependencies = [
- "c-kzg",
  "educe",
  "ethereum_hashing 0.8.0",
  "ethereum_serde_utils 0.8.0",
@@ -4773,7 +4772,7 @@ dependencies = [
 [[package]]
 name = "logging"
 version = "0.2.0"
-source = "git+https://github.com/shane-moore/lighthouse?rev=66ff63a#66ff63a8d8d9fd75c5a842477f7789b93a996ee0"
+source = "git+https://github.com/sigp/lighthouse?rev=4b3a9d3#4b3a9d3d10a6181a1a1588880de133457eb90816"
 dependencies = [
  "chrono",
  "logroller",
@@ -4828,7 +4827,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 [[package]]
 name = "lru_cache"
 version = "0.1.0"
-source = "git+https://github.com/shane-moore/lighthouse?rev=66ff63a#66ff63a8d8d9fd75c5a842477f7789b93a996ee0"
+source = "git+https://github.com/sigp/lighthouse?rev=4b3a9d3#4b3a9d3d10a6181a1a1588880de133457eb90816"
 dependencies = [
  "fnv",
 ]
@@ -4909,7 +4908,7 @@ dependencies = [
 [[package]]
 name = "merkle_proof"
 version = "0.2.0"
-source = "git+https://github.com/shane-moore/lighthouse?rev=66ff63a#66ff63a8d8d9fd75c5a842477f7789b93a996ee0"
+source = "git+https://github.com/sigp/lighthouse?rev=4b3a9d3#4b3a9d3d10a6181a1a1588880de133457eb90816"
 dependencies = [
  "alloy-primitives 1.5.7",
  "ethereum_hashing 0.8.0",
@@ -5007,7 +5006,7 @@ dependencies = [
 [[package]]
 name = "metrics"
 version = "0.2.0"
-source = "git+https://github.com/shane-moore/lighthouse?rev=66ff63a#66ff63a8d8d9fd75c5a842477f7789b93a996ee0"
+source = "git+https://github.com/sigp/lighthouse?rev=4b3a9d3#4b3a9d3d10a6181a1a1588880de133457eb90816"
 dependencies = [
  "prometheus",
 ]
@@ -5249,7 +5248,7 @@ dependencies = [
 [[package]]
 name = "network_utils"
 version = "0.1.0"
-source = "git+https://github.com/shane-moore/lighthouse?rev=66ff63a#66ff63a8d8d9fd75c5a842477f7789b93a996ee0"
+source = "git+https://github.com/sigp/lighthouse?rev=4b3a9d3#4b3a9d3d10a6181a1a1588880de133457eb90816"
 dependencies = [
  "discv5",
  "libp2p-identity",
@@ -5814,7 +5813,7 @@ dependencies = [
 [[package]]
 name = "pretty_reqwest_error"
 version = "0.1.0"
-source = "git+https://github.com/shane-moore/lighthouse?rev=66ff63a#66ff63a8d8d9fd75c5a842477f7789b93a996ee0"
+source = "git+https://github.com/sigp/lighthouse?rev=4b3a9d3#4b3a9d3d10a6181a1a1588880de133457eb90816"
 dependencies = [
  "reqwest",
  "sensitive_url",
@@ -5975,7 +5974,7 @@ dependencies = [
 [[package]]
 name = "proto_array"
 version = "0.2.0"
-source = "git+https://github.com/shane-moore/lighthouse?rev=66ff63a#66ff63a8d8d9fd75c5a842477f7789b93a996ee0"
+source = "git+https://github.com/sigp/lighthouse?rev=4b3a9d3#4b3a9d3d10a6181a1a1588880de133457eb90816"
 dependencies = [
  "ethereum_ssz",
  "ethereum_ssz_derive",
@@ -7152,7 +7151,7 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 [[package]]
 name = "slashing_protection"
 version = "0.1.0"
-source = "git+https://github.com/shane-moore/lighthouse?rev=66ff63a#66ff63a8d8d9fd75c5a842477f7789b93a996ee0"
+source = "git+https://github.com/sigp/lighthouse?rev=4b3a9d3#4b3a9d3d10a6181a1a1588880de133457eb90816"
 dependencies = [
  "bls",
  "eip_3076",
@@ -7172,7 +7171,7 @@ dependencies = [
 [[package]]
 name = "slot_clock"
 version = "0.2.0"
-source = "git+https://github.com/shane-moore/lighthouse?rev=66ff63a#66ff63a8d8d9fd75c5a842477f7789b93a996ee0"
+source = "git+https://github.com/sigp/lighthouse?rev=4b3a9d3#4b3a9d3d10a6181a1a1588880de133457eb90816"
 dependencies = [
  "metrics",
  "parking_lot",
@@ -7418,7 +7417,7 @@ dependencies = [
 [[package]]
 name = "swap_or_not_shuffle"
 version = "0.2.0"
-source = "git+https://github.com/shane-moore/lighthouse?rev=66ff63a#66ff63a8d8d9fd75c5a842477f7789b93a996ee0"
+source = "git+https://github.com/sigp/lighthouse?rev=4b3a9d3#4b3a9d3d10a6181a1a1588880de133457eb90816"
 dependencies = [
  "alloy-primitives 1.5.7",
  "ethereum_hashing 0.8.0",
@@ -7521,7 +7520,7 @@ checksum = "c63f48baada5c52e65a29eef93ab4f8982681b67f9e8d29c7b05abcfec2b9ffe"
 [[package]]
 name = "task_executor"
 version = "0.1.0"
-source = "git+https://github.com/shane-moore/lighthouse?rev=66ff63a#66ff63a8d8d9fd75c5a842477f7789b93a996ee0"
+source = "git+https://github.com/sigp/lighthouse?rev=4b3a9d3#4b3a9d3d10a6181a1a1588880de133457eb90816"
 dependencies = [
  "async-channel 1.9.0",
  "futures",
@@ -7564,7 +7563,7 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 [[package]]
 name = "test_random_derive"
 version = "0.2.0"
-source = "git+https://github.com/shane-moore/lighthouse?rev=66ff63a#66ff63a8d8d9fd75c5a842477f7789b93a996ee0"
+source = "git+https://github.com/sigp/lighthouse?rev=4b3a9d3#4b3a9d3d10a6181a1a1588880de133457eb90816"
 dependencies = [
  "quote",
  "syn 2.0.117",
@@ -8023,7 +8022,7 @@ checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 [[package]]
 name = "types"
 version = "0.2.1"
-source = "git+https://github.com/shane-moore/lighthouse?rev=66ff63a#66ff63a8d8d9fd75c5a842477f7789b93a996ee0"
+source = "git+https://github.com/sigp/lighthouse?rev=4b3a9d3#4b3a9d3d10a6181a1a1588880de133457eb90816"
 dependencies = [
  "alloy-primitives 1.5.7",
  "alloy-rlp",
@@ -8212,7 +8211,7 @@ dependencies = [
 [[package]]
 name = "validator_metrics"
 version = "0.1.0"
-source = "git+https://github.com/shane-moore/lighthouse?rev=66ff63a#66ff63a8d8d9fd75c5a842477f7789b93a996ee0"
+source = "git+https://github.com/sigp/lighthouse?rev=4b3a9d3#4b3a9d3d10a6181a1a1588880de133457eb90816"
 dependencies = [
  "metrics",
 ]
@@ -8220,7 +8219,7 @@ dependencies = [
 [[package]]
 name = "validator_services"
 version = "0.1.0"
-source = "git+https://github.com/shane-moore/lighthouse?rev=66ff63a#66ff63a8d8d9fd75c5a842477f7789b93a996ee0"
+source = "git+https://github.com/sigp/lighthouse?rev=4b3a9d3#4b3a9d3d10a6181a1a1588880de133457eb90816"
 dependencies = [
  "beacon_node_fallback",
  "bls",
@@ -8245,7 +8244,7 @@ dependencies = [
 [[package]]
 name = "validator_store"
 version = "0.1.0"
-source = "git+https://github.com/shane-moore/lighthouse?rev=66ff63a#66ff63a8d8d9fd75c5a842477f7789b93a996ee0"
+source = "git+https://github.com/sigp/lighthouse?rev=4b3a9d3#4b3a9d3d10a6181a1a1588880de133457eb90816"
 dependencies = [
  "bls",
  "eth2",
@@ -8995,7 +8994,7 @@ dependencies = [
 [[package]]
 name = "workspace_members"
 version = "0.1.0"
-source = "git+https://github.com/shane-moore/lighthouse?rev=66ff63a#66ff63a8d8d9fd75c5a842477f7789b93a996ee0"
+source = "git+https://github.com/sigp/lighthouse?rev=4b3a9d3#4b3a9d3d10a6181a1a1588880de133457eb90816"
 dependencies = [
  "cargo_metadata",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,24 +69,23 @@ ssv_types = { path = "anchor/common/ssv_types" }
 subnet_service = { path = "anchor/subnet_service" }
 version = { path = "anchor/common/version" }
 
-# Lighthouse latest from unstable (d62054e)
-# todo: update after https://github.com/sigp/lighthouse/pull/8880 is merged
-beacon_node_fallback = { git = "https://github.com/sigp/lighthouse", rev = "f4b5b03" }
-bls = { git = "https://github.com/sigp/lighthouse", rev = "f4b5b03" }
-eth2 = { git = "https://github.com/sigp/lighthouse", rev = "f4b5b03" }
-eth2_keystore = { git = "https://github.com/sigp/lighthouse", rev = "f4b5b03" }
-eth2_network_config = { git = "https://github.com/sigp/lighthouse", rev = "f4b5b03" }
-health_metrics = { git = "https://github.com/sigp/lighthouse", rev = "f4b5b03" }
-metrics = { git = "https://github.com/sigp/lighthouse", rev = "f4b5b03" }
-network_utils = { git = "https://github.com/sigp/lighthouse", rev = "f4b5b03" }
-slashing_protection = { git = "https://github.com/sigp/lighthouse", rev = "f4b5b03" }
-slot_clock = { git = "https://github.com/sigp/lighthouse", rev = "f4b5b03" }
-task_executor = { git = "https://github.com/sigp/lighthouse", rev = "f4b5b03" }
-types = { git = "https://github.com/sigp/lighthouse", rev = "f4b5b03" }
-validator_metrics = { git = "https://github.com/sigp/lighthouse", rev = "f4b5b03" }
-validator_services = { git = "https://github.com/sigp/lighthouse", rev = "f4b5b03" }
-validator_store = { git = "https://github.com/sigp/lighthouse", rev = "f4b5b03" }
-workspace_members = { git = "https://github.com/sigp/lighthouse", rev = "f4b5b03" }
+# Lighthouse latest from unstable (4b3a9d3)
+beacon_node_fallback = { git = "https://github.com/sigp/lighthouse", rev = "4b3a9d3" }
+bls = { git = "https://github.com/sigp/lighthouse", rev = "4b3a9d3" }
+eth2 = { git = "https://github.com/sigp/lighthouse", rev = "4b3a9d3" }
+eth2_keystore = { git = "https://github.com/sigp/lighthouse", rev = "4b3a9d3" }
+eth2_network_config = { git = "https://github.com/sigp/lighthouse", rev = "4b3a9d3" }
+health_metrics = { git = "https://github.com/sigp/lighthouse", rev = "4b3a9d3" }
+metrics = { git = "https://github.com/sigp/lighthouse", rev = "4b3a9d3" }
+network_utils = { git = "https://github.com/sigp/lighthouse", rev = "4b3a9d3" }
+slashing_protection = { git = "https://github.com/sigp/lighthouse", rev = "4b3a9d3" }
+slot_clock = { git = "https://github.com/sigp/lighthouse", rev = "4b3a9d3" }
+task_executor = { git = "https://github.com/sigp/lighthouse", rev = "4b3a9d3" }
+types = { git = "https://github.com/sigp/lighthouse", rev = "4b3a9d3" }
+validator_metrics = { git = "https://github.com/sigp/lighthouse", rev = "4b3a9d3" }
+validator_services = { git = "https://github.com/sigp/lighthouse", rev = "4b3a9d3" }
+validator_store = { git = "https://github.com/sigp/lighthouse", rev = "4b3a9d3" }
+workspace_members = { git = "https://github.com/sigp/lighthouse", rev = "4b3a9d3" }
 
 alloy = { version = "1.2.1", features = [
     "sol-types",
@@ -170,26 +169,6 @@ tree_hash = "0.12.0"
 tree_hash_derive = "0.12.0"
 typenum = "1.18"
 zeroize = "1.8.1"
-
-# todo: Remove once streaming ValidatorStore PR is merged
-# https://github.com/sigp/lighthouse/pull/8880
-[patch.'https://github.com/sigp/lighthouse']
-beacon_node_fallback = { git = "https://github.com/shane-moore/lighthouse", rev = "66ff63a" }
-bls = { git = "https://github.com/shane-moore/lighthouse", rev = "66ff63a" }
-eth2 = { git = "https://github.com/shane-moore/lighthouse", rev = "66ff63a" }
-eth2_keystore = { git = "https://github.com/shane-moore/lighthouse", rev = "66ff63a" }
-eth2_network_config = { git = "https://github.com/shane-moore/lighthouse", rev = "66ff63a" }
-health_metrics = { git = "https://github.com/shane-moore/lighthouse", rev = "66ff63a" }
-metrics = { git = "https://github.com/shane-moore/lighthouse", rev = "66ff63a" }
-network_utils = { git = "https://github.com/shane-moore/lighthouse", rev = "66ff63a" }
-slashing_protection = { git = "https://github.com/shane-moore/lighthouse", rev = "66ff63a" }
-slot_clock = { git = "https://github.com/shane-moore/lighthouse", rev = "66ff63a" }
-task_executor = { git = "https://github.com/shane-moore/lighthouse", rev = "66ff63a" }
-types = { git = "https://github.com/shane-moore/lighthouse", rev = "66ff63a" }
-validator_metrics = { git = "https://github.com/shane-moore/lighthouse", rev = "66ff63a" }
-validator_services = { git = "https://github.com/shane-moore/lighthouse", rev = "66ff63a" }
-validator_store = { git = "https://github.com/shane-moore/lighthouse", rev = "66ff63a" }
-workspace_members = { git = "https://github.com/shane-moore/lighthouse", rev = "66ff63a" }
 
 [patch.crates-io]
 quick-protobuf = { git = "https://github.com/sigp/quick-protobuf.git", rev = "87c4ccb9bb2af494de375f5f6c62850badd26304" }


### PR DESCRIPTION
## Issue Addressed
Dependency cleanup after sigp/lighthouse#8880 was merged upstream.

## Proposed Changes
  - Update all lighthouse deps to latest sigp `unstable` (`4b3a9d3`)
  - Remove `[patch]` section pointing to `shane-moore/lighthouse fork`

## Additional Info
N/A
