### PR TITLE
ci: strengthen PR template with evidence, risk, and rollback prompts

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,12 +1,38 @@
-## Issue Addressed
+Keep this concise. Use bullets where helpful. Write `N/A` if not applicable.
 
-Which issue # does this PR address?
+## Problem, Evidence, and Context (Required)
 
-## Proposed Changes
+- What real problem does this solve, or what real value does it add now?
+- Why is this worth doing now?
+- What evidence supports that?
+- Relevant links: issue, discussion, spec, related PRs.
 
-Please list or describe the changes introduced by this PR.
+## Change Overview (Required)
 
-## Additional Info
+- What changed at a high level?
+- How should the reviewer understand or read this diff?
+- What intentionally did not change?
 
-Please provide any additional information. For example, future considerations
-or information useful for reviewers.
+## Risks, Trade-offs, and Mitigations (Required)
+
+- What are the main risks or blast radius?
+- What trade-offs are being made?
+- How are those risks being mitigated?
+
+## Validation (Required)
+
+- What proves the change does what it must do?
+- Examples: targeted tests, manual repro, benchmark/profiling result, before/after behavior, spec-parity check.
+
+## Rollback (Required for behavior or runtime changes; optional otherwise)
+
+- How can this be safely reverted?
+- Any config, data, or operational impact?
+
+## Blockers / Dependencies (Optional)
+
+- Anything that must happen before or after merge.
+
+## Additional Info / Next Steps (Optional)
+
+- Anything else reviewers should know.


### PR DESCRIPTION
## Problem, Evidence, and Context
PR https://github.com/sigp/anchor/pull/870 was merged to `unstable` but needs to be in `stable` to take effect.

## Change Overview
Changes detailed in #870. I just cherry picked the commit to this new branch so we can open this PR to `stable`.

## Risks, Trade-offs, and Mitigations
Since it's a cherry pick, the file content changes are exactly the same as currently in `unstable`, so there should be no merge conflicts if we were to back-merge `stable` to `unstable` at some point in the future, or if we merge `unstable` to `stable`

## Validation
N/A

## Rollback
N/A

## Blockers / Dependencies

N/A

## Additional Info / Next Steps
N/A
