### PR TITLE
refactor: rename committee batch-size field

### DIFF
--- a/anchor/signature_collector/src/lib.rs
+++ b/anchor/signature_collector/src/lib.rs
@@ -63,10 +63,11 @@ struct SignatureCollector {
     for_slot: Slot,
 }
 
-/// Outgoing partial signature messages that collected for a committee
-/// As soon as the partial signature for every validator in the committee is ready, it is sent.
-struct CommitteeSignatures {
-    collected_signatures: Vec<PartialSignatureMessage>,
+/// Locally accumulated validator partial signatures for one outgoing committee message.
+/// As soon as this operator has produced the full validator batch for the committee round, the
+/// message is sent.
+struct CommitteePartialSignatureBatch {
+    batched_validator_partial_signatures: Vec<PartialSignatureMessage>,
     for_slot: Slot,
 }
 
@@ -85,10 +86,11 @@ pub struct SignatureCollectorManager<S: SlotClock> {
     message_sender: Arc<dyn MessageSender>,
     /// A map from the signing root and signing validator to the corresponding signature collector.
     signature_collectors: DashMap<(Hash256, ValidatorIndex), SignatureCollector>,
-    /// A map from a hash of an underlying decided committee value and committee id to a container
-    /// for all partial signatures based on that value for the committee.
+    /// A map from the hash of a decided committee value and committee ID to the local batch of
+    /// validator partial signatures for that committee round.
     /// Note that this hash may differ from the actual signing root.
-    committee_signatures: DashMap<(Hash256, CommitteeId), CommitteeSignatures>,
+    committee_partial_signature_batches:
+        DashMap<(Hash256, CommitteeId), CommitteePartialSignatureBatch>,
 }
 
 impl<S: SlotClock + Clone + 'static> SignatureCollectorManager<S> {
@@ -108,7 +110,7 @@ impl<S: SlotClock + Clone + 'static> SignatureCollectorManager<S> {
             slots_per_epoch,
             message_sender,
             signature_collectors: DashMap::new(),
-            committee_signatures: DashMap::new(),
+            committee_partial_signature_batches: DashMap::new(),
         });
 
         manager
@@ -216,36 +218,43 @@ impl<S: SlotClock + Clone + 'static> SignatureCollectorManager<S> {
                         }
                     }
                     SignatureRequester::Committee {
-                        num_signatures_to_collect,
+                        validator_partial_signature_batch_size,
                         base_hash,
                     } => {
-                        // We have to collect all signatures from the given validators.
-                        // To check this create or get an entry from the `committee_signatures` map.
+                        // Batch one locally produced partial signature per validator before
+                        // sending a single committee message for this round.
                         let mut entry = match manager
-                            .committee_signatures
+                            .committee_partial_signature_batches
                             .entry((base_hash, metadata.committee_id))
                         {
                             Entry::Occupied(occupied) => occupied,
-                            Entry::Vacant(vacant) => vacant.insert_entry(CommitteeSignatures {
-                                collected_signatures: Vec::with_capacity(num_signatures_to_collect),
+                            Entry::Vacant(vacant) => vacant.insert_entry(CommitteePartialSignatureBatch {
+                                batched_validator_partial_signatures: Vec::with_capacity(
+                                    validator_partial_signature_batch_size,
+                                ),
                                 for_slot: metadata.slot,
                             }),
                         };
-                        let collected_signatures = &mut entry.get_mut().collected_signatures;
+                        let validator_partial_signature_batch =
+                            &mut entry.get_mut().batched_validator_partial_signatures;
 
-                        // Enter the signature we just signed for this validator.
-                        collected_signatures.push(message.clone());
+                        // Add the partial signature we just produced for this validator to the
+                        // local batch.
+                        validator_partial_signature_batch.push(message.clone());
 
                         trace!(
-                            have = collected_signatures.len(),
-                            need = num_signatures_to_collect,
-                            "Checking if we have all signatures to send"
+                            have = validator_partial_signature_batch.len(),
+                            need = validator_partial_signature_batch_size,
+                            "Checking whether the batch of validator partial signatures is ready to send"
                         );
 
-                        // If we collected the correct number of signatures, create and sign the
-                        // final message.
-                        if collected_signatures.len() == num_signatures_to_collect {
-                            let signatures = entry.remove().collected_signatures;
+                        // Once the local batch of validator partial signatures is complete,
+                        // create and send the committee message.
+                        if validator_partial_signature_batch.len()
+                            == validator_partial_signature_batch_size
+                        {
+                            let signatures =
+                                entry.remove().batched_validator_partial_signatures;
 
                             let msg = match manager.create_message(
                                 &metadata,
@@ -413,8 +422,8 @@ impl<S: SlotClock + Clone + 'static> SignatureCollectorManager<S> {
             let cutoff = slot.saturating_sub(SIGNATURE_COLLECTOR_RETAIN_SLOTS);
             self.signature_collectors
                 .retain(|_, collector| collector.for_slot >= cutoff);
-            self.committee_signatures
-                .retain(|_, signatures| signatures.for_slot >= cutoff);
+            self.committee_partial_signature_batches
+                .retain(|_, batch| batch.for_slot >= cutoff);
         }
     }
 }
@@ -426,7 +435,14 @@ pub struct SignatureMetadata {
     pub kind: PartialSignatureKind,
     /// The role to transmit. Only needed for the network message we send.
     pub role: Role,
-    /// The signature threshold amount after which we can reconstruct the full signature.
+    /// The threshold of operator shares used by the per-validator reconstruction collector.
+    /// Once partial signatures from this many operators have arrived over the network, the full
+    /// validator signature can be reconstructed.
+    ///
+    /// This is distinct from
+    /// `SignatureRequester::Committee::validator_partial_signature_batch_size`, which only
+    /// controls how many validator partial signatures this operator batches locally before sending
+    /// its own committee message.
     pub threshold: u64,
     /// The slot relevant for this signature. The collector instance is cleaned up one slot after
     /// this. Also used in the network message.
@@ -435,8 +451,8 @@ pub struct SignatureMetadata {
     pub committee_id: CommitteeId,
 }
 
-/// Who is signing this - only a single validator, or potentially multiple validators in a
-/// committee? This is relevant because we send only one message in the latter case.
+/// Describes whether this request signs for a single validator or for multiple validators in a
+/// committee. This matters because the committee case sends one message for the whole batch.
 #[derive(Debug, Clone)]
 pub enum SignatureRequester {
     /// The only validator signing this is the one passed when `sign_and_collect` is called.
@@ -444,14 +460,19 @@ pub enum SignatureRequester {
         /// The public key of the validator. Used in the created network message.
         pubkey: PublicKeyBytes,
     },
-    /// We need to wait for all these validators to submit their signature until we can send.
+    /// The local operator is signing for multiple validators in one committee round.
+    /// We batch those validator partial signatures into a single outgoing committee message instead
+    /// of sending one message per validator.
     Committee {
-        /// The number of signatures we have to wait for.
-        num_signatures_to_collect: usize,
-        /// A hash that identifies what we are signing. We wait with sending the message until we
-        /// have created enough signatures with this `base_hash`. We need this to differentiate
-        /// "groups" of signatures. We cannot use the signing root, as we need to group signatures
-        /// with differing signing roots.
+        /// How many validator partial signatures this operator must produce locally before sending
+        /// the batched committee message.
+        ///
+        /// This is a local batching count, not the network reconstruction threshold from
+        /// `SignatureMetadata::threshold`.
+        validator_partial_signature_batch_size: usize,
+        /// Identifies which partial signatures belong in the same outgoing committee message.
+        /// We cannot use the signing root because the batched signatures may have different
+        /// signing roots.
         base_hash: Hash256,
     },
 }

--- a/anchor/validator_store/src/lib.rs
+++ b/anchor/validator_store/src/lib.rs
@@ -322,19 +322,22 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> AnchorValidator
 
     /// Collect committee signatures for a batch of signing requests.
     ///
-    /// Shared across all `sign_committee_*` methods. Builds `CollectionMode::Committee`,
-    /// fans out `collect_signature` calls concurrently, and returns the collected signatures.
+    /// Shared across all `sign_committee_*` methods. It builds `CollectionMode::Committee`,
+    /// runs `collect_signature` concurrently for each validator, and returns the signatures.
+    /// The `validator_partial_signature_batch_size` parameter is the number of validator partial
+    /// signatures this operator puts into one outgoing committee message. It is not the threshold
+    /// for reconstructing a signature from other operators' shares.
     async fn collect_prepared_signatures<D>(
         &self,
         role: Role,
         slot: Slot,
         cluster: &Cluster,
-        num_signatures_to_collect: usize,
+        validator_partial_signature_batch_size: usize,
         data_hash: Hash256,
         prepared: &[SigningRequest<D>],
     ) -> Result<HashMap<ValidatorIndex, Signature>, Error> {
         let collection_mode = CollectionMode::Committee {
-            num_signatures_to_collect,
+            validator_partial_signature_batch_size,
             base_hash: data_hash,
         };
 
@@ -467,10 +470,10 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> AnchorValidator
                     pubkey: validator.public_key,
                 },
                 CollectionMode::Committee {
-                    num_signatures_to_collect,
+                    validator_partial_signature_batch_size,
                     base_hash,
                 } => SignatureRequester::Committee {
-                    num_signatures_to_collect,
+                    validator_partial_signature_batch_size,
                     base_hash,
                 },
             };
@@ -1276,11 +1279,11 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> AnchorValidator
         // roots, which `collect_prepared_signatures` cannot handle (it deduplicates by
         // `ValidatorIndex`).
         let committee_validator_indices = self.get_committee_validator_indices(&committee_id);
-        let num_signatures_to_collect = decided_data
+        let validator_partial_signature_batch_size = decided_data
             .post_consensus_signature_count(|idx| committee_validator_indices.contains(idx));
         let data_hash = decided_data.hash();
         let collection_mode = CollectionMode::Committee {
-            num_signatures_to_collect,
+            validator_partial_signature_batch_size,
             base_hash: data_hash,
         };
 
@@ -1402,7 +1405,7 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> AnchorValidator
 
         // Collect signatures and assemble results
         let committee_validator_indices = self.get_committee_validator_indices(&committee_id);
-        let num_signatures_to_collect = voting_context
+        let validator_partial_signature_batch_size = voting_context
             .voting_assignments
             .voting_message_count_for_committee(|idx| committee_validator_indices.contains(idx));
 
@@ -1411,7 +1414,7 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> AnchorValidator
                 Role::Committee,
                 slot,
                 &cluster,
-                num_signatures_to_collect,
+                validator_partial_signature_batch_size,
                 data.hash(),
                 &prepared,
             )
@@ -1526,7 +1529,7 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> AnchorValidator
 
         // Collect signatures and assemble results
         let committee_validator_indices = self.get_committee_validator_indices(&committee_id);
-        let num_signatures_to_collect = voting_context_tx
+        let validator_partial_signature_batch_size = voting_context_tx
             .voting_assignments
             .voting_message_count_for_committee(|idx| committee_validator_indices.contains(idx));
 
@@ -1535,7 +1538,7 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> AnchorValidator
                 Role::Committee,
                 slot,
                 &cluster,
-                num_signatures_to_collect,
+                validator_partial_signature_batch_size,
                 data.hash(),
                 &prepared,
             )
@@ -1679,7 +1682,7 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> AnchorValidator
 
         // Collect signatures and assemble results
         let committee_validator_indices = self.get_committee_validator_indices(&committee_id);
-        let num_signatures_to_collect = decided_data
+        let validator_partial_signature_batch_size = decided_data
             .post_consensus_signature_count(|idx| committee_validator_indices.contains(idx));
 
         let signatures = self
@@ -1687,7 +1690,7 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> AnchorValidator
                 Role::AggregatorCommittee,
                 slot,
                 &cluster,
-                num_signatures_to_collect,
+                validator_partial_signature_batch_size,
                 decided_data.hash(),
                 &prepared,
             )
@@ -2072,7 +2075,11 @@ pub struct ContributionAndProofSigningData<E: EthSpec> {
 enum CollectionMode {
     SingleValidator,
     Committee {
-        num_signatures_to_collect: usize,
+        /// The number of validator partial signatures this operator batches locally into the
+        /// outgoing committee message for the round.
+        validator_partial_signature_batch_size: usize,
+        /// Identifies which validator partial signatures belong in the same outgoing committee
+        /// message.
         base_hash: Hash256,
     },
 }
@@ -2496,19 +2503,18 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> ValidatorStore
             let signing_root = slot.signing_root(domain_hash);
             let (validator, cluster) = self.get_validator_and_cluster(validator_pubkey)?;
 
-            // We do not want to spend too long on the selection proof. We will not produce an
-            // aggregation anyway if the proof is not known at 2/3rds into the slot - so we abort
-            // then.
+            // Stop at two thirds of the slot. If the selection proof is not ready by then, we
+            // will not produce an aggregation anyway.
             let delay = Duration::from_secs(self.spec.seconds_per_slot) * 2 / 3;
 
             let signature = if self.fork_schedule.active_fork(epoch) >= Fork::Boole {
                 let committee_id = cluster.committee_id();
                 let voting_assignments = self.get_voting_assignments(slot).await?;
 
-                // Defensive check: validator should be in `VotingAssignments` since both this
-                // function call and `VotingAssignments` are derived from `DutiesService`. If not,
-                // there's an inconsistency (e.g., stale cache after poll timeout) and we
-                // should not participate with a wrong `num_signatures_to_collect`.
+                // Defensive check: the validator should be present in `VotingAssignments` because
+                // both this call and `VotingAssignments` come from `DutiesService`. If not, we
+                // have an inconsistency, for example a stale cache after a poll timeout, and
+                // should not participate with the wrong batch size.
                 if !voting_assignments
                     .attesting_committees
                     .contains_key(&validator_pubkey)
@@ -2526,15 +2532,14 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> ValidatorStore
                 let committee_validator_indices =
                     self.get_committee_validator_indices(&committee_id);
 
-                // Calculate how many selection proofs to collect using the selection proof counting
-                // method.
-                let num_signatures_to_collect = voting_assignments
+                // Count how many selection-proof partial signatures belong in this batch.
+                let validator_partial_signature_batch_size = voting_assignments
                     .selection_proof_count_for_committee(|idx| {
                         committee_validator_indices.contains(idx)
                     });
 
-                // Compute deterministic `base_hash` for batching (same across all operators in a
-                // committee)
+                // Compute a deterministic batch ID. Every operator in the committee must derive
+                // the same `base_hash`.
                 let batch_id = SelectionProofBatchId::new(slot, committee_id);
                 let base_hash = batch_id.hash();
 
@@ -2545,7 +2550,7 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> ValidatorStore
                 );
 
                 let collection_mode = CollectionMode::Committee {
-                    num_signatures_to_collect,
+                    validator_partial_signature_batch_size,
                     base_hash,
                 };
 
@@ -2564,7 +2569,7 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> ValidatorStore
                 )
                 .await?
             } else {
-                // Single validator collection (original behavior)
+                // Use the original single-validator path.
                 self.timeout_within_slot(
                     slot,
                     delay,
@@ -2608,20 +2613,20 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> ValidatorStore
             .signing_root(domain_hash);
             let (validator, cluster) = self.get_validator_and_cluster(*validator_pubkey)?;
 
-            // We do not want to spend too long on the selection proof. We will not produce an
-            // aggregation anyway if the proof is not known at 2/3rds into the slot - so we abort
-            // then.
+            // Stop at two thirds of the slot. If the selection proof is not ready by then, we
+            // will not produce an aggregation anyway.
             let delay = Duration::from_secs(self.spec.seconds_per_slot) * 2 / 3;
 
             let signature = if self.fork_schedule.active_fork(epoch) >= Fork::Boole {
-                // Boole fork: Committee-based batching (batches with attestation selection proofs)
+                // Under Boole, sync selection proofs use the same committee path as attestation
+                // selection proofs.
                 let committee_id = cluster.committee_id();
                 let voting_assignments = self.get_voting_assignments(slot).await?;
 
-                // Defensive check: validator should be in `VotingAssignments` since both this
-                // function call and `VotingAssignments` are derived from `DutiesService`. If not,
-                // there's an inconsistency (e.g., stale cache after poll timeout) and we
-                // should not participate with a wrong `num_signatures_to_collect`.
+                // Defensive check: the validator should be present in `VotingAssignments` because
+                // both this call and `VotingAssignments` come from `DutiesService`. If not, we
+                // have an inconsistency, for example a stale cache after a poll timeout, and
+                // should not participate with the wrong batch size.
                 let validator_index = validator.index.ok_or(SpecificError::MissingIndex)?;
                 if !voting_assignments
                     .sync_validators_by_subnet
@@ -2640,16 +2645,14 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> ValidatorStore
                 let committee_validator_indices =
                     self.get_committee_validator_indices(&committee_id);
 
-                // Calculate how many selection proofs to collect using the selection proof counting
-                // method.
-                let num_signatures_to_collect = voting_assignments
+                // Count how many selection-proof partial signatures belong in this batch.
+                let validator_partial_signature_batch_size = voting_assignments
                     .selection_proof_count_for_committee(|idx| {
                         committee_validator_indices.contains(idx)
                     });
 
-                // Compute deterministic `base_hash` for batching (SAME as attestation selection
-                // proofs). This ensures all selection proofs (attestation + sync) batch together
-                // into one P2P message per committee.
+                // Use the same deterministic batch ID as attestation selection proofs so both
+                // attestation and sync selection proofs are sent in one committee message.
                 let batch_id = SelectionProofBatchId::new(slot, committee_id);
                 let base_hash = batch_id.hash();
 
@@ -2661,7 +2664,7 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> ValidatorStore
                 );
 
                 let collection_mode = CollectionMode::Committee {
-                    num_signatures_to_collect,
+                    validator_partial_signature_batch_size,
                     base_hash,
                 };
 
@@ -2680,7 +2683,7 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> ValidatorStore
                 )
                 .await?
             } else {
-                // Single-validator collection (original behavior)
+                // Use the original single-validator path.
                 self.timeout_within_slot(
                     slot,
                     delay,

--- a/anchor/validator_store/src/testing/committee_attestation.rs
+++ b/anchor/validator_store/src/testing/committee_attestation.rs
@@ -1,4 +1,4 @@
-//! Integration tests for the committee-batching attestation path in `sign_attestations()`.
+//! Integration tests for the committee attestation path in `sign_attestations()`.
 use std::time::Duration;
 
 use futures::StreamExt;
@@ -11,9 +11,11 @@ use super::common::*;
 use crate::Error;
 
 type SignAttestationsResult = Vec<Result<Vec<(u64, Attestation<MainnetEthSpec>)>, Error>>;
+const PRIMARY_COMMITTEE_VALIDATOR_COUNT: usize = 2;
+const SINGLE_VALIDATOR_COMMITTEE_VALIDATOR_COUNT: usize = 1;
 
 /// `sign_attestations` groups attestations by `CommitteeId`, runs consensus once per committee,
-/// collects signatures for each validator, and streams one batch of signed attestations per
+/// collects one signature per validator, and streams one batch of signed attestations per
 /// committee.
 #[tokio::test(flavor = "multi_thread")]
 async fn sign_attestations_produces_one_stream_item_per_committee() {
@@ -21,12 +23,12 @@ async fn sign_attestations_produces_one_stream_item_per_committee() {
     let our_operator_id = OperatorId(1);
     let committee_a = create_committee_setup(
         &[OperatorId(1), OperatorId(2), OperatorId(3), OperatorId(4)],
-        2,
+        PRIMARY_COMMITTEE_VALIDATOR_COUNT,
         0,
     );
     let committee_b = create_committee_setup(
         &[OperatorId(1), OperatorId(5), OperatorId(6), OperatorId(7)],
-        1,
+        SINGLE_VALIDATOR_COMMITTEE_VALIDATOR_COUNT,
         100,
     );
     // Precondition: committees must have distinct IDs for the test to be meaningful
@@ -49,40 +51,63 @@ async fn sign_attestations_produces_one_stream_item_per_committee() {
         .collect()
         .await;
 
-    // Assert — 2 stream items (one per committee), 3 total signed attestations
+    // Assert: 2 stream items, one per committee, and 3 signed attestations in total.
     assert_eq!(results.len(), 2, "expected one stream item per committee");
     let all_signed: Vec<_> = results
         .into_iter()
         .map(|r| r.expect("each committee batch should succeed"))
         .collect();
     let total: usize = all_signed.iter().map(|batch| batch.len()).sum();
-    assert_eq!(total, 3, "expected 3 total signed attestations");
+    let expected_total =
+        PRIMARY_COMMITTEE_VALIDATOR_COUNT + SINGLE_VALIDATOR_COMMITTEE_VALIDATOR_COUNT;
+    assert_eq!(
+        total, expected_total,
+        "expected {expected_total} total signed attestations"
+    );
 
-    // Verify the mock signature collector was called via the committee path with the expected
-    // per-committee request counts. In this harness all validators are attesters and there are no
-    // sync committee duties, so the expected counts are the number of validators per committee.
+    // We make one `sign_and_collect` call per validator.
+    // The committee requester carries the batch size for that validator's committee:
+    // committee A has 2 validators, so it produces 2 calls, each with a batch size of 2;
+    // committee B has 1 validator, so it produces 1 call with a batch size of 1.
     let captured = harness.captured_calls.lock();
-    assert_eq!(captured.len(), 3, "expected 3 sign_and_collect calls");
-    let mut requested_counts: Vec<_> = captured
+    assert_eq!(
+        captured.len(),
+        expected_total,
+        "expected {expected_total} sign_and_collect calls"
+    );
+    let batch_sizes: Vec<_> = captured
         .iter()
         .map(|call| match &call.requester {
             SignatureRequester::Committee {
-                num_signatures_to_collect,
+                validator_partial_signature_batch_size,
                 ..
-            } => *num_signatures_to_collect,
+            } => *validator_partial_signature_batch_size,
             other => panic!("expected SignatureRequester::Committee, got: {other:?}"),
         })
         .collect();
-    requested_counts.sort_unstable();
+
+    let calls_with_batch_size = |batch_size: usize| {
+        batch_sizes
+            .iter()
+            .filter(|&&size| size == batch_size)
+            .count()
+    };
     assert_eq!(
-        requested_counts,
-        vec![1, 2, 2],
-        "expected committee requester counts to match validators per committee"
+        calls_with_batch_size(PRIMARY_COMMITTEE_VALIDATOR_COUNT),
+        PRIMARY_COMMITTEE_VALIDATOR_COUNT,
+        "committee A should make one call per validator, and each call should batch {} validator partial signatures",
+        PRIMARY_COMMITTEE_VALIDATOR_COUNT,
+    );
+    assert_eq!(
+        calls_with_batch_size(SINGLE_VALIDATOR_COMMITTEE_VALIDATOR_COUNT),
+        SINGLE_VALIDATOR_COMMITTEE_VALIDATOR_COUNT,
+        "committee B should make one call per validator, and that call should batch {} validator partial signature",
+        SINGLE_VALIDATOR_COMMITTEE_VALIDATOR_COUNT,
     );
 }
 
-/// A committee stuck at `get_voting_context` (no voting context for its slot) does not block
-/// another committee from signing successfully. Verifies `FuturesUnordered` independence.
+/// A committee stuck in `get_voting_context` because its slot has no voting context does not block
+/// another committee from signing successfully. This verifies the `FuturesUnordered` isolation.
 #[tokio::test(flavor = "multi_thread")]
 async fn sign_attestations_failure_isolation() {
     // Arrange
@@ -112,7 +137,7 @@ async fn sign_attestations_failure_isolation() {
     let first = tokio::time::timeout(Duration::from_secs(5), stream.next()).await;
     let second = tokio::time::timeout(Duration::from_millis(500), stream.next()).await;
 
-    // Assert — committee A completes, committee B stays stuck
+    // Assert: committee A completes, while committee B remains stuck.
     let first_item = first
         .expect("first committee should complete within timeout")
         .expect("stream should yield an item");


### PR DESCRIPTION
## Problem, Evidence, and Context (Required)

- The committee signing path used names such as `num_signatures_to_collect`, `collected_signatures`, and `CommitteeSignatures`.
- Those names sounded like the network-side reconstruction path, even though this code is only batching the partial signatures produced locally by one operator before it sends a committee message.
- `SignatureMetadata::threshold` already describes a different concept: how many operator shares must arrive before a full validator signature can be reconstructed.
- That collision in naming made the committee path harder to read than it should be.
- Evidence: the committee attestation test previously had to explain the behavior with an opaque sorted list, `[1, 2, 2]`.

## Change Overview (Required)

- Rename `num_signatures_to_collect` to `validator_partial_signature_batch_size` in `signature_collector` and `validator_store`.
- Rename the local storage from `collected_signatures` to `batched_validator_partial_signatures`, and rename the corresponding local variable to `validator_partial_signature_batch`.
- Rename the private helper type `CommitteeSignatures` to `CommitteePartialSignatureBatch`, and rename its map from `committee_signatures` to `committee_partial_signature_batches`.
- Rewrite the surrounding comments and documentation in plain English so the local batching path is clearly separated from the network reconstruction path.
- Keep the committee attestation test explicit about two facts: we make one `sign_and_collect` call per validator, and each call carries the batch size for that validator's committee.
- What did not change: runtime behavior, batching rules, and reconstruction thresholds.
- Suggested review order:
  - `anchor/signature_collector/src/lib.rs`
  - `anchor/validator_store/src/lib.rs`
  - `anchor/validator_store/src/testing/committee_attestation.rs`

## Risks, Trade-offs, and Mitigations (Required)

- Main risk: a mechanical rename could miss a call site or leave old terminology behind.
- Trade-off: the new names are longer, but they say what the code is actually doing and no longer collide with `threshold`.
- Mitigation: the affected call sites, comments, and tests were updated together, and the focused validation set was rerun.

## Validation (Required)

- `cargo fmt --all`
- `cargo fmt --all --check`
- `cargo test -p signature_collector`
- `cargo test -p anchor_validator_store committee_`
- `cargo clippy -p signature_collector -p anchor_validator_store --all-targets -- -D warnings`
- The commit hook also reran `cargo fmt --all`, `cargo clippy --all`, and `cargo sort workspace` during the amend.

## Rollback (Required for behavior or runtime changes; optional otherwise)

- Safe rollback: revert commit `6630d23a1`.
- No config, data, or operational impact.

## Blockers / Dependencies (Optional)

- N/A.

## Additional Info / Next Steps (Optional)

- N/A.
