### PR TITLE
refactor: extract ConsensusDecider trait for testability

### DIFF
--- a/anchor/client/src/lib.rs
+++ b/anchor/client/src/lib.rs
@@ -551,7 +551,7 @@ impl Client {
         // Spawn the network listening task
         executor.spawn(network.run::<E>(), "network");
 
-        let validator_store = AnchorValidatorStore::<_, E>::new(
+        let validator_store = AnchorValidatorStore::<_, E, _>::new(
             database.clone(),
             Box::new(signature_collector),
             qbft_manager,

--- a/anchor/qbft_manager/src/lib.rs
+++ b/anchor/qbft_manager/src/lib.rs
@@ -1,4 +1,4 @@
-use std::{fmt::Debug, hash::Hash, num::NonZeroU64, sync::Arc};
+use std::{fmt::Debug, future::Future, hash::Hash, num::NonZeroU64, sync::Arc};
 
 use bls::PublicKeyBytes;
 use dashmap::DashMap;
@@ -382,6 +382,35 @@ impl<E: EthSpec, S: SlotClock + Clone + 'static> QbftManager<E, S> {
             self.aggregator_committee_instances
                 .retain(|k, _| *k.instance_height >= cutoff.as_usize());
         }
+    }
+}
+
+/// Abstraction over QBFT consensus. Allows swapping in a mock for tests that don't
+/// need real consensus (e.g., testing signing pipelines).
+///
+/// Uses static dispatch (not `dyn`) because `decide_instance` is generic over
+/// `D: QbftDecidable<E>`, which prevents object safety.
+pub trait ConsensusDecider<E: EthSpec>: Send + Sync {
+    fn decide_instance<D: QbftDecidable<E>>(
+        &self,
+        id: D::Id,
+        initial: D,
+        validator: Box<dyn QbftDataValidator<D>>,
+        timeout_mode: TimeoutMode,
+        committee_members: &IndexSet<OperatorId>,
+    ) -> impl Future<Output = Result<Completed<D>, QbftError>> + Send;
+}
+
+impl<E: EthSpec, S: SlotClock + 'static> ConsensusDecider<E> for QbftManager<E, S> {
+    fn decide_instance<D: QbftDecidable<E>>(
+        &self,
+        id: D::Id,
+        initial: D,
+        validator: Box<dyn QbftDataValidator<D>>,
+        timeout_mode: TimeoutMode,
+        committee_members: &IndexSet<OperatorId>,
+    ) -> impl Future<Output = Result<Completed<D>, QbftError>> + Send {
+        self.decide_instance(id, initial, validator, timeout_mode, committee_members)
     }
 }
 

--- a/anchor/validator_store/src/lib.rs
+++ b/anchor/validator_store/src/lib.rs
@@ -30,8 +30,8 @@ use openssl::{
 use parking_lot::Mutex;
 use qbft::Completed;
 use qbft_manager::{
-    AggregatorCommitteeInstanceId, CommitteeInstanceId, ProposerInstanceId, QbftError, QbftManager,
-    TimeoutMode, ValidatorDutyKind,
+    AggregatorCommitteeInstanceId, CommitteeInstanceId, ConsensusDecider, ProposerInstanceId,
+    QbftError, QbftManager, TimeoutMode, ValidatorDutyKind,
 };
 use safe_arith::{ArithError, SafeArith};
 use signature_collector::{
@@ -95,11 +95,15 @@ const SELECTION_PROOF_LOG_NAME: &str = "selection proof";
 const SYNC_SELECTION_PROOF_LOG_NAME: &str = "sync selection proof";
 const SYNC_COMMITTEE_CONTRIBUTION_LOG_NAME: &str = "sync committee contribution";
 
-pub struct AnchorValidatorStore<T: SlotClock + 'static, E: EthSpec> {
+pub struct AnchorValidatorStore<
+    T: SlotClock + 'static,
+    E: EthSpec,
+    C: ConsensusDecider<E> = QbftManager<E, T>,
+> {
     database: Arc<NetworkDatabase>,
     decrypted_keys: Mutex<LruCache<[u8; ENCRYPTED_KEY_LENGTH], SecretKey>>,
     signature_collector: Box<dyn SignatureCollecting>,
-    qbft_manager: Arc<QbftManager<E, T>>,
+    consensus: Arc<C>,
     slashing_protection: Arc<SlashingDatabase>,
     slashing_protection_last_prune: Mutex<Epoch>,
     disable_slashing_protection: bool,
@@ -123,12 +127,12 @@ pub struct AnchorValidatorStore<T: SlotClock + 'static, E: EthSpec> {
     task_executor: TaskExecutor,
 }
 
-impl<T: SlotClock, E: EthSpec> AnchorValidatorStore<T, E> {
+impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> AnchorValidatorStore<T, E, C> {
     #[expect(clippy::too_many_arguments)]
     pub fn new(
         database: Arc<NetworkDatabase>,
         signature_collector: Box<dyn SignatureCollecting>,
-        qbft_manager: Arc<QbftManager<E, T>>,
+        consensus: Arc<C>,
         slashing_protection: Arc<SlashingDatabase>,
         disable_slashing_protection: bool,
         slot_clock: T,
@@ -142,12 +146,12 @@ impl<T: SlotClock, E: EthSpec> AnchorValidatorStore<T, E> {
         strict_mfp: bool,
         is_synced: watch::Receiver<bool>,
         task_executor: TaskExecutor,
-    ) -> Arc<AnchorValidatorStore<T, E>> {
+    ) -> Arc<AnchorValidatorStore<T, E, C>> {
         Arc::new(Self {
             database,
             decrypted_keys: Mutex::new(LruCache::new(MAX_VALIDATORS_PER_OPERATOR)),
             signature_collector,
-            qbft_manager,
+            consensus,
             slashing_protection,
             slashing_protection_last_prune: Mutex::new(Epoch::new(0)),
             disable_slashing_protection,
@@ -432,7 +436,7 @@ impl<T: SlotClock, E: EthSpec> AnchorValidatorStore<T, E> {
 
         // Initiate QBFT consensus for this block proposal
         let completed = self
-            .qbft_manager
+            .consensus
             .decide_instance(
                 instance_id,
                 consensus_data,
@@ -797,7 +801,7 @@ impl<T: SlotClock, E: EthSpec> AnchorValidatorStore<T, E> {
         };
 
         let completed = self
-            .qbft_manager
+            .consensus
             .decide_instance(
                 AggregatorCommitteeInstanceId {
                     committee: committee_id,
@@ -970,7 +974,7 @@ impl<T: SlotClock, E: EthSpec> AnchorValidatorStore<T, E> {
         };
 
         let completed = self
-            .qbft_manager
+            .consensus
             .decide_instance(
                 ProposerInstanceId {
                     validator: validator_pubkey,
@@ -1087,7 +1091,7 @@ impl<T: SlotClock, E: EthSpec> AnchorValidatorStore<T, E> {
         };
 
         let completed = self
-            .qbft_manager
+            .consensus
             .decide_instance(
                 AggregatorCommitteeInstanceId {
                     committee: committee_id,
@@ -1268,7 +1272,7 @@ impl<T: SlotClock, E: EthSpec> AnchorValidatorStore<T, E> {
         };
 
         let completed = self
-            .qbft_manager
+            .consensus
             .decide_instance(
                 ProposerInstanceId {
                     validator: aggregator_pubkey,
@@ -1466,7 +1470,7 @@ impl<T: SlotClock, E: EthSpec> AnchorValidatorStore<T, E> {
         };
 
         let completed = self
-            .qbft_manager
+            .consensus
             .decide_instance(
                 CommitteeInstanceId {
                     committee: committee_id,
@@ -1616,7 +1620,7 @@ impl<T: SlotClock, E: EthSpec> AnchorValidatorStore<T, E> {
         };
 
         let completed = self
-            .qbft_manager
+            .consensus
             .decide_instance(
                 CommitteeInstanceId {
                     committee: committee_id,
@@ -2182,7 +2186,9 @@ fn convert_slashing_result(value: Result<Safe, NotSafe>) -> Result<(), Error> {
 
 pub type Error = ValidatorStoreError<SpecificError>;
 
-impl<T: SlotClock, E: EthSpec> ValidatorStore for AnchorValidatorStore<T, E> {
+impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> ValidatorStore
+    for AnchorValidatorStore<T, E, C>
+{
     type Error = SpecificError;
     type E = E;
 


### PR DESCRIPTION
## Problem, Evidence, and Context

- Testing the signing pipeline in `AnchorValidatorStore` currently requires a real `QbftManager`, which needs a full networking stack and slot clock. This makes integration tests slow and complex.
- Extracting a `ConsensusDecider` trait allows future tests to swap in a mock that returns pre-determined consensus results, enabling focused testing of the signing logic without real QBFT.
- This is step 1 of #896.

## Change Overview

- **`qbft_manager`**: Added a `ConsensusDecider<E>` trait with a single method `decide_instance`, plus a blanket implementation for `QbftManager<E, S>` that delegates to the existing method.
- **`validator_store`**: Added a third type parameter `C: ConsensusDecider<E>` with default `= QbftManager<E, T>`, so all existing code using `AnchorValidatorStore<T, E>` compiles unchanged. Renamed the internal field from `qbft_manager` to `consensus` and updated all 7 call sites.
- **`client`**: Updated one turbofish from `<_, E>` to `<_, E, _>` to account for the new type parameter.

The trait uses static dispatch (`impl Future` return) rather than `dyn` because `decide_instance` is generic over `D: QbftDecidable<E>`, which prevents object safety. This differs from `SignatureCollecting` (which uses `dyn`) for that technical reason.

- No behavioral changes. All runtime code paths are identical.

## Risks, Trade-offs, and Mitigations

- **Low risk**: The default type parameter means all downstream code is unchanged. The only non-test caller (`client/src/lib.rs`) just needs a `_` in the turbofish.
- **Trade-off**: Static dispatch means test mocks must also be generic-compatible, but this is unavoidable given the generic `D` parameter on `decide_instance`.

## Validation

- `cargo clippy -p anchor_validator_store --tests -- -D warnings` passes
- `cargo clippy -p qbft_manager --tests -- -D warnings` passes
- `cargo test -p anchor_validator_store` passes
- `cargo test -p qbft_manager` passes
- Full `make lint` passes

## Rollback

- Pure refactor with no runtime behavior change. Safe to revert at any time.

## Next Steps

- Step 2 (#896): Add a `MockConsensusDecider` and use it in `validator_store` integration tests to test signing pipelines without real QBFT.