### PR TITLE
refactor: extract SignatureCollecting trait for testability

### DIFF
--- a/anchor/client/src/lib.rs
+++ b/anchor/client/src/lib.rs
@@ -553,7 +553,7 @@ impl Client {
 
         let validator_store = AnchorValidatorStore::<_, E>::new(
             database.clone(),
-            signature_collector,
+            Box::new(signature_collector),
             qbft_manager,
             slashing_protection,
             config.disable_slashing_protection,

--- a/anchor/signature_collector/src/lib.rs
+++ b/anchor/signature_collector/src/lib.rs
@@ -1,6 +1,8 @@
 use std::{
     collections::{HashMap, hash_map},
+    future::Future,
     mem,
+    pin::Pin,
     sync::Arc,
 };
 
@@ -511,6 +513,35 @@ impl From<RecvError> for CollectionError {
 impl From<bls_lagrange::Error> for CollectionError {
     fn from(err: bls_lagrange::Error) -> Self {
         CollectionError::RecoverError(err)
+    }
+}
+
+/// Trait abstracting signature collection for testability.
+///
+/// Production code uses `Arc<SignatureCollectorManager<S>>` which implements this trait.
+/// Tests can provide a mock that returns canned signatures or errors.
+pub trait SignatureCollecting: Send + Sync {
+    fn sign_and_collect(
+        &self,
+        metadata: SignatureMetadata,
+        requester: SignatureRequester,
+        signing_data: ValidatorSigningData,
+    ) -> Pin<Box<dyn Future<Output = Result<Arc<Signature>, CollectionError>> + Send + '_>>;
+}
+
+impl<S: SlotClock + Clone + 'static> SignatureCollecting for Arc<SignatureCollectorManager<S>> {
+    fn sign_and_collect(
+        &self,
+        metadata: SignatureMetadata,
+        requester: SignatureRequester,
+        signing_data: ValidatorSigningData,
+    ) -> Pin<Box<dyn Future<Output = Result<Arc<Signature>, CollectionError>> + Send + '_>> {
+        Box::pin(SignatureCollectorManager::sign_and_collect(
+            self,
+            metadata,
+            requester,
+            signing_data,
+        ))
     }
 }
 

--- a/anchor/validator_store/src/lib.rs
+++ b/anchor/validator_store/src/lib.rs
@@ -35,7 +35,7 @@ use qbft_manager::{
 };
 use safe_arith::{ArithError, SafeArith};
 use signature_collector::{
-    CollectionError, SignatureCollectorManager, SignatureMetadata, SignatureRequester,
+    CollectionError, SignatureCollecting, SignatureMetadata, SignatureRequester,
     ValidatorSigningData,
 };
 use slashing_protection::{CheckSlashability, NotSafe, Safe, SlashingDatabase};
@@ -98,7 +98,7 @@ const SYNC_COMMITTEE_CONTRIBUTION_LOG_NAME: &str = "sync committee contribution"
 pub struct AnchorValidatorStore<T: SlotClock + 'static, E: EthSpec> {
     database: Arc<NetworkDatabase>,
     decrypted_keys: Mutex<LruCache<[u8; ENCRYPTED_KEY_LENGTH], SecretKey>>,
-    signature_collector: Arc<SignatureCollectorManager<T>>,
+    signature_collector: Box<dyn SignatureCollecting>,
     qbft_manager: Arc<QbftManager<E, T>>,
     slashing_protection: Arc<SlashingDatabase>,
     slashing_protection_last_prune: Mutex<Epoch>,
@@ -127,7 +127,7 @@ impl<T: SlotClock, E: EthSpec> AnchorValidatorStore<T, E> {
     #[expect(clippy::too_many_arguments)]
     pub fn new(
         database: Arc<NetworkDatabase>,
-        signature_collector: Arc<SignatureCollectorManager<T>>,
+        signature_collector: Box<dyn SignatureCollecting>,
         qbft_manager: Arc<QbftManager<E, T>>,
         slashing_protection: Arc<SlashingDatabase>,
         disable_slashing_protection: bool,


### PR DESCRIPTION
## Problem, Evidence, and Context

- `AnchorValidatorStore` is tightly coupled to `SignatureCollectorManager` via a concrete `Arc<SignatureCollectorManager<T>>` field, making integration tests require the full signature collection infrastructure (processor queues, message senders, partial signature routing)
- PRs #893 and #894 (addressing #878) introduce ~1400 lines of test harness that simulates an entire SSV network primarily to work around this coupling
- Extracting a trait at this boundary follows the existing pattern used by `MessageSender` (`Arc<dyn MessageSender>`) and enables test mocks that return canned signatures directly

## Change Overview

- Added `SignatureCollecting` trait in `signature_collector` with a single method: `sign_and_collect`
- Implemented the trait for `Arc<SignatureCollectorManager<S>>` (the existing production type)
- Changed `AnchorValidatorStore.signature_collector` field from `Arc<SignatureCollectorManager<T>>` to `Box<dyn SignatureCollecting>`
- Updated the construction site in `client` to wrap with `Box::new()`
- No behavioral changes — production code paths are identical

## Risks, Trade-offs, and Mitigations

- One extra heap allocation (`Box`) and dynamic dispatch for `sign_and_collect` calls — negligible given that each call involves network I/O, BLS cryptography, and async task coordination
- The trait uses `Pin<Box<dyn Future>>` return type since async trait methods are not yet object-safe in stable Rust — this is standard practice and consistent with other async boundaries in the codebase

## Validation

- `make cargo-fmt-check` — clean
- `make lint` — clean
- `cargo test -p anchor_validator_store -p signature_collector` — all 21 tests pass
- No behavioral change to verify — this is a pure interface extraction

## Rollback

N/A — pure refactor, trivially reversible

## Blockers / Dependencies

N/A

## Additional Info / Next Steps

- This enables test mocks for `validator_store` integration tests (#878, #886) without needing the full `SignatureCollectorManager` infrastructure or partial signature routing simulation
- A mock implementing `SignatureCollecting` can capture the `SignatureRequester` passed to `sign_and_collect`, directly verifying that `CollectionMode::Committee` receives the correct `num_signatures_to_collect` — which is the core assertion needed for #878 test case 3 and #886 test case 3