### PR TITLE
fix(eth): process contract logs one block at a time

### DIFF
--- a/anchor/database/src/cluster_operations.rs
+++ b/anchor/database/src/cluster_operations.rs
@@ -1,8 +1,6 @@
-use std::str::FromStr;
-
 use bls::PublicKeyBytes;
 use rusqlite::{OptionalExtension, Transaction, params};
-use ssv_types::{Cluster, ClusterId, OperatorId, Share, ValidatorMetadata};
+use ssv_types::{Cluster, ClusterId, ClusterMember, OperatorId, Share, ValidatorMetadata};
 use types::Address;
 
 use super::{DatabaseError, NetworkDatabase, PendingStateUpdates, sql_operations};
@@ -144,43 +142,32 @@ impl NetworkDatabase {
         validator_pubkey: &PublicKeyBytes,
         tx: &Transaction<'_>,
     ) -> Result<Option<Cluster>, DatabaseError> {
-        let cluster_row = tx
+        let Some(cluster_id) = tx
             .prepare_cached(sql_operations::GET_CLUSTER_BY_VALIDATOR)?
             .query_row(params![validator_pubkey.to_string()], |row| {
-                Ok((
-                    ClusterId(row.get("cluster_id")?),
-                    row.get::<_, String>("owner")?,
-                    row.get::<_, Option<String>>("fee_recipient")?,
-                    row.get::<_, bool>("liquidated")?,
-                ))
+                Ok(ClusterId(row.get("cluster_id")?))
             })
-            .optional()?;
-
-        let Some((cluster_id, owner, fee_recipient, liquidated)) = cluster_row else {
+            .optional()?
+        else {
             return Ok(None);
         };
 
         let cluster_members = tx
             .prepare_cached(sql_operations::GET_CLUSTER_MEMBERS)?
-            .query_map([cluster_id.0], |row| row.get(0))?
+            .query_map([cluster_id.0], |row| {
+                Ok(ClusterMember {
+                    cluster_id,
+                    operator_id: row.get(0)?,
+                })
+            })?
             .collect::<Result<Vec<_>, _>>()?;
-        let owner = Address::from_str(&owner).map_err(|e| {
-            DatabaseError::SQLError(format!("Failed to parse cluster owner from database: {e}"))
-        })?;
-        let fee_recipient = match fee_recipient {
-            Some(fee_recipient) => Address::from_str(&fee_recipient).map_err(|e| {
-                DatabaseError::SQLError(format!("Failed to parse fee recipient from database: {e}"))
-            })?,
-            None => owner,
-        };
 
-        Ok(Some(Cluster {
-            cluster_id,
-            owner,
-            fee_recipient,
-            liquidated,
-            cluster_members: cluster_members.into_iter().collect(),
-        }))
+        tx.prepare_cached(sql_operations::GET_CLUSTER_BY_VALIDATOR)?
+            .query_row(params![validator_pubkey.to_string()], |row| {
+                Cluster::try_from((row, cluster_members))
+            })
+            .optional()
+            .map_err(DatabaseError::from)
     }
 
     /// Bump the nonce of the owner in the active transaction and queue the matching state update.

--- a/anchor/database/src/cluster_operations.rs
+++ b/anchor/database/src/cluster_operations.rs
@@ -1,3 +1,5 @@
+use std::str::FromStr;
+
 use bls::PublicKeyBytes;
 use rusqlite::{OptionalExtension, Transaction, params};
 use ssv_types::{Cluster, ClusterId, ClusterMember, OperatorId, Share, ValidatorMetadata};
@@ -142,10 +144,15 @@ impl NetworkDatabase {
         validator_pubkey: &PublicKeyBytes,
         tx: &Transaction<'_>,
     ) -> Result<Option<Cluster>, DatabaseError> {
-        let Some(cluster_id) = tx
+        let Some((cluster_id, owner, fee_recipient, liquidated)) = tx
             .prepare_cached(sql_operations::GET_CLUSTER_BY_VALIDATOR)?
             .query_row(params![validator_pubkey.to_string()], |row| {
-                Ok(ClusterId(row.get("cluster_id")?))
+                Ok((
+                    ClusterId(row.get("cluster_id")?),
+                    row.get::<_, String>("owner")?,
+                    row.get::<_, Option<String>>("fee_recipient")?,
+                    row.get("liquidated")?,
+                ))
             })
             .optional()?
         else {
@@ -162,12 +169,24 @@ impl NetworkDatabase {
             })?
             .collect::<Result<Vec<_>, _>>()?;
 
-        tx.prepare_cached(sql_operations::GET_CLUSTER_BY_VALIDATOR)?
-            .query_row(params![validator_pubkey.to_string()], |row| {
-                Cluster::try_from((row, cluster_members))
-            })
-            .optional()
-            .map_err(DatabaseError::from)
+        let owner =
+            Address::from_str(&owner).map_err(|err| DatabaseError::SQLError(err.to_string()))?;
+        let fee_recipient = match fee_recipient {
+            Some(fee_recipient) => Address::from_str(&fee_recipient)
+                .map_err(|err| DatabaseError::SQLError(err.to_string()))?,
+            None => owner,
+        };
+
+        Ok(Some(Cluster {
+            cluster_id,
+            owner,
+            fee_recipient,
+            liquidated,
+            cluster_members: cluster_members
+                .into_iter()
+                .map(|member| member.operator_id)
+                .collect(),
+        }))
     }
 
     /// Bump the nonce of the owner in the active transaction and queue the matching state update.

--- a/anchor/database/src/cluster_operations.rs
+++ b/anchor/database/src/cluster_operations.rs
@@ -1,5 +1,3 @@
-use std::str::FromStr;
-
 use bls::PublicKeyBytes;
 use rusqlite::{OptionalExtension, Transaction, params};
 use ssv_types::{Cluster, ClusterId, ClusterMember, OperatorId, Share, ValidatorMetadata};
@@ -144,49 +142,24 @@ impl NetworkDatabase {
         validator_pubkey: &PublicKeyBytes,
         tx: &Transaction<'_>,
     ) -> Result<Option<Cluster>, DatabaseError> {
-        let Some((cluster_id, owner, fee_recipient, liquidated)) = tx
-            .prepare_cached(sql_operations::GET_CLUSTER_BY_VALIDATOR)?
+        tx.prepare_cached(sql_operations::GET_CLUSTER_BY_VALIDATOR)?
             .query_row(params![validator_pubkey.to_string()], |row| {
-                Ok((
-                    ClusterId(row.get("cluster_id")?),
-                    row.get::<_, String>("owner")?,
-                    row.get::<_, Option<String>>("fee_recipient")?,
-                    row.get("liquidated")?,
-                ))
+                let cluster_id = ClusterId(row.get("cluster_id")?);
+
+                let cluster_members = tx
+                    .prepare_cached(sql_operations::GET_CLUSTER_MEMBERS)?
+                    .query_map([cluster_id.0], |member_row| {
+                        Ok(ClusterMember {
+                            cluster_id,
+                            operator_id: member_row.get(0)?,
+                        })
+                    })?
+                    .collect::<Result<Vec<_>, _>>()?;
+
+                Cluster::try_from((row, cluster_members))
             })
-            .optional()?
-        else {
-            return Ok(None);
-        };
-
-        let cluster_members = tx
-            .prepare_cached(sql_operations::GET_CLUSTER_MEMBERS)?
-            .query_map([cluster_id.0], |row| {
-                Ok(ClusterMember {
-                    cluster_id,
-                    operator_id: row.get(0)?,
-                })
-            })?
-            .collect::<Result<Vec<_>, _>>()?;
-
-        let owner =
-            Address::from_str(&owner).map_err(|err| DatabaseError::SQLError(err.to_string()))?;
-        let fee_recipient = match fee_recipient {
-            Some(fee_recipient) => Address::from_str(&fee_recipient)
-                .map_err(|err| DatabaseError::SQLError(err.to_string()))?,
-            None => owner,
-        };
-
-        Ok(Some(Cluster {
-            cluster_id,
-            owner,
-            fee_recipient,
-            liquidated,
-            cluster_members: cluster_members
-                .into_iter()
-                .map(|member| member.operator_id)
-                .collect(),
-        }))
+            .optional()
+            .map_err(DatabaseError::from)
     }
 
     /// Bump the nonce of the owner in the active transaction and queue the matching state update.

--- a/anchor/database/src/cluster_operations.rs
+++ b/anchor/database/src/cluster_operations.rs
@@ -1,5 +1,7 @@
+use std::str::FromStr;
+
 use bls::PublicKeyBytes;
-use rusqlite::{Transaction, params};
+use rusqlite::{OptionalExtension, Transaction, params};
 use ssv_types::{Cluster, ClusterId, OperatorId, Share, ValidatorMetadata};
 use types::Address;
 
@@ -134,6 +136,51 @@ impl NetworkDatabase {
         self.delete_validator_tx(validator_pubkey, tx, &mut state_updates)?;
         self.apply_pending_state_updates(state_updates);
         Ok(())
+    }
+
+    /// Load a cluster by validator public key through the transaction's view of the database.
+    pub fn get_cluster_by_validator_tx(
+        &self,
+        validator_pubkey: &PublicKeyBytes,
+        tx: &Transaction<'_>,
+    ) -> Result<Option<Cluster>, DatabaseError> {
+        let cluster_row = tx
+            .prepare_cached(sql_operations::GET_CLUSTER_BY_VALIDATOR)?
+            .query_row(params![validator_pubkey.to_string()], |row| {
+                Ok((
+                    ClusterId(row.get("cluster_id")?),
+                    row.get::<_, String>("owner")?,
+                    row.get::<_, Option<String>>("fee_recipient")?,
+                    row.get::<_, bool>("liquidated")?,
+                ))
+            })
+            .optional()?;
+
+        let Some((cluster_id, owner, fee_recipient, liquidated)) = cluster_row else {
+            return Ok(None);
+        };
+
+        let cluster_members = tx
+            .prepare_cached(sql_operations::GET_CLUSTER_MEMBERS)?
+            .query_map([cluster_id.0], |row| row.get(0))?
+            .collect::<Result<Vec<_>, _>>()?;
+        let owner = Address::from_str(&owner).map_err(|e| {
+            DatabaseError::SQLError(format!("Failed to parse cluster owner from database: {e}"))
+        })?;
+        let fee_recipient = match fee_recipient {
+            Some(fee_recipient) => Address::from_str(&fee_recipient).map_err(|e| {
+                DatabaseError::SQLError(format!("Failed to parse fee recipient from database: {e}"))
+            })?,
+            None => owner,
+        };
+
+        Ok(Some(Cluster {
+            cluster_id,
+            owner,
+            fee_recipient,
+            liquidated,
+            cluster_members: cluster_members.into_iter().collect(),
+        }))
     }
 
     /// Bump the nonce of the owner in the active transaction and queue the matching state update.

--- a/anchor/database/src/cluster_operations.rs
+++ b/anchor/database/src/cluster_operations.rs
@@ -80,17 +80,17 @@ impl NetworkDatabase {
     pub fn update_status_tx(
         &self,
         cluster_id: ClusterId,
-        status: bool,
+        liquidated: bool,
         tx: &Transaction<'_>,
         state_updates: &mut PendingStateUpdates,
     ) -> Result<(), DatabaseError> {
         tx.prepare_cached(sql_operations::UPDATE_CLUSTER_STATUS)?
             .execute(params![
-                status,      // status of the cluster (liquidated = false, active = true)
+                liquidated,  // liquidated flag
                 *cluster_id  // Id of the cluster
             ])?;
 
-        state_updates.update_cluster_status(cluster_id, status);
+        state_updates.update_cluster_status(cluster_id, liquidated);
 
         Ok(())
     }
@@ -99,11 +99,11 @@ impl NetworkDatabase {
     pub fn update_status(
         &self,
         cluster_id: ClusterId,
-        status: bool,
+        liquidated: bool,
         tx: &Transaction<'_>,
     ) -> Result<(), DatabaseError> {
         let mut state_updates = PendingStateUpdates::default();
-        self.update_status_tx(cluster_id, status, tx, &mut state_updates)?;
+        self.update_status_tx(cluster_id, liquidated, tx, &mut state_updates)?;
         self.apply_pending_state_updates(state_updates);
         Ok(())
     }

--- a/anchor/database/src/lib.rs
+++ b/anchor/database/src/lib.rs
@@ -63,9 +63,9 @@ where
     T::Err: std::error::Error + Send + Sync + 'static,
 {
     let value = row.get::<_, String>(column)?;
-    value.parse().map_err(|e| {
-        rusqlite::Error::FromSqlConversionFailure(column, Type::Text, Box::new(e))
-    })
+    value
+        .parse()
+        .map_err(|e| rusqlite::Error::FromSqlConversionFailure(column, Type::Text, Box::new(e)))
 }
 
 pub(crate) fn parse_optional_text_column<T>(

--- a/anchor/database/src/lib.rs
+++ b/anchor/database/src/lib.rs
@@ -10,7 +10,7 @@ use once_cell::sync::OnceCell;
 use openssl::{pkey::Public, rsa::Rsa};
 use r2d2::CustomizeConnection;
 use r2d2_sqlite::SqliteConnectionManager;
-use rusqlite::{Connection, OptionalExtension, Transaction, params};
+use rusqlite::{Connection, OptionalExtension, Row, Transaction, params, types::Type};
 use ssv_types::{Cluster, ClusterId, CommitteeId, Operator, OperatorId, Share, ValidatorMetadata};
 use tokio::sync::{
     watch,
@@ -56,6 +56,34 @@ const CONNECTION_TIMEOUT: Duration = Duration::from_secs(60);
 
 type Pool = r2d2::Pool<SqliteConnectionManager>;
 type PoolConn = r2d2::PooledConnection<SqliteConnectionManager>;
+
+pub(crate) fn parse_text_column<T>(row: &Row<'_>, column: usize) -> rusqlite::Result<T>
+where
+    T: std::str::FromStr,
+    T::Err: std::error::Error + Send + Sync + 'static,
+{
+    let value = row.get::<_, String>(column)?;
+    value.parse().map_err(|e| {
+        rusqlite::Error::FromSqlConversionFailure(column, Type::Text, Box::new(e))
+    })
+}
+
+pub(crate) fn parse_optional_text_column<T>(
+    row: &Row<'_>,
+    column: usize,
+) -> rusqlite::Result<Option<T>>
+where
+    T: std::str::FromStr,
+    T::Err: std::error::Error + Send + Sync + 'static,
+{
+    row.get::<_, Option<String>>(column)?
+        .map(|value| {
+            value.parse().map_err(|e| {
+                rusqlite::Error::FromSqlConversionFailure(column, Type::Text, Box::new(e))
+            })
+        })
+        .transpose()
+}
 
 /// All the shares that belong to the current operator.
 /// IMPORTANT: There are parts of the code that assume this only contains shares that belong to the

--- a/anchor/database/src/lib.rs
+++ b/anchor/database/src/lib.rs
@@ -225,6 +225,16 @@ impl NetworkDatabase {
         }
     }
 
+    /// Read the largest seen OperatorId through the transaction's view of the database.
+    pub fn get_max_operator_id_seen_tx(
+        &self,
+        tx: &Transaction<'_>,
+    ) -> Result<Option<u64>, DatabaseError> {
+        tx.prepare_cached(sql_operations::GET_MAX_OPERATOR_ID_SEEN)?
+            .query_row([], |row| row.get(0))
+            .map_err(DatabaseError::from)
+    }
+
     /// Update the last processed block number in the database transaction.
     pub fn processed_block_tx(
         &self,

--- a/anchor/database/src/lib.rs
+++ b/anchor/database/src/lib.rs
@@ -10,7 +10,7 @@ use once_cell::sync::OnceCell;
 use openssl::{pkey::Public, rsa::Rsa};
 use r2d2::CustomizeConnection;
 use r2d2_sqlite::SqliteConnectionManager;
-use rusqlite::{Connection, OptionalExtension, Row, Transaction, params, types::Type};
+use rusqlite::{Connection, OptionalExtension, Transaction, params};
 use ssv_types::{Cluster, ClusterId, CommitteeId, Operator, OperatorId, Share, ValidatorMetadata};
 use tokio::sync::{
     watch,
@@ -56,34 +56,6 @@ const CONNECTION_TIMEOUT: Duration = Duration::from_secs(60);
 
 type Pool = r2d2::Pool<SqliteConnectionManager>;
 type PoolConn = r2d2::PooledConnection<SqliteConnectionManager>;
-
-pub(crate) fn parse_text_column<T>(row: &Row<'_>, column: usize) -> rusqlite::Result<T>
-where
-    T: std::str::FromStr,
-    T::Err: std::error::Error + Send + Sync + 'static,
-{
-    let value = row.get::<_, String>(column)?;
-    value
-        .parse()
-        .map_err(|e| rusqlite::Error::FromSqlConversionFailure(column, Type::Text, Box::new(e)))
-}
-
-pub(crate) fn parse_optional_text_column<T>(
-    row: &Row<'_>,
-    column: usize,
-) -> rusqlite::Result<Option<T>>
-where
-    T: std::str::FromStr,
-    T::Err: std::error::Error + Send + Sync + 'static,
-{
-    row.get::<_, Option<String>>(column)?
-        .map(|value| {
-            value.parse().map_err(|e| {
-                rusqlite::Error::FromSqlConversionFailure(column, Type::Text, Box::new(e))
-            })
-        })
-        .transpose()
-}
 
 /// All the shares that belong to the current operator.
 /// IMPORTANT: There are parts of the code that assume this only contains shares that belong to the

--- a/anchor/database/src/pending_updates.rs
+++ b/anchor/database/src/pending_updates.rs
@@ -196,7 +196,11 @@ impl StateUpdate {
             }
             Self::DeleteValidator { validator_pubkey } => {
                 state.multi_state.shares.remove(&validator_pubkey);
-                // This assumes the validator was already present in memory for the pending tx flow.
+                // Invariant: callers only enqueue validator removal after validating the
+                // validator through the current tx/database view, and replay assumes
+                // NetworkState is still aligned with that state at this point. If the metadata
+                // is missing here, silently continuing would hide an invariant break after the
+                // share removal above and leave NetworkState partially updated.
                 let metadata = state
                     .multi_state
                     .validator_metadata

--- a/anchor/database/src/pending_updates.rs
+++ b/anchor/database/src/pending_updates.rs
@@ -25,7 +25,7 @@ enum StateUpdate {
     InsertValidator(Box<InsertValidatorStateUpdate>),
     UpdateClusterStatus {
         cluster_id: ClusterId,
-        status: bool,
+        liquidated: bool,
     },
     DeleteValidator {
         validator_pubkey: PublicKeyBytes,
@@ -90,9 +90,11 @@ impl PendingStateUpdates {
         )));
     }
 
-    pub(crate) fn update_cluster_status(&mut self, cluster_id: ClusterId, status: bool) {
-        self.updates
-            .push(StateUpdate::UpdateClusterStatus { cluster_id, status });
+    pub(crate) fn update_cluster_status(&mut self, cluster_id: ClusterId, liquidated: bool) {
+        self.updates.push(StateUpdate::UpdateClusterStatus {
+            cluster_id,
+            liquidated,
+        });
     }
 
     pub(crate) fn delete_validator(&mut self, validator_pubkey: PublicKeyBytes) {
@@ -189,9 +191,12 @@ impl StateUpdate {
                     validator,
                 );
             }
-            Self::UpdateClusterStatus { cluster_id, status } => {
+            Self::UpdateClusterStatus {
+                cluster_id,
+                liquidated,
+            } => {
                 if let Some(cluster) = state.multi_state.clusters.get_mut_by(&cluster_id) {
-                    cluster.liquidated = status;
+                    cluster.liquidated = liquidated;
                 }
             }
             Self::DeleteValidator { validator_pubkey } => {

--- a/anchor/database/src/sql_operations.rs
+++ b/anchor/database/src/sql_operations.rs
@@ -55,6 +55,17 @@ pub const GET_CLUSTER_MEMBERS: &str = r#"
     FROM cluster_members
     WHERE cluster_id = ?1
 "#;
+pub const GET_CLUSTER_BY_VALIDATOR: &str = r#"
+    SELECT DISTINCT
+        c.cluster_id,
+        c.owner,
+        o.fee_recipient,
+        c.liquidated
+    FROM validators v
+    JOIN clusters c ON v.cluster_id = c.cluster_id
+    LEFT JOIN owners o ON c.owner = o.owner
+    WHERE v.validator_pubkey = ?1
+"#;
 
 // Validator
 pub const INSERT_VALIDATOR: &str = r#"
@@ -65,6 +76,7 @@ pub const INSERT_VALIDATOR: &str = r#"
 "#;
 pub const DELETE_VALIDATOR: &str = r#"DELETE from validators WHERE validator_pubkey = ?1"#;
 pub const GET_ALL_VALIDATORS: &str = r#"SELECT * FROM validators"#;
+pub const GET_VALIDATOR: &str = r#"SELECT * FROM validators WHERE validator_pubkey = ?1"#;
 // Shares
 pub const INSERT_SHARE: &str = r#"
     INSERT INTO shares
@@ -75,6 +87,12 @@ pub const INSERT_SHARE: &str = r#"
 pub const GET_SHARES: &str = r#"
     SELECT share_pubkey, encrypted_key, operator_id, cluster_id, validator_pubkey
     FROM shares WHERE operator_id = ?1
+"#;
+pub const GET_OWN_SHARE: &str = r#"
+    SELECT 1
+    FROM shares
+    WHERE validator_pubkey = ?1 AND operator_id = ?2
+    LIMIT 1
 "#;
 // Misc Datta
 pub const INSERT_OR_UPDATE_OWNER_FEE_RECIPIENT: &str = r#"

--- a/anchor/database/src/sql_operations.rs
+++ b/anchor/database/src/sql_operations.rs
@@ -56,7 +56,7 @@ pub const GET_CLUSTER_MEMBERS: &str = r#"
     WHERE cluster_id = ?1
 "#;
 pub const GET_CLUSTER_BY_VALIDATOR: &str = r#"
-    SELECT DISTINCT
+    SELECT
         c.cluster_id,
         c.owner,
         o.fee_recipient,

--- a/anchor/database/src/state.rs
+++ b/anchor/database/src/state.rs
@@ -1,6 +1,4 @@
-use std::{
-    collections::{HashMap, HashSet},
-};
+use std::collections::{HashMap, HashSet};
 
 use base64::prelude::*;
 use bls::PublicKeyBytes;

--- a/anchor/database/src/state.rs
+++ b/anchor/database/src/state.rs
@@ -13,7 +13,7 @@ use types::Address;
 use crate::{
     ClusterMultiIndexMap, DatabaseError, MetadataMultiIndexMap, MultiIndexMap, MultiState,
     NonUniqueIndex, Pool, PoolConn, PubkeyOrId, ShareMultiIndexMap, SingleState, UniqueIndex,
-    parse_text_column, sql_operations,
+    sql_operations,
 };
 
 // Container to hold all network state
@@ -250,7 +250,13 @@ impl NetworkState {
         let mut stmt = conn.prepare(sql_operations::GET_ALL_NONCES)?;
         let nonces = stmt
             .query_map([], |row| {
-                let owner = parse_text_column(row, 0)?;
+                let owner = row.get::<_, String>(0)?.parse().map_err(|e| {
+                    rusqlite::Error::FromSqlConversionFailure(
+                        0,
+                        rusqlite::types::Type::Text,
+                        Box::new(e),
+                    )
+                })?;
                 // Get the nonce from column 1
                 let nonce = row.get(1)?;
                 Ok((owner, nonce))

--- a/anchor/database/src/state.rs
+++ b/anchor/database/src/state.rs
@@ -1,12 +1,11 @@
 use std::{
     collections::{HashMap, HashSet},
-    str::FromStr,
 };
 
 use base64::prelude::*;
 use bls::PublicKeyBytes;
 use openssl::{pkey::Public, rsa::Rsa};
-use rusqlite::{Error as SqlError, OptionalExtension, params, types::Type};
+use rusqlite::{OptionalExtension, params};
 use ssv_types::{
     Cluster, ClusterId, ClusterMember, CommitteeId, CommitteeInfo, IndexSet, Operator, OperatorId,
     Share, ValidatorIndex, ValidatorMetadata,
@@ -16,7 +15,7 @@ use types::Address;
 use crate::{
     ClusterMultiIndexMap, DatabaseError, MetadataMultiIndexMap, MultiIndexMap, MultiState,
     NonUniqueIndex, Pool, PoolConn, PubkeyOrId, ShareMultiIndexMap, SingleState, UniqueIndex,
-    sql_operations,
+    parse_text_column, sql_operations,
 };
 
 // Container to hold all network state
@@ -253,11 +252,7 @@ impl NetworkState {
         let mut stmt = conn.prepare(sql_operations::GET_ALL_NONCES)?;
         let nonces = stmt
             .query_map([], |row| {
-                // Get the owner from column 0
-                let owner_str = row.get::<_, String>(0)?;
-                let owner = Address::from_str(&owner_str)
-                    .map_err(|e| SqlError::FromSqlConversionFailure(1, Type::Text, Box::new(e)))?;
-
+                let owner = parse_text_column(row, 0)?;
                 // Get the nonce from column 1
                 let nonce = row.get(1)?;
                 Ok((owner, nonce))

--- a/anchor/database/src/tests/validator_tests.rs
+++ b/anchor/database/src/tests/validator_tests.rs
@@ -1,8 +1,37 @@
 #[cfg(test)]
 mod validator_database_tests {
+    use bls::PublicKeyBytes;
     use types::Graffiti;
 
     use crate::test_utils::{InMemoryTestFixture, assertions};
+
+    // ==================== Transaction view tests ====================
+
+    /// Ensures `has_own_share_tx` treats "no configured own operator" as "no share".
+    ///
+    /// This branch is specific to the transaction-view helper and is not exercised by the
+    /// integration tests, which all populate the local operator first.
+    #[test]
+    fn test_has_own_share_tx_no_operator_returns_false() {
+        // Arrange: create an empty database with no local operator configured.
+        let fixture = InMemoryTestFixture::new_empty();
+        let validator_pubkey = PublicKeyBytes::empty();
+
+        let mut conn = fixture.db.connection().unwrap();
+        let tx = conn.transaction().unwrap();
+
+        // Act: ask whether the current operator owns a share for an arbitrary validator.
+        let has_share = fixture
+            .db
+            .has_own_share_tx(&validator_pubkey, &tx)
+            .expect("Failed to check own share in transaction view");
+
+        // Assert: without a configured own operator, the helper must return false rather than
+        // erroring or querying with an invalid operator id.
+        assert!(!has_share);
+    }
+
+    // ==================== Validator update tests ====================
 
     #[test]
     /// Test updating the graffiti of a validator

--- a/anchor/database/src/validator_operations.rs
+++ b/anchor/database/src/validator_operations.rs
@@ -1,7 +1,7 @@
 use std::{collections::HashMap, str::FromStr};
 
 use bls::PublicKeyBytes;
-use rusqlite::{Transaction, params};
+use rusqlite::{OptionalExtension, Transaction, params};
 use ssv_types::ValidatorIndex;
 use tracing::debug;
 use types::{Address, Graffiti};
@@ -76,6 +76,37 @@ impl NetworkDatabase {
             Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
             Err(e) => Err(DatabaseError::from(e)),
         }
+    }
+
+    /// Load validator metadata by public key through the transaction's view of the database.
+    pub fn get_validator_metadata_tx(
+        &self,
+        validator_pubkey: &PublicKeyBytes,
+        tx: &Transaction<'_>,
+    ) -> Result<Option<ssv_types::ValidatorMetadata>, DatabaseError> {
+        tx.prepare_cached(sql_operations::GET_VALIDATOR)?
+            .query_row(params![validator_pubkey.to_string()], |row| row.try_into())
+            .optional()
+            .map_err(DatabaseError::from)
+    }
+
+    /// Check whether the current operator has a share for a validator in the transaction view.
+    pub fn has_own_share_tx(
+        &self,
+        validator_pubkey: &PublicKeyBytes,
+        tx: &Transaction<'_>,
+    ) -> Result<bool, DatabaseError> {
+        let Some(operator_id) = self.get_own_operator_id_tx(tx)? else {
+            return Ok(false);
+        };
+
+        Ok(tx
+            .prepare_cached(sql_operations::GET_OWN_SHARE)?
+            .query_row(params![validator_pubkey.to_string(), *operator_id], |_| {
+                Ok(())
+            })
+            .optional()?
+            .is_some())
     }
 
     /// Update the Graffiti for a Validator

--- a/anchor/database/src/validator_operations.rs
+++ b/anchor/database/src/validator_operations.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, str::FromStr};
+use std::collections::HashMap;
 
 use bls::PublicKeyBytes;
 use rusqlite::{OptionalExtension, Transaction, params};
@@ -7,7 +7,8 @@ use tracing::debug;
 use types::{Address, Graffiti};
 
 use crate::{
-    DatabaseError, NetworkDatabase, PendingStateUpdates, multi_index::UniqueIndex, sql_operations,
+    DatabaseError, NetworkDatabase, PendingStateUpdates, multi_index::UniqueIndex,
+    parse_optional_text_column, sql_operations,
 };
 
 /// Implements all validator specific database functionality
@@ -55,20 +56,7 @@ impl NetworkDatabase {
         let mut stmt = tx.prepare_cached(sql_operations::GET_OWNER_FEE_RECIPIENT)?;
 
         let result = stmt.query_row(params![owner.to_string()], |row| {
-            let address_str: Option<String> = row.get(0)?;
-            // If the address is None, return None
-            if let Some(address_str) = address_str {
-                let address = Address::from_str(&address_str).map_err(|e| {
-                    rusqlite::Error::FromSqlConversionFailure(
-                        0,
-                        rusqlite::types::Type::Text,
-                        Box::new(e),
-                    )
-                })?;
-                Ok(Some(address))
-            } else {
-                Ok(None)
-            }
+            parse_optional_text_column(row, 0)
         });
 
         match result {

--- a/anchor/database/src/validator_operations.rs
+++ b/anchor/database/src/validator_operations.rs
@@ -7,8 +7,7 @@ use tracing::debug;
 use types::{Address, Graffiti};
 
 use crate::{
-    DatabaseError, NetworkDatabase, PendingStateUpdates, multi_index::UniqueIndex,
-    parse_optional_text_column, sql_operations,
+    DatabaseError, NetworkDatabase, PendingStateUpdates, multi_index::UniqueIndex, sql_operations,
 };
 
 /// Implements all validator specific database functionality
@@ -56,7 +55,17 @@ impl NetworkDatabase {
         let mut stmt = tx.prepare_cached(sql_operations::GET_OWNER_FEE_RECIPIENT)?;
 
         let result = stmt.query_row(params![owner.to_string()], |row| {
-            parse_optional_text_column(row, 0)
+            row.get::<_, Option<String>>(0)?
+                .map(|value| {
+                    value.parse().map_err(|e| {
+                        rusqlite::Error::FromSqlConversionFailure(
+                            0,
+                            rusqlite::types::Type::Text,
+                            Box::new(e),
+                        )
+                    })
+                })
+                .transpose()
         });
 
         match result {

--- a/anchor/eth/src/event_processor.rs
+++ b/anchor/eth/src/event_processor.rs
@@ -86,46 +86,45 @@ impl EventProcessor {
             .connection()
             .map_err(|e| ExecutionError::Database(e.to_string()))?;
 
-        // Buffer the current block so each call to `process_block_logs` owns exactly one block.
+        // Buffer the current block so each transaction/process step owns exactly one block.
         let mut current_block = None;
         let mut block_logs = Vec::new();
 
         for log in logs {
             let block_number = log.block_number.unwrap_or(end_block);
 
-            if let Some(current_block_number) =
-                current_block.filter(|current_block_number| *current_block_number != block_number)
+            // We hit a block boundary, so flush the previous block before buffering this one.
+            if current_block
+                .is_some_and(|current_block_number| current_block_number != block_number)
             {
-                self.flush_buffered_block(
+                self.flush_current_block_if_any(
                     &mut conn,
-                    &block_logs,
+                    &mut current_block,
+                    &mut block_logs,
                     live,
-                    current_block_number,
                     &mut validators_added,
                     &mut validators_removed,
                 )?;
-                block_logs.clear();
             }
 
             current_block = Some(block_number);
             block_logs.push(log);
         }
 
-        if let Some(block_number) = current_block {
-            self.flush_buffered_block(
-                &mut conn,
-                &block_logs,
-                live,
-                block_number,
-                &mut validators_added,
-                &mut validators_removed,
-            )?;
-        }
+        // Flush the final buffered block. The loop above only flushes when it sees the next block.
+        let last_flushed_block = self.flush_current_block_if_any(
+            &mut conn,
+            &mut current_block,
+            &mut block_logs,
+            live,
+            &mut validators_added,
+            &mut validators_removed,
+        )?;
 
-        if current_block != Some(end_block) {
-            // Flush an empty block so the last processed block still advances when the fetched
-            // range ends on a block with no relevant logs.
-            self.flush_buffered_block(
+        if last_flushed_block != Some(end_block) {
+            // The fetched range ended on a block with no relevant logs, so flush an empty block
+            // to still advance `last_processed_block` to `end_block`.
+            self.process_block_logs(
                 &mut conn,
                 &[],
                 live,
@@ -149,15 +148,19 @@ impl EventProcessor {
         Ok(())
     }
 
-    fn flush_buffered_block(
+    fn flush_current_block_if_any(
         &self,
         conn: &mut Connection,
-        block_logs: &[Log],
+        current_block: &mut Option<u64>,
+        block_logs: &mut Vec<Log>,
         live: bool,
-        block_number: u64,
         validators_added: &mut u64,
         validators_removed: &mut u64,
-    ) -> Result<(), ExecutionError> {
+    ) -> Result<Option<u64>, ExecutionError> {
+        let Some(block_number) = current_block.take() else {
+            return Ok(None);
+        };
+
         self.process_block_logs(
             conn,
             block_logs,
@@ -165,7 +168,9 @@ impl EventProcessor {
             block_number,
             validators_added,
             validators_removed,
-        )
+        )?;
+        block_logs.clear();
+        Ok(Some(block_number))
     }
 
     fn process_block_logs(

--- a/anchor/eth/src/event_processor.rs
+++ b/anchor/eth/src/event_processor.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use alloy::{primitives::Address, rpc::types::Log, sol_types::SolEvent};
 use bls::PublicKeyBytes;
-use database::{NetworkDatabase, SlashingProtection, UniqueIndex};
+use database::{NetworkDatabase, PendingStateUpdates, SlashingProtection};
 use indexmap::IndexSet;
 use rusqlite::Transaction;
 use ssv_types::{Cluster, ClusterId, Operator, OperatorId, ValidatorIndex};
@@ -78,6 +78,7 @@ impl EventProcessor {
         let tx = conn
             .transaction()
             .map_err(|e| ExecutionError::Database(e.to_string()))?;
+        let mut state_updates = PendingStateUpdates::default();
 
         for (index, log) in logs.iter().enumerate() {
             trace!(log_index = index, topic = ?log.topic0(), "Processing individual log");
@@ -93,34 +94,36 @@ impl EventProcessor {
 
             // Process log based on signature hash
             let result = match *topic0 {
-                SSVContract::OperatorAdded::SIGNATURE_HASH => self.process_operator_added(log, &tx),
+                SSVContract::OperatorAdded::SIGNATURE_HASH => {
+                    self.process_operator_added(log, &tx, &mut state_updates)
+                }
 
                 SSVContract::OperatorRemoved::SIGNATURE_HASH => {
-                    self.process_operator_removed(log, &tx)
+                    self.process_operator_removed(log, &tx, &mut state_updates)
                 }
 
                 SSVContract::ValidatorAdded::SIGNATURE_HASH => self
-                    .process_validator_added(log, &tx)
+                    .process_validator_added(log, &tx, &mut state_updates)
                     .inspect(|_| validators_added += 1),
 
                 SSVContract::ValidatorRemoved::SIGNATURE_HASH => self
-                    .process_validator_removed(log, &tx)
+                    .process_validator_removed(log, &tx, &mut state_updates)
                     .inspect(|_| validators_removed += 1),
 
                 SSVContract::ClusterLiquidated::SIGNATURE_HASH => {
-                    self.process_cluster_liquidated(log, &tx)
+                    self.process_cluster_liquidated(log, &tx, &mut state_updates)
                 }
 
                 SSVContract::ClusterReactivated::SIGNATURE_HASH => {
-                    self.process_cluster_reactivated(log, &tx)
+                    self.process_cluster_reactivated(log, &tx, &mut state_updates)
                 }
 
                 SSVContract::FeeRecipientAddressUpdated::SIGNATURE_HASH => {
-                    self.process_fee_recipient_updated(log, &tx)
+                    self.process_fee_recipient_updated(log, &tx, &mut state_updates)
                 }
 
                 SSVContract::ValidatorExited::SIGNATURE_HASH => {
-                    self.process_validator_exited(log, live)
+                    self.process_validator_exited(log, &tx, live)
                 }
                 _ => {
                     debug!(?topic0, "Unknown event signature, skipping");
@@ -145,12 +148,13 @@ impl EventProcessor {
 
         metrics::stop_timer(timer);
         self.db
-            .processed_block(end_block, &tx)
+            .processed_block_tx(end_block, &tx, &mut state_updates)
             .map_err(|e| ExecutionError::Database(e.to_string()))?;
 
         // Commit everything!
         tx.commit()
             .map_err(|e| ExecutionError::Database(e.to_string()))?;
+        self.db.publish_pending_state_updates(state_updates);
 
         // Log summaries for validator operations
         if validators_added > 0 {
@@ -169,6 +173,7 @@ impl EventProcessor {
         &self,
         log: &Log,
         tx: &Transaction<'_>,
+        state_updates: &mut PendingStateUpdates,
     ) -> Result<(), ExecutionError> {
         // Destructure operator added event
         let SSVContract::OperatorAdded {
@@ -182,13 +187,20 @@ impl EventProcessor {
         trace!(operator_id = ?operator_id, owner = ?owner, "Processing operator added");
 
         // Confirm that this operator does not already exist
-        if self.db.state().operator_exists(&operator_id) {
+        if self
+            .db
+            .operator_exists_tx(operator_id, tx)
+            .map_err(|e| ExecutionError::Database(e.to_string()))?
+        {
             return Err(ExecutionError::Duplicate(format!(
                 "Operator with id {operator_id:?} already exists in database"
             )));
         }
 
-        let max_seen = self.db.state().get_max_operator_id_seen();
+        let max_seen = self
+            .db
+            .get_max_operator_id_seen_tx(tx)
+            .map_err(|e| ExecutionError::Database(e.to_string()))?;
 
         // Only check for missing operators if we have a previous max (not a migrated database)
         if let Some(max_seen) = max_seen
@@ -201,7 +213,7 @@ impl EventProcessor {
         }
 
         self.db
-            .set_max_operator_id_seen(operatorId, tx)
+            .set_max_operator_id_seen_tx(operatorId, tx, state_updates)
             .map_err(|e| ExecutionError::Database(e.to_string()))?;
 
         let data = publicKey.as_ref();
@@ -228,7 +240,7 @@ impl EventProcessor {
             );
             ExecutionError::InvalidEvent(format!("Failed to construct operator: {e}"))
         })?;
-        self.db.insert_operator(&operator, tx).map_err(|e| {
+        self.db.insert_operator_tx(&operator, tx, state_updates).map_err(|e| {
             debug!(
                 operator_id = ?operator_id,
                 error = %e,
@@ -251,6 +263,7 @@ impl EventProcessor {
         &self,
         log: &Log,
         tx: &Transaction<'_>,
+        state_updates: &mut PendingStateUpdates,
     ) -> Result<(), ExecutionError> {
         // Extract the ID of the Operator
         let SSVContract::OperatorRemoved { operatorId } =
@@ -259,14 +272,16 @@ impl EventProcessor {
         trace!(operator_id = ?operator_id, "Processing operator removed");
 
         // Delete the operator from database and in memory
-        self.db.delete_operator(operator_id, tx).map_err(|e| {
-            debug!(
-                operator_id = ?operator_id,
-                error = %e,
-                "Failed to remove operator"
-            );
-            ExecutionError::Database(format!("Failed to remove operator: {e}"))
-        })?;
+        self.db
+            .delete_operator_tx(operator_id, tx, state_updates)
+            .map_err(|e| {
+                debug!(
+                    operator_id = ?operator_id,
+                    error = %e,
+                    "Failed to remove operator"
+                );
+                ExecutionError::Database(format!("Failed to remove operator: {e}"))
+            })?;
 
         debug!(operator_id = ?operatorId, "Operator removed from network");
         metrics::inc_counter_vec(&metrics::EXECUTION_EVENTS_PROCESSED, &["operator_removed"]);
@@ -281,6 +296,7 @@ impl EventProcessor {
         &self,
         log: &Log,
         tx: &Transaction<'_>,
+        state_updates: &mut PendingStateUpdates,
     ) -> Result<(), ExecutionError> {
         // Parse and destructure log
         let SSVContract::ValidatorAdded {
@@ -294,10 +310,13 @@ impl EventProcessor {
 
         // Get the expected nonce and then increment it. This will happen regardless of if the
         // event is malformed or not
-        let nonce = self.db.bump_and_get_nonce(&owner, tx).map_err(|e| {
-            debug!(owner = ?owner, "Failed to bump nonce");
-            ExecutionError::Database(format!("Failed to bump nonce: {e}"))
-        })?;
+        let nonce = self
+            .db
+            .bump_and_get_nonce_tx(&owner, tx, state_updates)
+            .map_err(|e| {
+                debug!(owner = ?owner, "Failed to bump nonce");
+                ExecutionError::Database(format!("Failed to bump nonce: {e}"))
+            })?;
 
         // During keysplitting, we only care about the nonce
         let Mode::Node {
@@ -316,7 +335,7 @@ impl EventProcessor {
 
         // Perform verification on the operator set and make sure they are all registered in the
         // network
-        validate_operators(&operator_ids, &cluster_id, &self.db.state())?;
+        validate_operators(&operator_ids, &cluster_id, &self.db, tx)?;
 
         // Parse the share byte stream into a list of valid Shares and then verify the signature
         trace!(cluster_id = ?cluster_id, "Parsing and verifying shares");
@@ -366,7 +385,7 @@ impl EventProcessor {
 
         // ...then the main database.
         self.db
-            .insert_validator(cluster, &validator_metadata, shares, tx)
+            .insert_validator_tx(cluster, &validator_metadata, shares, tx, state_updates)
             .map_err(|e| {
                 debug!(cluster_id = ?cluster_id, error = %e, validator_metadata = ?validator_metadata.public_key, "Failed to insert validator into cluster");
                 ExecutionError::Database(format!("Failed to insert validator into cluster: {e}"))
@@ -391,6 +410,7 @@ impl EventProcessor {
         &self,
         log: &Log,
         tx: &Transaction<'_>,
+        state_updates: &mut PendingStateUpdates,
     ) -> Result<(), ExecutionError> {
         // Parse and destructure log
         let SSVContract::ValidatorRemoved {
@@ -407,9 +427,12 @@ impl EventProcessor {
         // Compute the cluster id
         let cluster_id = compute_cluster_id(owner, &operatorIds);
 
-        let state = self.db.state();
         // Get the metadata for this validator
-        let metadata = match state.metadata().get_by(&validator_pubkey) {
+        let metadata = match self
+            .db
+            .get_validator_metadata_tx(&validator_pubkey, tx)
+            .map_err(|e| ExecutionError::Database(e.to_string()))?
+        {
             Some(data) => data,
             None => {
                 debug!(
@@ -423,7 +446,11 @@ impl EventProcessor {
         };
 
         // Get the cluster that this validator is in
-        let cluster = match state.clusters().get_by(&validator_pubkey) {
+        let cluster = match self
+            .db
+            .get_cluster_by_validator_tx(&validator_pubkey, tx)
+            .map_err(|e| ExecutionError::Database(e.to_string()))?
+        {
             Some(data) => data,
             None => {
                 debug!(
@@ -462,11 +489,10 @@ impl EventProcessor {
                 "Validator does not match".to_string(),
             ));
         }
-        drop(state);
 
         // Remove the validator and all corresponding cluster data
         self.db
-            .delete_validator(&validator_pubkey, tx)
+            .delete_validator_tx(&validator_pubkey, tx, state_updates)
             .map_err(|e| {
                 debug!(
                     cluster_id = ?cluster_id,
@@ -491,6 +517,7 @@ impl EventProcessor {
         &self,
         log: &Log,
         tx: &Transaction<'_>,
+        state_updates: &mut PendingStateUpdates,
     ) -> Result<(), ExecutionError> {
         let SSVContract::ClusterLiquidated {
             owner,
@@ -503,14 +530,16 @@ impl EventProcessor {
         trace!(cluster_id = ?cluster_id, "Processing cluster liquidation");
 
         // Update the status of the cluster to be liquidated
-        self.db.update_status(cluster_id, true, tx).map_err(|e| {
-            debug!(
-                cluster_id = ?cluster_id,
-                error = %e,
-                "Failed to mark cluster as liquidated"
-            );
-            ExecutionError::Database(format!("Failed to mark cluster as liquidated: {e}"))
-        })?;
+        self.db
+            .update_status_tx(cluster_id, true, tx, state_updates)
+            .map_err(|e| {
+                debug!(
+                    cluster_id = ?cluster_id,
+                    error = %e,
+                    "Failed to mark cluster as liquidated"
+                );
+                ExecutionError::Database(format!("Failed to mark cluster as liquidated: {e}"))
+            })?;
 
         debug!(
             cluster_id = ?cluster_id,
@@ -529,6 +558,7 @@ impl EventProcessor {
         &self,
         log: &Log,
         tx: &Transaction<'_>,
+        state_updates: &mut PendingStateUpdates,
     ) -> Result<(), ExecutionError> {
         let SSVContract::ClusterReactivated {
             owner,
@@ -541,14 +571,16 @@ impl EventProcessor {
         trace!(cluster_id = ?cluster_id, "Processing cluster reactivation");
 
         // Update the status of the cluster to be active
-        self.db.update_status(cluster_id, false, tx).map_err(|e| {
-            debug!(
-                cluster_id = ?cluster_id,
-                error = %e,
-                "Failed to mark cluster as active"
-            );
-            ExecutionError::Database(format!("Failed to mark cluster as active: {e}"))
-        })?;
+        self.db
+            .update_status_tx(cluster_id, false, tx, state_updates)
+            .map_err(|e| {
+                debug!(
+                    cluster_id = ?cluster_id,
+                    error = %e,
+                    "Failed to mark cluster as active"
+                );
+                ExecutionError::Database(format!("Failed to mark cluster as active: {e}"))
+            })?;
 
         debug!(
             cluster_id = ?cluster_id,
@@ -568,6 +600,7 @@ impl EventProcessor {
         &self,
         log: &Log,
         tx: &Transaction<'_>,
+        state_updates: &mut PendingStateUpdates,
     ) -> Result<(), ExecutionError> {
         let SSVContract::FeeRecipientAddressUpdated {
             owner,
@@ -575,7 +608,7 @@ impl EventProcessor {
         } = SSVContract::FeeRecipientAddressUpdated::decode_from_log(log)?;
         // update the fee recipient address in the database
         self.db
-            .update_fee_recipient(owner, recipientAddress, tx)
+            .update_fee_recipient_tx(owner, recipientAddress, tx, state_updates)
             .map_err(|e| {
                 debug!(
                     owner = ?owner,
@@ -597,7 +630,12 @@ impl EventProcessor {
     }
 
     // A validator has exited the beacon chain
-    fn process_validator_exited(&self, log: &Log, live: bool) -> Result<(), ExecutionError> {
+    fn process_validator_exited(
+        &self,
+        log: &Log,
+        tx: &Transaction<'_>,
+        live: bool,
+    ) -> Result<(), ExecutionError> {
         // In KeySplit mode, we don't need to process validator exits
         let Mode::Node { exit_tx, .. } = &self.mode else {
             return Ok(());
@@ -611,25 +649,25 @@ impl EventProcessor {
         let validator_pubkey = parse_validator_pubkey(&publicKey)?;
         let computed_cluster_id = compute_cluster_id(owner, &operatorIds);
 
-        self.verify_validator_owner(&owner, &validator_pubkey, &computed_cluster_id)?;
+        self.verify_validator_owner(&owner, &validator_pubkey, &computed_cluster_id, tx)?;
 
         let operator_ids: Vec<OperatorId> = operatorIds.iter().map(|id| OperatorId(*id)).collect();
 
         // Perform verification on the operator set and make sure they are all registered in the
         // network
-        validate_operators(&operator_ids, &computed_cluster_id, &self.db.state())?;
+        validate_operators(&operator_ids, &computed_cluster_id, &self.db, tx)?;
 
         let block_timestamp = log
             .block_timestamp
             .ok_or_else(|| ExecutionError::InvalidEvent("Block timestamp not set".to_string()))?;
 
-        let validator_index = match self.get_validator_index(&validator_pubkey) {
+        let validator_index = match self.get_validator_index(&validator_pubkey, tx) {
             Ok(Some(value)) => value,
             Ok(None) => return Ok(()),
             Err(value) => return Err(value),
         };
 
-        let is_our_validator = self.is_our_validator(&validator_pubkey);
+        let is_our_validator = self.is_our_validator(&validator_pubkey, tx)?;
 
         if !live {
             if is_our_validator {
@@ -675,8 +713,14 @@ impl EventProcessor {
         Ok(())
     }
 
-    fn is_our_validator(&self, validator_pubkey: &PublicKeyBytes) -> bool {
-        self.db.state().shares().get_by(validator_pubkey).is_some()
+    fn is_our_validator(
+        &self,
+        validator_pubkey: &PublicKeyBytes,
+        tx: &Transaction<'_>,
+    ) -> Result<bool, ExecutionError> {
+        self.db
+            .has_own_share_tx(validator_pubkey, tx)
+            .map_err(|e| ExecutionError::Database(e.to_string()))
     }
 
     /// Retrieves the validator index for a given validator public key from the database.
@@ -691,10 +735,14 @@ impl EventProcessor {
     fn get_validator_index(
         &self,
         validator_pubkey: &PublicKeyBytes,
+        tx: &Transaction<'_>,
     ) -> Result<Option<ValidatorIndex>, ExecutionError> {
         // Get the validator metadata including its index
-        let state = self.db.state();
-        let validator_metadata = match state.metadata().get_by(validator_pubkey) {
+        let validator_metadata = match self
+            .db
+            .get_validator_metadata_tx(validator_pubkey, tx)
+            .map_err(|e| ExecutionError::Database(e.to_string()))?
+        {
             Some(metadata) => metadata,
             None => {
                 return Err(ExecutionError::InvalidEvent(
@@ -741,12 +789,14 @@ impl EventProcessor {
         owner: &Address,
         validator_pubkey: &PublicKeyBytes,
         computed_cluster_id: &ClusterId,
+        tx: &Transaction<'_>,
     ) -> Result<(), ExecutionError> {
-        // Get validator's metadata from the database
-        let state = self.db.state();
-
         // Get the cluster for this validator to access owner information
-        let cluster = match state.clusters().get_by(validator_pubkey) {
+        let cluster = match self
+            .db
+            .get_cluster_by_validator_tx(validator_pubkey, tx)
+            .map_err(|e| ExecutionError::Database(e.to_string()))?
+        {
             Some(cluster) => cluster,
             None => {
                 return Err(ExecutionError::InvalidEvent(

--- a/anchor/eth/src/event_processor.rs
+++ b/anchor/eth/src/event_processor.rs
@@ -119,6 +119,8 @@ impl EventProcessor {
         }
 
         if current_block != Some(end_block) {
+            // Flush an empty block so the last processed block still advances when the fetched
+            // range ends on a block with no relevant logs.
             self.process_block_logs(
                 &mut conn,
                 &[],
@@ -225,14 +227,11 @@ impl EventProcessor {
         tx.commit()
             .map_err(|e| ExecutionError::Database(e.to_string()))?;
         self.db.publish_pending_state_updates(state_updates);
-        self.execute_post_commit_actions(post_commit_actions)?;
+        self.execute_post_commit_actions(post_commit_actions);
         Ok(())
     }
 
-    fn execute_post_commit_actions(
-        &self,
-        post_commit_actions: Vec<PostCommitAction>,
-    ) -> Result<(), ExecutionError> {
+    fn execute_post_commit_actions(&self, post_commit_actions: Vec<PostCommitAction>) {
         let Mode::Node {
             index_sync_tx,
             exit_tx,
@@ -240,9 +239,12 @@ impl EventProcessor {
         } = &self.mode
         else {
             debug_assert!(post_commit_actions.is_empty());
-            return Ok(());
+            return;
         };
 
+        // These side effects run after the block transaction commits and NetworkState is
+        // published, so failures are logged but not returned to the sync loop. Retrying from the
+        // caller would only reprocess already-committed events.
         for action in post_commit_actions {
             match action {
                 PostCommitAction::IndexSync(validator_pubkey) => {
@@ -253,26 +255,21 @@ impl EventProcessor {
                 PostCommitAction::ValidatorExit(request) => {
                     let validator_pubkey = request.validator_pubkey;
 
-                    exit_tx.send(request).map_err(|err| {
+                    if let Err(err) = exit_tx.send(request) {
                         error!(
                             validator_pubkey = %validator_pubkey,
                             ?err,
                             "Failed to send validator exit request to processor"
                         );
-                        ExecutionError::Misc(
-                            "Failed to send validator exit request to processor".to_string(),
-                        )
-                    })?;
-
-                    info!(
-                        validator_pubkey = %validator_pubkey,
-                        "Queued validator for exit processing"
-                    );
+                    } else {
+                        info!(
+                            validator_pubkey = %validator_pubkey,
+                            "Queued validator for exit processing"
+                        );
+                    }
                 }
             }
         }
-
-        Ok(())
     }
 
     // A new Operator has been registered in the network.

--- a/anchor/eth/src/event_processor.rs
+++ b/anchor/eth/src/event_processor.rs
@@ -60,7 +60,12 @@ impl EventProcessor {
         Self { db, mode }
     }
 
-    /// Process a new set of logs
+    /// Process a fetched batch of logs.
+    ///
+    /// The fetch layer can hand us logs spanning multiple blocks, but PR2 commits and publishes
+    /// one block at a time. We therefore buffer each block's logs, flush them when the block
+    /// number changes, and finally flush `end_block` even if it had no relevant logs so
+    /// `last_processed_block` still advances across empty blocks.
     #[instrument(skip(self, logs), fields(logs_count = logs.len()), level = "debug")]
     pub fn process_logs(
         &self,
@@ -81,15 +86,16 @@ impl EventProcessor {
             .connection()
             .map_err(|e| ExecutionError::Database(e.to_string()))?;
 
+        // Buffer the current block so each call to `process_block_logs` owns exactly one block.
         let mut current_block = None;
         let mut block_logs = Vec::new();
 
         for log in logs {
             let block_number = log.block_number.unwrap_or(end_block);
 
-            match current_block {
-                Some(current_block_number) if current_block_number != block_number => {
-                    self.process_block_logs(
+            if let Some(current_block_number) = current_block {
+                if current_block_number != block_number {
+                    self.flush_buffered_block(
                         &mut conn,
                         &block_logs,
                         live,
@@ -98,17 +104,15 @@ impl EventProcessor {
                         &mut validators_removed,
                     )?;
                     block_logs.clear();
-                    current_block = Some(block_number);
                 }
-                Some(_) => {}
-                None => current_block = Some(block_number),
             }
 
+            current_block = Some(block_number);
             block_logs.push(log);
         }
 
         if let Some(block_number) = current_block {
-            self.process_block_logs(
+            self.flush_buffered_block(
                 &mut conn,
                 &block_logs,
                 live,
@@ -121,7 +125,7 @@ impl EventProcessor {
         if current_block != Some(end_block) {
             // Flush an empty block so the last processed block still advances when the fetched
             // range ends on a block with no relevant logs.
-            self.process_block_logs(
+            self.flush_buffered_block(
                 &mut conn,
                 &[],
                 live,
@@ -143,6 +147,25 @@ impl EventProcessor {
 
         debug!(logs_count, "Completed processing logs");
         Ok(())
+    }
+
+    fn flush_buffered_block(
+        &self,
+        conn: &mut Connection,
+        block_logs: &[Log],
+        live: bool,
+        block_number: u64,
+        validators_added: &mut u64,
+        validators_removed: &mut u64,
+    ) -> Result<(), ExecutionError> {
+        self.process_block_logs(
+            conn,
+            block_logs,
+            live,
+            block_number,
+            validators_added,
+            validators_removed,
+        )
     }
 
     fn process_block_logs(

--- a/anchor/eth/src/event_processor.rs
+++ b/anchor/eth/src/event_processor.rs
@@ -93,18 +93,18 @@ impl EventProcessor {
         for log in logs {
             let block_number = log.block_number.unwrap_or(end_block);
 
-            if let Some(current_block_number) = current_block {
-                if current_block_number != block_number {
-                    self.flush_buffered_block(
-                        &mut conn,
-                        &block_logs,
-                        live,
-                        current_block_number,
-                        &mut validators_added,
-                        &mut validators_removed,
-                    )?;
-                    block_logs.clear();
-                }
+            if let Some(current_block_number) =
+                current_block.filter(|current_block_number| *current_block_number != block_number)
+            {
+                self.flush_buffered_block(
+                    &mut conn,
+                    &block_logs,
+                    live,
+                    current_block_number,
+                    &mut validators_added,
+                    &mut validators_removed,
+                )?;
+                block_logs.clear();
             }
 
             current_block = Some(block_number);

--- a/anchor/eth/src/event_processor.rs
+++ b/anchor/eth/src/event_processor.rs
@@ -37,6 +37,11 @@ pub enum Mode {
     KeySplit,
 }
 
+enum PostCommitAction {
+    IndexSync(PublicKeyBytes),
+    ValidatorExit(ExitRequest),
+}
+
 /// The Event Processor. This handles all verification and recording of events.
 /// It will be passed logs from the sync layer to be processed and saved into the database
 ///
@@ -79,6 +84,7 @@ impl EventProcessor {
             .transaction()
             .map_err(|e| ExecutionError::Database(e.to_string()))?;
         let mut state_updates = PendingStateUpdates::default();
+        let mut post_commit_actions = Vec::new();
 
         for (index, log) in logs.iter().enumerate() {
             trace!(log_index = index, topic = ?log.topic0(), "Processing individual log");
@@ -103,7 +109,12 @@ impl EventProcessor {
                 }
 
                 SSVContract::ValidatorAdded::SIGNATURE_HASH => self
-                    .process_validator_added(log, &tx, &mut state_updates)
+                    .process_validator_added(
+                        log,
+                        &tx,
+                        &mut state_updates,
+                        &mut post_commit_actions,
+                    )
                     .inspect(|_| validators_added += 1),
 
                 SSVContract::ValidatorRemoved::SIGNATURE_HASH => self
@@ -123,7 +134,7 @@ impl EventProcessor {
                 }
 
                 SSVContract::ValidatorExited::SIGNATURE_HASH => {
-                    self.process_validator_exited(log, &tx, live)
+                    self.process_validator_exited(log, &tx, live, &mut post_commit_actions)
                 }
                 _ => {
                     debug!(?topic0, "Unknown event signature, skipping");
@@ -155,6 +166,7 @@ impl EventProcessor {
         tx.commit()
             .map_err(|e| ExecutionError::Database(e.to_string()))?;
         self.db.publish_pending_state_updates(state_updates);
+        self.execute_post_commit_actions(post_commit_actions)?;
 
         // Log summaries for validator operations
         if validators_added > 0 {
@@ -165,6 +177,52 @@ impl EventProcessor {
         }
 
         debug!(logs_count = logs.len(), "Completed processing logs");
+        Ok(())
+    }
+
+    fn execute_post_commit_actions(
+        &self,
+        post_commit_actions: Vec<PostCommitAction>,
+    ) -> Result<(), ExecutionError> {
+        let Mode::Node {
+            index_sync_tx,
+            exit_tx,
+            ..
+        } = &self.mode
+        else {
+            debug_assert!(post_commit_actions.is_empty());
+            return Ok(());
+        };
+
+        for action in post_commit_actions {
+            match action {
+                PostCommitAction::IndexSync(validator_pubkey) => {
+                    if let Err(err) = index_sync_tx.send(validator_pubkey) {
+                        error!(?err, "Failed to send validator to index lookup");
+                    }
+                }
+                PostCommitAction::ValidatorExit(request) => {
+                    let validator_pubkey = request.validator_pubkey;
+
+                    exit_tx.send(request).map_err(|err| {
+                        error!(
+                            validator_pubkey = %validator_pubkey,
+                            ?err,
+                            "Failed to send validator exit request to processor"
+                        );
+                        ExecutionError::Misc(
+                            "Failed to send validator exit request to processor".to_string(),
+                        )
+                    })?;
+
+                    info!(
+                        validator_pubkey = %validator_pubkey,
+                        "Queued validator for exit processing"
+                    );
+                }
+            }
+        }
+
         Ok(())
     }
 
@@ -297,6 +355,7 @@ impl EventProcessor {
         log: &Log,
         tx: &Transaction<'_>,
         state_updates: &mut PendingStateUpdates,
+        post_commit_actions: &mut Vec<PostCommitAction>,
     ) -> Result<(), ExecutionError> {
         // Parse and destructure log
         let SSVContract::ValidatorAdded {
@@ -320,7 +379,6 @@ impl EventProcessor {
 
         // During keysplitting, we only care about the nonce
         let Mode::Node {
-            index_sync_tx: index_lookup_queue,
             slashing_protection,
             ..
         } = &self.mode
@@ -391,10 +449,7 @@ impl EventProcessor {
                 ExecutionError::Database(format!("Failed to insert validator into cluster: {e}"))
             })?;
 
-        // Schedule validator for index lookup
-        if let Err(err) = index_lookup_queue.send(validator_pubkey) {
-            error!(?err, "Failed to send validator to index lookup");
-        }
+        post_commit_actions.push(PostCommitAction::IndexSync(validator_pubkey));
 
         trace!(
             cluster_id = ?cluster_id,
@@ -635,9 +690,10 @@ impl EventProcessor {
         log: &Log,
         tx: &Transaction<'_>,
         live: bool,
+        post_commit_actions: &mut Vec<PostCommitAction>,
     ) -> Result<(), ExecutionError> {
         // In KeySplit mode, we don't need to process validator exits
-        let Mode::Node { exit_tx, .. } = &self.mode else {
+        let Mode::Node { .. } = &self.mode else {
             return Ok(());
         };
         let SSVContract::ValidatorExited {
@@ -689,26 +745,7 @@ impl EventProcessor {
             is_our_validator,
         };
 
-        match exit_tx.send(request) {
-            Ok(_) => {
-                info!(
-                    validator_pubkey = %validator_pubkey,
-                    "Queued validator for exit processing"
-                );
-            }
-            Err(err) => {
-                // If the channel is closed, we can't send the exit request
-                // This is a fatal error and should be handled by the caller
-                error!(
-                    validator_pubkey = %validator_pubkey,
-                    ?err,
-                    "Failed to send validator exit request to processor"
-                );
-                return Err(ExecutionError::Misc(
-                    "Failed to send validator exit request to processor".to_string(),
-                ));
-            }
-        }
+        post_commit_actions.push(PostCommitAction::ValidatorExit(request));
 
         Ok(())
     }

--- a/anchor/eth/src/event_processor.rs
+++ b/anchor/eth/src/event_processor.rs
@@ -4,7 +4,7 @@ use alloy::{primitives::Address, rpc::types::Log, sol_types::SolEvent};
 use bls::PublicKeyBytes;
 use database::{NetworkDatabase, PendingStateUpdates, SlashingProtection};
 use indexmap::IndexSet;
-use rusqlite::Transaction;
+use rusqlite::{Connection, Transaction};
 use ssv_types::{Cluster, ClusterId, Operator, OperatorId, ValidatorIndex};
 use tracing::{debug, error, info, instrument, trace, warn};
 
@@ -68,105 +68,68 @@ impl EventProcessor {
         live: bool,
         end_block: u64,
     ) -> Result<(), ExecutionError> {
-        debug!(logs_count = logs.len(), "Starting log processing");
+        let logs_count = logs.len();
+        debug!(logs_count, "Starting log processing");
         let timer = metrics::start_timer(&metrics::EXECUTION_LOG_PROCESSING_TIME);
 
         // Counters for summary logging
         let mut validators_added = 0;
         let mut validators_removed = 0;
 
-        // Open a transaction for the log batch.
         let mut conn = self
             .db
             .connection()
             .map_err(|e| ExecutionError::Database(e.to_string()))?;
-        let tx = conn
-            .transaction()
-            .map_err(|e| ExecutionError::Database(e.to_string()))?;
-        let mut state_updates = PendingStateUpdates::default();
-        let mut post_commit_actions = Vec::new();
 
-        for (index, log) in logs.iter().enumerate() {
-            trace!(log_index = index, topic = ?log.topic0(), "Processing individual log");
+        let mut current_block = None;
+        let mut block_logs = Vec::new();
 
-            // Extract the topic0 to identify the event type
-            let topic0 = match log.topic0() {
-                Some(topic) => topic,
-                None => {
-                    warn!("Log missing topic0, skipping");
-                    continue;
+        for log in logs {
+            let block_number = log.block_number.unwrap_or(end_block);
+
+            match current_block {
+                Some(current_block_number) if current_block_number != block_number => {
+                    self.process_block_logs(
+                        &mut conn,
+                        &block_logs,
+                        live,
+                        current_block_number,
+                        &mut validators_added,
+                        &mut validators_removed,
+                    )?;
+                    block_logs.clear();
+                    current_block = Some(block_number);
                 }
-            };
-
-            // Process log based on signature hash
-            let result = match *topic0 {
-                SSVContract::OperatorAdded::SIGNATURE_HASH => {
-                    self.process_operator_added(log, &tx, &mut state_updates)
-                }
-
-                SSVContract::OperatorRemoved::SIGNATURE_HASH => {
-                    self.process_operator_removed(log, &tx, &mut state_updates)
-                }
-
-                SSVContract::ValidatorAdded::SIGNATURE_HASH => self
-                    .process_validator_added(
-                        log,
-                        &tx,
-                        &mut state_updates,
-                        &mut post_commit_actions,
-                    )
-                    .inspect(|_| validators_added += 1),
-
-                SSVContract::ValidatorRemoved::SIGNATURE_HASH => self
-                    .process_validator_removed(log, &tx, &mut state_updates)
-                    .inspect(|_| validators_removed += 1),
-
-                SSVContract::ClusterLiquidated::SIGNATURE_HASH => {
-                    self.process_cluster_liquidated(log, &tx, &mut state_updates)
-                }
-
-                SSVContract::ClusterReactivated::SIGNATURE_HASH => {
-                    self.process_cluster_reactivated(log, &tx, &mut state_updates)
-                }
-
-                SSVContract::FeeRecipientAddressUpdated::SIGNATURE_HASH => {
-                    self.process_fee_recipient_updated(log, &tx, &mut state_updates)
-                }
-
-                SSVContract::ValidatorExited::SIGNATURE_HASH => {
-                    self.process_validator_exited(log, &tx, live, &mut post_commit_actions)
-                }
-                _ => {
-                    debug!(?topic0, "Unknown event signature, skipping");
-                    continue;
-                }
-            };
-
-            // Handle any errors from the event processing
-            if let Err(e) = result {
-                let tx_hash = log
-                    .transaction_hash
-                    .map(|hash| hash.to_string())
-                    .unwrap_or_else(|| "unknown".to_string());
-                if live {
-                    warn!(tx_hash, "Malformed event: {e}");
-                } else {
-                    trace!(tx_hash, "Malformed event: {e}");
-                }
-                continue;
+                Some(_) => {}
+                None => current_block = Some(block_number),
             }
+
+            block_logs.push(log);
+        }
+
+        if let Some(block_number) = current_block {
+            self.process_block_logs(
+                &mut conn,
+                &block_logs,
+                live,
+                block_number,
+                &mut validators_added,
+                &mut validators_removed,
+            )?;
+        }
+
+        if current_block != Some(end_block) {
+            self.process_block_logs(
+                &mut conn,
+                &[],
+                live,
+                end_block,
+                &mut validators_added,
+                &mut validators_removed,
+            )?;
         }
 
         metrics::stop_timer(timer);
-        self.db
-            .processed_block_tx(end_block, &tx, &mut state_updates)
-            .map_err(|e| ExecutionError::Database(e.to_string()))?;
-
-        // Commit everything!
-        tx.commit()
-            .map_err(|e| ExecutionError::Database(e.to_string()))?;
-        self.db.publish_pending_state_updates(state_updates);
-        self.execute_post_commit_actions(post_commit_actions)?;
 
         // Log summaries for validator operations
         if validators_added > 0 {
@@ -176,7 +139,93 @@ impl EventProcessor {
             debug!(count = validators_removed, "Removed validators");
         }
 
-        debug!(logs_count = logs.len(), "Completed processing logs");
+        debug!(logs_count, "Completed processing logs");
+        Ok(())
+    }
+
+    fn process_block_logs(
+        &self,
+        conn: &mut Connection,
+        logs: &[Log],
+        live: bool,
+        block_number: u64,
+        validators_added: &mut u64,
+        validators_removed: &mut u64,
+    ) -> Result<(), ExecutionError> {
+        let tx = conn
+            .transaction()
+            .map_err(|e| ExecutionError::Database(e.to_string()))?;
+        let mut state_updates = PendingStateUpdates::default();
+        let mut post_commit_actions = Vec::new();
+
+        for (index, log) in logs.iter().enumerate() {
+            trace!(
+                block_number,
+                log_index = index,
+                topic = ?log.topic0(),
+                "Processing individual log"
+            );
+
+            let topic0 = match log.topic0() {
+                Some(topic) => topic,
+                None => {
+                    warn!(block_number, "Log missing topic0, skipping");
+                    continue;
+                }
+            };
+
+            let result = match *topic0 {
+                SSVContract::OperatorAdded::SIGNATURE_HASH => {
+                    self.process_operator_added(log, &tx, &mut state_updates)
+                }
+                SSVContract::OperatorRemoved::SIGNATURE_HASH => {
+                    self.process_operator_removed(log, &tx, &mut state_updates)
+                }
+                SSVContract::ValidatorAdded::SIGNATURE_HASH => self
+                    .process_validator_added(log, &tx, &mut state_updates, &mut post_commit_actions)
+                    .inspect(|_| *validators_added += 1),
+                SSVContract::ValidatorRemoved::SIGNATURE_HASH => self
+                    .process_validator_removed(log, &tx, &mut state_updates)
+                    .inspect(|_| *validators_removed += 1),
+                SSVContract::ClusterLiquidated::SIGNATURE_HASH => {
+                    self.process_cluster_liquidated(log, &tx, &mut state_updates)
+                }
+                SSVContract::ClusterReactivated::SIGNATURE_HASH => {
+                    self.process_cluster_reactivated(log, &tx, &mut state_updates)
+                }
+                SSVContract::FeeRecipientAddressUpdated::SIGNATURE_HASH => {
+                    self.process_fee_recipient_updated(log, &tx, &mut state_updates)
+                }
+                SSVContract::ValidatorExited::SIGNATURE_HASH => {
+                    self.process_validator_exited(log, &tx, live, &mut post_commit_actions)
+                }
+                _ => {
+                    debug!(block_number, ?topic0, "Unknown event signature, skipping");
+                    continue;
+                }
+            };
+
+            if let Err(e) = result {
+                let tx_hash = log
+                    .transaction_hash
+                    .map(|hash| hash.to_string())
+                    .unwrap_or_else(|| "unknown".to_string());
+                if live {
+                    warn!(block_number, tx_hash, "Malformed event: {e}");
+                } else {
+                    trace!(block_number, tx_hash, "Malformed event: {e}");
+                }
+            }
+        }
+
+        self.db
+            .processed_block_tx(block_number, &tx, &mut state_updates)
+            .map_err(|e| ExecutionError::Database(e.to_string()))?;
+
+        tx.commit()
+            .map_err(|e| ExecutionError::Database(e.to_string()))?;
+        self.db.publish_pending_state_updates(state_updates);
+        self.execute_post_commit_actions(post_commit_actions)?;
         Ok(())
     }
 
@@ -298,14 +347,16 @@ impl EventProcessor {
             );
             ExecutionError::InvalidEvent(format!("Failed to construct operator: {e}"))
         })?;
-        self.db.insert_operator_tx(&operator, tx, state_updates).map_err(|e| {
-            debug!(
-                operator_id = ?operator_id,
-                error = %e,
-                "Failed to insert operator into database"
-            );
-            ExecutionError::Database(format!("Failed to insert operator into database: {e}"))
-        })?;
+        self.db
+            .insert_operator_tx(&operator, tx, state_updates)
+            .map_err(|e| {
+                debug!(
+                    operator_id = ?operator_id,
+                    error = %e,
+                    "Failed to insert operator into database"
+                );
+                ExecutionError::Database(format!("Failed to insert operator into database: {e}"))
+            })?;
 
         debug!(
             operator_id = ?operator_id,

--- a/anchor/eth/src/util.rs
+++ b/anchor/eth/src/util.rs
@@ -7,7 +7,8 @@ use alloy::{
     transports::{Transport, http::Http, layers::FallbackLayer},
 };
 use bls::{PublicKeyBytes, Signature};
-use database::NetworkState;
+use database::NetworkDatabase;
+use rusqlite::Transaction;
 use reqwest::Client;
 use sensitive_url::SensitiveUrl;
 use ssv_types::{ClusterId, ENCRYPTED_KEY_LENGTH, OperatorId, Share, ValidatorMetadata};
@@ -130,7 +131,8 @@ pub fn verify_signature(
 pub fn validate_operators(
     operator_ids: &[OperatorId],
     cluster_id: &ClusterId,
-    network_state: &NetworkState,
+    db: &NetworkDatabase,
+    tx: &Transaction<'_>,
 ) -> Result<(), ExecutionError> {
     trace!(cluster_id = ?cluster_id, "Validating operators");
 
@@ -165,13 +167,15 @@ pub fn validate_operators(
         ));
     }
 
-    if operator_ids
-        .iter()
-        .any(|id| !network_state.operator_exists(id))
-    {
-        return Err(ExecutionError::Database(
-            "One or more operators do not exist".to_string(),
-        ));
+    for operator_id in operator_ids {
+        let exists = db
+            .operator_exists_tx(*operator_id, tx)
+            .map_err(|e| ExecutionError::Database(e.to_string()))?;
+        if !exists {
+            return Err(ExecutionError::Database(
+                "One or more operators do not exist".to_string(),
+            ));
+        }
     }
 
     Ok(())

--- a/anchor/eth/src/util.rs
+++ b/anchor/eth/src/util.rs
@@ -172,9 +172,9 @@ pub fn validate_operators(
             .operator_exists_tx(*operator_id, tx)
             .map_err(|e| ExecutionError::Database(e.to_string()))?;
         if !exists {
-            return Err(ExecutionError::Database(
-                "One or more operators do not exist".to_string(),
-            ));
+            return Err(ExecutionError::Database(format!(
+                "Operator {operator_id} does not exist"
+            )));
         }
     }
 

--- a/anchor/eth/src/util.rs
+++ b/anchor/eth/src/util.rs
@@ -8,8 +8,8 @@ use alloy::{
 };
 use bls::{PublicKeyBytes, Signature};
 use database::NetworkDatabase;
-use rusqlite::Transaction;
 use reqwest::Client;
+use rusqlite::Transaction;
 use sensitive_url::SensitiveUrl;
 use ssv_types::{ClusterId, ENCRYPTED_KEY_LENGTH, OperatorId, Share, ValidatorMetadata};
 use tower::ServiceBuilder;

--- a/anchor/eth/tests/common/mod.rs
+++ b/anchor/eth/tests/common/mod.rs
@@ -277,29 +277,7 @@ pub fn create_operator_added_log(
     public_key: Bytes,
     fee: u64,
 ) -> Log {
-    let event = SSVContract::OperatorAdded {
-        operatorId: operator_id,
-        owner,
-        publicKey: public_key,
-        fee: U256::from(fee),
-    };
-
-    // Create topics array with the event signature and indexed parameters
-    let mut topics = vec![SSVContract::OperatorAdded::SIGNATURE_HASH];
-    topics.push(encode_operator_id_topic(operator_id));
-    topics.push(encode_owner_topic(owner));
-
-    // Encode the non-indexed data
-    let data = event.encode_data();
-
-    create_mock_log(
-        Address::default(), // contract address
-        topics,
-        data.into(),
-        Some(12345),
-        Some(FixedBytes::default()),
-        Some(0),
-    )
+    create_operator_added_log_at_position(operator_id, owner, public_key, fee, 12345, 0, 0)
 }
 
 /// Helper function to create an OperatorAdded event log at an explicit position.
@@ -343,37 +321,7 @@ pub fn create_validator_added_log(
     public_key: Bytes,
     shares: Bytes,
 ) -> Log {
-    let cluster = SSVContract::Cluster {
-        validatorCount: 1,
-        networkFeeIndex: 0,
-        index: 0,
-        active: true,
-        balance: U256::from(0),
-    };
-
-    let event = SSVContract::ValidatorAdded {
-        owner,
-        operatorIds: operator_ids,
-        publicKey: public_key,
-        shares,
-        cluster,
-    };
-
-    // Create topics array with the event signature and indexed parameters
-    let mut topics = vec![SSVContract::ValidatorAdded::SIGNATURE_HASH];
-    topics.push(encode_owner_topic(owner)); // indexed owner
-
-    // Encode the non-indexed data
-    let data = event.encode_data();
-
-    create_mock_log(
-        Address::default(), // contract address
-        topics,
-        data.into(),
-        Some(12346),
-        Some(FixedBytes::default()),
-        Some(1),
-    )
+    create_validator_added_log_at_position(owner, operator_ids, public_key, shares, 12346, 0, 1)
 }
 
 /// Helper function to create a ValidatorAdded event log at an explicit position.
@@ -420,25 +368,7 @@ pub fn create_validator_added_log_at_position(
 
 /// Helper function to create an OperatorRemoved event log
 pub fn create_operator_removed_log(operator_id: u64) -> Log {
-    let _event = SSVContract::OperatorRemoved {
-        operatorId: operator_id,
-    };
-
-    // Create topics array with the event signature and indexed parameters
-    let mut topics = vec![SSVContract::OperatorRemoved::SIGNATURE_HASH];
-    topics.push(encode_operator_id_topic(operator_id));
-
-    // OperatorRemoved has no non-indexed data
-    let data = Bytes::new();
-
-    create_mock_log(
-        Address::default(), // contract address
-        topics,
-        data,
-        Some(12400),
-        Some(FixedBytes::default()),
-        Some(0),
-    )
+    create_operator_removed_log_at_position(operator_id, 12400, 0, 0)
 }
 
 /// Helper function to create an OperatorRemoved event log at an explicit position.
@@ -468,36 +398,7 @@ pub fn create_validator_removed_log(
     operator_ids: Vec<u64>,
     public_key: Bytes,
 ) -> Log {
-    let cluster = SSVContract::Cluster {
-        validatorCount: 0, // 0 after removal
-        networkFeeIndex: 0,
-        index: 0,
-        active: false, // inactive after removal
-        balance: U256::from(0),
-    };
-
-    let event = SSVContract::ValidatorRemoved {
-        owner,
-        operatorIds: operator_ids,
-        publicKey: public_key,
-        cluster,
-    };
-
-    // Create topics array with the event signature and indexed parameters
-    let mut topics = vec![SSVContract::ValidatorRemoved::SIGNATURE_HASH];
-    topics.push(encode_owner_topic(owner)); // indexed owner
-
-    // Encode the non-indexed data
-    let data = event.encode_data();
-
-    create_mock_log(
-        Address::default(), // contract address
-        topics,
-        data.into(),
-        Some(12401),
-        Some(FixedBytes::default()),
-        Some(2),
-    )
+    create_validator_removed_log_at_position(owner, operator_ids, public_key, 12401, 0, 2)
 }
 
 /// Helper function to create a ValidatorRemoved event log at an explicit position.

--- a/anchor/eth/tests/common/mod.rs
+++ b/anchor/eth/tests/common/mod.rs
@@ -441,6 +441,33 @@ pub fn create_validator_removed_log_at_position(
     )
 }
 
+/// Helper function to create a ValidatorExited event log.
+pub fn create_validator_exited_log(
+    owner: Address,
+    operator_ids: Vec<u64>,
+    public_key: Bytes,
+) -> Log {
+    let event = SSVContract::ValidatorExited {
+        owner,
+        operatorIds: operator_ids,
+        publicKey: public_key,
+    };
+
+    let mut topics = vec![SSVContract::ValidatorExited::SIGNATURE_HASH];
+    topics.push(encode_owner_topic(owner));
+
+    let data = event.encode_data();
+
+    create_mock_log(
+        Address::default(),
+        topics,
+        data.into(),
+        Some(12402),
+        Some(FixedBytes::default()),
+        Some(0),
+    )
+}
+
 /// Verify that an operator is soft deleted (removed from memory but still exists in database with
 /// removed=TRUE)
 pub fn verify_operator_soft_deleted(processor: &EventProcessor, operator_id: OperatorId) {

--- a/anchor/eth/tests/common/mod.rs
+++ b/anchor/eth/tests/common/mod.rs
@@ -215,6 +215,27 @@ pub fn create_mock_log(
     transaction_hash: Option<FixedBytes<32>>,
     log_index: Option<u64>,
 ) -> Log {
+    create_mock_log_at_position(
+        address,
+        topics,
+        data,
+        block_number,
+        Some(0),
+        transaction_hash,
+        log_index,
+    )
+}
+
+/// Helper function to create a mock Log object with explicit block and transaction position.
+pub fn create_mock_log_at_position(
+    address: Address,
+    topics: Vec<FixedBytes<32>>,
+    data: Bytes,
+    block_number: Option<u64>,
+    transaction_index: Option<u64>,
+    transaction_hash: Option<FixedBytes<32>>,
+    log_index: Option<u64>,
+) -> Log {
     let log_data = LogData::new(topics, data).expect("Failed to create log data");
 
     Log {
@@ -226,7 +247,7 @@ pub fn create_mock_log(
         block_number,
         block_timestamp: Some(1234567890u64),
         transaction_hash,
-        transaction_index: Some(0u64),
+        transaction_index,
         log_index,
         removed: false,
     }
@@ -281,6 +302,40 @@ pub fn create_operator_added_log(
     )
 }
 
+/// Helper function to create an OperatorAdded event log at an explicit position.
+pub fn create_operator_added_log_at_position(
+    operator_id: u64,
+    owner: Address,
+    public_key: Bytes,
+    fee: u64,
+    block_number: u64,
+    transaction_index: u64,
+    log_index: u64,
+) -> Log {
+    let event = SSVContract::OperatorAdded {
+        operatorId: operator_id,
+        owner,
+        publicKey: public_key,
+        fee: U256::from(fee),
+    };
+
+    let mut topics = vec![SSVContract::OperatorAdded::SIGNATURE_HASH];
+    topics.push(encode_operator_id_topic(operator_id));
+    topics.push(encode_owner_topic(owner));
+
+    let data = event.encode_data();
+
+    create_mock_log_at_position(
+        Address::default(),
+        topics,
+        data.into(),
+        Some(block_number),
+        Some(transaction_index),
+        Some(FixedBytes::default()),
+        Some(log_index),
+    )
+}
+
 /// Helper function to create a ValidatorAdded event log
 pub fn create_validator_added_log(
     owner: Address,
@@ -321,6 +376,48 @@ pub fn create_validator_added_log(
     )
 }
 
+/// Helper function to create a ValidatorAdded event log at an explicit position.
+pub fn create_validator_added_log_at_position(
+    owner: Address,
+    operator_ids: Vec<u64>,
+    public_key: Bytes,
+    shares: Bytes,
+    block_number: u64,
+    transaction_index: u64,
+    log_index: u64,
+) -> Log {
+    let cluster = SSVContract::Cluster {
+        validatorCount: 1,
+        networkFeeIndex: 0,
+        index: 0,
+        active: true,
+        balance: U256::from(0),
+    };
+
+    let event = SSVContract::ValidatorAdded {
+        owner,
+        operatorIds: operator_ids,
+        publicKey: public_key,
+        shares,
+        cluster,
+    };
+
+    let mut topics = vec![SSVContract::ValidatorAdded::SIGNATURE_HASH];
+    topics.push(encode_owner_topic(owner));
+
+    let data = event.encode_data();
+
+    create_mock_log_at_position(
+        Address::default(),
+        topics,
+        data.into(),
+        Some(block_number),
+        Some(transaction_index),
+        Some(FixedBytes::default()),
+        Some(log_index),
+    )
+}
+
 /// Helper function to create an OperatorRemoved event log
 pub fn create_operator_removed_log(operator_id: u64) -> Log {
     let _event = SSVContract::OperatorRemoved {
@@ -341,6 +438,27 @@ pub fn create_operator_removed_log(operator_id: u64) -> Log {
         Some(12400),
         Some(FixedBytes::default()),
         Some(0),
+    )
+}
+
+/// Helper function to create an OperatorRemoved event log at an explicit position.
+pub fn create_operator_removed_log_at_position(
+    operator_id: u64,
+    block_number: u64,
+    transaction_index: u64,
+    log_index: u64,
+) -> Log {
+    let mut topics = vec![SSVContract::OperatorRemoved::SIGNATURE_HASH];
+    topics.push(encode_operator_id_topic(operator_id));
+
+    create_mock_log_at_position(
+        Address::default(),
+        topics,
+        Bytes::new(),
+        Some(block_number),
+        Some(transaction_index),
+        Some(FixedBytes::default()),
+        Some(log_index),
     )
 }
 
@@ -379,6 +497,46 @@ pub fn create_validator_removed_log(
         Some(12401),
         Some(FixedBytes::default()),
         Some(2),
+    )
+}
+
+/// Helper function to create a ValidatorRemoved event log at an explicit position.
+pub fn create_validator_removed_log_at_position(
+    owner: Address,
+    operator_ids: Vec<u64>,
+    public_key: Bytes,
+    block_number: u64,
+    transaction_index: u64,
+    log_index: u64,
+) -> Log {
+    let cluster = SSVContract::Cluster {
+        validatorCount: 0,
+        networkFeeIndex: 0,
+        index: 0,
+        active: false,
+        balance: U256::from(0),
+    };
+
+    let event = SSVContract::ValidatorRemoved {
+        owner,
+        operatorIds: operator_ids,
+        publicKey: public_key,
+        cluster,
+    };
+
+    let mut topics = vec![SSVContract::ValidatorRemoved::SIGNATURE_HASH];
+    topics.push(encode_owner_topic(owner));
+
+    let data = event.encode_data();
+
+    create_mock_log_at_position(
+        Address::default(),
+        topics,
+        data.into(),
+        Some(block_number),
+        Some(transaction_index),
+        Some(FixedBytes::default()),
+        Some(log_index),
     )
 }
 

--- a/anchor/eth/tests/integration.rs
+++ b/anchor/eth/tests/integration.rs
@@ -1,13 +1,31 @@
-use std::{collections::HashMap, str::FromStr, sync::Arc};
+use std::{
+    collections::HashMap,
+    panic::{AssertUnwindSafe, catch_unwind},
+    str::FromStr,
+    sync::Arc,
+};
 
 use alloy::primitives::{Address, Bytes};
 use database::test_utils::queries;
-use eth::util::compute_cluster_id;
+use eth::{
+    SlashingProtection,
+    event_processor::{EventProcessor, Mode},
+    util::compute_cluster_id,
+};
 use ssv_types::*;
 
 mod common;
 
 use common::*;
+
+#[derive(Debug, Default)]
+struct PanicSlashingProtection;
+
+impl SlashingProtection for PanicSlashingProtection {
+    fn register_validator(&self, _public_key: bls::PublicKeyBytes) -> Result<(), String> {
+        panic!("intentional panic for block-boundary regression test");
+    }
+}
 
 #[tokio::test]
 async fn test_operator_added_event_processing() {
@@ -178,6 +196,197 @@ async fn test_same_block_operator_and_validator_processing() {
             panic!("validator should have been queued for index sync");
         }
     }
+}
+
+/// Ensures a single `process_logs` call flushes block `N` before processing block `N+1`.
+///
+/// This is the core new behavior in PR2: a validator added in the second block of the fetched
+/// batch must be able to observe the operators committed from the first block in that same call.
+#[tokio::test]
+async fn test_cross_block_operator_and_validator_processing() {
+    setup_tracing();
+
+    // Arrange: build one fetched batch containing operator events in block N and a validator add
+    // in block N+1 that depends on those operators.
+    let mut test = ProcessorFixture::new_empty();
+    let cluster_owner = Address::from_str(TEST_CLUSTER_OWNER).expect("Invalid address");
+    let operator_ids = vec![1u64, 2u64, 3u64, 4u64];
+    let operator_block = 12363;
+    let validator_block = 12364;
+    let mut logs = Vec::new();
+
+    for (log_index, operator_id) in operator_ids.iter().enumerate() {
+        logs.push(create_operator_added_log_at_position(
+            *operator_id,
+            Address::random(),
+            create_valid_rsa_public_key_bytes(),
+            1000 + *operator_id,
+            operator_block,
+            0,
+            log_index as u64,
+        ));
+    }
+
+    let (shares, validator_pubkey_bytes) =
+        create_valid_shares_data_for_owner_and_nonce(&operator_ids, cluster_owner, 0);
+    let validator_public_key = Bytes::from(validator_pubkey_bytes.serialize().to_vec());
+    logs.push(create_validator_added_log_at_position(
+        cluster_owner,
+        operator_ids.clone(),
+        validator_public_key,
+        shares,
+        validator_block,
+        0,
+        0,
+    ));
+
+    // Act: process both blocks together in one fetched batch.
+    let result = test.processor.process_logs(logs, true, validator_block);
+
+    // Assert: the validator add succeeds, proving block N was committed before block N+1 ran.
+    assert!(
+        result.is_ok(),
+        "cross-block operator and validator processing should succeed"
+    );
+
+    for operator_id in operator_ids {
+        verify_operator_stored(&test.processor, OperatorId(operator_id));
+    }
+
+    let validator_pubkey_str = format!("0x{}", hex::encode(validator_pubkey_bytes.serialize()));
+    verify_validator_added(&test.processor, &validator_pubkey_str);
+    verify_cluster_created(&test.processor, cluster_owner, &[1u64, 2u64, 3u64, 4u64]);
+    assert_eq!(
+        test.processor.db.state().get_last_processed_block(),
+        validator_block
+    );
+
+    tokio::select! {
+        validator_key = test.index_sync_rx.recv() => {
+            assert_eq!(
+                validator_key,
+                Some(validator_pubkey_bytes),
+                "validator should be queued for index sync after the later block commits"
+            );
+        }
+        _ = tokio::time::sleep(tokio::time::Duration::from_millis(100)) => {
+            panic!("validator should have been queued for index sync");
+        }
+    }
+}
+
+/// Ensures a fatal error in block `N+1` does not roll back the already flushed state from block
+/// `N` in the same `process_logs` call.
+#[tokio::test]
+async fn test_cross_block_failure_preserves_previous_block_commit() {
+    setup_tracing();
+
+    // Arrange: first block adds operators, second block panics during validator registration.
+    // Catching that unwind lets us distinguish a real block-boundary commit from "one tx for the
+    // whole fetched batch", because block `N` should remain committed afterwards.
+    let fixture = InMemoryTestFixture::new_empty();
+    let (index_sync_tx, _index_sync_rx) = tokio::sync::mpsc::unbounded_channel();
+    let (exit_tx, _exit_rx) = tokio::sync::mpsc::unbounded_channel();
+    let db = Arc::new(fixture.data.db);
+    let processor = EventProcessor::new(
+        Arc::clone(&db),
+        Mode::Node {
+            index_sync_tx,
+            exit_tx,
+            slashing_protection: Arc::new(PanicSlashingProtection),
+        },
+    );
+
+    let operator_ids = vec![1u64, 2u64, 3u64, 4u64];
+    let operator_block = 12365;
+    let panicking_block = 12366;
+    let cluster_owner = Address::from_str(TEST_CLUSTER_OWNER).expect("Invalid address");
+    let (shares, validator_pubkey_bytes) =
+        create_valid_shares_data_for_owner_and_nonce(&operator_ids, cluster_owner, 0);
+    let validator_public_key = Bytes::from(validator_pubkey_bytes.serialize().to_vec());
+    let mut logs = Vec::new();
+
+    for (log_index, operator_id) in operator_ids.iter().enumerate() {
+        logs.push(create_operator_added_log_at_position(
+            *operator_id,
+            Address::random(),
+            create_valid_rsa_public_key_bytes(),
+            1000 + *operator_id,
+            operator_block,
+            0,
+            log_index as u64,
+        ));
+    }
+
+    logs.push(create_validator_added_log_at_position(
+        cluster_owner,
+        operator_ids.clone(),
+        validator_public_key,
+        shares,
+        panicking_block,
+        0,
+        0,
+    ));
+
+    // Act: process both blocks in one fetched batch and catch the intentional panic from block
+    // N+1.
+    let result = catch_unwind(AssertUnwindSafe(|| {
+        processor.process_logs(logs, true, panicking_block)
+    }));
+
+    // Assert: block N+1 panics before its transaction commits, but block N remains durably
+    // committed.
+    assert!(
+        result.is_err(),
+        "the second block should panic during slashing registration"
+    );
+
+    for operator_id in operator_ids {
+        verify_operator_stored(&processor, OperatorId(operator_id));
+    }
+
+    assert_eq!(
+        db.state().get_last_processed_block(),
+        operator_block,
+        "the committed progress boundary should stop at the last successfully flushed block"
+    );
+}
+
+/// Ensures `process_logs` still advances progress through `end_block` when the fetched range ends
+/// on blocks that contain no relevant logs.
+#[tokio::test]
+async fn test_cross_block_empty_tail_advances_processed_block() {
+    setup_tracing();
+
+    // Arrange: only the first block in the fetched range has relevant logs.
+    let test = ProcessorFixture::new_empty();
+    let operator_block = 12367;
+    let end_block = 12369;
+    let operator_id = 1u64;
+    let log = create_operator_added_log_at_position(
+        operator_id,
+        Address::random(),
+        create_valid_rsa_public_key_bytes(),
+        1000 + operator_id,
+        operator_block,
+        0,
+        0,
+    );
+
+    // Act: process a range whose final block is empty from Anchor's point of view.
+    let result = test.processor.process_logs(vec![log], true, end_block);
+
+    // Assert: the relevant log commits, and progress still advances through the empty tail.
+    assert!(
+        result.is_ok(),
+        "processing should succeed even when the fetched range ends on empty blocks"
+    );
+    verify_operator_stored(&test.processor, OperatorId(operator_id));
+    assert_eq!(
+        test.processor.db.state().get_last_processed_block(),
+        end_block,
+        "the empty tail block should still be marked as processed"
+    );
 }
 
 #[tokio::test]

--- a/anchor/eth/tests/integration.rs
+++ b/anchor/eth/tests/integration.rs
@@ -1,4 +1,4 @@
-use std::{str::FromStr, sync::Arc};
+use std::{collections::HashMap, str::FromStr, sync::Arc};
 
 use alloy::primitives::{Address, Bytes};
 use database::test_utils::queries;
@@ -321,4 +321,63 @@ async fn test_keysplit_mode_processing() {
 
     // Verify operator was stored even in KeySplit mode
     verify_operator_stored(&processor, OperatorId(operator_id));
+}
+
+#[tokio::test]
+async fn test_validator_exit_channel_failure_is_non_fatal() {
+    setup_tracing();
+
+    let test = ProcessorFixture::new_empty();
+    let owner = Address::from_str(TEST_CLUSTER_OWNER).expect("Invalid address");
+    let operator_ids = vec![1u64, 2u64, 3u64, 4u64];
+
+    let operator_logs: Vec<_> = operator_ids
+        .iter()
+        .map(|operator_id| {
+            create_operator_added_log(
+                *operator_id,
+                Address::random(),
+                create_valid_rsa_public_key_bytes(),
+                1000 + *operator_id,
+            )
+        })
+        .collect();
+    let operator_result = test.processor.process_logs(operator_logs, true, 12400);
+    assert!(
+        operator_result.is_ok(),
+        "operator setup batch should succeed"
+    );
+
+    let (shares, validator_pubkey_bytes) =
+        create_valid_shares_data_for_owner_and_nonce(&operator_ids, owner, 0);
+    let public_key = Bytes::from(validator_pubkey_bytes.serialize().to_vec());
+    let add_result = test.processor.process_logs(
+        vec![create_validator_added_log(
+            owner,
+            operator_ids.clone(),
+            public_key.clone(),
+            shares,
+        )],
+        true,
+        12401,
+    );
+    assert!(add_result.is_ok(), "validator setup event should succeed");
+    test.processor
+        .db
+        .set_validator_indices(HashMap::from([(
+            validator_pubkey_bytes,
+            ValidatorIndex(123),
+        )]))
+        .expect("validator index should be set before exit processing");
+
+    let result = test.processor.process_logs(
+        vec![create_validator_exited_log(owner, operator_ids, public_key)],
+        true,
+        12402,
+    );
+    assert!(
+        result.is_ok(),
+        "post-commit exit send failures should be logged and not returned"
+    );
+    assert_eq!(test.processor.db.state().get_last_processed_block(), 12402);
 }

--- a/anchor/eth/tests/integration.rs
+++ b/anchor/eth/tests/integration.rs
@@ -198,12 +198,14 @@ async fn test_same_block_operator_and_validator_processing() {
     }
 }
 
-/// Ensures a single `process_logs` call flushes block `N` before processing block `N+1`.
+/// Ensures a single `process_logs` call can span multiple blocks successfully.
 ///
-/// This is the core new behavior in PR2: a validator added in the second block of the fetched
-/// batch must be able to observe the operators committed from the first block in that same call.
+/// This is the multi-block happy path for PR2: a validator added in the second block of the
+/// fetched batch can observe the operators created in the first block within the same
+/// `process_logs` call. The stronger commit-boundary guarantee is covered separately by
+/// `test_cross_block_failure_preserves_previous_block_commit`.
 #[tokio::test]
-async fn test_cross_block_operator_and_validator_processing() {
+async fn test_cross_block_operator_and_validator_processing_succeeds() {
     setup_tracing();
 
     // Arrange: build one fetched batch containing operator events in block N and a validator add
@@ -243,7 +245,8 @@ async fn test_cross_block_operator_and_validator_processing() {
     // Act: process both blocks together in one fetched batch.
     let result = test.processor.process_logs(logs, true, validator_block);
 
-    // Assert: the validator add succeeds, proving block N was committed before block N+1 ran.
+    // Assert: the multi-block batch succeeds and the later block can depend on state created in
+    // the earlier block.
     assert!(
         result.is_ok(),
         "cross-block operator and validator processing should succeed"

--- a/anchor/eth/tests/integration.rs
+++ b/anchor/eth/tests/integration.rs
@@ -118,30 +118,37 @@ async fn test_same_block_operator_and_validator_processing() {
     let mut test = ProcessorFixture::new_empty();
     let cluster_owner = Address::from_str(TEST_CLUSTER_OWNER).expect("Invalid address");
     let operator_ids = vec![1u64, 2u64, 3u64, 4u64];
+    let same_block = 12360;
     let mut logs = Vec::new();
 
-    for operator_id in &operator_ids {
+    for (log_index, operator_id) in operator_ids.iter().enumerate() {
         let owner = Address::random();
         let public_key = create_valid_rsa_public_key_bytes();
-        logs.push(create_operator_added_log(
+        logs.push(create_operator_added_log_at_position(
             *operator_id,
             owner,
             public_key,
             1000 + *operator_id,
+            same_block,
+            0,
+            log_index as u64,
         ));
     }
 
     let (shares, validator_pubkey_bytes) =
         create_valid_shares_data_for_owner_and_nonce(&operator_ids, cluster_owner, 0);
     let validator_public_key = Bytes::from(validator_pubkey_bytes.serialize().to_vec());
-    logs.push(create_validator_added_log(
+    logs.push(create_validator_added_log_at_position(
         cluster_owner,
         operator_ids.clone(),
         validator_public_key,
         shares,
+        same_block,
+        1,
+        0,
     ));
 
-    let result = test.processor.process_logs(logs, true, 12360);
+    let result = test.processor.process_logs(logs, true, same_block);
     assert!(
         result.is_ok(),
         "same-block operator and validator processing should succeed"
@@ -154,6 +161,10 @@ async fn test_same_block_operator_and_validator_processing() {
     let validator_pubkey_str = format!("0x{}", hex::encode(validator_pubkey_bytes.serialize()));
     verify_validator_added(&test.processor, &validator_pubkey_str);
     verify_cluster_created(&test.processor, cluster_owner, &[1u64, 2u64, 3u64, 4u64]);
+    assert_eq!(
+        test.processor.db.state().get_last_processed_block(),
+        same_block
+    );
 
     tokio::select! {
         validator_key = test.index_sync_rx.recv() => {
@@ -176,14 +187,19 @@ async fn test_same_block_validator_add_and_remove_processing() {
     let test = ProcessorFixture::new_empty();
     let cluster_owner = Address::from_str(TEST_CLUSTER_OWNER).expect("Invalid address");
     let operator_ids = vec![1u64, 2u64, 3u64, 4u64];
+    let same_block = 12362;
     let operator_logs: Vec<_> = operator_ids
         .iter()
-        .map(|operator_id| {
-            create_operator_added_log(
+        .enumerate()
+        .map(|(log_index, operator_id)| {
+            create_operator_added_log_at_position(
                 *operator_id,
                 Address::random(),
                 create_valid_rsa_public_key_bytes(),
                 1000 + *operator_id,
+                12361,
+                0,
+                log_index as u64,
             )
         })
         .collect();
@@ -198,16 +214,26 @@ async fn test_same_block_validator_add_and_remove_processing() {
         create_valid_shares_data_for_owner_and_nonce(&operator_ids, cluster_owner, 0);
     let validator_public_key = Bytes::from(validator_pubkey_bytes.serialize().to_vec());
     let logs = vec![
-        create_validator_added_log(
+        create_validator_added_log_at_position(
             cluster_owner,
             operator_ids.clone(),
             validator_public_key.clone(),
             shares,
+            same_block,
+            0,
+            0,
         ),
-        create_validator_removed_log(cluster_owner, operator_ids.clone(), validator_public_key),
+        create_validator_removed_log_at_position(
+            cluster_owner,
+            operator_ids.clone(),
+            validator_public_key,
+            same_block,
+            1,
+            0,
+        ),
     ];
 
-    let result = test.processor.process_logs(logs, true, 12362);
+    let result = test.processor.process_logs(logs, true, same_block);
     assert!(
         result.is_ok(),
         "same-block validator add and remove processing should succeed"
@@ -230,7 +256,10 @@ async fn test_same_block_validator_add_and_remove_processing() {
         queries::get_cluster(cluster_id, &tx).is_none(),
         "cluster should be removed after its only validator is removed"
     );
-    assert_eq!(test.processor.db.state().get_last_processed_block(), 12362);
+    assert_eq!(
+        test.processor.db.state().get_last_processed_block(),
+        same_block
+    );
 }
 
 #[tokio::test]

--- a/anchor/eth/tests/integration.rs
+++ b/anchor/eth/tests/integration.rs
@@ -474,8 +474,10 @@ async fn test_same_block_validator_add_and_remove_processing() {
     );
 }
 
+/// Ensures pre-existing malformed-event semantics are preserved: malformed events are skipped,
+/// while valid events in the same `process_logs` call still commit.
 #[tokio::test]
-async fn test_database_transaction_rollback_on_error() {
+async fn test_malformed_events_skipped_without_affecting_valid_events() {
     // Setup test fixture with processor
     let test = ProcessorFixture::new_empty();
 

--- a/anchor/eth/tests/integration.rs
+++ b/anchor/eth/tests/integration.rs
@@ -1,6 +1,8 @@
 use std::{str::FromStr, sync::Arc};
 
 use alloy::primitives::{Address, Bytes};
+use database::test_utils::queries;
+use eth::util::compute_cluster_id;
 use ssv_types::*;
 
 mod common;
@@ -107,6 +109,128 @@ async fn test_multiple_events_processing() {
     // Verify processed block was updated using proper database API
     let block_number = test.processor.db.state().get_last_processed_block();
     assert_eq!(block_number, 12350, "Block number should be updated");
+}
+
+#[tokio::test]
+async fn test_same_block_operator_and_validator_processing() {
+    setup_tracing();
+
+    let mut test = ProcessorFixture::new_empty();
+    let cluster_owner = Address::from_str(TEST_CLUSTER_OWNER).expect("Invalid address");
+    let operator_ids = vec![1u64, 2u64, 3u64, 4u64];
+    let mut logs = Vec::new();
+
+    for operator_id in &operator_ids {
+        let owner = Address::random();
+        let public_key = create_valid_rsa_public_key_bytes();
+        logs.push(create_operator_added_log(
+            *operator_id,
+            owner,
+            public_key,
+            1000 + *operator_id,
+        ));
+    }
+
+    let (shares, validator_pubkey_bytes) =
+        create_valid_shares_data_for_owner_and_nonce(&operator_ids, cluster_owner, 0);
+    let validator_public_key = Bytes::from(validator_pubkey_bytes.serialize().to_vec());
+    logs.push(create_validator_added_log(
+        cluster_owner,
+        operator_ids.clone(),
+        validator_public_key,
+        shares,
+    ));
+
+    let result = test.processor.process_logs(logs, true, 12360);
+    assert!(
+        result.is_ok(),
+        "same-block operator and validator processing should succeed"
+    );
+
+    for operator_id in operator_ids {
+        verify_operator_stored(&test.processor, OperatorId(operator_id));
+    }
+
+    let validator_pubkey_str = format!("0x{}", hex::encode(validator_pubkey_bytes.serialize()));
+    verify_validator_added(&test.processor, &validator_pubkey_str);
+    verify_cluster_created(&test.processor, cluster_owner, &[1u64, 2u64, 3u64, 4u64]);
+
+    tokio::select! {
+        validator_key = test.index_sync_rx.recv() => {
+            assert_eq!(
+                validator_key,
+                Some(validator_pubkey_bytes),
+                "validator should be queued for index sync"
+            );
+        }
+        _ = tokio::time::sleep(tokio::time::Duration::from_millis(100)) => {
+            panic!("validator should have been queued for index sync");
+        }
+    }
+}
+
+#[tokio::test]
+async fn test_same_block_validator_add_and_remove_processing() {
+    setup_tracing();
+
+    let test = ProcessorFixture::new_empty();
+    let cluster_owner = Address::from_str(TEST_CLUSTER_OWNER).expect("Invalid address");
+    let operator_ids = vec![1u64, 2u64, 3u64, 4u64];
+    let operator_logs: Vec<_> = operator_ids
+        .iter()
+        .map(|operator_id| {
+            create_operator_added_log(
+                *operator_id,
+                Address::random(),
+                create_valid_rsa_public_key_bytes(),
+                1000 + *operator_id,
+            )
+        })
+        .collect();
+
+    let operator_result = test.processor.process_logs(operator_logs, true, 12361);
+    assert!(
+        operator_result.is_ok(),
+        "operator setup batch should succeed"
+    );
+
+    let (shares, validator_pubkey_bytes) =
+        create_valid_shares_data_for_owner_and_nonce(&operator_ids, cluster_owner, 0);
+    let validator_public_key = Bytes::from(validator_pubkey_bytes.serialize().to_vec());
+    let logs = vec![
+        create_validator_added_log(
+            cluster_owner,
+            operator_ids.clone(),
+            validator_public_key.clone(),
+            shares,
+        ),
+        create_validator_removed_log(cluster_owner, operator_ids.clone(), validator_public_key),
+    ];
+
+    let result = test.processor.process_logs(logs, true, 12362);
+    assert!(
+        result.is_ok(),
+        "same-block validator add and remove processing should succeed"
+    );
+
+    let mut conn = test
+        .processor
+        .db
+        .connection()
+        .expect("Failed to get database connection");
+    let tx = conn.transaction().expect("Failed to start transaction");
+    let validator_pubkey_str = format!("0x{}", hex::encode(validator_pubkey_bytes.serialize()));
+    let cluster_id = compute_cluster_id(cluster_owner, &operator_ids);
+
+    assert!(
+        queries::get_validator(&validator_pubkey_str, &tx).is_none(),
+        "validator should be removed after the batch completes"
+    );
+    assert!(
+        queries::get_cluster(cluster_id, &tx).is_none(),
+        "cluster should be removed after its only validator is removed"
+    );
+    assert_eq!(test.processor.db.state().get_last_processed_block(), 12362);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Problem, Evidence, and Context (Required)

- This fixes the behavior bug that remains after PR 1: later contract events in the same block need to see earlier writes through the active SQLite transaction before `NetworkState` is published.
- This is worth doing now because PR `#885` is being replaced by a smaller reviewed stack, and PR `#898` already prepared the database layer for this boundary change.
- Evidence: `event_processor` previously mixed tx writes with in-memory reads, which breaks same-block flows once publication is deferred. This PR adds focused same-block integration coverage for `OperatorAdded` + `ValidatorAdded` and `ValidatorAdded` + `ValidatorRemoved`.
- Relevant links: `#880`, `#898`, replacement for the behavior-fix portion of `#885`.

## Change Overview (Required)

- Process fetched contract logs one block at a time inside `event_processor`, with one SQLite transaction per block.
- Route same-block reads through tx-scoped database helpers instead of `self.db.state()`.
- Publish `NetworkState` and trigger index-sync / exit side effects only after the block transaction commits.
- Add position-aware test helpers so integration tests can model real same-block ordering.
- Intentionally did not change schema, sync resume machinery, or `NetworkState` consumers outside this boundary.

## Risks, Trade-offs, and Mitigations (Required)

- Main risk is changing the event-processing boundary in historical and live sync.
- The diff stays scoped to `event_processor`, the small set of tx-scoped reads it needs, and targeted integration coverage.
- Trade-off: fetched multi-block batches are now committed block-by-block instead of as one larger transaction. That is intentional so durable progress, state publication, and post-commit side effects align with block processing.

## Validation (Required)

- `cargo check -p eth`
- `cargo fmt --all --check`
- `cargo clippy -p database -p eth --all-targets -- -D warnings`
- `cargo test -p eth --tests`

## Rollback (Required for behavior or runtime changes; optional otherwise)

- Safe revert after PR `#898` if needed.
- No schema or migration impact.
- Reverts to the pre-PR2 batch-wide event-processing boundary.

## Blockers / Dependencies (Optional)

- Depends on merged PR `#898`.

## Additional Info / Next Steps (Optional)

- A follow-up cleanup PR can remove any dead helper or cursor-adjacent code left over from the replaced direction.
