### PR TITLE
feat: add share pubkey queries

### DIFF
--- a/anchor/database/src/share_operations.rs
+++ b/anchor/database/src/share_operations.rs
@@ -36,19 +36,7 @@ impl NetworkDatabase {
         let conn = self.connection()?;
         let mut stmt = conn.prepare(sql_operations::GET_SHARE_PUBKEYS_FOR_VALIDATOR)?;
         let mut rows = stmt.query(params![validator_pubkey.to_string()])?;
-
-        let mut result = HashMap::new();
-        while let Some(row) = rows.next()? {
-            let operator_id: u64 = row.get(0)?;
-            let share_pubkey_str: String = row.get(1)?;
-            let share_pubkey = PublicKeyBytes::from_str(&share_pubkey_str).map_err(|e| {
-                DatabaseError::SQLError(format!(
-                    "Invalid share pubkey for operator {operator_id}: {e}"
-                ))
-            })?;
-            result.insert(OperatorId(operator_id), share_pubkey);
-        }
-        Ok(result)
+        Self::collect_share_pubkeys(&mut rows)
     }
 
     /// Fetch all operator share public keys for a given validator index.
@@ -59,7 +47,13 @@ impl NetworkDatabase {
         let conn = self.connection()?;
         let mut stmt = conn.prepare(sql_operations::GET_SHARE_PUBKEYS_FOR_VALIDATOR_INDEX)?;
         let mut rows = stmt.query(params![validator_index])?;
+        Self::collect_share_pubkeys(&mut rows)
+    }
 
+    /// Decode rows of `(operator_id, share_pubkey)` into a map.
+    fn collect_share_pubkeys(
+        rows: &mut rusqlite::Rows<'_>,
+    ) -> Result<HashMap<OperatorId, PublicKeyBytes>, DatabaseError> {
         let mut result = HashMap::new();
         while let Some(row) = rows.next()? {
             let operator_id: u64 = row.get(0)?;

--- a/anchor/database/src/share_operations.rs
+++ b/anchor/database/src/share_operations.rs
@@ -58,7 +58,6 @@ impl NetworkDatabase {
     ) -> Result<HashMap<OperatorId, PublicKeyBytes>, DatabaseError> {
         let conn = self.connection()?;
         let mut stmt = conn.prepare(sql_operations::GET_SHARE_PUBKEYS_FOR_VALIDATOR_INDEX)?;
-        let validator_index: u64 = validator_index.into();
         let mut rows = stmt.query(params![validator_index])?;
 
         let mut result = HashMap::new();

--- a/anchor/database/src/share_operations.rs
+++ b/anchor/database/src/share_operations.rs
@@ -1,6 +1,8 @@
+use std::{collections::HashMap, str::FromStr};
+
 use bls::PublicKeyBytes;
 use rusqlite::{Transaction, params};
-use ssv_types::Share;
+use ssv_types::{OperatorId, Share};
 
 use super::{DatabaseError, NetworkDatabase, sql_operations};
 
@@ -21,5 +23,55 @@ impl NetworkDatabase {
                 share.encrypted_private_key
             ])?;
         Ok(())
+    }
+
+    /// Fetch all operator share public keys for a given validator.
+    ///
+    /// Returns a map from `OperatorId` to the operator's BLS share public key.
+    /// Used during signature reconstruction to verify individual shares.
+    pub fn get_share_pubkeys_for_validator(
+        &self,
+        validator_pubkey: &PublicKeyBytes,
+    ) -> Result<HashMap<OperatorId, PublicKeyBytes>, DatabaseError> {
+        let conn = self.connection()?;
+        let mut stmt = conn.prepare(sql_operations::GET_SHARE_PUBKEYS_FOR_VALIDATOR)?;
+        let mut rows = stmt.query(params![validator_pubkey.to_string()])?;
+
+        let mut result = HashMap::new();
+        while let Some(row) = rows.next()? {
+            let operator_id: u64 = row.get(0)?;
+            let share_pubkey_str: String = row.get(1)?;
+            let share_pubkey = PublicKeyBytes::from_str(&share_pubkey_str).map_err(|e| {
+                DatabaseError::SQLError(format!(
+                    "Invalid share pubkey for operator {operator_id}: {e}"
+                ))
+            })?;
+            result.insert(OperatorId(operator_id), share_pubkey);
+        }
+        Ok(result)
+    }
+
+    /// Fetch all operator share public keys for a given validator index.
+    pub fn get_share_pubkeys_for_validator_index(
+        &self,
+        validator_index: ssv_types::ValidatorIndex,
+    ) -> Result<HashMap<OperatorId, PublicKeyBytes>, DatabaseError> {
+        let conn = self.connection()?;
+        let mut stmt = conn.prepare(sql_operations::GET_SHARE_PUBKEYS_FOR_VALIDATOR_INDEX)?;
+        let validator_index: u64 = validator_index.into();
+        let mut rows = stmt.query(params![validator_index])?;
+
+        let mut result = HashMap::new();
+        while let Some(row) = rows.next()? {
+            let operator_id: u64 = row.get(0)?;
+            let share_pubkey_str: String = row.get(1)?;
+            let share_pubkey = PublicKeyBytes::from_str(&share_pubkey_str).map_err(|e| {
+                DatabaseError::SQLError(format!(
+                    "Invalid share pubkey for operator {operator_id}: {e}"
+                ))
+            })?;
+            result.insert(OperatorId(operator_id), share_pubkey);
+        }
+        Ok(result)
     }
 }

--- a/anchor/database/src/sql_operations.rs
+++ b/anchor/database/src/sql_operations.rs
@@ -88,6 +88,16 @@ pub const GET_SHARES: &str = r#"
     SELECT share_pubkey, encrypted_key, operator_id, cluster_id, validator_pubkey
     FROM shares WHERE operator_id = ?1
 "#;
+pub const GET_SHARE_PUBKEYS_FOR_VALIDATOR: &str = r#"
+    SELECT operator_id, share_pubkey
+    FROM shares WHERE validator_pubkey = ?1
+"#;
+pub const GET_SHARE_PUBKEYS_FOR_VALIDATOR_INDEX: &str = r#"
+    SELECT s.operator_id, s.share_pubkey
+    FROM shares s
+    JOIN validators v ON v.validator_pubkey = s.validator_pubkey
+    WHERE v.validator_index = ?1
+"#;
 pub const GET_OWN_SHARE: &str = r#"
     SELECT 1
     FROM shares

--- a/anchor/database/src/tests/mod.rs
+++ b/anchor/database/src/tests/mod.rs
@@ -5,6 +5,8 @@ mod metadata_tests;
 #[cfg(test)]
 mod operator_tests;
 #[cfg(test)]
+mod share_tests;
+#[cfg(test)]
 mod state_tests;
 #[cfg(test)]
 mod validator_tests;

--- a/anchor/database/src/tests/share_tests.rs
+++ b/anchor/database/src/tests/share_tests.rs
@@ -1,0 +1,69 @@
+#[cfg(test)]
+mod share_pubkey_tests {
+    use std::collections::HashMap;
+
+    use bls::PublicKeyBytes;
+    use ssv_types::{OperatorId, ValidatorIndex};
+
+    use crate::test_utils::{InMemoryTestFixture, generators};
+
+    /// Index well outside the fixture's random range (0..100)
+    const NON_EXISTENT_VALIDATOR_INDEX: ValidatorIndex = ValidatorIndex(999_999);
+
+    fn assert_share_pubkeys(
+        result: &HashMap<OperatorId, PublicKeyBytes>,
+        fixture: &InMemoryTestFixture,
+    ) {
+        assert_eq!(result.len(), fixture.shares.len());
+        for share in &fixture.shares {
+            let pubkey = result
+                .get(&share.operator_id)
+                .expect("operator should be present in result");
+            assert_eq!(*pubkey, share.share_pubkey);
+        }
+    }
+
+    #[test]
+    fn test_get_share_pubkeys() {
+        // Arrange
+        let fixture = InMemoryTestFixture::new();
+        let validator_index = fixture
+            .validator
+            .index
+            .expect("fixture validator should have an index");
+
+        // Act
+        let by_pubkey = fixture
+            .db
+            .get_share_pubkeys_for_validator(&fixture.validator.public_key)
+            .expect("query by pubkey should succeed");
+        let by_index = fixture
+            .db
+            .get_share_pubkeys_for_validator_index(validator_index)
+            .expect("query by index should succeed");
+
+        // Assert
+        assert_share_pubkeys(&by_pubkey, &fixture);
+        assert_share_pubkeys(&by_index, &fixture);
+    }
+
+    #[test]
+    fn test_get_share_pubkeys_empty() {
+        // Arrange
+        let fixture = InMemoryTestFixture::new_empty();
+
+        // Act
+        let by_pubkey = fixture
+            .db
+            .get_share_pubkeys_for_validator(&generators::pubkey::random())
+            .expect("query by pubkey should succeed on empty db");
+        let by_index = fixture
+            .db
+            .get_share_pubkeys_for_validator_index(NON_EXISTENT_VALIDATOR_INDEX)
+            .expect("query by index should succeed on empty db");
+
+        // Assert
+        assert!(by_pubkey.is_empty());
+        assert!(by_index.is_empty());
+    }
+}


### PR DESCRIPTION
## Problem, Evidence, and Context

- PR #890 was flagged for splitting into a 3-PR stack per [review comment](https://github.com/sigp/anchor/pull/890#issuecomment-4118041676)
- This is PR 1/3: adds DB queries needed by the signature verification and duplicate resolution features in PRs 2 and 3
- Tracking issue: #931, sub-issue: #932

## Change Overview

- Two new SQL constants in `sql_operations.rs`: `GET_SHARE_PUBKEYS_FOR_VALIDATOR` and `GET_SHARE_PUBKEYS_FOR_VALIDATOR_INDEX`
- Two new query methods in `share_operations.rs`: `get_share_pubkeys_for_validator()` and `get_share_pubkeys_for_validator_index()`
- Pure data layer additions — no behavior change, no new callers yet (consumers arrive in PRs 2 and 3)

## Risks, Trade-offs, and Mitigations

- Minimal risk — new queries only, no existing code modified
- Queries have no callers until PR 2 lands; shipping them first keeps each PR small and independently reviewable

## Validation

- Existing test suite passes (no behavior change)
- Queries follow established patterns in `share_operations.rs`

## Rollback

N/A — pure additive, no runtime impact.

## Blockers / Dependencies

- None — can merge independently

## Additional Info / Next Steps

- PR 2 (#933): post-reconstruction signature verification with fallback
- PR 3 (#934): duplicate signature resolution