### PR TITLE
test: proposer consensus-data spec coverage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7251,6 +7251,7 @@ version = "0.1.0"
 dependencies = [
  "base64",
  "bls",
+ "eth2",
  "ethereum_ssz",
  "ethereum_ssz_derive",
  "hex",

--- a/anchor/spec_tests/Cargo.toml
+++ b/anchor/spec_tests/Cargo.toml
@@ -4,9 +4,16 @@ version = "0.1.0"
 edition.workspace = true
 authors = ["Sigma Prime <contact@sigmaprime.io>"]
 
+[features]
+# Replaces real BLS cryptography with stub implementations, allowing SSZ decode
+# of blocks with synthetic BLS points (as used in Go ssv-spec fixtures).
+# Mirrors Lighthouse's ef_tests pattern: ef_tests/Cargo.toml also uses bls/fake_crypto.
+fake_crypto = ["bls/fake_crypto"]
+
 [dependencies]
 base64 = { workspace = true }
 bls = { workspace = true }
+eth2 = { workspace = true }
 ethereum_ssz = { workspace = true }
 ethereum_ssz_derive = { workspace = true }
 hex = { workspace = true }

--- a/anchor/spec_tests/src/runner/types_dispatcher.rs
+++ b/anchor/spec_tests/src/runner/types_dispatcher.rs
@@ -60,6 +60,16 @@ fn dispatch_fixture_by_prefix(prefix: &str, path: &Path, contents: &str) -> Disp
             DispatchOutcome::Executed(run_test::<types::EncryptionSpecTest>(path, contents))
         }
 
+        // Proposer consensus data validation tests
+        "proposerconsensusdata.ProposerConsensusDataTest" => {
+            DispatchOutcome::Executed(run_test::<types::ProposerConsensusDataTest>(path, contents))
+        }
+
+        // Proposer block data extraction tests
+        "consensusdataproposer.ProposerSpecTest" => {
+            DispatchOutcome::Executed(run_test::<types::ConsensusDataProposerTest>(path, contents))
+        }
+
         // TODO(spec-tests): Add more test types here as they are implemented.
         // This arm will be replaced with panic!() once all test types are added.
         _ => {

--- a/anchor/spec_tests/src/types/consensus_data_proposer.rs
+++ b/anchor/spec_tests/src/types/consensus_data_proposer.rs
@@ -1,0 +1,192 @@
+use serde::Deserialize;
+use ssv_types::consensus::ProposerConsensusData;
+use ssz::{Decode, DecodeError, Encode};
+use tree_hash::TreeHash;
+use types::{Hash256, MainnetEthSpec};
+
+use crate::{
+    SpecTest,
+    utils::{
+        deserializers::{deserialize_base64, deserialize_base64_or_null, deserialize_hex_hash256},
+        error_codes, is_bls_validation_error,
+    },
+};
+
+/// Mirrors Go's `ProposerSpecTest.Run()`: SSZ-decode consensus data, extract block,
+/// then verify blinded state, roots, and SSZ roundtrips.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct ConsensusDataProposerTest {
+    #[serde(rename = "DataCd", deserialize_with = "deserialize_base64")]
+    consensus_data_ssz: Vec<u8>,
+
+    #[serde(
+        rename = "DataBlk",
+        deserialize_with = "deserialize_base64_or_null",
+        default
+    )]
+    expected_block_ssz: Option<Vec<u8>>,
+
+    blinded: bool,
+
+    #[serde(
+        rename = "ExpectedBlkRoot",
+        deserialize_with = "deserialize_hex_hash256"
+    )]
+    expected_block_root: Hash256,
+
+    #[serde(
+        rename = "ExpectedCdRoot",
+        deserialize_with = "deserialize_hex_hash256"
+    )]
+    expected_consensus_data_root: Hash256,
+
+    expected_error_code: i64,
+}
+
+impl SpecTest for ConsensusDataProposerTest {
+    fn run(&self) -> Result<(), String> {
+        // Decode ProposerConsensusData from SSZ
+        let proposer_data = match ProposerConsensusData::from_ssz_bytes(&self.consensus_data_ssz) {
+            Ok(data) => data,
+            Err(DecodeError::NoMatchingVariant) => {
+                return self.expect_error(error_codes::UNKNOWN_BLOCK_VERSION);
+            }
+            Err(_) => return self.expect_error(error_codes::UNMARSHAL_SSZ),
+        };
+
+        // Decode block — try blinded first, then full (mirrors Go's GetBlockData)
+        let blinded_err = match proposer_data.decode_blinded_block::<MainnetEthSpec>() {
+            Ok(blinded_block) => {
+                self.expect_success()?;
+                self.verify_block(
+                    true,
+                    blinded_block.tree_hash_root(),
+                    &blinded_block.as_ssz_bytes(),
+                )?;
+                return self.verify_consensus_data(&proposer_data);
+            }
+            Err(e) => e,
+        };
+
+        let full_err = match proposer_data.decode_block_contents::<MainnetEthSpec>() {
+            Ok(full_contents) => {
+                self.expect_success()?;
+                // Go's `vBlk.Root()` returns the inner `BeaconBlock` root, but
+                // `vBlk.Deneb.MarshalSSZ()` encodes the full block contents (block + blobs).
+                // `FullBlockContents` doesn't implement `Encode`, so we compare against the
+                // raw `data_ssz` bytes from `ProposerConsensusData` which is what was decoded.
+                let inner_block = full_contents.block();
+                self.verify_block(false, inner_block.tree_hash_root(), &proposer_data.data_ssz)?;
+                return self.verify_consensus_data(&proposer_data);
+            }
+            Err(e) => e,
+        };
+
+        // Both decoders failed. Go fixtures use synthetic BLS points that Go's fastssz
+        // accepts but Lighthouse rejects (`BLST_BAD_ENCODING`). Without `fake_crypto`,
+        // all success fixtures hit this path and `verify_block()` is never reached — only
+        // consensus data root/SSZ verification runs. With `fake_crypto` enabled
+        // (`cargo test -p spec_tests --features fake_crypto`), BLS validation is skipped,
+        // blocks decode successfully above, and `verify_block()` provides full coverage
+        // matching Go's `ProposerSpecTest.Run()`.
+        let blinded_bls_error = is_bls_validation_error(&blinded_err);
+        if blinded_bls_error || is_bls_validation_error(&full_err) {
+            self.expect_success()?;
+            // If blinded decode reached BLS validation, the block is structurally blinded.
+            if blinded_bls_error != self.blinded {
+                return Err(format!(
+                    "Block blinded state mismatch (BLS path): got {blinded_bls_error}, expected {}",
+                    self.blinded,
+                ));
+            }
+            return self.verify_consensus_data(&proposer_data);
+        }
+
+        self.expect_error(error_codes::UNMARSHAL_SSZ)
+    }
+}
+
+impl ConsensusDataProposerTest {
+    /// Check that expected_error_code is NO_ERROR (decode succeeded).
+    fn expect_success(&self) -> Result<(), String> {
+        if self.expected_error_code != error_codes::NO_ERROR {
+            Err(format!(
+                "Expected error code {}, but block extraction succeeded",
+                self.expected_error_code,
+            ))
+        } else {
+            Ok(())
+        }
+    }
+
+    /// Verify block blinded state, root, and SSZ roundtrip.
+    fn verify_block(
+        &self,
+        is_blinded: bool,
+        block_root: Hash256,
+        block_ssz: &[u8],
+    ) -> Result<(), String> {
+        if is_blinded != self.blinded {
+            return Err(format!(
+                "Block blinded state mismatch: got {is_blinded}, expected {}",
+                self.blinded,
+            ));
+        }
+
+        if block_root != self.expected_block_root {
+            return Err(format!(
+                "Block root mismatch: got {block_root}, expected {}",
+                self.expected_block_root,
+            ));
+        }
+
+        let expected = self
+            .expected_block_ssz
+            .as_ref()
+            .ok_or("Expected DataBlk for success case, but got null")?;
+        if block_ssz != expected.as_slice() {
+            return Err(format!(
+                "Block SSZ roundtrip mismatch: got {} bytes, expected {} bytes",
+                block_ssz.len(),
+                expected.len(),
+            ));
+        }
+
+        Ok(())
+    }
+
+    /// Verify consensus data hash tree root and SSZ roundtrip.
+    fn verify_consensus_data(&self, proposer_data: &ProposerConsensusData) -> Result<(), String> {
+        let root = proposer_data.tree_hash_root();
+        if root != self.expected_consensus_data_root {
+            return Err(format!(
+                "ConsensusData root mismatch: got {root}, expected {}",
+                self.expected_consensus_data_root,
+            ));
+        }
+
+        let re_encoded = proposer_data.as_ssz_bytes();
+        if re_encoded != self.consensus_data_ssz {
+            return Err(format!(
+                "ConsensusData SSZ roundtrip mismatch: re-encoded {} bytes, original {} bytes",
+                re_encoded.len(),
+                self.consensus_data_ssz.len(),
+            ));
+        }
+
+        Ok(())
+    }
+
+    /// Check that the actual error code matches the expected one.
+    fn expect_error(&self, actual_code: i64) -> Result<(), String> {
+        if actual_code != self.expected_error_code {
+            Err(format!(
+                "Expected error code {}, got {actual_code}",
+                self.expected_error_code,
+            ))
+        } else {
+            Ok(())
+        }
+    }
+}

--- a/anchor/spec_tests/src/types/mod.rs
+++ b/anchor/spec_tests/src/types/mod.rs
@@ -1,8 +1,10 @@
 mod aggregator_committee_consensus_data_encoding;
 mod beacon_vote_encoding;
+mod consensus_data_proposer;
 mod encryption;
 mod partial_sig_message;
 mod partial_sig_message_encoding;
+mod proposer_consensus_data;
 mod proposer_consensus_data_encoding;
 mod signed_ssv_msg;
 mod signed_ssv_msg_encoding;
@@ -11,9 +13,11 @@ mod ssv_msg;
 
 pub use aggregator_committee_consensus_data_encoding::*;
 pub use beacon_vote_encoding::*;
+pub use consensus_data_proposer::*;
 pub use encryption::*;
 pub use partial_sig_message::*;
 pub use partial_sig_message_encoding::*;
+pub use proposer_consensus_data::*;
 pub use proposer_consensus_data_encoding::*;
 pub use signed_ssv_msg::*;
 pub use signed_ssv_msg_encoding::*;

--- a/anchor/spec_tests/src/types/proposer_consensus_data.rs
+++ b/anchor/spec_tests/src/types/proposer_consensus_data.rs
@@ -1,0 +1,52 @@
+use serde::Deserialize;
+use ssv_types::consensus::{BEACON_ROLE_PROPOSER, ProposerConsensusData};
+use types::{ForkName, MainnetEthSpec};
+
+use crate::{
+    SpecTest,
+    utils::{can_decode_block, dtos::RawConsensusData, error_codes},
+};
+
+/// Mirrors Go's `ConsensusData.Validate()` for proposer duties.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct ProposerConsensusDataTest {
+    consensus_data: RawConsensusData,
+    expected_error_code: i64,
+}
+
+impl SpecTest for ProposerConsensusDataTest {
+    fn run(&self) -> Result<(), String> {
+        let actual_code = match self.validate() {
+            Ok(()) => error_codes::NO_ERROR,
+            Err(code) => code,
+        };
+
+        if actual_code != self.expected_error_code {
+            return Err(format!(
+                "Expected error code {}, got {actual_code}",
+                self.expected_error_code,
+            ));
+        }
+
+        Ok(())
+    }
+}
+
+impl ProposerConsensusDataTest {
+    fn validate(&self) -> Result<(), i64> {
+        let proposer_data = ProposerConsensusData::try_from(&self.consensus_data)
+            .map_err(|_| error_codes::UNKNOWN_DUTY_ROLE_DATA)?;
+
+        if proposer_data.duty.r#type != BEACON_ROLE_PROPOSER {
+            return Err(error_codes::UNKNOWN_DUTY_ROLE_DATA);
+        }
+
+        let fork: ForkName = proposer_data.version.into();
+        if can_decode_block::<MainnetEthSpec>(&proposer_data.data_ssz, fork) {
+            Ok(())
+        } else {
+            Err(error_codes::UNMARSHAL_SSZ)
+        }
+    }
+}

--- a/anchor/spec_tests/src/utils/deserializers.rs
+++ b/anchor/spec_tests/src/utils/deserializers.rs
@@ -49,6 +49,40 @@ pub fn deserialize_base64_list<'de, D: serde::Deserializer<'de>>(
         .collect()
 }
 
+/// Deserializes a base64-encoded string that may be `null` into `Option<Vec<u8>>`.
+///
+/// Error fixtures have `null` while success fixtures have a base64 string.
+pub fn deserialize_base64_or_null<'de, D: serde::Deserializer<'de>>(
+    deserializer: D,
+) -> Result<Option<Vec<u8>>, D::Error> {
+    let opt: Option<String> = Option::deserialize(deserializer)?;
+    match opt {
+        None => Ok(None),
+        Some(s) => {
+            let bytes = STANDARD
+                .decode(s)
+                .map_err(|e| serde::de::Error::custom(format!("Failed to decode base64: {e}")))?;
+            Ok(Some(bytes))
+        }
+    }
+}
+
+/// Deserializes a base64-encoded string, treating empty strings as empty `Vec<u8>`.
+///
+/// Some error fixtures have `"DataSSZ": ""` which is valid since it represents empty data
+/// that should fail SSZ decoding.
+pub fn deserialize_base64_or_empty<'de, D: serde::Deserializer<'de>>(
+    deserializer: D,
+) -> Result<Vec<u8>, D::Error> {
+    let s = String::deserialize(deserializer)?;
+    if s.is_empty() {
+        return Ok(Vec::new());
+    }
+    STANDARD
+        .decode(s)
+        .map_err(|e| serde::de::Error::custom(format!("Failed to decode base64: {e}")))
+}
+
 // ─── Hex ─────────────────────────────────────────────────────────────────────
 
 /// Deserializes an optional hex string (with or without `0x` prefix) into `Option<Vec<u8>>`.
@@ -58,6 +92,17 @@ pub fn deserialize_hex_option<'de, D: serde::Deserializer<'de>>(
     Option::<String>::deserialize(deserializer)?
         .map(|s| decode_hex::<D::Error>(&s))
         .transpose()
+}
+
+/// Deserializes a hex string (without `0x` prefix) into `Hash256`.
+///
+/// The Go spec fixtures encode hash roots as 64-character hex strings representing 32 bytes.
+pub fn deserialize_hex_hash256<'de, D: serde::Deserializer<'de>>(
+    deserializer: D,
+) -> Result<Hash256, D::Error> {
+    let hex_str = String::deserialize(deserializer)?;
+    let bytes = decode_hex::<D::Error>(&hex_str)?;
+    bytes_to_hash256::<D::Error>(&bytes)
 }
 
 // ─── Hash256 ─────────────────────────────────────────────────────────────────

--- a/anchor/spec_tests/src/utils/dtos.rs
+++ b/anchor/spec_tests/src/utils/dtos.rs
@@ -3,19 +3,23 @@
 //! These DTOs bridge Go's JSON serialization format to Anchor's production types
 //! without polluting production types with serde annotations.
 
+use std::str::FromStr;
+
 use serde::Deserialize;
 use ssv_types::{
     OperatorId, ValidatorIndex,
+    consensus::{BeaconRole, DataVersion, ProposerConsensusData, ValidatorDuty},
     message::{MsgType, SSVMessage},
     msgid::MessageId,
     partial_sig::{PartialSignatureKind, PartialSignatureMessage},
 };
-use ssz::DecodeError;
-use types::Hash256;
+use ssz::{Decode, DecodeError, Encode};
+use ssz_types::VariableList;
+use types::{ForkName, Hash256, Slot};
 
 use super::deserializers::{
-    deserialize_base64, deserialize_hex_message_id, deserialize_hex_option,
-    deserialize_partial_signature_kind,
+    deserialize_base64, deserialize_base64_or_empty, deserialize_hex_message_id,
+    deserialize_hex_option, deserialize_partial_signature_kind,
 };
 
 /// DTO for `SSVMessage`.
@@ -100,4 +104,98 @@ pub struct RawPartialSignatureMessages {
     pub kind: PartialSignatureKind,
     pub slot: String,
     pub messages: Vec<RawPartialSignatureMessage>,
+}
+
+/// DTO for Go's `Duty` object inside `ConsensusData`.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct RawDuty {
+    #[serde(rename = "Type")]
+    pub duty_type: u64,
+    pub pub_key: String,
+    pub slot: String,
+    pub validator_index: String,
+    pub committee_index: u64,
+    pub committee_length: u64,
+    pub committees_at_slot: u64,
+    pub validator_committee_index: u64,
+    #[serde(default)]
+    pub validator_sync_committee_indices: Option<Vec<u64>>,
+}
+
+impl TryFrom<&RawDuty> for ValidatorDuty {
+    type Error = String;
+
+    fn try_from(raw: &RawDuty) -> Result<Self, String> {
+        let role = BeaconRole::from_ssz_bytes(&raw.duty_type.as_ssz_bytes())
+            .map_err(|e| format!("Invalid duty type {}: {e:?}", raw.duty_type))?;
+
+        let pub_key = bls::PublicKeyBytes::from_str(&raw.pub_key)
+            .map_err(|e| format!("Invalid pub_key: {e:?}"))?;
+
+        let slot = raw
+            .slot
+            .parse::<u64>()
+            .map(Slot::new)
+            .map_err(|e| format!("Invalid slot: {e}"))?;
+
+        let validator_index = raw
+            .validator_index
+            .parse::<usize>()
+            .map(ValidatorIndex)
+            .map_err(|e| format!("Invalid validator_index: {e}"))?;
+
+        let sync_indices: Vec<u64> = raw
+            .validator_sync_committee_indices
+            .clone()
+            .unwrap_or_default();
+        let validator_sync_committee_indices = VariableList::new(sync_indices)
+            .map_err(|_| "validator_sync_committee_indices exceeds max length")?;
+
+        Ok(ValidatorDuty {
+            r#type: role,
+            pub_key,
+            slot,
+            validator_index,
+            committee_index: raw.committee_index,
+            committee_length: raw.committee_length,
+            committees_at_slot: raw.committees_at_slot,
+            validator_committee_index: raw.validator_committee_index,
+            validator_sync_committee_indices,
+        })
+    }
+}
+
+/// DTO for Go's `ConsensusData` fixture (proposer variant).
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct RawConsensusData {
+    pub duty: RawDuty,
+    pub version: String,
+    #[serde(
+        rename = "DataSSZ",
+        deserialize_with = "deserialize_base64_or_empty",
+        default
+    )]
+    pub data_ssz: Vec<u8>,
+}
+
+impl TryFrom<&RawConsensusData> for ProposerConsensusData {
+    type Error = String;
+
+    fn try_from(raw: &RawConsensusData) -> Result<Self, String> {
+        let duty = ValidatorDuty::try_from(&raw.duty)?;
+
+        let fork = ForkName::from_str(&raw.version)
+            .map_err(|e| format!("Invalid version '{}': {e}", raw.version))?;
+
+        let data_ssz =
+            VariableList::new(raw.data_ssz.clone()).map_err(|_| "data_ssz exceeds max length")?;
+
+        Ok(ProposerConsensusData {
+            duty,
+            version: DataVersion::from(fork),
+            data_ssz,
+        })
+    }
 }

--- a/anchor/spec_tests/src/utils/encoding_helpers.rs
+++ b/anchor/spec_tests/src/utils/encoding_helpers.rs
@@ -1,7 +1,8 @@
 use base64::{Engine, engine::general_purpose::STANDARD};
-use ssz::{Decode, Encode};
+use eth2::types::FullBlockContents;
+use ssz::{Decode, DecodeError, Encode};
 use tree_hash::TreeHash;
-use types::Hash256;
+use types::{BlindedBeaconBlock, EthSpec, ForkName, Hash256};
 
 /// Decode a base64 string into bytes.
 pub fn decode_base64(s: &str) -> Result<Vec<u8>, String> {
@@ -37,4 +38,33 @@ pub fn check_roundtrip_with_root<T: Decode + Encode + TreeHash>(
         ));
     }
     Ok(())
+}
+
+/// Returns `true` if the SSZ decode error is a BLS point validation failure.
+///
+/// Lighthouse validates BLS during SSZ deserialization; Go's `fastssz` does not.
+/// Spec fixtures may contain synthetic BLS values that are structurally valid SSZ.
+pub fn is_bls_validation_error(err: &DecodeError) -> bool {
+    matches!(err, DecodeError::BytesInvalid(msg) if msg.contains("BLST"))
+}
+
+/// Check whether data can be decoded as a blinded or full beacon block.
+///
+/// Tries blinded first, then full (mirrors Go's `GetBlockData()` order).
+/// Go's `fastssz` skips BLS validation, so spec fixtures may contain synthetic BLS
+/// points that Lighthouse rejects. Returns `true` if either decode succeeds or fails
+/// only due to BLS validation. With the `fake_crypto` feature enabled, BLS validation
+/// is skipped and blocks always decode via the success path.
+pub fn can_decode_block<E: EthSpec>(data: &[u8], fork: ForkName) -> bool {
+    let blinded_err = match BlindedBeaconBlock::<E>::from_ssz_bytes_for_fork(data, fork) {
+        Ok(_) => return true,
+        Err(e) => e,
+    };
+
+    let full_err = match FullBlockContents::<E>::from_ssz_bytes_for_fork(data, fork) {
+        Ok(_) => return true,
+        Err(e) => e,
+    };
+
+    is_bls_validation_error(&blinded_err) || is_bls_validation_error(&full_err)
 }

--- a/anchor/spec_tests/src/utils/error_codes.rs
+++ b/anchor/spec_tests/src/utils/error_codes.rs
@@ -42,5 +42,18 @@ pub const NO_PARTIAL_SIG_MESSAGES: i64 = 19;
 /// `SSVMessageHasInvalidSignatureErrorCode` (iota 38 → value 39)
 pub const SSV_MESSAGE_HAS_INVALID_SIGNATURE: i64 = 39;
 
+// --- ProposerConsensusData / GetBlockData codes ---
+
+/// `UnmarshalSSZErrorCode` (iota 0 → value 1) — SSZ decode failure.
+pub const UNMARSHAL_SSZ: i64 = 1;
+
+/// `UnknownDutyRoleDataErrorCode` (iota 9 → value 10) — duty type is not `BNRoleProposer`.
+pub const UNKNOWN_DUTY_ROLE_DATA: i64 = 10;
+
+/// `UnknownBlockVersionErrorCode` (iota 10 → value 11) — unrecognized fork version.
+pub const UNKNOWN_BLOCK_VERSION: i64 = 11;
+
+// --- Sentinel ---
+
 /// Sentinel for Anchor-specific errors without Go equivalents.
 pub const UNMAPPED_ERROR_CODE: i64 = -1;

--- a/anchor/spec_tests/src/utils/mod.rs
+++ b/anchor/spec_tests/src/utils/mod.rs
@@ -7,7 +7,10 @@ pub mod dtos;
 pub mod encoding_helpers;
 pub mod error_codes;
 
-pub use encoding_helpers::{check_roundtrip, check_roundtrip_with_root, decode_base64};
+pub use encoding_helpers::{
+    can_decode_block, check_roundtrip, check_roundtrip_with_root, decode_base64,
+    is_bls_validation_error,
+};
 
 /// Matches Go's `TestingValidatorPubKey`:
 /// https://github.com/ssvlabs/ssv-spec/blob/45153e4e4b8c61b929f701b7af52e3f725668421/types/testingutils/keys.go#L16-L22


### PR DESCRIPTION
## Problem, Evidence, and Context

- Anchor's spec test suite lacks coverage for the Go ssv-spec proposer consensus data test types.
- Needed to maintain spec parity as the test matrix grows. Continuation of the spec test effort from PR #837.
- Extracted from PR #839 per [review feedback](https://github.com/sigp/anchor/pull/839#issuecomment-4215024532). Closes #941.

## Change Overview

Two new spec test types:

1. **`ProposerConsensusDataTest`** — Mirrors Go's `ConsensusData.Validate()`: checks duty type is proposer, then verifies the block data is decodable (blinded-first, then full). Good parity with Go.

2. **`ConsensusDataProposerTest`** — Mirrors Go's `ProposerSpecTest.Run()`: SSZ-decodes `ProposerConsensusData`, extracts block data, verifies blinded state, block root, block SSZ, consensus data root, and consensus data SSZ roundtrip. Includes a BLS fallback path because Lighthouse validates BLS points during SSZ deserialization while Go's `fastssz` does not. With `fake_crypto` enabled, full parity with Go is achieved.

Shared infrastructure added: `RawConsensusData`/`RawDuty` DTOs, `can_decode_block` helper, `is_bls_validation_error` helper, `deserialize_hex_hash256`/`deserialize_base64_or_null`/`deserialize_base64_or_empty` serde helpers, and proposer-related error codes.

## Risks, Trade-offs, and Mitigations

- **BLS validation gap without `fake_crypto`**: Without `--features fake_crypto`, `ConsensusDataProposerTest` skips block root, block SSZ, and blinded state checks for success fixtures (falls through to BLS fallback path which only verifies consensus data). Core assertions of the most complex test are bypassed in default mode. CI should run with `fake_crypto` for full coverage.
- **`is_bls_validation_error` string matching**: Uses `msg.contains("BLST")` — fragile against Lighthouse error message changes but stable in practice and test-only.
- **Full block SSZ comparison**: Uses input bytes instead of re-encoding `FullBlockContents` (which doesn't implement `Encode`). Functionally correct but weaker than Go's marshal-and-compare.

## Validation

- `cargo test -p spec_tests --features fake_crypto` — all fixtures pass
- `cargo clippy` and `cargo fmt` clean

## Rollback

N/A — test-only changes, no runtime impact.

## Blockers / Dependencies
- `fake_crypto` CI target tracked in #938.