### PR TITLE
chore(deps): bump rustls-webpki to 0.103.10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6691,9 +6691,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.9"
+version = "0.103.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
 dependencies = [
  "ring",
  "rustls-pki-types",


### PR DESCRIPTION
## Problem, Evidence, and Context (Required)

- `cargo audit` started failing on `unstable` because `rustls-webpki 0.103.9` is flagged by `RUSTSEC-2026-0049`.
- This is worth doing now because it is breaking `check-code` in CI.
- Evidence: the failing advisory points to `rustls-webpki 0.103.9` and recommends upgrading to `>=0.103.10`.
- Relevant links: https://rustsec.org/advisories/RUSTSEC-2026-0049

## Change Overview (Required)

- Bump the lockfile entry for `rustls-webpki` from `0.103.9` to `0.103.10`.
- Cargo also re-resolved `data-encoding-macro-internal 0.1.17` to use `syn 1.0.109` instead of `syn 2.0.117`. That crate declares `syn >= 1, < 3`, so this is a valid lockfile normalization rather than a behavior change.
- This is intentionally a minimal, lockfile-only fix. Start and end with `Cargo.lock`; there is no code change to review.
- Intentionally did not change any application code, dependency declarations, or unrelated audit warnings.

## Risks, Trade-offs, and Mitigations (Required)

- Risk is low because this only updates a transitive dependency within the existing resolver bounds.
- The trade-off is that this does not address the pre-existing audit warnings for unmaintained/unsound crates; it only fixes the newly-failing vulnerability.
- Risk is mitigated by keeping the diff isolated to the lockfile and validating both `cargo audit` and a clean build afterwards.

## Validation (Required)

- `CARGO_HOME=/tmp/cargo-home-auditfix cargo audit`
- `CARGO_HOME=/tmp/cargo-home-auditfix cargo check -p eth --quiet`

## Rollback (Required for behavior or runtime changes; optional otherwise)

- Safe to revert by reverting this commit or downgrading the lockfile entry.
- No config, data, or operational changes.

## Blockers / Dependencies (Optional)

- N/A

## Additional Info / Next Steps (Optional)

- This was split out from the `#904` work so the dependency fix can be reviewed and merged independently.
