### PR TITLE
test: add aggregate committee coverage

### DIFF
--- a/anchor/validator_store/src/testing/committee_aggregate.rs
+++ b/anchor/validator_store/src/testing/committee_aggregate.rs
@@ -10,7 +10,7 @@ use crate::Error;
 type SignAggregatesResult = Vec<Result<Vec<SignedAggregateAndProof<MainnetEthSpec>>, Error>>;
 
 const PRIMARY_COMMITTEE_VALIDATOR_COUNT: usize = 2;
-const SECONDARY_COMMITTEE_VALIDATOR_COUNT: usize = 1;
+const SINGLE_VALIDATOR_COMMITTEE_COUNT: usize = 1;
 const EXPECTED_TOTAL_SIGNED_AGGREGATES: usize = 3;
 const EXPECTED_SIGN_AND_COLLECT_CALLS: usize = 3;
 const EXPECTED_REQUESTED_COUNTS: [usize; 3] = [1, 2, 2];
@@ -22,7 +22,7 @@ const EXPECTED_REQUESTED_COUNTS: [usize; 3] = [1, 2, 2];
 async fn sign_aggregate_and_proofs_produces_one_stream_item_per_committee() {
     // Arrange
     let committee_a = create_primary_committee_setup(PRIMARY_COMMITTEE_VALIDATOR_COUNT);
-    let committee_b = create_secondary_committee_setup(SECONDARY_COMMITTEE_VALIDATOR_COUNT);
+    let committee_b = create_secondary_committee_setup(SINGLE_VALIDATOR_COMMITTEE_COUNT);
     assert_ne!(
         committee_a.cluster.committee_id(),
         committee_b.cluster.committee_id(),
@@ -85,8 +85,8 @@ async fn sign_aggregate_and_proofs_produces_one_stream_item_per_committee() {
 #[tokio::test(flavor = "multi_thread")]
 async fn sign_aggregate_and_proofs_failure_isolation() {
     // Arrange
-    let committee_a = create_primary_committee_setup(SECONDARY_COMMITTEE_VALIDATOR_COUNT);
-    let committee_b = create_secondary_committee_setup(SECONDARY_COMMITTEE_VALIDATOR_COUNT);
+    let committee_a = create_primary_committee_setup(SINGLE_VALIDATOR_COMMITTEE_COUNT);
+    let committee_b = create_secondary_committee_setup(SINGLE_VALIDATOR_COMMITTEE_COUNT);
     let harness = ValidatorStoreTestHarness::new(vec![committee_a, committee_b], OUR_OPERATOR_ID);
     harness.seed_aggregation_assignments_for_slot(TEST_SLOT, &[PRIMARY_COMMITTEE_INDEX]);
     let aggregates = vec![

--- a/anchor/validator_store/src/testing/committee_aggregate.rs
+++ b/anchor/validator_store/src/testing/committee_aggregate.rs
@@ -1,9 +1,6 @@
 //! Integration tests for the committee-batching aggregate path in `sign_aggregate_and_proofs()`.
-use std::time::Duration;
-
 use futures::StreamExt;
 use signature_collector::SignatureRequester;
-use ssv_types::OperatorId;
 use types::{MainnetEthSpec, SignedAggregateAndProof};
 use validator_store::ValidatorStore;
 
@@ -12,33 +9,33 @@ use crate::Error;
 
 type SignAggregatesResult = Vec<Result<Vec<SignedAggregateAndProof<MainnetEthSpec>>, Error>>;
 
+const PRIMARY_COMMITTEE_VALIDATOR_COUNT: usize = 2;
+const SECONDARY_COMMITTEE_VALIDATOR_COUNT: usize = 1;
+const EXPECTED_TOTAL_SIGNED_AGGREGATES: usize = 3;
+const EXPECTED_SIGN_AND_COLLECT_CALLS: usize = 3;
+const EXPECTED_REQUESTED_COUNTS: [usize; 3] = [1, 2, 2];
+
 /// `sign_aggregate_and_proofs` groups aggregates by `CommitteeId`, runs consensus once per
 /// committee, collects committee signatures for each validator, and streams one batch per
 /// committee.
 #[tokio::test(flavor = "multi_thread")]
 async fn sign_aggregate_and_proofs_produces_one_stream_item_per_committee() {
     // Arrange
-    let our_operator_id = OperatorId(1);
-    let committee_a = create_committee_setup(
-        &[OperatorId(1), OperatorId(2), OperatorId(3), OperatorId(4)],
-        2,
-        0,
-    );
-    let committee_b = create_committee_setup(
-        &[OperatorId(1), OperatorId(5), OperatorId(6), OperatorId(7)],
-        1,
-        100,
-    );
+    let committee_a = create_primary_committee_setup(PRIMARY_COMMITTEE_VALIDATOR_COUNT);
+    let committee_b = create_secondary_committee_setup(SECONDARY_COMMITTEE_VALIDATOR_COUNT);
     assert_ne!(
         committee_a.cluster.committee_id(),
         committee_b.cluster.committee_id(),
     );
-    let harness = ValidatorStoreTestHarness::new(vec![committee_a, committee_b], our_operator_id);
-    harness.seed_aggregation_assignments_for_slot(TEST_SLOT, &[0, 1]);
+    let harness = ValidatorStoreTestHarness::new(vec![committee_a, committee_b], OUR_OPERATOR_ID);
+    harness.seed_aggregation_assignments_for_slot(
+        TEST_SLOT,
+        &[PRIMARY_COMMITTEE_INDEX, SECONDARY_COMMITTEE_INDEX],
+    );
     let aggregates = vec![
-        harness.create_aggregate(0, 0),
-        harness.create_aggregate(0, 1),
-        harness.create_aggregate(1, 0),
+        harness.create_aggregate(PRIMARY_COMMITTEE_INDEX, FIRST_VALIDATOR_INDEX),
+        harness.create_aggregate(PRIMARY_COMMITTEE_INDEX, SECOND_VALIDATOR_INDEX),
+        harness.create_aggregate(SECONDARY_COMMITTEE_INDEX, FIRST_VALIDATOR_INDEX),
     ];
 
     // Act
@@ -55,10 +52,17 @@ async fn sign_aggregate_and_proofs_produces_one_stream_item_per_committee() {
         .map(|r| r.expect("each committee batch should succeed"))
         .collect();
     let total: usize = all_signed.iter().map(|batch| batch.len()).sum();
-    assert_eq!(total, 3, "expected 3 total signed aggregates");
+    assert_eq!(
+        total, EXPECTED_TOTAL_SIGNED_AGGREGATES,
+        "expected 3 total signed aggregates"
+    );
 
     let captured = harness.captured_calls.lock();
-    assert_eq!(captured.len(), 3, "expected 3 sign_and_collect calls");
+    assert_eq!(
+        captured.len(),
+        EXPECTED_SIGN_AND_COLLECT_CALLS,
+        "expected 3 sign_and_collect calls"
+    );
     let mut requested_counts: Vec<_> = captured
         .iter()
         .map(|call| match &call.requester {
@@ -71,8 +75,7 @@ async fn sign_aggregate_and_proofs_produces_one_stream_item_per_committee() {
         .collect();
     requested_counts.sort_unstable();
     assert_eq!(
-        requested_counts,
-        vec![1, 2, 2],
+        requested_counts, EXPECTED_REQUESTED_COUNTS,
         "expected committee requester counts to match aggregators per committee"
     );
 }
@@ -82,22 +85,17 @@ async fn sign_aggregate_and_proofs_produces_one_stream_item_per_committee() {
 #[tokio::test(flavor = "multi_thread")]
 async fn sign_aggregate_and_proofs_failure_isolation() {
     // Arrange
-    let our_operator_id = OperatorId(1);
-    let committee_a = create_committee_setup(
-        &[OperatorId(1), OperatorId(2), OperatorId(3), OperatorId(4)],
-        1,
-        0,
-    );
-    let committee_b = create_committee_setup(
-        &[OperatorId(1), OperatorId(5), OperatorId(6), OperatorId(7)],
-        1,
-        100,
-    );
-    let harness = ValidatorStoreTestHarness::new(vec![committee_a, committee_b], our_operator_id);
-    harness.seed_aggregation_assignments_for_slot(TEST_SLOT, &[0]);
+    let committee_a = create_primary_committee_setup(SECONDARY_COMMITTEE_VALIDATOR_COUNT);
+    let committee_b = create_secondary_committee_setup(SECONDARY_COMMITTEE_VALIDATOR_COUNT);
+    let harness = ValidatorStoreTestHarness::new(vec![committee_a, committee_b], OUR_OPERATOR_ID);
+    harness.seed_aggregation_assignments_for_slot(TEST_SLOT, &[PRIMARY_COMMITTEE_INDEX]);
     let aggregates = vec![
-        harness.create_aggregate(0, 0),
-        harness.create_aggregate_at_slot(1, 0, TEST_SLOT + 1),
+        harness.create_aggregate(PRIMARY_COMMITTEE_INDEX, FIRST_VALIDATOR_INDEX),
+        harness.create_aggregate_at_slot(
+            SECONDARY_COMMITTEE_INDEX,
+            FIRST_VALIDATOR_INDEX,
+            NEXT_SLOT,
+        ),
     ];
 
     // Act
@@ -105,8 +103,8 @@ async fn sign_aggregate_and_proofs_failure_isolation() {
         .validator_store
         .sign_aggregate_and_proofs(aggregates);
     tokio::pin!(stream);
-    let first = tokio::time::timeout(Duration::from_secs(5), stream.next()).await;
-    let second = tokio::time::timeout(Duration::from_millis(500), stream.next()).await;
+    let first = tokio::time::timeout(STREAM_ITEM_TIMEOUT, stream.next()).await;
+    let second = tokio::time::timeout(BLOCKED_STREAM_TIMEOUT, stream.next()).await;
 
     // Assert
     let first_item = first

--- a/anchor/validator_store/src/testing/committee_aggregate.rs
+++ b/anchor/validator_store/src/testing/committee_aggregate.rs
@@ -11,9 +11,6 @@ type SignAggregatesResult = Vec<Result<Vec<SignedAggregateAndProof<MainnetEthSpe
 
 const PRIMARY_COMMITTEE_VALIDATOR_COUNT: usize = 2;
 const SINGLE_VALIDATOR_COMMITTEE_COUNT: usize = 1;
-const EXPECTED_TOTAL_SIGNED_AGGREGATES: usize = 3;
-const EXPECTED_SIGN_AND_COLLECT_CALLS: usize = 3;
-const EXPECTED_REQUESTED_COUNTS: [usize; 3] = [1, 2, 2];
 
 /// `sign_aggregate_and_proofs` with empty input yields zero stream items.
 #[tokio::test(flavor = "multi_thread")]
@@ -72,16 +69,14 @@ async fn sign_aggregate_and_proofs_produces_one_stream_item_per_committee() {
         .map(|r| r.expect("each committee batch should succeed"))
         .collect();
     let total: usize = all_signed.iter().map(|batch| batch.len()).sum();
-    assert_eq!(
-        total, EXPECTED_TOTAL_SIGNED_AGGREGATES,
-        "expected 3 total signed aggregates"
-    );
+    let expected_total = PRIMARY_COMMITTEE_VALIDATOR_COUNT + SINGLE_VALIDATOR_COMMITTEE_COUNT;
+    assert_eq!(total, expected_total, "expected {expected_total} total signed aggregates");
 
     let captured = harness.captured_calls.lock();
     assert_eq!(
         captured.len(),
-        EXPECTED_SIGN_AND_COLLECT_CALLS,
-        "expected 3 sign_and_collect calls"
+        expected_total,
+        "expected {expected_total} sign_and_collect calls"
     );
     let mut requested_counts: Vec<_> = captured
         .iter()
@@ -94,11 +89,18 @@ async fn sign_aggregate_and_proofs_produces_one_stream_item_per_committee() {
         })
         .collect();
     requested_counts.sort_unstable();
-    // Committee A has two aggregators and committee B has one, so the per-validator collection
-    // requests should be [1, 2, 2] irrespective of stream ordering.
+    // Each validator gets one sign_and_collect call. Committee A's validators each request
+    // `PRIMARY_COMMITTEE_VALIDATOR_COUNT` signatures, committee B's request
+    // `SINGLE_VALIDATOR_COMMITTEE_COUNT`. Sorted ascending:
+    let mut expected_counts = vec![
+        SINGLE_VALIDATOR_COMMITTEE_COUNT,
+        PRIMARY_COMMITTEE_VALIDATOR_COUNT,
+        PRIMARY_COMMITTEE_VALIDATOR_COUNT,
+    ];
+    expected_counts.sort_unstable();
     assert_eq!(
-        requested_counts, EXPECTED_REQUESTED_COUNTS,
-        "expected committee requester counts to match aggregators per committee"
+        requested_counts, expected_counts,
+        "expected committee requester counts to match validators per committee"
     );
 }
 

--- a/anchor/validator_store/src/testing/committee_aggregate.rs
+++ b/anchor/validator_store/src/testing/committee_aggregate.rs
@@ -15,6 +15,24 @@ const EXPECTED_TOTAL_SIGNED_AGGREGATES: usize = 3;
 const EXPECTED_SIGN_AND_COLLECT_CALLS: usize = 3;
 const EXPECTED_REQUESTED_COUNTS: [usize; 3] = [1, 2, 2];
 
+/// `sign_aggregate_and_proofs` with empty input yields zero stream items.
+#[tokio::test(flavor = "multi_thread")]
+async fn sign_aggregate_and_proofs_empty_input() {
+    let committee = create_primary_committee_setup(SINGLE_VALIDATOR_COMMITTEE_COUNT);
+    let harness = ValidatorStoreTestHarness::new(vec![committee], OUR_OPERATOR_ID);
+
+    let results: SignAggregatesResult = harness
+        .validator_store
+        .sign_aggregate_and_proofs(vec![])
+        .collect()
+        .await;
+
+    assert!(
+        results.is_empty(),
+        "empty input should yield zero stream items"
+    );
+}
+
 /// `sign_aggregate_and_proofs` groups aggregates by `CommitteeId`, runs consensus once per
 /// committee, collects committee signatures for each validator, and streams one batch per
 /// committee.
@@ -77,7 +95,7 @@ async fn sign_aggregate_and_proofs_produces_one_stream_item_per_committee() {
         .collect();
     requested_counts.sort_unstable();
     // Committee A has two aggregators and committee B has one, so the per-validator collection
-    // requests should be [2, 2, 1] irrespective of stream ordering.
+    // requests should be [1, 2, 2] irrespective of stream ordering.
     assert_eq!(
         requested_counts, EXPECTED_REQUESTED_COUNTS,
         "expected committee requester counts to match aggregators per committee"
@@ -118,7 +136,12 @@ async fn sign_aggregate_and_proofs_failure_isolation() {
     let first_item = first
         .expect("first committee should complete within timeout")
         .expect("stream should yield an item");
-    assert!(first_item.is_ok());
+    let signed = first_item.expect("first committee should succeed");
+    assert_eq!(
+        signed.len(),
+        1,
+        "successful committee should produce one signed item"
+    );
     assert!(
         second.is_err(),
         "stuck committee should not produce a result"

--- a/anchor/validator_store/src/testing/committee_aggregate.rs
+++ b/anchor/validator_store/src/testing/committee_aggregate.rs
@@ -86,7 +86,7 @@ async fn sign_aggregate_and_proofs_produces_one_stream_item_per_committee() {
 
 /// A committee blocked waiting for `AggregationAssignments` does not prevent another committee
 /// from producing its aggregate batch. Verifies the committee futures are isolated.
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "current_thread", start_paused = true)]
 async fn sign_aggregate_and_proofs_failure_isolation() {
     // Arrange
     let committee_a = create_primary_committee_setup(SINGLE_VALIDATOR_COMMITTEE_COUNT);

--- a/anchor/validator_store/src/testing/committee_aggregate.rs
+++ b/anchor/validator_store/src/testing/committee_aggregate.rs
@@ -28,6 +28,8 @@ async fn sign_aggregate_and_proofs_produces_one_stream_item_per_committee() {
         committee_b.cluster.committee_id(),
     );
     let harness = ValidatorStoreTestHarness::new(vec![committee_a, committee_b], OUR_OPERATOR_ID);
+    // Seed aggregate assignments for both committees at TEST_SLOT so both committee batches can
+    // resolve their decided aggregate data.
     harness.seed_aggregation_assignments_for_slot(
         TEST_SLOT,
         &[PRIMARY_COMMITTEE_INDEX, SECONDARY_COMMITTEE_INDEX],
@@ -74,6 +76,8 @@ async fn sign_aggregate_and_proofs_produces_one_stream_item_per_committee() {
         })
         .collect();
     requested_counts.sort_unstable();
+    // Committee A has two aggregators and committee B has one, so the per-validator collection
+    // requests should be [2, 2, 1] irrespective of stream ordering.
     assert_eq!(
         requested_counts, EXPECTED_REQUESTED_COUNTS,
         "expected committee requester counts to match aggregators per committee"
@@ -88,9 +92,13 @@ async fn sign_aggregate_and_proofs_failure_isolation() {
     let committee_a = create_primary_committee_setup(SINGLE_VALIDATOR_COMMITTEE_COUNT);
     let committee_b = create_secondary_committee_setup(SINGLE_VALIDATOR_COMMITTEE_COUNT);
     let harness = ValidatorStoreTestHarness::new(vec![committee_a, committee_b], OUR_OPERATOR_ID);
+    // Only the primary committee gets aggregate assignments for TEST_SLOT.
     harness.seed_aggregation_assignments_for_slot(TEST_SLOT, &[PRIMARY_COMMITTEE_INDEX]);
     let aggregates = vec![
+        // Committee A uses TEST_SLOT and should complete.
         harness.create_aggregate(PRIMARY_COMMITTEE_INDEX, FIRST_VALIDATOR_INDEX),
+        // Committee B uses NEXT_SLOT, where no aggregate assignments were seeded, so it should
+        // stay blocked in the aggregate-assignment lookup.
         harness.create_aggregate_at_slot(
             SECONDARY_COMMITTEE_INDEX,
             FIRST_VALIDATOR_INDEX,

--- a/anchor/validator_store/src/testing/committee_aggregate.rs
+++ b/anchor/validator_store/src/testing/committee_aggregate.rs
@@ -1,6 +1,9 @@
-//! Integration tests for the committee-batching aggregate path in `sign_aggregate_and_proofs()`.
+//! Integration tests for committee aggregate signing in `sign_aggregate_and_proofs()`.
+use std::time::Duration;
+
 use futures::StreamExt;
 use signature_collector::SignatureRequester;
+use ssv_types::OperatorId;
 use types::{MainnetEthSpec, SignedAggregateAndProof};
 use validator_store::ValidatorStore;
 
@@ -9,13 +12,30 @@ use crate::Error;
 
 type SignAggregatesResult = Vec<Result<Vec<SignedAggregateAndProof<MainnetEthSpec>>, Error>>;
 
+const PRIMARY_COMMITTEE_OPERATOR_IDS: [OperatorId; 4] =
+    [OperatorId(1), OperatorId(2), OperatorId(3), OperatorId(4)];
+const SECONDARY_COMMITTEE_OPERATOR_IDS: [OperatorId; 4] =
+    [OperatorId(1), OperatorId(5), OperatorId(6), OperatorId(7)];
+
+const OUR_OPERATOR_ID: OperatorId = OperatorId(1);
+const PRIMARY_COMMITTEE_INDEX: usize = 0;
+const SECONDARY_COMMITTEE_INDEX: usize = 1;
+const FIRST_VALIDATOR_INDEX: usize = 0;
+const SECOND_VALIDATOR_INDEX: usize = 1;
+
 const PRIMARY_COMMITTEE_VALIDATOR_COUNT: usize = 2;
-const SINGLE_VALIDATOR_COMMITTEE_COUNT: usize = 1;
+const SINGLE_VALIDATOR_COUNT: usize = 1;
+const PRIMARY_COMMITTEE_STARTING_VALIDATOR_INDEX: usize = 0;
+const SECONDARY_COMMITTEE_STARTING_VALIDATOR_INDEX: usize = 100;
+
+const NEXT_SLOT: u64 = TEST_SLOT + 1;
+const STREAM_ITEM_TIMEOUT: Duration = Duration::from_secs(5);
+const BLOCKED_STREAM_TIMEOUT: Duration = Duration::from_millis(500);
 
 /// `sign_aggregate_and_proofs` with empty input yields zero stream items.
 #[tokio::test(flavor = "multi_thread")]
 async fn sign_aggregate_and_proofs_empty_input() {
-    let committee = create_primary_committee_setup(SINGLE_VALIDATOR_COMMITTEE_COUNT);
+    let committee = create_primary_committee_setup(SINGLE_VALIDATOR_COUNT);
     let harness = ValidatorStoreTestHarness::new(vec![committee], OUR_OPERATOR_ID);
 
     let results: SignAggregatesResult = harness
@@ -31,13 +51,12 @@ async fn sign_aggregate_and_proofs_empty_input() {
 }
 
 /// `sign_aggregate_and_proofs` groups aggregates by `CommitteeId`, runs consensus once per
-/// committee, collects committee signatures for each validator, and streams one batch per
-/// committee.
+/// committee, collects one signature per validator, and streams one batch per committee.
 #[tokio::test(flavor = "multi_thread")]
 async fn sign_aggregate_and_proofs_produces_one_stream_item_per_committee() {
     // Arrange
     let committee_a = create_primary_committee_setup(PRIMARY_COMMITTEE_VALIDATOR_COUNT);
-    let committee_b = create_secondary_committee_setup(SINGLE_VALIDATOR_COMMITTEE_COUNT);
+    let committee_b = create_secondary_committee_setup(SINGLE_VALIDATOR_COUNT);
     assert_ne!(
         committee_a.cluster.committee_id(),
         committee_b.cluster.committee_id(),
@@ -69,48 +88,60 @@ async fn sign_aggregate_and_proofs_produces_one_stream_item_per_committee() {
         .map(|r| r.expect("each committee batch should succeed"))
         .collect();
     let total: usize = all_signed.iter().map(|batch| batch.len()).sum();
-    let expected_total = PRIMARY_COMMITTEE_VALIDATOR_COUNT + SINGLE_VALIDATOR_COMMITTEE_COUNT;
-    assert_eq!(total, expected_total, "expected {expected_total} total signed aggregates");
+    let expected_total = PRIMARY_COMMITTEE_VALIDATOR_COUNT + SINGLE_VALIDATOR_COUNT;
+    assert_eq!(
+        total, expected_total,
+        "expected {expected_total} total signed aggregates"
+    );
 
+    // We make one `sign_and_collect` call per validator.
+    // The committee requester stores the local batch size for that validator's committee:
+    // committee A has 2 validators, so it produces 2 calls, each with batch size 2;
+    // committee B has 1 validator, so it produces 1 call with batch size 1.
     let captured = harness.captured_calls.lock();
     assert_eq!(
         captured.len(),
         expected_total,
         "expected {expected_total} sign_and_collect calls"
     );
-    let mut requested_counts: Vec<_> = captured
+    let batch_sizes: Vec<_> = captured
         .iter()
         .map(|call| match &call.requester {
             SignatureRequester::Committee {
-                num_signatures_to_collect,
+                validator_partial_signature_batch_size,
                 ..
-            } => *num_signatures_to_collect,
+            } => *validator_partial_signature_batch_size,
             other => panic!("expected SignatureRequester::Committee, got: {other:?}"),
         })
         .collect();
-    requested_counts.sort_unstable();
-    // Each validator gets one sign_and_collect call. Committee A's validators each request
-    // `PRIMARY_COMMITTEE_VALIDATOR_COUNT` signatures, committee B's request
-    // `SINGLE_VALIDATOR_COMMITTEE_COUNT`. Sorted ascending:
-    let mut expected_counts = vec![
-        SINGLE_VALIDATOR_COMMITTEE_COUNT,
-        PRIMARY_COMMITTEE_VALIDATOR_COUNT,
-        PRIMARY_COMMITTEE_VALIDATOR_COUNT,
-    ];
-    expected_counts.sort_unstable();
+
+    let calls_with_batch_size = |batch_size: usize| {
+        batch_sizes
+            .iter()
+            .filter(|&&size| size == batch_size)
+            .count()
+    };
     assert_eq!(
-        requested_counts, expected_counts,
-        "expected committee requester counts to match validators per committee"
+        calls_with_batch_size(PRIMARY_COMMITTEE_VALIDATOR_COUNT),
+        PRIMARY_COMMITTEE_VALIDATOR_COUNT,
+        "committee A should make one call per validator, and each call should have batch size {}",
+        PRIMARY_COMMITTEE_VALIDATOR_COUNT,
+    );
+    assert_eq!(
+        calls_with_batch_size(SINGLE_VALIDATOR_COUNT),
+        SINGLE_VALIDATOR_COUNT,
+        "committee B should make one call for its only validator, and that call should have batch size {}",
+        SINGLE_VALIDATOR_COUNT,
     );
 }
 
-/// A committee blocked waiting for `AggregationAssignments` does not prevent another committee
-/// from producing its aggregate batch. Verifies the committee futures are isolated.
+/// One committee blocked on missing `AggregationAssignments` must not stop another committee from
+/// producing its aggregate batch. This verifies that committee futures stay isolated.
 #[tokio::test(flavor = "current_thread", start_paused = true)]
 async fn sign_aggregate_and_proofs_failure_isolation() {
     // Arrange
-    let committee_a = create_primary_committee_setup(SINGLE_VALIDATOR_COMMITTEE_COUNT);
-    let committee_b = create_secondary_committee_setup(SINGLE_VALIDATOR_COMMITTEE_COUNT);
+    let committee_a = create_primary_committee_setup(SINGLE_VALIDATOR_COUNT);
+    let committee_b = create_secondary_committee_setup(SINGLE_VALIDATOR_COUNT);
     let harness = ValidatorStoreTestHarness::new(vec![committee_a, committee_b], OUR_OPERATOR_ID);
     // Only the primary committee gets aggregate assignments for TEST_SLOT.
     harness.seed_aggregation_assignments_for_slot(TEST_SLOT, &[PRIMARY_COMMITTEE_INDEX]);
@@ -148,4 +179,20 @@ async fn sign_aggregate_and_proofs_failure_isolation() {
         second.is_err(),
         "stuck committee should not produce a result"
     );
+}
+
+fn create_primary_committee_setup(num_validators: usize) -> CommitteeSetup {
+    create_committee_setup(
+        &PRIMARY_COMMITTEE_OPERATOR_IDS,
+        num_validators,
+        PRIMARY_COMMITTEE_STARTING_VALIDATOR_INDEX,
+    )
+}
+
+fn create_secondary_committee_setup(num_validators: usize) -> CommitteeSetup {
+    create_committee_setup(
+        &SECONDARY_COMMITTEE_OPERATOR_IDS,
+        num_validators,
+        SECONDARY_COMMITTEE_STARTING_VALIDATOR_INDEX,
+    )
 }

--- a/anchor/validator_store/src/testing/committee_aggregate.rs
+++ b/anchor/validator_store/src/testing/committee_aggregate.rs
@@ -1,0 +1,120 @@
+//! Integration tests for the committee-batching aggregate path in `sign_aggregate_and_proofs()`.
+use std::time::Duration;
+
+use futures::StreamExt;
+use signature_collector::SignatureRequester;
+use ssv_types::OperatorId;
+use types::{MainnetEthSpec, SignedAggregateAndProof};
+use validator_store::ValidatorStore;
+
+use super::common::*;
+use crate::Error;
+
+type SignAggregatesResult = Vec<Result<Vec<SignedAggregateAndProof<MainnetEthSpec>>, Error>>;
+
+/// `sign_aggregate_and_proofs` groups aggregates by `CommitteeId`, runs consensus once per
+/// committee, collects committee signatures for each validator, and streams one batch per
+/// committee.
+#[tokio::test(flavor = "multi_thread")]
+async fn sign_aggregate_and_proofs_produces_one_stream_item_per_committee() {
+    // Arrange
+    let our_operator_id = OperatorId(1);
+    let committee_a = create_committee_setup(
+        &[OperatorId(1), OperatorId(2), OperatorId(3), OperatorId(4)],
+        2,
+        0,
+    );
+    let committee_b = create_committee_setup(
+        &[OperatorId(1), OperatorId(5), OperatorId(6), OperatorId(7)],
+        1,
+        100,
+    );
+    assert_ne!(
+        committee_a.cluster.committee_id(),
+        committee_b.cluster.committee_id(),
+    );
+    let harness = ValidatorStoreTestHarness::new(vec![committee_a, committee_b], our_operator_id);
+    harness.seed_aggregation_assignments_for_slot(TEST_SLOT, &[0, 1]);
+    let aggregates = vec![
+        harness.create_aggregate(0, 0),
+        harness.create_aggregate(0, 1),
+        harness.create_aggregate(1, 0),
+    ];
+
+    // Act
+    let results: SignAggregatesResult = harness
+        .validator_store
+        .sign_aggregate_and_proofs(aggregates)
+        .collect()
+        .await;
+
+    // Assert
+    assert_eq!(results.len(), 2, "expected one stream item per committee");
+    let all_signed: Vec<Vec<SignedAggregateAndProof<MainnetEthSpec>>> = results
+        .into_iter()
+        .map(|r| r.expect("each committee batch should succeed"))
+        .collect();
+    let total: usize = all_signed.iter().map(|batch| batch.len()).sum();
+    assert_eq!(total, 3, "expected 3 total signed aggregates");
+
+    let captured = harness.captured_calls.lock();
+    assert_eq!(captured.len(), 3, "expected 3 sign_and_collect calls");
+    let mut requested_counts: Vec<_> = captured
+        .iter()
+        .map(|call| match &call.requester {
+            SignatureRequester::Committee {
+                num_signatures_to_collect,
+                ..
+            } => *num_signatures_to_collect,
+            other => panic!("expected SignatureRequester::Committee, got: {other:?}"),
+        })
+        .collect();
+    requested_counts.sort_unstable();
+    assert_eq!(
+        requested_counts,
+        vec![1, 2, 2],
+        "expected committee requester counts to match aggregators per committee"
+    );
+}
+
+/// A committee blocked waiting for `AggregationAssignments` does not prevent another committee
+/// from producing its aggregate batch. Verifies the committee futures are isolated.
+#[tokio::test(flavor = "multi_thread")]
+async fn sign_aggregate_and_proofs_failure_isolation() {
+    // Arrange
+    let our_operator_id = OperatorId(1);
+    let committee_a = create_committee_setup(
+        &[OperatorId(1), OperatorId(2), OperatorId(3), OperatorId(4)],
+        1,
+        0,
+    );
+    let committee_b = create_committee_setup(
+        &[OperatorId(1), OperatorId(5), OperatorId(6), OperatorId(7)],
+        1,
+        100,
+    );
+    let harness = ValidatorStoreTestHarness::new(vec![committee_a, committee_b], our_operator_id);
+    harness.seed_aggregation_assignments_for_slot(TEST_SLOT, &[0]);
+    let aggregates = vec![
+        harness.create_aggregate(0, 0),
+        harness.create_aggregate_at_slot(1, 0, TEST_SLOT + 1),
+    ];
+
+    // Act
+    let stream = harness
+        .validator_store
+        .sign_aggregate_and_proofs(aggregates);
+    tokio::pin!(stream);
+    let first = tokio::time::timeout(Duration::from_secs(5), stream.next()).await;
+    let second = tokio::time::timeout(Duration::from_millis(500), stream.next()).await;
+
+    // Assert
+    let first_item = first
+        .expect("first committee should complete within timeout")
+        .expect("stream should yield an item");
+    assert!(first_item.is_ok());
+    assert!(
+        second.is_err(),
+        "stuck committee should not produce a result"
+    );
+}

--- a/anchor/validator_store/src/testing/committee_attestation.rs
+++ b/anchor/validator_store/src/testing/committee_attestation.rs
@@ -141,7 +141,12 @@ async fn sign_attestations_failure_isolation() {
     let first_item = first
         .expect("first committee should complete within timeout")
         .expect("stream should yield an item");
-    assert!(first_item.is_ok());
+    let signed = first_item.expect("first committee should succeed");
+    assert_eq!(
+        signed.len(),
+        1,
+        "successful committee should produce one signed item"
+    );
     assert!(
         second.is_err(),
         "stuck committee should not produce a result"

--- a/anchor/validator_store/src/testing/committee_attestation.rs
+++ b/anchor/validator_store/src/testing/committee_attestation.rs
@@ -141,12 +141,7 @@ async fn sign_attestations_failure_isolation() {
     let first_item = first
         .expect("first committee should complete within timeout")
         .expect("stream should yield an item");
-    let signed = first_item.expect("first committee should succeed");
-    assert_eq!(
-        signed.len(),
-        1,
-        "successful committee should produce one signed item"
-    );
+    assert!(first_item.is_ok());
     assert!(
         second.is_err(),
         "stuck committee should not produce a result"

--- a/anchor/validator_store/src/testing/common.rs
+++ b/anchor/validator_store/src/testing/common.rs
@@ -21,16 +21,20 @@ use ssv_types::{
     Cluster, ClusterId, ENCRYPTED_KEY_LENGTH, IndexSet, OperatorId, Share, ValidatorIndex,
     ValidatorMetadata, consensus::QbftDataValidator,
 };
+use ssz::Encode;
+use ssz_types::VariableList;
 use task_executor::TaskExecutor;
 use tempfile::TempDir;
 use tokio::sync::watch;
 use types::{
     Attestation, AttestationBase, AttestationData, ChainSpec, Checkpoint, Epoch, EthSpec, Graffiti,
-    Hash256, MainnetEthSpec, Slot,
+    Hash256, MainnetEthSpec, SelectionProof, Slot,
 };
+use validator_store::AggregateToSign;
 use validator_store::AttestationToSign;
 
-use crate::{AnchorValidatorStore, VotingAssignments, VotingContext};
+use crate::{AggregationAssignments, AnchorValidatorStore, VotingAssignments, VotingContext};
+use ssv_types::consensus::{AggregatorCommitteeConsensusData, AssignedAggregator, DataVersion};
 
 pub(super) const TEST_SLOT: u64 = 1;
 const SLOT_DURATION_SECS: u64 = 12;
@@ -318,6 +322,83 @@ impl ValidatorStoreTestHarness {
         });
     }
 
+    /// Seeds `AggregationAssignments` for the given committees at the provided slot.
+    ///
+    /// Each validator in the selected committee is treated as an attestation aggregator for a
+    /// single beacon committee index derived from the test committee position.
+    pub(super) fn seed_aggregation_assignments_for_slot(
+        &self,
+        slot: u64,
+        committee_indices: &[usize],
+    ) {
+        let mut aggregator_committees = HashMap::new();
+        let mut consensus_data_by_ssv_committee = HashMap::new();
+
+        for &committee_idx in committee_indices {
+            let setup = &self.committee_setups[committee_idx];
+            let beacon_committee_index = committee_idx as u64;
+
+            for validator in &setup.validators {
+                aggregator_committees.insert(validator.public_key, beacon_committee_index);
+            }
+
+            let aggregators: Vec<_> = setup
+                .validators
+                .iter()
+                .map(|validator| AssignedAggregator {
+                    validator_index: validator.index.expect("test validator should have index"),
+                    selection_proof: Signature::empty(),
+                    committee_index: beacon_committee_index,
+                })
+                .collect();
+
+            let aggregated_attestation = AttestationBase::<MainnetEthSpec> {
+                aggregation_bits: ssz_types::BitList::with_capacity(128)
+                    .expect("bitlist should be valid"),
+                data: AttestationData {
+                    slot: Slot::new(slot),
+                    index: beacon_committee_index,
+                    beacon_block_root: Hash256::zero(),
+                    source: Checkpoint {
+                        epoch: Epoch::new(0),
+                        root: Hash256::zero(),
+                    },
+                    target: Checkpoint {
+                        epoch: Epoch::new(0),
+                        root: Hash256::zero(),
+                    },
+                },
+                signature: AggregateSignature::infinity(),
+            };
+
+            let consensus_data = AggregatorCommitteeConsensusData::<MainnetEthSpec> {
+                version: DataVersion::from(types::ForkName::Deneb),
+                aggregators: VariableList::new(aggregators)
+                    .expect("aggregator list should be valid"),
+                aggregator_committee_indexes: VariableList::new(vec![beacon_committee_index])
+                    .expect("committee indexes should be valid"),
+                aggregated_attestations: VariableList::new(vec![
+                    VariableList::new(aggregated_attestation.as_ssz_bytes())
+                        .expect("attestation bytes should fit"),
+                ])
+                .expect("aggregated attestations should be valid"),
+                contributors: VariableList::empty(),
+                sync_committee_contributions: VariableList::empty(),
+            };
+
+            consensus_data_by_ssv_committee
+                .insert(setup.cluster.committee_id(), Arc::new(consensus_data));
+        }
+
+        self.validator_store
+            .update_aggregation_assignments(AggregationAssignments {
+                slot: Slot::new(slot),
+                aggregator_committees,
+                multi_sync_aggregators: HashMap::new(),
+                consensus_data_by_ssv_committee,
+            });
+    }
+
     pub(super) fn create_attestation(
         &self,
         committee_idx: usize,
@@ -359,6 +440,50 @@ impl ValidatorStoreTestHarness {
                 },
                 signature: AggregateSignature::infinity(),
             }),
+        }
+    }
+
+    pub(super) fn create_aggregate(
+        &self,
+        committee_idx: usize,
+        validator_idx: usize,
+    ) -> AggregateToSign<MainnetEthSpec> {
+        self.create_aggregate_at_slot(committee_idx, validator_idx, TEST_SLOT)
+    }
+
+    pub(super) fn create_aggregate_at_slot(
+        &self,
+        committee_idx: usize,
+        validator_idx: usize,
+        slot: u64,
+    ) -> AggregateToSign<MainnetEthSpec> {
+        let validator = &self.committee_setups[committee_idx].validators[validator_idx];
+        let validator_index = validator
+            .index
+            .expect("test validator should have an index");
+
+        AggregateToSign {
+            pubkey: validator.public_key,
+            aggregator_index: *validator_index as u64,
+            aggregate: Attestation::Base(AttestationBase {
+                aggregation_bits: ssz_types::BitList::with_capacity(128)
+                    .expect("bitlist should be valid"),
+                data: AttestationData {
+                    slot: Slot::new(slot),
+                    index: committee_idx as u64,
+                    beacon_block_root: Hash256::zero(),
+                    source: Checkpoint {
+                        epoch: Epoch::new(0),
+                        root: Hash256::zero(),
+                    },
+                    target: Checkpoint {
+                        epoch: Epoch::new(0),
+                        root: Hash256::zero(),
+                    },
+                },
+                signature: AggregateSignature::infinity(),
+            }),
+            selection_proof: SelectionProof::from(Signature::empty()),
         }
     }
 }

--- a/anchor/validator_store/src/testing/common.rs
+++ b/anchor/validator_store/src/testing/common.rs
@@ -19,7 +19,10 @@ use slashing_protection::SlashingDatabase;
 use slot_clock::{ManualSlotClock, SlotClock};
 use ssv_types::{
     Cluster, ClusterId, ENCRYPTED_KEY_LENGTH, IndexSet, OperatorId, Share, ValidatorIndex,
-    ValidatorMetadata, consensus::QbftDataValidator,
+    ValidatorMetadata,
+    consensus::{
+        AggregatorCommitteeConsensusData, AssignedAggregator, DataVersion, QbftDataValidator,
+    },
 };
 use ssz::Encode;
 use ssz_types::VariableList;
@@ -30,11 +33,9 @@ use types::{
     Attestation, AttestationBase, AttestationData, ChainSpec, Checkpoint, Epoch, EthSpec, Graffiti,
     Hash256, MainnetEthSpec, SelectionProof, Slot,
 };
-use validator_store::AggregateToSign;
-use validator_store::AttestationToSign;
+use validator_store::{AggregateToSign, AttestationToSign};
 
 use crate::{AggregationAssignments, AnchorValidatorStore, VotingAssignments, VotingContext};
-use ssv_types::consensus::{AggregatorCommitteeConsensusData, AssignedAggregator, DataVersion};
 
 pub(super) const TEST_SLOT: u64 = 1;
 const SLOT_DURATION_SECS: u64 = 12;

--- a/anchor/validator_store/src/testing/common.rs
+++ b/anchor/validator_store/src/testing/common.rs
@@ -38,7 +38,22 @@ use validator_store::{AggregateToSign, AttestationToSign};
 use crate::{AggregationAssignments, AnchorValidatorStore, VotingAssignments, VotingContext};
 
 pub(super) const TEST_SLOT: u64 = 1;
+pub(super) const NEXT_SLOT: u64 = TEST_SLOT + 1;
+pub(super) const OUR_OPERATOR_ID: OperatorId = OperatorId(1);
+pub(super) const PRIMARY_COMMITTEE_INDEX: usize = 0;
+pub(super) const SECONDARY_COMMITTEE_INDEX: usize = 1;
+pub(super) const FIRST_VALIDATOR_INDEX: usize = 0;
+pub(super) const SECOND_VALIDATOR_INDEX: usize = 1;
+pub(super) const STREAM_ITEM_TIMEOUT: Duration = Duration::from_secs(5);
+pub(super) const BLOCKED_STREAM_TIMEOUT: Duration = Duration::from_millis(500);
+
 const SLOT_DURATION_SECS: u64 = 12;
+const PRIMARY_COMMITTEE_OPERATOR_IDS: [OperatorId; 4] =
+    [OperatorId(1), OperatorId(2), OperatorId(3), OperatorId(4)];
+const SECONDARY_COMMITTEE_OPERATOR_IDS: [OperatorId; 4] =
+    [OperatorId(1), OperatorId(5), OperatorId(6), OperatorId(7)];
+const PRIMARY_COMMITTEE_STARTING_VALIDATOR_INDEX: usize = 0;
+const SECONDARY_COMMITTEE_STARTING_VALIDATOR_INDEX: usize = 100;
 
 // ==================== Mock consensus decider ====================
 
@@ -105,6 +120,12 @@ pub(super) struct CommitteeSetup {
     shares: Vec<Share>,
 }
 
+/// Builds a synthetic SSV committee for tests.
+///
+/// - `operator_ids`: committee members in the cluster.
+/// - `num_validators`: validators assigned to that SSV committee in the harness.
+/// - `starting_validator_index`: first validator index/public-key seed, used to keep committees
+///   distinct in tests.
 pub(super) fn create_committee_setup(
     operator_ids: &[OperatorId],
     num_validators: usize,
@@ -158,6 +179,22 @@ pub(super) fn create_committee_setup(
         validators,
         shares,
     }
+}
+
+pub(super) fn create_primary_committee_setup(num_validators: usize) -> CommitteeSetup {
+    create_committee_setup(
+        &PRIMARY_COMMITTEE_OPERATOR_IDS,
+        num_validators,
+        PRIMARY_COMMITTEE_STARTING_VALIDATOR_INDEX,
+    )
+}
+
+pub(super) fn create_secondary_committee_setup(num_validators: usize) -> CommitteeSetup {
+    create_committee_setup(
+        &SECONDARY_COMMITTEE_OPERATOR_IDS,
+        num_validators,
+        SECONDARY_COMMITTEE_STARTING_VALIDATOR_INDEX,
+    )
 }
 
 // ==================== Test harness ====================

--- a/anchor/validator_store/src/testing/common.rs
+++ b/anchor/validator_store/src/testing/common.rs
@@ -38,22 +38,7 @@ use validator_store::{AggregateToSign, AttestationToSign};
 use crate::{AggregationAssignments, AnchorValidatorStore, VotingAssignments, VotingContext};
 
 pub(super) const TEST_SLOT: u64 = 1;
-pub(super) const NEXT_SLOT: u64 = TEST_SLOT + 1;
-pub(super) const OUR_OPERATOR_ID: OperatorId = OperatorId(1);
-pub(super) const PRIMARY_COMMITTEE_INDEX: usize = 0;
-pub(super) const SECONDARY_COMMITTEE_INDEX: usize = 1;
-pub(super) const FIRST_VALIDATOR_INDEX: usize = 0;
-pub(super) const SECOND_VALIDATOR_INDEX: usize = 1;
-pub(super) const STREAM_ITEM_TIMEOUT: Duration = Duration::from_secs(5);
-pub(super) const BLOCKED_STREAM_TIMEOUT: Duration = Duration::from_millis(500);
-
 const SLOT_DURATION_SECS: u64 = 12;
-const PRIMARY_COMMITTEE_OPERATOR_IDS: [OperatorId; 4] =
-    [OperatorId(1), OperatorId(2), OperatorId(3), OperatorId(4)];
-const SECONDARY_COMMITTEE_OPERATOR_IDS: [OperatorId; 4] =
-    [OperatorId(1), OperatorId(5), OperatorId(6), OperatorId(7)];
-const PRIMARY_COMMITTEE_STARTING_VALIDATOR_INDEX: usize = 0;
-const SECONDARY_COMMITTEE_STARTING_VALIDATOR_INDEX: usize = 100;
 
 // ==================== Mock consensus decider ====================
 
@@ -120,12 +105,10 @@ pub(super) struct CommitteeSetup {
     shares: Vec<Share>,
 }
 
-/// Builds a synthetic SSV committee for tests.
+/// Builds a synthetic committee with deterministic validator and share data.
 ///
-/// - `operator_ids`: committee members in the cluster.
-/// - `num_validators`: validators assigned to that SSV committee in the harness.
-/// - `starting_validator_index`: first validator index/public-key seed, used to keep committees
-///   distinct in tests.
+/// `starting_validator_index` lets tests create distinct committees without repeating the full
+/// fixture setup inline.
 pub(super) fn create_committee_setup(
     operator_ids: &[OperatorId],
     num_validators: usize,
@@ -179,22 +162,6 @@ pub(super) fn create_committee_setup(
         validators,
         shares,
     }
-}
-
-pub(super) fn create_primary_committee_setup(num_validators: usize) -> CommitteeSetup {
-    create_committee_setup(
-        &PRIMARY_COMMITTEE_OPERATOR_IDS,
-        num_validators,
-        PRIMARY_COMMITTEE_STARTING_VALIDATOR_INDEX,
-    )
-}
-
-pub(super) fn create_secondary_committee_setup(num_validators: usize) -> CommitteeSetup {
-    create_committee_setup(
-        &SECONDARY_COMMITTEE_OPERATOR_IDS,
-        num_validators,
-        SECONDARY_COMMITTEE_STARTING_VALIDATOR_INDEX,
-    )
 }
 
 // ==================== Test harness ====================

--- a/anchor/validator_store/src/testing/mod.rs
+++ b/anchor/validator_store/src/testing/mod.rs
@@ -1,3 +1,4 @@
 mod common;
 
+mod committee_aggregate;
 mod committee_attestation;


### PR DESCRIPTION
Closes #886

## Problem, Evidence, and Context (Required)

- Addresses #886.
- `sign_aggregate_and_proofs` already has committee-path logic on `unstable`, but it was still missing focused integration coverage for the aggregate-specific cases:
  - multiple committees in one call
  - one `sign_and_collect` call per validator in the committee path
  - isolation when one committee is blocked waiting for aggregate assignments
- This rebased branch drops the stale attestation-side churn and keeps the PR focused on aggregate coverage only.

## Change Overview (Required)

- Adds a dedicated aggregate committee integration test module.
- Extends the shared `validator_store` test harness only where the aggregate test needs it: seeding `AggregationAssignments` and building aggregate fixtures for specific committees and slots.
- Keeps the scenario-specific committee setup and the batch-size assertions in `committee_aggregate.rs`, so reviewers do not need to decode shared constants in `common.rs`.
- Makes the committee-path assertion explicit: we expect one `sign_and_collect` call per validator, and the requester's batch size should match that validator's committee size.
- Intentionally unchanged: production aggregate signing logic and runtime behavior.

## Risks, Trade-offs, and Mitigations (Required)

- Risk is low because this is test-only coverage.
- The shared harness grows slightly, but only with aggregate-specific helpers that are reused directly by the new test.
- No production code paths, configuration, or runtime behavior changed.

## Validation (Required)

- `cargo fmt --all --check`
- `cargo test -p anchor_validator_store committee_ -- --nocapture`
- `cargo clippy -p anchor_validator_store --all-targets -- -D warnings`
- The commit hook also ran `cargo fmt --all`, `cargo clippy --all`, and `cargo sort workspace`.

## Rollback (Required for behavior or runtime changes; optional otherwise)

- Revert this PR.
- No config, data, or operational impact.

## Blockers / Dependencies (Optional)

- N/A

## Additional Info / Next Steps (Optional)

- Reviewer reading order: start with `committee_aggregate.rs`, then open the new aggregate helpers in `common.rs` if needed.
