### PR TITLE
feat: partial sig with fallback

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7127,6 +7127,7 @@ dependencies = [
  "ethereum_ssz",
  "fork",
  "message_sender",
+ "metrics",
  "processor",
  "slot_clock",
  "ssv_types",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7128,6 +7128,7 @@ dependencies = [
  "fork",
  "message_sender",
  "metrics",
+ "openssl",
  "processor",
  "rand 0.9.2",
  "slot_clock",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7129,6 +7129,7 @@ dependencies = [
  "message_sender",
  "metrics",
  "processor",
+ "rand 0.9.2",
  "slot_clock",
  "ssv_types",
  "thiserror 2.0.18",

--- a/anchor/client/src/lib.rs
+++ b/anchor/client/src/lib.rs
@@ -502,6 +502,7 @@ impl Client {
             E::slots_per_epoch(),
             message_sender.clone(),
             slot_clock.clone(),
+            database.clone(),
         )
         .map_err(|e| format!("Unable to initialize signature collector manager: {e:?}"))?;
 

--- a/anchor/database/src/share_operations.rs
+++ b/anchor/database/src/share_operations.rs
@@ -1,6 +1,8 @@
+use std::{collections::HashMap, str::FromStr};
+
 use bls::PublicKeyBytes;
 use rusqlite::{Transaction, params};
-use ssv_types::Share;
+use ssv_types::{OperatorId, Share};
 
 use super::{DatabaseError, NetworkDatabase, sql_operations};
 
@@ -21,5 +23,31 @@ impl NetworkDatabase {
                 share.encrypted_private_key
             ])?;
         Ok(())
+    }
+
+    /// Fetch all operator share public keys for a given validator.
+    ///
+    /// Returns a map from `OperatorId` to the operator's BLS share public key for this validator.
+    /// Used during signature reconstruction to verify individual shares on the fallback path.
+    pub fn get_share_pubkeys_for_validator(
+        &self,
+        validator_pubkey: &PublicKeyBytes,
+    ) -> Result<HashMap<OperatorId, PublicKeyBytes>, DatabaseError> {
+        let conn = self.connection()?;
+        let mut stmt = conn.prepare(sql_operations::GET_SHARE_PUBKEYS_FOR_VALIDATOR)?;
+        let mut rows = stmt.query(params![validator_pubkey.to_string()])?;
+
+        let mut result = HashMap::new();
+        while let Some(row) = rows.next()? {
+            let operator_id: u64 = row.get(0)?;
+            let share_pubkey_str: String = row.get(1)?;
+            let share_pubkey = PublicKeyBytes::from_str(&share_pubkey_str).map_err(|e| {
+                DatabaseError::SQLError(format!(
+                    "Invalid share pubkey for operator {operator_id}: {e}"
+                ))
+            })?;
+            result.insert(OperatorId(operator_id), share_pubkey);
+        }
+        Ok(result)
     }
 }

--- a/anchor/database/src/share_operations.rs
+++ b/anchor/database/src/share_operations.rs
@@ -50,4 +50,27 @@ impl NetworkDatabase {
         }
         Ok(result)
     }
+
+    /// Fetch all operator share public keys for a given validator index.
+    pub fn get_share_pubkeys_for_validator_index(
+        &self,
+        validator_index: ssv_types::ValidatorIndex,
+    ) -> Result<HashMap<OperatorId, PublicKeyBytes>, DatabaseError> {
+        let conn = self.connection()?;
+        let mut stmt = conn.prepare(sql_operations::GET_SHARE_PUBKEYS_FOR_VALIDATOR_INDEX)?;
+        let mut rows = stmt.query(params![validator_index.as_u64()])?;
+
+        let mut result = HashMap::new();
+        while let Some(row) = rows.next()? {
+            let operator_id: u64 = row.get(0)?;
+            let share_pubkey_str: String = row.get(1)?;
+            let share_pubkey = PublicKeyBytes::from_str(&share_pubkey_str).map_err(|e| {
+                DatabaseError::SQLError(format!(
+                    "Invalid share pubkey for operator {operator_id}: {e}"
+                ))
+            })?;
+            result.insert(OperatorId(operator_id), share_pubkey);
+        }
+        Ok(result)
+    }
 }

--- a/anchor/database/src/share_operations.rs
+++ b/anchor/database/src/share_operations.rs
@@ -58,7 +58,8 @@ impl NetworkDatabase {
     ) -> Result<HashMap<OperatorId, PublicKeyBytes>, DatabaseError> {
         let conn = self.connection()?;
         let mut stmt = conn.prepare(sql_operations::GET_SHARE_PUBKEYS_FOR_VALIDATOR_INDEX)?;
-        let mut rows = stmt.query(params![validator_index.as_u64()])?;
+        let validator_index: u64 = validator_index.into();
+        let mut rows = stmt.query(params![validator_index])?;
 
         let mut result = HashMap::new();
         while let Some(row) = rows.next()? {

--- a/anchor/database/src/sql_operations.rs
+++ b/anchor/database/src/sql_operations.rs
@@ -81,6 +81,12 @@ pub const GET_SHARE_PUBKEYS_FOR_VALIDATOR: &str = r#"
     SELECT operator_id, share_pubkey
     FROM shares WHERE validator_pubkey = ?1
 "#;
+pub const GET_SHARE_PUBKEYS_FOR_VALIDATOR_INDEX: &str = r#"
+    SELECT s.operator_id, s.share_pubkey
+    FROM shares s
+    JOIN validators v ON v.validator_pubkey = s.validator_pubkey
+    WHERE v.validator_index = ?1
+"#;
 
 // Misc Datta
 pub const INSERT_OR_UPDATE_OWNER_FEE_RECIPIENT: &str = r#"

--- a/anchor/database/src/sql_operations.rs
+++ b/anchor/database/src/sql_operations.rs
@@ -77,6 +77,10 @@ pub const GET_SHARES: &str = r#"
     SELECT share_pubkey, encrypted_key, operator_id, cluster_id, validator_pubkey
     FROM shares WHERE operator_id = ?1
 "#;
+pub const GET_SHARE_PUBKEYS_FOR_VALIDATOR: &str = r#"
+    SELECT operator_id, share_pubkey
+    FROM shares WHERE validator_pubkey = ?1
+"#;
 
 // Misc Datta
 pub const INSERT_OR_UPDATE_OWNER_FEE_RECIPIENT: &str = r#"

--- a/anchor/signature_collector/Cargo.toml
+++ b/anchor/signature_collector/Cargo.toml
@@ -20,3 +20,6 @@ thiserror = { workspace = true }
 tokio = { workspace = true, features = ["sync"] }
 tracing = { workspace = true }
 types = { workspace = true }
+
+[dev-dependencies]
+rand = { workspace = true }

--- a/anchor/signature_collector/Cargo.toml
+++ b/anchor/signature_collector/Cargo.toml
@@ -22,4 +22,7 @@ tracing = { workspace = true }
 types = { workspace = true }
 
 [dev-dependencies]
+database = { workspace = true, features = ["test-utils"] }
+openssl = { workspace = true }
 rand = { workspace = true }
+tokio = { workspace = true, features = ["test-util", "macros", "rt-multi-thread"] }

--- a/anchor/signature_collector/Cargo.toml
+++ b/anchor/signature_collector/Cargo.toml
@@ -12,6 +12,7 @@ database = { workspace = true }
 ethereum_ssz = { workspace = true }
 fork = { workspace = true }
 message_sender = { workspace = true }
+metrics = { workspace = true }
 processor = { workspace = true }
 slot_clock = { workspace = true }
 ssv_types = { workspace = true }

--- a/anchor/signature_collector/src/lib.rs
+++ b/anchor/signature_collector/src/lib.rs
@@ -638,9 +638,7 @@ async fn signature_collector(
                     return;
                 }
                 CombineOutcome::VerificationFailed => {
-                    metrics::inc_counter(
-                        &metrics::SIGNATURE_VERIFICATION_FAILURES_TOTAL,
-                    );
+                    metrics::inc_counter(&metrics::SIGNATURE_VERIFICATION_FAILURES_TOTAL);
                     warn!("Reconstructed signature failed verification so run fallback");
                     let share_pubkeys = match fetch_share_pubkeys(&database, validator_pk).await {
                         Ok(pubkeys) => pubkeys,
@@ -790,3 +788,6 @@ fn find_invalid_shares(
     }
     invalid
 }
+
+#[cfg(test)]
+mod tests;

--- a/anchor/signature_collector/src/lib.rs
+++ b/anchor/signature_collector/src/lib.rs
@@ -613,7 +613,7 @@ async fn signature_collector(
             }
         }
 
-        if let Some(threshold) = threshold
+        while let Some(threshold) = threshold
             && signature_share.len() as u64 >= threshold
         {
             let Some(validator_pk) = &validator_pubkey else {
@@ -630,6 +630,7 @@ async fn signature_collector(
                         }
                     }
                     full_signature = Some(signature);
+                    break;
                 }
                 CombineOutcome::CombineFailed(err) => {
                     error!(?err, "Failed to recover signature");

--- a/anchor/signature_collector/src/lib.rs
+++ b/anchor/signature_collector/src/lib.rs
@@ -388,8 +388,9 @@ impl<S: SlotClock + Clone + 'static> SignatureCollectorManager<S> {
                     sender: tx.clone(),
                     for_slot: slot,
                 });
+                let db = self.database.clone();
                 let _ = self.processor.permitless.send_async(
-                    Box::pin(signature_collector(rx, signing_root).instrument(span)),
+                    Box::pin(signature_collector(rx, signing_root, db).instrument(span)),
                     COLLECTOR_NAME,
                 );
                 trace!(
@@ -526,12 +527,14 @@ impl From<bls_lagrange::Error> for CollectionError {
 async fn signature_collector(
     mut rx: mpsc::UnboundedReceiver<CollectorMessage>,
     signing_root: Hash256,
+    database: Arc<NetworkDatabase>,
 ) {
     let mut notifiers = vec![];
     let mut signature_share = HashMap::new();
     let mut full_signature: Option<Arc<Signature>> = None;
     let mut threshold = None;
     let mut validator_pubkey: Option<PublicKeyBytes> = None;
+    let mut evicted: HashSet<OperatorId> = HashSet::new();
 
     while let Some(message) = rx.recv().await {
         trace!(msg=?message.kind, "Signature collector received message");
@@ -573,19 +576,37 @@ async fn signature_collector(
                     continue;
                 }
 
+                if evicted.contains(&operator_id) {
+                    trace!(%operator_id, "Ignoring share from evicted operator");
+                    continue;
+                }
+
                 // Insert the signature into our map.
-                match signature_share.entry(operator_id) {
+                let received_different_share = match signature_share.entry(operator_id) {
                     hash_map::Entry::Vacant(entry) => {
-                        entry.insert(*signature);
+                        entry.insert(signature.as_ref().clone());
+                        false
                     }
-                    hash_map::Entry::Occupied(entry) => {
-                        if entry.get() != &*signature {
-                            // We can not know which signature is correct. This is serious
-                            // misbehaviour from the operator!
-                            error!(
-                                ?operator_id,
-                                "Received conflicting signatures from operator"
-                            );
+                    hash_map::Entry::Occupied(entry) => entry.get() != &*signature,
+                };
+
+                // Conflicting sig from same operator so verify both, keep valid one
+                if received_different_share {
+                    warn!(?operator_id, "Conflicting signature from operator");
+                    if let Some(validator_pk) = &validator_pubkey {
+                        match fetch_share_pubkeys(&database, validator_pk).await {
+                            Ok(pubkeys) => {
+                                resolve_duplicate_signature(
+                                    &mut signature_share,
+                                    operator_id,
+                                    &signature,
+                                    signing_root,
+                                    &pubkeys,
+                                );
+                            }
+                            Err(err) => {
+                                error!(?err, "DB lookup failed for duplicate resolution");
+                            }
                         }
                     }
                 }
@@ -595,35 +616,99 @@ async fn signature_collector(
         if let Some(threshold) = threshold
             && signature_share.len() as u64 >= threshold
         {
-            let signature = match combine_signatures(mem::take(&mut signature_share)) {
-                Ok(signature) => Arc::new(signature),
-                Err(err) => {
+            let Some(validator_pk) = &validator_pubkey else {
+                error!("No validator pubkey available for verification");
+                return;
+            };
+
+            match try_combine_and_verify(&signature_share, validator_pk, signing_root) {
+                CombineOutcome::Success(signature) => {
+                    trace!(?signature, "Successfully recovered signature");
+                    for notifier in mem::take(&mut notifiers) {
+                        if notifier.send(Arc::clone(&signature)).is_err() {
+                            warn!("Callback dropped since signature is no longer relevant");
+                        }
+                    }
+                    full_signature = Some(signature);
+                }
+                CombineOutcome::CombineFailed(err) => {
                     error!(?err, "Failed to recover signature");
                     return;
                 }
-            };
-
-            trace!(?signature, "Successfully recovered signature");
-
-            for notifier in mem::take(&mut notifiers) {
-                if notifier.send(Arc::clone(&signature)).is_err() {
-                    warn!("Callback dropped - signature is no longer relevant");
+                CombineOutcome::VerificationFailed => {
+                    warn!("Reconstructed signature failed verification so run fallback");
+                    let share_pubkeys = match fetch_share_pubkeys(&database, validator_pk).await {
+                        Ok(pubkeys) => pubkeys,
+                        Err(err) => {
+                            error!(?err, "Failed to look up share pubkeys");
+                            return;
+                        }
+                    };
+                    let invalid_operators =
+                        find_invalid_shares(&signature_share, signing_root, &share_pubkeys);
+                    if invalid_operators.is_empty() {
+                        error!("Verification failed but no individual share was invalid");
+                        return;
+                    }
+                    warn!(?invalid_operators, "Evicting invalid shares");
+                    for op in &invalid_operators {
+                        signature_share.remove(op);
+                        evicted.insert(*op);
+                    }
                 }
             }
-            full_signature = Some(signature);
         }
     }
 }
 
+async fn fetch_share_pubkeys(
+    database: &Arc<NetworkDatabase>,
+    validator_pk: &PublicKeyBytes,
+) -> Result<HashMap<OperatorId, PublicKeyBytes>, database::DatabaseError> {
+    let db = Arc::clone(database);
+    let pk = *validator_pk;
+    tokio::task::spawn_blocking(move || db.get_share_pubkeys_for_validator(&pk))
+        .await
+        .map_err(|e| database::DatabaseError::SQLError(e.to_string()))?
+}
+
 fn combine_signatures(
-    shares: HashMap<OperatorId, Signature>,
+    shares: &HashMap<OperatorId, Signature>,
 ) -> Result<Signature, CollectionError> {
     let (ids, signatures): (Vec<_>, Vec<_>) = shares
-        .into_iter()
-        .map(|(k, s)| KeyId::try_from(*k).map(|k| (k, s)))
+        .iter()
+        .map(|(k, s)| KeyId::try_from(**k).map(|k| (k, s.clone())))
         .collect::<Result<_, _>>()?;
 
     Ok(bls_lagrange::combine_signatures(&signatures, &ids)?)
+}
+
+/// Outcome of attempting to combine and verify partial signatures.
+enum CombineOutcome {
+    /// Reconstruction + master-key verification succeeded.
+    Success(Arc<Signature>),
+    /// Lagrange interpolation failed (structural error in shares).
+    CombineFailed(CollectionError),
+    /// Reconstruction succeeded but BLS verification against master pubkey failed.
+    VerificationFailed,
+}
+
+/// Combine shares via Lagrange interpolation and verify against the validator pubkey.
+fn try_combine_and_verify(
+    shares: &HashMap<OperatorId, Signature>,
+    validator_pubkey: &PublicKeyBytes,
+    signing_root: Hash256,
+) -> CombineOutcome {
+    let combined = match combine_signatures(shares) {
+        Ok(sig) => sig,
+        Err(err) => return CombineOutcome::CombineFailed(err),
+    };
+
+    if verify_reconstructed_signature(&combined, validator_pubkey, signing_root) {
+        CombineOutcome::Success(Arc::new(combined))
+    } else {
+        CombineOutcome::VerificationFailed
+    }
 }
 
 /// Verify a reconstructed signature against the validator's master pubkey.
@@ -638,7 +723,45 @@ fn verify_reconstructed_signature(
     signature.verify(&pk, signing_root)
 }
 
-/// Verify each partial signature against its operator's share pubkey.
+/// Resolve duplicate signature per spec
+/// Verify both, keep valid one. If neither valid, remove both.
+fn resolve_duplicate_signature(
+    shares: &mut HashMap<OperatorId, Signature>,
+    operator_id: OperatorId,
+    new_signature: &Signature,
+    signing_root: Hash256,
+    share_pubkeys: &HashMap<OperatorId, PublicKeyBytes>,
+) {
+    let Some(share_pubkey) = share_pubkeys.get(&operator_id) else {
+        shares.remove(&operator_id);
+        return;
+    };
+
+    if let Some(old_sig) = shares.get(&operator_id)
+        && verify_partial_signature(old_sig, signing_root, share_pubkey)
+    {
+        return;
+    }
+
+    shares.remove(&operator_id);
+
+    if verify_partial_signature(new_signature, signing_root, share_pubkey) {
+        shares.insert(operator_id, new_signature.clone());
+    }
+}
+
+fn verify_partial_signature(
+    signature: &Signature,
+    signing_root: Hash256,
+    share_pubkey: &PublicKeyBytes,
+) -> bool {
+    let Ok(pk) = share_pubkey.decompress() else {
+        return false;
+    };
+    signature.verify(&pk, signing_root)
+}
+
+/// Verify each partial signature against its operator's share pubkey from the db.
 /// Returns the set of operator IDs whose signatures are invalid.
 fn find_invalid_shares(
     shares: &HashMap<OperatorId, Signature>,
@@ -649,11 +772,7 @@ fn find_invalid_shares(
     for (operator_id, signature) in shares {
         match share_pubkeys.get(operator_id) {
             Some(pubkey) => {
-                let Ok(pk) = pubkey.decompress() else {
-                    invalid.insert(*operator_id);
-                    continue;
-                };
-                if !signature.verify(&pk, signing_root) {
+                if !verify_partial_signature(signature, signing_root, pubkey) {
                     invalid.insert(*operator_id);
                 }
             }

--- a/anchor/signature_collector/src/lib.rs
+++ b/anchor/signature_collector/src/lib.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::{HashMap, hash_map},
+    collections::{HashMap, HashSet, hash_map},
     mem,
     sync::Arc,
 };
@@ -155,6 +155,7 @@ impl<S: SlotClock + Clone + 'static> SignatureCollectorManager<S> {
         // first, register notifier with preexisting or newly spawned instance
         let cloned_metadata = metadata.clone();
         let manager = self.clone();
+        let validator_pubkey = validator_signing_data.validator_pubkey;
         self.processor.permitless.send_immediate(
             move |drop_on_finish| {
                 let sender = manager.get_or_spawn(
@@ -166,6 +167,7 @@ impl<S: SlotClock + Clone + 'static> SignatureCollectorManager<S> {
                     kind: CollectorMessageKind::RegisterNotifier {
                         notify: result_tx,
                         threshold: cloned_metadata.threshold,
+                        validator_pubkey,
                     },
                     _drop_on_finish: drop_on_finish,
                 });
@@ -387,7 +389,7 @@ impl<S: SlotClock + Clone + 'static> SignatureCollectorManager<S> {
                     for_slot: slot,
                 });
                 let _ = self.processor.permitless.send_async(
-                    Box::pin(signature_collector(rx).instrument(span)),
+                    Box::pin(signature_collector(rx, signing_root).instrument(span)),
                     COLLECTOR_NAME,
                 );
                 trace!(
@@ -477,6 +479,7 @@ enum CollectorMessageKind {
     RegisterNotifier {
         notify: oneshot::Sender<Arc<Signature>>,
         threshold: u64,
+        validator_pubkey: PublicKeyBytes,
     },
     /// A new partial signature is available - either because it arrived from the network, or
     /// because we created it
@@ -520,11 +523,15 @@ impl From<bls_lagrange::Error> for CollectionError {
 }
 
 /// The actual signature collector task, waiting for messages
-async fn signature_collector(mut rx: mpsc::UnboundedReceiver<CollectorMessage>) {
+async fn signature_collector(
+    mut rx: mpsc::UnboundedReceiver<CollectorMessage>,
+    signing_root: Hash256,
+) {
     let mut notifiers = vec![];
     let mut signature_share = HashMap::new();
     let mut full_signature: Option<Arc<Signature>> = None;
     let mut threshold = None;
+    let mut validator_pubkey: Option<PublicKeyBytes> = None;
 
     while let Some(message) = rx.recv().await {
         trace!(msg=?message.kind, "Signature collector received message");
@@ -532,6 +539,7 @@ async fn signature_collector(mut rx: mpsc::UnboundedReceiver<CollectorMessage>) 
             CollectorMessageKind::RegisterNotifier {
                 notify,
                 threshold: new_threshold,
+                validator_pubkey: new_validator_pubkey,
             } => {
                 if let Some(full_signature) = &full_signature {
                     // We already got a reconstructed signature, send it immediately.
@@ -541,6 +549,7 @@ async fn signature_collector(mut rx: mpsc::UnboundedReceiver<CollectorMessage>) 
                 } else {
                     // Register the notifier and threshold.
                     notifiers.push(notify);
+                    validator_pubkey = Some(new_validator_pubkey);
                     if let Some(old_threshold) = threshold
                         && new_threshold != old_threshold
                     {
@@ -615,4 +624,44 @@ fn combine_signatures(
         .collect::<Result<_, _>>()?;
 
     Ok(bls_lagrange::combine_signatures(&signatures, &ids)?)
+}
+
+/// Verify a reconstructed signature against the validator's master pubkey.
+fn verify_reconstructed_signature(
+    signature: &Signature,
+    validator_pubkey: &PublicKeyBytes,
+    signing_root: Hash256,
+) -> bool {
+    let Ok(pk) = validator_pubkey.decompress() else {
+        return false;
+    };
+    signature.verify(&pk, signing_root)
+}
+
+/// Verify each partial signature against its operator's share pubkey.
+/// Returns the set of operator IDs whose signatures are invalid.
+fn find_invalid_shares(
+    shares: &HashMap<OperatorId, Signature>,
+    signing_root: Hash256,
+    share_pubkeys: &HashMap<OperatorId, PublicKeyBytes>,
+) -> HashSet<OperatorId> {
+    let mut invalid = HashSet::new();
+    for (operator_id, signature) in shares {
+        match share_pubkeys.get(operator_id) {
+            Some(pubkey) => {
+                let Ok(pk) = pubkey.decompress() else {
+                    invalid.insert(*operator_id);
+                    continue;
+                };
+                if !signature.verify(&pk, signing_root) {
+                    invalid.insert(*operator_id);
+                }
+            }
+            None => {
+                warn!(%operator_id, "No share pubkey found in DB — marking as invalid");
+                invalid.insert(*operator_id);
+            }
+        }
+    }
+    invalid
 }

--- a/anchor/signature_collector/src/lib.rs
+++ b/anchor/signature_collector/src/lib.rs
@@ -728,6 +728,10 @@ fn verify_reconstructed_signature(
     signing_root: Hash256,
 ) -> bool {
     let Ok(pk) = validator_pubkey.decompress() else {
+        error!(
+            ?validator_pubkey,
+            "Failed to decompress validator pubkey during reconstructed signature verification"
+        );
         return false;
     };
     signature.verify(&pk, signing_root)
@@ -769,6 +773,10 @@ fn verify_partial_signature(
     share_pubkey: &PublicKeyBytes,
 ) -> bool {
     let Ok(pk) = share_pubkey.decompress() else {
+        error!(
+            ?share_pubkey,
+            "Failed to decompress share pubkey during partial signature verification"
+        );
         return false;
     };
     signature.verify(&pk, signing_root)

--- a/anchor/signature_collector/src/lib.rs
+++ b/anchor/signature_collector/src/lib.rs
@@ -38,6 +38,8 @@ use tokio::{
 use tracing::{Instrument, debug_span, error, trace, warn};
 use types::{Hash256, Slot};
 
+pub(crate) mod metrics;
+
 const COLLECTOR_NAME: &str = "signature_collector";
 const COLLECTOR_MESSAGE_NAME: &str = "signature_collector_message";
 const COLLECTOR_CLEANER_NAME: &str = "signature_collector_cleaner";
@@ -636,6 +638,9 @@ async fn signature_collector(
                     return;
                 }
                 CombineOutcome::VerificationFailed => {
+                    metrics::inc_counter(
+                        &metrics::SIGNATURE_VERIFICATION_FAILURES_TOTAL,
+                    );
                     warn!("Reconstructed signature failed verification so run fallback");
                     let share_pubkeys = match fetch_share_pubkeys(&database, validator_pk).await {
                         Ok(pubkeys) => pubkeys,
@@ -654,6 +659,7 @@ async fn signature_collector(
                     for op in &invalid_operators {
                         signature_share.remove(op);
                         evicted.insert(*op);
+                        metrics::inc_counter(&metrics::OPERATOR_EVICTIONS_TOTAL);
                     }
                 }
             }

--- a/anchor/signature_collector/src/lib.rs
+++ b/anchor/signature_collector/src/lib.rs
@@ -171,7 +171,7 @@ impl<S: SlotClock + Clone + 'static> SignatureCollectorManager<S> {
                         threshold: cloned_metadata.threshold,
                         validator_pubkey,
                     },
-                    _drop_on_finish: drop_on_finish,
+                    _drop_on_finish: Some(drop_on_finish),
                 });
             },
             COLLECTOR_MESSAGE_NAME,
@@ -353,7 +353,7 @@ impl<S: SlotClock + Clone + 'static> SignatureCollectorManager<S> {
                         operator_id: message.signer,
                         signature: Box::new(message.partial_signature),
                     },
-                    _drop_on_finish: drop_on_finish,
+                    _drop_on_finish: Some(drop_on_finish),
                 }) {
                     error!(
                         ?err,
@@ -473,7 +473,7 @@ pub struct ValidatorSigningData {
 
 struct CollectorMessage {
     kind: CollectorMessageKind,
-    _drop_on_finish: DropOnFinish,
+    _drop_on_finish: Option<DropOnFinish>,
 }
 
 #[derive(Debug)]

--- a/anchor/signature_collector/src/lib.rs
+++ b/anchor/signature_collector/src/lib.rs
@@ -7,7 +7,7 @@ use std::{
 use bls::{PublicKeyBytes, SecretKey, Signature};
 use bls_lagrange::KeyId;
 use dashmap::{DashMap, Entry};
-use database::OwnOperatorId;
+use database::{NetworkDatabase, OwnOperatorId};
 use fork::ForkSchedule;
 use message_sender::MessageSender;
 use processor::{Error, Error::Queue, Senders, work::DropOnFinish};
@@ -87,6 +87,8 @@ pub struct SignatureCollectorManager<S: SlotClock> {
     /// for all partial signatures based on that value for the committee.
     /// Note that this hash may differ from the actual signing root.
     committee_signatures: DashMap<(Hash256, CommitteeId), CommitteeSignatures>,
+    /// Database handle for fallback share pubkey lookup during signature verification.
+    database: Arc<NetworkDatabase>,
 }
 
 impl<S: SlotClock + Clone + 'static> SignatureCollectorManager<S> {
@@ -97,6 +99,7 @@ impl<S: SlotClock + Clone + 'static> SignatureCollectorManager<S> {
         slots_per_epoch: u64,
         message_sender: Arc<dyn MessageSender>,
         slot_clock: S,
+        database: Arc<NetworkDatabase>,
     ) -> Result<Arc<Self>, CollectionError> {
         let manager = Arc::new(Self {
             processor,
@@ -107,6 +110,7 @@ impl<S: SlotClock + Clone + 'static> SignatureCollectorManager<S> {
             message_sender,
             signature_collectors: DashMap::new(),
             committee_signatures: DashMap::new(),
+            database,
         });
 
         manager
@@ -459,6 +463,7 @@ pub struct ValidatorSigningData {
     pub root: Hash256,
     pub index: ValidatorIndex,
     pub share: Option<SecretKey>,
+    pub validator_pubkey: PublicKeyBytes,
 }
 
 struct CollectorMessage {

--- a/anchor/signature_collector/src/lib.rs
+++ b/anchor/signature_collector/src/lib.rs
@@ -536,8 +536,6 @@ async fn signature_collector(
     let mut full_signature: Option<Arc<Signature>> = None;
     let mut threshold = None;
     let mut validator_pubkey: Option<PublicKeyBytes> = None;
-    let mut evicted: HashSet<OperatorId> = HashSet::new();
-
     while let Some(message) = rx.recv().await {
         trace!(msg=?message.kind, "Signature collector received message");
         match message.kind {
@@ -575,11 +573,6 @@ async fn signature_collector(
             } => {
                 if full_signature.is_some() {
                     // Already got the full signature.
-                    continue;
-                }
-
-                if evicted.contains(&operator_id) {
-                    trace!(%operator_id, "Ignoring share from evicted operator");
                     continue;
                 }
 
@@ -653,11 +646,9 @@ async fn signature_collector(
                         error!("Verification failed but no individual share was invalid");
                         return;
                     }
-                    warn!(?invalid_operators, "Evicting invalid shares");
+                    warn!(?invalid_operators, "Removing invalid shares");
                     for op in &invalid_operators {
                         signature_share.remove(op);
-                        evicted.insert(*op);
-                        metrics::inc_counter(&metrics::OPERATOR_EVICTIONS_TOTAL);
                     }
                 }
             }

--- a/anchor/signature_collector/src/lib.rs
+++ b/anchor/signature_collector/src/lib.rs
@@ -392,7 +392,9 @@ impl<S: SlotClock + Clone + 'static> SignatureCollectorManager<S> {
                 });
                 let db = self.database.clone();
                 let _ = self.processor.permitless.send_async(
-                    Box::pin(signature_collector(rx, signing_root, db).instrument(span)),
+                    Box::pin(
+                        signature_collector(rx, signing_root, validator_index, db).instrument(span),
+                    ),
                     COLLECTOR_NAME,
                 );
                 trace!(
@@ -529,6 +531,7 @@ impl From<bls_lagrange::Error> for CollectionError {
 async fn signature_collector(
     mut rx: mpsc::UnboundedReceiver<CollectorMessage>,
     signing_root: Hash256,
+    validator_index: ValidatorIndex,
     database: Arc<NetworkDatabase>,
 ) {
     let mut notifiers = vec![];
@@ -588,20 +591,22 @@ async fn signature_collector(
                 // Conflicting sig from same operator so verify both, keep valid one
                 if received_different_share {
                     warn!(?operator_id, "Conflicting signature from operator");
-                    if let Some(validator_pk) = &validator_pubkey {
-                        match fetch_share_pubkeys(&database, validator_pk).await {
-                            Ok(pubkeys) => {
-                                resolve_duplicate_signature(
-                                    &mut signature_share,
-                                    operator_id,
-                                    &signature,
-                                    signing_root,
-                                    &pubkeys,
-                                );
-                            }
-                            Err(err) => {
-                                error!(?err, "DB lookup failed for duplicate resolution");
-                            }
+                    match fetch_share_pubkeys_by_validator_index(&database, validator_index).await {
+                        Ok(pubkeys) => {
+                            resolve_duplicate_signature(
+                                &mut signature_share,
+                                operator_id,
+                                &signature,
+                                signing_root,
+                                &pubkeys,
+                            );
+                        }
+                        Err(err) => {
+                            error!(
+                                ?err,
+                                ?validator_index,
+                                "DB lookup failed for duplicate resolution"
+                            );
                         }
                     }
                 }
@@ -667,6 +672,16 @@ async fn fetch_share_pubkeys(
         .map_err(|e| database::DatabaseError::SQLError(e.to_string()))?
 }
 
+async fn fetch_share_pubkeys_by_validator_index(
+    database: &Arc<NetworkDatabase>,
+    validator_index: ValidatorIndex,
+) -> Result<HashMap<OperatorId, PublicKeyBytes>, database::DatabaseError> {
+    let db = Arc::clone(database);
+    tokio::task::spawn_blocking(move || db.get_share_pubkeys_for_validator_index(validator_index))
+        .await
+        .map_err(|e| database::DatabaseError::SQLError(e.to_string()))?
+}
+
 fn combine_signatures(
     shares: &HashMap<OperatorId, Signature>,
 ) -> Result<Signature, CollectionError> {
@@ -728,6 +743,7 @@ fn resolve_duplicate_signature(
     share_pubkeys: &HashMap<OperatorId, PublicKeyBytes>,
 ) {
     let Some(share_pubkey) = share_pubkeys.get(&operator_id) else {
+        warn!(%operator_id, "No share pubkey found for duplicate resolution");
         shares.remove(&operator_id);
         return;
     };
@@ -742,6 +758,8 @@ fn resolve_duplicate_signature(
 
     if verify_partial_signature(new_signature, signing_root, share_pubkey) {
         shares.insert(operator_id, new_signature.clone());
+    } else {
+        warn!(%operator_id, "Both conflicting signatures were invalid");
     }
 }
 

--- a/anchor/signature_collector/src/lib.rs
+++ b/anchor/signature_collector/src/lib.rs
@@ -648,7 +648,12 @@ async fn signature_collector(
                     let invalid_operators =
                         find_invalid_shares(&signature_share, signing_root, &share_pubkeys);
                     if invalid_operators.is_empty() {
-                        error!("Verification failed but no individual share was invalid");
+                        let operators: Vec<_> = signature_share.keys().copied().collect();
+                        error!(
+                            ?signing_root,
+                            ?operators,
+                            "Verification failed but no individual share was invalid"
+                        );
                         return;
                     }
                     warn!(?invalid_operators, "Removing invalid shares");
@@ -669,7 +674,13 @@ async fn fetch_share_pubkeys(
     let pk = *validator_pk;
     tokio::task::spawn_blocking(move || db.get_share_pubkeys_for_validator(&pk))
         .await
-        .map_err(|e| database::DatabaseError::SQLError(e.to_string()))?
+        .map_err(|err| {
+            error!(
+                ?err,
+                "spawn_blocking failed while fetching share pubkeys by validator pubkey"
+            );
+            database::DatabaseError::SQLError(err.to_string())
+        })?
 }
 
 async fn fetch_share_pubkeys_by_validator_index(
@@ -679,7 +690,13 @@ async fn fetch_share_pubkeys_by_validator_index(
     let db = Arc::clone(database);
     tokio::task::spawn_blocking(move || db.get_share_pubkeys_for_validator_index(validator_index))
         .await
-        .map_err(|e| database::DatabaseError::SQLError(e.to_string()))?
+        .map_err(|err| {
+            error!(
+                ?err,
+                "spawn_blocking failed while fetching share pubkeys by validator index"
+            );
+            database::DatabaseError::SQLError(err.to_string())
+        })?
 }
 
 fn combine_signatures(

--- a/anchor/signature_collector/src/metrics.rs
+++ b/anchor/signature_collector/src/metrics.rs
@@ -10,10 +10,3 @@ pub static SIGNATURE_VERIFICATION_FAILURES_TOTAL: LazyLock<Result<IntCounter>> =
         )
     },
 );
-
-pub static OPERATOR_EVICTIONS_TOTAL: LazyLock<Result<IntCounter>> = LazyLock::new(|| {
-    try_create_int_counter(
-        "anchor_signature_collector_operator_evictions_total",
-        "Count of operators evicted for submitting invalid partial signatures",
-    )
-});

--- a/anchor/signature_collector/src/metrics.rs
+++ b/anchor/signature_collector/src/metrics.rs
@@ -2,13 +2,14 @@ use std::sync::LazyLock;
 
 pub use metrics::*;
 
-pub static SIGNATURE_VERIFICATION_FAILURES_TOTAL: LazyLock<Result<IntCounter>> =
-    LazyLock::new(|| {
+pub static SIGNATURE_VERIFICATION_FAILURES_TOTAL: LazyLock<Result<IntCounter>> = LazyLock::new(
+    || {
         try_create_int_counter(
             "anchor_signature_collector_verification_failures_total",
             "Count of reconstructed signatures that failed BLS verification against the validator master pubkey",
         )
-    });
+    },
+);
 
 pub static OPERATOR_EVICTIONS_TOTAL: LazyLock<Result<IntCounter>> = LazyLock::new(|| {
     try_create_int_counter(

--- a/anchor/signature_collector/src/metrics.rs
+++ b/anchor/signature_collector/src/metrics.rs
@@ -1,0 +1,18 @@
+use std::sync::LazyLock;
+
+pub use metrics::*;
+
+pub static SIGNATURE_VERIFICATION_FAILURES_TOTAL: LazyLock<Result<IntCounter>> =
+    LazyLock::new(|| {
+        try_create_int_counter(
+            "anchor_signature_collector_verification_failures_total",
+            "Count of reconstructed signatures that failed BLS verification against the validator master pubkey",
+        )
+    });
+
+pub static OPERATOR_EVICTIONS_TOTAL: LazyLock<Result<IntCounter>> = LazyLock::new(|| {
+    try_create_int_counter(
+        "anchor_signature_collector_operator_evictions_total",
+        "Count of operators evicted for submitting invalid partial signatures",
+    )
+});

--- a/anchor/signature_collector/src/tests.rs
+++ b/anchor/signature_collector/src/tests.rs
@@ -117,6 +117,10 @@ fn sign_shares(
         .collect()
 }
 
+fn test_validator_index() -> ValidatorIndex {
+    ValidatorIndex(1)
+}
+
 // ==================== `find_invalid_shares` tests ====================
 
 /// Three valid shares and one garbage share. The function should identify
@@ -483,7 +487,12 @@ async fn integration_happy_path_all_valid() {
     let signing_root = material.signing_root;
 
     // Spawn the collector task
-    let handle = tokio::spawn(signature_collector(rx, signing_root, db));
+    let handle = tokio::spawn(signature_collector(
+        rx,
+        signing_root,
+        test_validator_index(),
+        db,
+    ));
 
     // Register a notifier expecting threshold 3
     let result_rx = send_register_notifier(&tx, THRESHOLD, material.master_pubkey_bytes);
@@ -522,7 +531,12 @@ async fn integration_fallback_removes_bad_and_succeeds() {
     let (tx, rx) = mpsc::unbounded_channel();
     let signing_root = material.signing_root;
 
-    let handle = tokio::spawn(signature_collector(rx, signing_root, db));
+    let handle = tokio::spawn(signature_collector(
+        rx,
+        signing_root,
+        test_validator_index(),
+        db,
+    ));
     let result_rx = send_register_notifier(&tx, THRESHOLD, material.master_pubkey_bytes);
 
     // Send 2 valid partial signatures
@@ -566,7 +580,12 @@ async fn integration_duplicate_resolution_keeps_valid() {
     let (tx, rx) = mpsc::unbounded_channel();
     let signing_root = material.signing_root;
 
-    let handle = tokio::spawn(signature_collector(rx, signing_root, db));
+    let handle = tokio::spawn(signature_collector(
+        rx,
+        signing_root,
+        test_validator_index(),
+        db,
+    ));
     let result_rx = send_register_notifier(&tx, THRESHOLD, material.master_pubkey_bytes);
 
     // Send valid sig for operator 1
@@ -592,6 +611,50 @@ async fn integration_duplicate_resolution_keeps_valid() {
     assert!(
         verify_reconstructed_signature(&reconstructed, &material.master_pubkey_bytes, signing_root),
         "Reconstructed signature should verify because valid duplicate was kept"
+    );
+
+    drop(tx);
+    handle.await.expect("Collector task should complete");
+}
+
+/// Duplicate resolution must also work before local registration provides the
+/// validator pubkey, since inbound network partials can spawn the collector first.
+#[tokio::test]
+async fn integration_duplicate_resolution_before_register_notifier() {
+    let material = create_test_key_material();
+    let garbage = create_garbage_key_material();
+    let db = create_seeded_database(&material);
+
+    let (tx, rx) = mpsc::unbounded_channel();
+    let signing_root = material.signing_root;
+
+    let handle = tokio::spawn(signature_collector(
+        rx,
+        signing_root,
+        test_validator_index(),
+        db,
+    ));
+
+    let (op1, sk1) = &material.shares[0];
+
+    // Network-first path: store a bad share, then a valid replacement, before notifier
+    // registration.
+    send_partial_sig(&tx, *op1, garbage.shares[0].1.sign(signing_root));
+    send_partial_sig(&tx, *op1, sk1.sign(signing_root));
+
+    let result_rx = send_register_notifier(&tx, THRESHOLD, material.master_pubkey_bytes);
+
+    let (op2, sk2) = &material.shares[1];
+    send_partial_sig(&tx, *op2, sk2.sign(signing_root));
+    let (op3, sk3) = &material.shares[2];
+    send_partial_sig(&tx, *op3, sk3.sign(signing_root));
+
+    let reconstructed = result_rx
+        .await
+        .expect("Should receive reconstructed signature");
+    assert!(
+        verify_reconstructed_signature(&reconstructed, &material.master_pubkey_bytes, signing_root),
+        "Reconstructed signature should verify because the valid replacement was retained"
     );
 
     drop(tx);

--- a/anchor/signature_collector/src/tests.rs
+++ b/anchor/signature_collector/src/tests.rs
@@ -1,0 +1,373 @@
+use std::collections::HashMap;
+
+use bls::{PublicKeyBytes, SecretKey, Signature};
+use bls_lagrange::{KeyId, split_with_rng};
+use rand::{prelude::*, rngs::StdRng};
+use types::Hash256;
+
+use super::*;
+
+/// RNG seed for deterministic test key generation.
+const TEST_RNG_SEED: u64 = 0xDEAD_BEEF_CAFE_0001;
+
+/// Number of total shares to split the master key into.
+const TOTAL_SHARES: u64 = 4;
+
+/// Threshold required to reconstruct the master signature.
+const THRESHOLD: u64 = 3;
+
+/// Signing root used across all tests (arbitrary 32-byte value).
+const SIGNING_ROOT_BYTES: [u8; 32] = [0xAB; 32];
+
+/// Holds all cryptographic material needed by the tests.
+struct TestKeyMaterial {
+    master_pubkey_bytes: PublicKeyBytes,
+    /// (`OperatorId`, `SecretKey`) pairs for each share.
+    shares: Vec<(OperatorId, SecretKey)>,
+    signing_root: Hash256,
+}
+
+/// Builds a second, independent set of shares whose signatures will fail
+/// verification against the original share pubkeys.
+struct GarbageKeyMaterial {
+    shares: Vec<(OperatorId, SecretKey)>,
+}
+
+/// Creates deterministic key material: a master key split into `TOTAL_SHARES`
+/// shares with `THRESHOLD` threshold.
+fn create_test_key_material() -> TestKeyMaterial {
+    let rng = &mut StdRng::seed_from_u64(TEST_RNG_SEED);
+
+    let master = SecretKey::random();
+    let master_pubkey_bytes = PublicKeyBytes::from(master.public_key());
+
+    let split_keys = split_with_rng(
+        &master,
+        THRESHOLD,
+        (1..=TOTAL_SHARES).map(|x| KeyId::try_from(x).unwrap()),
+        rng,
+    )
+    .expect("split should succeed");
+
+    let shares: Vec<(OperatorId, SecretKey)> = split_keys
+        .into_iter()
+        .map(|(kid, sk)| {
+            let op_id = OperatorId(u64::from(kid));
+            (op_id, sk)
+        })
+        .collect();
+
+    let signing_root = Hash256::from(SIGNING_ROOT_BYTES);
+
+    TestKeyMaterial {
+        master_pubkey_bytes,
+        shares,
+        signing_root,
+    }
+}
+
+/// Creates a second independent master key and splits it, producing shares
+/// whose signatures are valid BLS signatures but will not verify against the
+/// original share pubkeys.
+fn create_garbage_key_material() -> GarbageKeyMaterial {
+    let rng = &mut StdRng::seed_from_u64(TEST_RNG_SEED ^ 0xFFFF_FFFF);
+
+    let garbage_master = SecretKey::random();
+
+    let split_keys = split_with_rng(
+        &garbage_master,
+        THRESHOLD,
+        (1..=TOTAL_SHARES).map(|x| KeyId::try_from(x).unwrap()),
+        rng,
+    )
+    .expect("garbage split should succeed");
+
+    let shares: Vec<(OperatorId, SecretKey)> = split_keys
+        .into_iter()
+        .map(|(kid, sk)| {
+            let op_id = OperatorId(u64::from(kid));
+            (op_id, sk)
+        })
+        .collect();
+
+    GarbageKeyMaterial { shares }
+}
+
+/// Builds a `share_pubkeys` map from the test key material (`OperatorId` -> share public key
+/// bytes).
+fn build_share_pubkey_map(material: &TestKeyMaterial) -> HashMap<OperatorId, PublicKeyBytes> {
+    material
+        .shares
+        .iter()
+        .map(|(op_id, sk)| (*op_id, PublicKeyBytes::from(sk.public_key())))
+        .collect()
+}
+
+/// Builds a `HashMap<OperatorId, Signature>` by signing the given root with each share.
+fn sign_shares(
+    shares: &[(OperatorId, SecretKey)],
+    signing_root: Hash256,
+) -> HashMap<OperatorId, Signature> {
+    shares
+        .iter()
+        .map(|(op_id, sk)| (*op_id, sk.sign(signing_root)))
+        .collect()
+}
+
+// ==================== `find_invalid_shares` tests ====================
+
+/// Three valid shares and one garbage share. The function should identify
+/// exactly the garbage operator as invalid.
+#[test]
+fn find_invalid_shares_identifies_bad() {
+    // Arrange
+    let material = create_test_key_material();
+    let garbage = create_garbage_key_material();
+    let share_pubkeys = build_share_pubkey_map(&material);
+
+    // Sign the first 3 shares with the correct keys
+    let mut sig_map: HashMap<OperatorId, Signature> = material.shares[..3]
+        .iter()
+        .map(|(op, sk)| (*op, sk.sign(material.signing_root)))
+        .collect();
+
+    // Sign the 4th share with the garbage key (same operator ID, wrong key)
+    let bad_op_id = material.shares[3].0;
+    let garbage_sig = garbage.shares[3].1.sign(material.signing_root);
+    sig_map.insert(bad_op_id, garbage_sig);
+
+    // Act
+    let invalid = find_invalid_shares(&sig_map, material.signing_root, &share_pubkeys);
+
+    // Assert
+    assert_eq!(
+        invalid.len(),
+        1,
+        "Expected exactly 1 invalid share, got {}",
+        invalid.len()
+    );
+    assert!(
+        invalid.contains(&bad_op_id),
+        "Expected operator {:?} to be flagged as invalid",
+        bad_op_id
+    );
+}
+
+/// All three shares are valid. The returned set should be empty.
+#[test]
+fn find_invalid_shares_all_valid() {
+    // Arrange
+    let material = create_test_key_material();
+    let share_pubkeys = build_share_pubkey_map(&material);
+    let sig_map = sign_shares(&material.shares[..3], material.signing_root);
+
+    // Act
+    let invalid = find_invalid_shares(&sig_map, material.signing_root, &share_pubkeys);
+
+    // Assert
+    assert!(
+        invalid.is_empty(),
+        "Expected no invalid shares, but got {:?}",
+        invalid
+    );
+}
+
+/// An operator is present in the shares map but has no corresponding entry in
+/// the pubkey map. It should be marked as invalid.
+#[test]
+fn find_invalid_shares_missing_pubkey() {
+    // Arrange
+    let material = create_test_key_material();
+    let sig_map = sign_shares(&material.shares[..3], material.signing_root);
+
+    // Build a pubkey map that is missing the first operator
+    let missing_op = material.shares[0].0;
+    let mut share_pubkeys = build_share_pubkey_map(&material);
+    share_pubkeys.remove(&missing_op);
+
+    // Act
+    let invalid = find_invalid_shares(&sig_map, material.signing_root, &share_pubkeys);
+
+    // Assert
+    assert!(
+        invalid.contains(&missing_op),
+        "Expected operator {:?} with missing pubkey to be flagged as invalid",
+        missing_op
+    );
+}
+
+// ==================== `try_combine_and_verify tests` ====================
+
+/// Three valid shares at threshold 3 should combine and verify successfully
+/// against the master public key.
+#[test]
+fn try_combine_valid() {
+    // Arrange
+    let material = create_test_key_material();
+    let sig_map = sign_shares(&material.shares[..3], material.signing_root);
+
+    // Act
+    let outcome = try_combine_and_verify(
+        &sig_map,
+        &material.master_pubkey_bytes,
+        material.signing_root,
+    );
+
+    // Assert
+    assert!(
+        matches!(outcome, CombineOutcome::Success(_)),
+        "Expected CombineOutcome::Success, got {:?}",
+        match &outcome {
+            CombineOutcome::Success(_) => "Success",
+            CombineOutcome::CombineFailed(_) => "CombineFailed",
+            CombineOutcome::VerificationFailed => "VerificationFailed",
+        }
+    );
+}
+
+/// Two valid shares plus one garbage share at threshold 3 should produce a
+/// reconstructed signature that fails verification against the master pubkey.
+#[test]
+fn try_combine_poisoned() {
+    // Arrange
+    let material = create_test_key_material();
+    let garbage = create_garbage_key_material();
+
+    // First 2 valid shares
+    let mut sig_map: HashMap<OperatorId, Signature> = material.shares[..2]
+        .iter()
+        .map(|(op, sk)| (*op, sk.sign(material.signing_root)))
+        .collect();
+
+    // Third share from garbage key material (valid BLS sig, wrong key)
+    let poisoned_op = material.shares[2].0;
+    let garbage_sig = garbage.shares[2].1.sign(material.signing_root);
+    sig_map.insert(poisoned_op, garbage_sig);
+
+    // Act
+    let outcome = try_combine_and_verify(
+        &sig_map,
+        &material.master_pubkey_bytes,
+        material.signing_root,
+    );
+
+    // Assert
+    assert!(
+        matches!(outcome, CombineOutcome::VerificationFailed),
+        "Expected CombineOutcome::VerificationFailed when one share is garbage"
+    );
+}
+
+// ==================== resolve_duplicate_signature tests ====================
+
+/// Old signature is valid, new signature is garbage. The old signature should
+/// be retained in the map.
+#[test]
+fn resolve_duplicate_keeps_valid() {
+    // Arrange
+    let material = create_test_key_material();
+    let garbage = create_garbage_key_material();
+    let share_pubkeys = build_share_pubkey_map(&material);
+
+    let target_op = material.shares[0].0;
+    let valid_sig = material.shares[0].1.sign(material.signing_root);
+    let garbage_sig = garbage.shares[0].1.sign(material.signing_root);
+
+    let mut shares = HashMap::new();
+    shares.insert(target_op, valid_sig.clone());
+
+    // Act
+    resolve_duplicate_signature(
+        &mut shares,
+        target_op,
+        &garbage_sig,
+        material.signing_root,
+        &share_pubkeys,
+    );
+
+    // Assert
+    assert!(
+        shares.contains_key(&target_op),
+        "Map should still contain the operator after duplicate resolution"
+    );
+    assert_eq!(
+        shares.get(&target_op),
+        Some(&valid_sig),
+        "The valid (old) signature should be retained"
+    );
+}
+
+/// Old signature is garbage, new signature is valid. The map should be updated
+/// to contain the new valid signature.
+#[test]
+fn resolve_duplicate_replaces_with_valid() {
+    // Arrange
+    let material = create_test_key_material();
+    let garbage = create_garbage_key_material();
+    let share_pubkeys = build_share_pubkey_map(&material);
+
+    let target_op = material.shares[0].0;
+    let valid_sig = material.shares[0].1.sign(material.signing_root);
+    let garbage_sig = garbage.shares[0].1.sign(material.signing_root);
+
+    // Start with the garbage sig in the map (simulates old invalid share)
+    let mut shares = HashMap::new();
+    shares.insert(target_op, garbage_sig);
+
+    // Act
+    resolve_duplicate_signature(
+        &mut shares,
+        target_op,
+        &valid_sig,
+        material.signing_root,
+        &share_pubkeys,
+    );
+
+    // Assert
+    assert!(
+        shares.contains_key(&target_op),
+        "Map should contain the operator after replacement"
+    );
+    assert_eq!(
+        shares.get(&target_op),
+        Some(&valid_sig),
+        "The new valid signature should replace the old garbage one"
+    );
+}
+
+/// Both old and new signatures are garbage. The operator should be removed
+/// from the map entirely.
+#[test]
+fn resolve_duplicate_removes_both() {
+    // Arrange
+    let material = create_test_key_material();
+    let garbage = create_garbage_key_material();
+    let share_pubkeys = build_share_pubkey_map(&material);
+
+    let target_op = material.shares[0].0;
+
+    // Create two different garbage signatures using two different garbage key sets
+    let garbage_old = garbage.shares[0].1.sign(material.signing_root);
+
+    // Use a different signing root to produce a distinct garbage signature
+    let different_root = Hash256::from([0xCD; 32]);
+    let garbage_new = garbage.shares[0].1.sign(different_root);
+
+    let mut shares = HashMap::new();
+    shares.insert(target_op, garbage_old);
+
+    // Act
+    resolve_duplicate_signature(
+        &mut shares,
+        target_op,
+        &garbage_new,
+        material.signing_root,
+        &share_pubkeys,
+    );
+
+    // Assert
+    assert!(
+        !shares.contains_key(&target_op),
+        "Map should not contain the operator when both signatures are invalid"
+    );
+}

--- a/anchor/signature_collector/src/tests.rs
+++ b/anchor/signature_collector/src/tests.rs
@@ -494,7 +494,9 @@ async fn integration_happy_path_all_valid() {
     }
 
     // Assert: notifier receives a valid reconstructed signature
-    let reconstructed = result_rx.await.expect("Should receive reconstructed signature");
+    let reconstructed = result_rx
+        .await
+        .expect("Should receive reconstructed signature");
 
     // Verify the reconstructed signature against the master pubkey
     assert!(
@@ -540,7 +542,9 @@ async fn integration_fallback_evicts_bad_and_succeeds() {
     send_partial_sig(&tx, *op4, sk4.sign(signing_root));
 
     // Assert: notifier receives a valid reconstructed signature
-    let reconstructed = result_rx.await.expect("Should receive reconstructed signature");
+    let reconstructed = result_rx
+        .await
+        .expect("Should receive reconstructed signature");
     assert!(
         verify_reconstructed_signature(&reconstructed, &material.master_pubkey_bytes, signing_root),
         "Reconstructed signature should verify after eviction + recovery"
@@ -582,7 +586,9 @@ async fn integration_duplicate_resolution_keeps_valid() {
     send_partial_sig(&tx, *op3, sk3.sign(signing_root));
 
     // Assert: notifier receives valid signature (op1's valid sig was retained)
-    let reconstructed = result_rx.await.expect("Should receive reconstructed signature");
+    let reconstructed = result_rx
+        .await
+        .expect("Should receive reconstructed signature");
     assert!(
         verify_reconstructed_signature(&reconstructed, &material.master_pubkey_bytes, signing_root),
         "Reconstructed signature should verify because valid duplicate was kept"

--- a/anchor/signature_collector/src/tests.rs
+++ b/anchor/signature_collector/src/tests.rs
@@ -597,4 +597,3 @@ async fn integration_duplicate_resolution_keeps_valid() {
     drop(tx);
     handle.await.expect("Collector task should complete");
 }
-

--- a/anchor/signature_collector/src/tests.rs
+++ b/anchor/signature_collector/src/tests.rs
@@ -510,10 +510,10 @@ async fn integration_happy_path_all_valid() {
 }
 
 ///  2 valid + 1 garbage share reach threshold,
-/// verification fails, garbage operator is evicted, then a 4th valid share
-/// brings us back to threshold and the collector succeeds.
+/// verification fails, garbage operator's share is removed, then a 4th valid
+/// share brings us back to threshold and the collector succeeds.
 #[tokio::test]
-async fn integration_fallback_evicts_bad_and_succeeds() {
+async fn integration_fallback_removes_bad_and_succeeds() {
     // Arrange
     let material = create_test_key_material();
     let garbage = create_garbage_key_material();
@@ -536,7 +536,7 @@ async fn integration_fallback_evicts_bad_and_succeeds() {
     send_partial_sig(&tx, bad_op, garbage_sig);
 
     // At this point threshold is reached but verification fails.
-    // The collector evicts operator 3, dropping below threshold.
+    // The collector removes operator 3's invalid share, dropping below threshold.
     // Now send the 4th valid share to bring us back to threshold.
     let (op4, sk4) = &material.shares[3];
     send_partial_sig(&tx, *op4, sk4.sign(signing_root));
@@ -547,7 +547,7 @@ async fn integration_fallback_evicts_bad_and_succeeds() {
         .expect("Should receive reconstructed signature");
     assert!(
         verify_reconstructed_signature(&reconstructed, &material.master_pubkey_bytes, signing_root),
-        "Reconstructed signature should verify after eviction + recovery"
+        "Reconstructed signature should verify after fallback + recovery"
     );
 
     drop(tx);
@@ -598,48 +598,3 @@ async fn integration_duplicate_resolution_keeps_valid() {
     handle.await.expect("Collector task should complete");
 }
 
-/// After an operator is evicted for submitting a bad share, subsequent messages
-/// from that operator should be silently ignored —> even if the new signature is
-/// valid. We prove this by NOT sending any other operator's share after the
-/// evicted operator retries: if the eviction check works, threshold is never
-/// reached and the notifier never fires.
-#[tokio::test]
-async fn integration_evicted_operator_ignored() {
-    // Arrange
-    let material = create_test_key_material();
-    let garbage = create_garbage_key_material();
-    let db = create_seeded_database(&material);
-
-    let (tx, rx) = mpsc::unbounded_channel();
-    let signing_root = material.signing_root;
-
-    let handle = tokio::spawn(signature_collector(rx, signing_root, db));
-    let result_rx = send_register_notifier(&tx, THRESHOLD, material.master_pubkey_bytes);
-
-    // Send 2 valid + 1 garbage to trigger eviction of operator 3
-    for (op_id, sk) in &material.shares[..2] {
-        send_partial_sig(&tx, *op_id, sk.sign(signing_root));
-    }
-    let bad_op = material.shares[2].0;
-    send_partial_sig(&tx, bad_op, garbage.shares[2].1.sign(signing_root));
-
-    // Eviction happened. Now send a VALID sig from the evicted operator.
-    // If eviction is enforced, this is silently ignored and we stay at 2
-    // shares (below threshold 3). If eviction is NOT enforced, this would
-    // be accepted, giving us 3 valid shares and triggering a successful
-    // reconstruction.
-    let valid_sig_from_evicted = material.shares[2].1.sign(signing_root);
-    send_partial_sig(&tx, bad_op, valid_sig_from_evicted);
-
-    // Drop the sender so the collector processes all queued messages and exits.
-    drop(tx);
-
-    // Assert: the notifier should NOT have received a result, because the
-    // evicted operator's valid sig was ignored and we never reached threshold.
-    assert!(
-        result_rx.await.is_err(),
-        "Notifier should not fire: evicted operator's valid sig must be ignored"
-    );
-
-    handle.await.expect("Collector task should complete");
-}

--- a/anchor/signature_collector/src/tests.rs
+++ b/anchor/signature_collector/src/tests.rs
@@ -1,9 +1,12 @@
-use std::collections::HashMap;
+use std::{collections::HashMap, sync::Arc};
 
 use bls::{PublicKeyBytes, SecretKey, Signature};
 use bls_lagrange::{KeyId, split_with_rng};
+use database::{NetworkDatabase, test_utils::generators};
 use rand::{prelude::*, rngs::StdRng};
-use types::Hash256;
+use ssv_types::{ENCRYPTED_KEY_LENGTH, Share, ValidatorMetadata};
+use tokio::sync::{mpsc, oneshot};
+use types::{Graffiti, Hash256};
 
 use super::*;
 
@@ -370,4 +373,267 @@ fn resolve_duplicate_removes_both() {
         !shares.contains_key(&target_op),
         "Map should not contain the operator when both signatures are invalid"
     );
+}
+
+// ==================== Integration test helpers ====================
+
+const TEST_NETWORK: &str = "test";
+
+/// Creates an in-memory `NetworkDatabase` seeded with a validator and operator shares
+/// whose `share_pubkey` values are real BLS public keys derived from the test key material.
+/// Returns the database for use with the `signature_collector()` async task.
+fn create_seeded_database(material: &TestKeyMaterial) -> Arc<NetworkDatabase> {
+    let rsa_pubkey = generators::pubkey::random_rsa();
+    let db = NetworkDatabase::new_in_memory(&rsa_pubkey, TEST_NETWORK)
+        .expect("Failed to create in-memory database");
+
+    let mut conn = db.connection().expect("Failed to get connection");
+    let tx = conn.transaction().expect("Failed to begin transaction");
+
+    // Create operators
+    let operators: Vec<_> = material
+        .shares
+        .iter()
+        .map(|(op_id, _)| generators::operator::with_id(**op_id))
+        .collect();
+    for op in &operators {
+        db.insert_operator(op, &tx)
+            .expect("Failed to insert operator");
+    }
+
+    // Create cluster with these operators
+    let cluster = generators::cluster::with_operators(&operators);
+
+    // Build shares with real BLS share pubkeys from key material
+    let shares: Vec<Share> = material
+        .shares
+        .iter()
+        .map(|(op_id, sk)| Share {
+            validator_pubkey: material.master_pubkey_bytes,
+            operator_id: *op_id,
+            cluster_id: cluster.cluster_id,
+            share_pubkey: PublicKeyBytes::from(sk.public_key()),
+            encrypted_private_key: [0u8; ENCRYPTED_KEY_LENGTH],
+        })
+        .collect();
+
+    // Create validator metadata with the real master pubkey
+    let validator = ValidatorMetadata {
+        public_key: material.master_pubkey_bytes,
+        cluster_id: cluster.cluster_id,
+        index: Some(ValidatorIndex(1)),
+        graffiti: Graffiti::default(),
+    };
+
+    db.insert_validator(cluster, &validator, shares, &tx)
+        .expect("Failed to insert validator");
+
+    tx.commit().expect("Failed to commit transaction");
+
+    Arc::new(db)
+}
+
+/// Sends a `RegisterNotifier` message to the collector channel.
+/// Returns the `oneshot::Receiver` that will receive the reconstructed signature.
+fn send_register_notifier(
+    tx: &mpsc::UnboundedSender<CollectorMessage>,
+    threshold: u64,
+    validator_pubkey: PublicKeyBytes,
+) -> oneshot::Receiver<Arc<Signature>> {
+    let (result_tx, result_rx) = oneshot::channel();
+    tx.send(CollectorMessage {
+        kind: CollectorMessageKind::RegisterNotifier {
+            notify: result_tx,
+            threshold,
+            validator_pubkey,
+        },
+        _drop_on_finish: None,
+    })
+    .expect("Failed to send RegisterNotifier");
+    result_rx
+}
+
+/// Sends a `PartialSignature` message to the collector channel.
+fn send_partial_sig(
+    tx: &mpsc::UnboundedSender<CollectorMessage>,
+    operator_id: OperatorId,
+    signature: Signature,
+) {
+    tx.send(CollectorMessage {
+        kind: CollectorMessageKind::PartialSignature {
+            operator_id,
+            signature: Box::new(signature),
+        },
+        _drop_on_finish: None,
+    })
+    .expect("Failed to send PartialSignature");
+}
+
+// ==================== Integration tests ====================
+
+/// End-to-end happy path: 3 valid shares reach threshold, collector reconstructs
+/// a valid signature and notifies the waiter.
+#[tokio::test]
+async fn integration_happy_path_all_valid() {
+    // Arrange
+    let material = create_test_key_material();
+    let db = create_seeded_database(&material);
+
+    let (tx, rx) = mpsc::unbounded_channel();
+    let signing_root = material.signing_root;
+
+    // Spawn the collector task
+    let handle = tokio::spawn(signature_collector(rx, signing_root, db));
+
+    // Register a notifier expecting threshold 3
+    let result_rx = send_register_notifier(&tx, THRESHOLD, material.master_pubkey_bytes);
+
+    // Send 3 valid partial signatures
+    for (op_id, sk) in &material.shares[..3] {
+        send_partial_sig(&tx, *op_id, sk.sign(signing_root));
+    }
+
+    // Assert: notifier receives a valid reconstructed signature
+    let reconstructed = result_rx.await.expect("Should receive reconstructed signature");
+
+    // Verify the reconstructed signature against the master pubkey
+    assert!(
+        verify_reconstructed_signature(&reconstructed, &material.master_pubkey_bytes, signing_root),
+        "Reconstructed signature should verify against master pubkey"
+    );
+
+    // Clean up: drop sender so the collector task exits
+    drop(tx);
+    handle.await.expect("Collector task should complete");
+}
+
+///  2 valid + 1 garbage share reach threshold,
+/// verification fails, garbage operator is evicted, then a 4th valid share
+/// brings us back to threshold and the collector succeeds.
+#[tokio::test]
+async fn integration_fallback_evicts_bad_and_succeeds() {
+    // Arrange
+    let material = create_test_key_material();
+    let garbage = create_garbage_key_material();
+    let db = create_seeded_database(&material);
+
+    let (tx, rx) = mpsc::unbounded_channel();
+    let signing_root = material.signing_root;
+
+    let handle = tokio::spawn(signature_collector(rx, signing_root, db));
+    let result_rx = send_register_notifier(&tx, THRESHOLD, material.master_pubkey_bytes);
+
+    // Send 2 valid partial signatures
+    for (op_id, sk) in &material.shares[..2] {
+        send_partial_sig(&tx, *op_id, sk.sign(signing_root));
+    }
+
+    // Send 1 garbage partial signature (operator 3 with wrong key)
+    let bad_op = material.shares[2].0;
+    let garbage_sig = garbage.shares[2].1.sign(signing_root);
+    send_partial_sig(&tx, bad_op, garbage_sig);
+
+    // At this point threshold is reached but verification fails.
+    // The collector evicts operator 3, dropping below threshold.
+    // Now send the 4th valid share to bring us back to threshold.
+    let (op4, sk4) = &material.shares[3];
+    send_partial_sig(&tx, *op4, sk4.sign(signing_root));
+
+    // Assert: notifier receives a valid reconstructed signature
+    let reconstructed = result_rx.await.expect("Should receive reconstructed signature");
+    assert!(
+        verify_reconstructed_signature(&reconstructed, &material.master_pubkey_bytes, signing_root),
+        "Reconstructed signature should verify after eviction + recovery"
+    );
+
+    drop(tx);
+    handle.await.expect("Collector task should complete");
+}
+
+/// Duplicate resolution via DB lookup: a valid sig is already held for an operator,
+/// then a garbage duplicate arrives. The collector should keep the valid sig.
+#[tokio::test]
+async fn integration_duplicate_resolution_keeps_valid() {
+    // Arrange
+    let material = create_test_key_material();
+    let garbage = create_garbage_key_material();
+    let db = create_seeded_database(&material);
+
+    let (tx, rx) = mpsc::unbounded_channel();
+    let signing_root = material.signing_root;
+
+    let handle = tokio::spawn(signature_collector(rx, signing_root, db));
+    let result_rx = send_register_notifier(&tx, THRESHOLD, material.master_pubkey_bytes);
+
+    // Send valid sig for operator 1
+    let (op1, sk1) = &material.shares[0];
+    send_partial_sig(&tx, *op1, sk1.sign(signing_root));
+
+    // Send valid sig for operator 2
+    let (op2, sk2) = &material.shares[1];
+    send_partial_sig(&tx, *op2, sk2.sign(signing_root));
+
+    // Send a garbage duplicate for operator 1 — triggers resolve_duplicate_signature
+    let garbage_dup = garbage.shares[0].1.sign(signing_root);
+    send_partial_sig(&tx, *op1, garbage_dup);
+
+    // Send valid sig for operator 3 to reach threshold
+    let (op3, sk3) = &material.shares[2];
+    send_partial_sig(&tx, *op3, sk3.sign(signing_root));
+
+    // Assert: notifier receives valid signature (op1's valid sig was retained)
+    let reconstructed = result_rx.await.expect("Should receive reconstructed signature");
+    assert!(
+        verify_reconstructed_signature(&reconstructed, &material.master_pubkey_bytes, signing_root),
+        "Reconstructed signature should verify because valid duplicate was kept"
+    );
+
+    drop(tx);
+    handle.await.expect("Collector task should complete");
+}
+
+/// After an operator is evicted for submitting a bad share, subsequent messages
+/// from that operator should be silently ignored —> even if the new signature is
+/// valid. We prove this by NOT sending any other operator's share after the
+/// evicted operator retries: if the eviction check works, threshold is never
+/// reached and the notifier never fires.
+#[tokio::test]
+async fn integration_evicted_operator_ignored() {
+    // Arrange
+    let material = create_test_key_material();
+    let garbage = create_garbage_key_material();
+    let db = create_seeded_database(&material);
+
+    let (tx, rx) = mpsc::unbounded_channel();
+    let signing_root = material.signing_root;
+
+    let handle = tokio::spawn(signature_collector(rx, signing_root, db));
+    let result_rx = send_register_notifier(&tx, THRESHOLD, material.master_pubkey_bytes);
+
+    // Send 2 valid + 1 garbage to trigger eviction of operator 3
+    for (op_id, sk) in &material.shares[..2] {
+        send_partial_sig(&tx, *op_id, sk.sign(signing_root));
+    }
+    let bad_op = material.shares[2].0;
+    send_partial_sig(&tx, bad_op, garbage.shares[2].1.sign(signing_root));
+
+    // Eviction happened. Now send a VALID sig from the evicted operator.
+    // If eviction is enforced, this is silently ignored and we stay at 2
+    // shares (below threshold 3). If eviction is NOT enforced, this would
+    // be accepted, giving us 3 valid shares and triggering a successful
+    // reconstruction.
+    let valid_sig_from_evicted = material.shares[2].1.sign(signing_root);
+    send_partial_sig(&tx, bad_op, valid_sig_from_evicted);
+
+    // Drop the sender so the collector processes all queued messages and exits.
+    drop(tx);
+
+    // Assert: the notifier should NOT have received a result, because the
+    // evicted operator's valid sig was ignored and we never reached threshold.
+    assert!(
+        result_rx.await.is_err(),
+        "Notifier should not fire: evicted operator's valid sig must be ignored"
+    );
+
+    handle.await.expect("Collector task should complete");
 }

--- a/anchor/validator_store/src/lib.rs
+++ b/anchor/validator_store/src/lib.rs
@@ -307,6 +307,7 @@ impl<T: SlotClock, E: EthSpec> AnchorValidatorStore<T, E> {
             root: signing_root,
             index: validator.index.ok_or(SpecificError::MissingIndex)?,
             share: decrypted_key_share,
+            validator_pubkey: validator.public_key,
         };
 
         let _timer =


### PR DESCRIPTION
## Problem, Evidence, and Context

  - The signature collector does not verify the combined BLS signature after Lagrange reconstruction, and has no fallback for identifying or recovering from invalid partial signatures.
  - This is a gap against the SSV spec (boole branch), which defines three functions we were missing:
    - [`ReconstructSignature`](https://github.com/ssvlabs/ssv-spec/blob/815d25f9/ssv/partial_sig_container.go#L87-L113) -> post-reconstruction BLS verification
    - [`FallBackAndVerifyEachSignature`](https://github.com/ssvlabs/ssv-spec/blob/815d25f9/ssv/runner_validations.go#L44-L54) -> per-share fallback verification
    - [`resolveDuplicateSignature`](https://github.com/ssvlabs/ssv-spec/blob/815d25f9/ssv/runner_signatures.go#L134-L155) -> duplicate share handling
  - Tracks #269

## Change Overview

  - After Lagrange reconstruction, verify the combined signature against the validator's master BLS pubkey
  - On verification failure, fall back to per-share verification using operator share pubkeys from DB, evict invalid shares, and continue waiting for replacement shares to restore quorum
  - Add `resolveDuplicateSignature` handling when conflicting partial sigs arrive from the same operator
  - Add metrics for signature verification failures and operator evictions
  - ~300 lines of production code, ~700 lines of tests

## Risks, Trade-offs, and Mitigations

  - The fallback path queries the DB via `spawn_blocking`.  This only fires when reconstruction verification fails, which should be rare in normal operation
  - Duplicate resolution also hits the DB, but the message validator's per-operator rate limit (`MAX_MESSAGES_PER_ROUND` = 1) bounds this to at most one query per operator per collector instance
  - No changes to the happy path -> reconstruction success follows the same code path as before

## Validation

  - 8 unit tests covering `verify_reconstructed_signature`, `verify_partial_signature`, `find_invalid_shares`, `resolve_duplicate_signature`, and `try_combine_and_verify`
  - 4 integration tests: happy path, fallback eviction + recovery, duplicate resolution, and evicted operator rejection

## Rollback

  - Clean revert, no data/schema changes. Reverting removes verification and returns to the prior behavior of trusting all partial signatures.

## Additional Info / Next Steps
  - Tests can be split to a separate PR if preferred; kept here because they validate the core logic.