### PR TITLE
chore: add validator index db index

### DIFF
--- a/anchor/database/src/schema.rs
+++ b/anchor/database/src/schema.rs
@@ -28,6 +28,15 @@ const MIGRATION_V2_TO_V3: &str = r#"
     UPDATE metadata SET schema_version = 3;
 "#;
 
+/// Migration from schema version 3 to 4: Add index on `validators.validator_index`
+///
+/// The `GET_SHARE_PUBKEYS_FOR_VALIDATOR_INDEX` query joins validators and shares
+/// filtering by `validator_index`. Without an index this causes a full table scan.
+const MIGRATION_V3_TO_V4: &str = r#"
+    CREATE INDEX idx_validators_validator_index ON validators(validator_index);
+    UPDATE metadata SET schema_version = 4;
+"#;
+
 enum UpgradeAction {
     UpToDate,
     DoUpdate {
@@ -183,7 +192,11 @@ fn get_upgrade_action(version: Option<SchemaVersion>) -> UpgradeAction {
             script: MIGRATION_V2_TO_V3,
             new_version: 3,
         },
-        Some(3) => UpgradeAction::UpToDate,
-        Some(4..) => UpgradeAction::Future,
+        Some(3) => UpgradeAction::DoUpdate {
+            script: MIGRATION_V3_TO_V4,
+            new_version: 4,
+        },
+        Some(4) => UpgradeAction::UpToDate,
+        Some(5..) => UpgradeAction::Future,
     }
 }

--- a/anchor/database/src/table_schema.sql
+++ b/anchor/database/src/table_schema.sql
@@ -1,8 +1,8 @@
--- SCHEMA VERSION 3
+-- SCHEMA VERSION 4
 
 -- we should avoid removing columns from this to keep compatibility between anchor Versions
 CREATE TABLE metadata (
-    schema_version INTEGER NOT NULL DEFAULT 3,
+    schema_version INTEGER NOT NULL DEFAULT 4,
     -- DEPRECATED: domain_type is no longer used for network isolation as of schema v3.
     -- Previously, we used domain_type (a 4-byte value derived from the fork) to prevent
     -- cross-network database usage. However, domain_type changes at each fork activation,
@@ -57,6 +57,7 @@ CREATE TABLE validators (
     graffiti BLOB DEFAULT X'0000000000000000000000000000000000000000000000000000000000000000',
     FOREIGN KEY (cluster_id) REFERENCES clusters(cluster_id)
 );
+CREATE INDEX idx_validators_validator_index ON validators(validator_index);
 
 CREATE TABLE shares (
     validator_pubkey TEXT NOT NULL,

--- a/anchor/database/src/tests/metadata_tests.rs
+++ b/anchor/database/src/tests/metadata_tests.rs
@@ -172,7 +172,7 @@ mod tests {
     }
 
     #[test]
-    fn test_migration_v1_to_v3() {
+    fn test_migration_v1_to_v4() {
         let temp_dir = TempDir::new().expect("Failed to create temp dir");
         let db_path = temp_dir.path().join("test.db");
 
@@ -220,7 +220,7 @@ mod tests {
     }
 
     #[test]
-    fn test_migration_v2_to_v3() {
+    fn test_migration_v2_to_v4() {
         let temp_dir = TempDir::new().expect("Failed to create temp dir");
         let db_path = temp_dir.path().join("test.db");
 

--- a/anchor/database/src/tests/metadata_tests.rs
+++ b/anchor/database/src/tests/metadata_tests.rs
@@ -33,8 +33,8 @@ mod tests {
         let metadata = queries::get_metadata(&conn).expect("Failed to get metadata");
 
         assert_eq!(
-            metadata.schema_version, 3,
-            "Initial schema version should be 3"
+            metadata.schema_version, 4,
+            "Initial schema version should be 4"
         );
         assert_eq!(
             metadata.network_name, TEST_NETWORK_1,
@@ -196,8 +196,8 @@ mod tests {
             let conn = Connection::open(&db_path).expect("Failed to open database");
             let metadata = queries::get_metadata(&conn).expect("Failed to get metadata");
             assert_eq!(
-                metadata.schema_version, 3,
-                "Should be upgraded to version 3"
+                metadata.schema_version, 4,
+                "Should be upgraded to version 4"
             );
 
             // Verify the network_name column was set
@@ -244,8 +244,8 @@ mod tests {
             let conn = Connection::open(&db_path).expect("Failed to open database");
             let metadata = queries::get_metadata(&conn).expect("Failed to get metadata");
             assert_eq!(
-                metadata.schema_version, 3,
-                "Should be upgraded to version 3"
+                metadata.schema_version, 4,
+                "Should be upgraded to version 4"
             );
 
             // Verify the network_name column was set
@@ -253,6 +253,47 @@ mod tests {
                 metadata.network_name, TEST_NETWORK_1,
                 "network_name should be set after migration"
             );
+        }
+    }
+
+    #[test]
+    fn test_migration_v3_to_v4() {
+        let temp_dir = TempDir::new().expect("Failed to create temp dir");
+        let db_path = temp_dir.path().join("test.db");
+
+        // Create a v3 database (with network_name but without validator_index index)
+        create_v3_database(&db_path, TEST_NETWORK_1);
+
+        // Verify it's version 3
+        {
+            let conn = Connection::open(&db_path).expect("Failed to open database");
+            let version: u64 = conn
+                .query_row("SELECT schema_version FROM metadata", [], |row| row.get(0))
+                .expect("Failed to get schema version");
+            assert_eq!(version, 3, "Should start at version 3");
+        }
+
+        // Run migration
+        schema::ensure_up_to_date(&db_path, TEST_NETWORK_1).expect("Migration should succeed");
+
+        // Verify migration succeeded
+        {
+            let conn = Connection::open(&db_path).expect("Failed to open database");
+            let metadata = queries::get_metadata(&conn).expect("Failed to get metadata");
+            assert_eq!(
+                metadata.schema_version, 4,
+                "Should be upgraded to version 4"
+            );
+
+            // Verify the index exists
+            let index_exists: bool = conn
+                .query_row(
+                    "SELECT COUNT(*) > 0 FROM sqlite_master WHERE type='index' AND name='idx_validators_validator_index'",
+                    [],
+                    |row| row.get(0),
+                )
+                .expect("Failed to check index");
+            assert!(index_exists, "idx_validators_validator_index should exist");
         }
     }
 
@@ -274,6 +315,9 @@ mod tests {
 
         conn.execute("INSERT INTO metadata (domain_type) VALUES (0)", [])
             .expect("Failed to insert v1 metadata");
+
+        // Create validators table (existed since v1, needed for v3->v4 index migration)
+        create_validators_table(&conn);
     }
 
     fn create_v2_database(db_path: &PathBuf) {
@@ -294,6 +338,54 @@ mod tests {
 
         conn.execute("INSERT INTO metadata (domain_type) VALUES (0)", [])
             .expect("Failed to insert v2 metadata");
+
+        // Create validators table (existed since v1, needed for v3->v4 index migration)
+        create_validators_table(&conn);
+    }
+
+    fn create_v3_database(db_path: &PathBuf, network_name: &str) {
+        let conn = Connection::open(db_path).expect("Failed to create v3 database");
+
+        // Create metadata table as it was in version 3
+        conn.execute(
+            "CREATE TABLE metadata (
+                schema_version INTEGER NOT NULL DEFAULT 3,
+                domain_type INTEGER NOT NULL DEFAULT 0,
+                network_name TEXT,
+                block_number INTEGER NOT NULL DEFAULT 0 CHECK (block_number >= 0),
+                max_operator_id_seen INTEGER DEFAULT 0
+            )",
+            [],
+        )
+        .expect("Failed to create v3 metadata table");
+
+        conn.execute(
+            "INSERT INTO metadata (network_name) VALUES (?1)",
+            [network_name],
+        )
+        .expect("Failed to insert v3 metadata");
+
+        // Create validators table (needed for v3->v4 index migration)
+        create_validators_table(&conn);
+    }
+
+    /// Creates the validators table (and its clusters dependency) for test databases.
+    /// The validators table existed since schema v1 and is needed for the v3->v4 index migration.
+    fn create_validators_table(conn: &Connection) {
+        conn.execute_batch(
+            "CREATE TABLE IF NOT EXISTS clusters (
+                cluster_id BLOB PRIMARY KEY,
+                owner TEXT NOT NULL
+            );
+            CREATE TABLE IF NOT EXISTS validators (
+                validator_pubkey TEXT PRIMARY KEY,
+                cluster_id BLOB NOT NULL,
+                validator_index INTEGER,
+                graffiti BLOB,
+                FOREIGN KEY (cluster_id) REFERENCES clusters(cluster_id)
+            );",
+        )
+        .expect("Failed to create validators table");
     }
 
     fn create_legacy_database(db_path: &PathBuf) {


### PR DESCRIPTION
## Problem, Evidence, and Context (Required)

- Without an index on `validators.validator_index`, the `GET_SHARE_PUBKEYS_FOR_VALIDATOR_INDEX` query (added in #936) falls back to a full table scan (`SCAN v`).
- With `POOL_SIZE = 1`, concurrent lookups serialize on the single SQLite connection. Benchmarks on a mainnet-scale synthetic DB (~140k validators, ~1.82M shares) showed ~8.2ms per lookup without the index vs ~0.14ms with it. At 20 stacked lookups, that's ~160ms serialized vs ~3ms.
- This was identified during [review of #936](https://github.com/sigp/anchor/pull/936#discussion_r3057785811) and tracked as #940.

## Change Overview (Required)

- Schema migration v3 → v4: adds `CREATE INDEX idx_validators_validator_index ON validators(validator_index)`.
- Updates `table_schema.sql` so new databases get the index from the start.
- Adds migration test (`test_migration_v3_to_v4`) and updates existing migration tests (`v1_to_v4`, `v2_to_v4`) to pass through the new migration step.

**Design choice — `CREATE INDEX` vs `UNIQUE` constraint:** `validator_index` is unique on the beacon chain, so a `UNIQUE` constraint would be semantically correct. However, a plain index was chosen because: (1) it's the minimal change, (2) `validator_index` can be `NULL` before activation, and (3) adding a uniqueness constraint to existing databases risks breaking the migration if any edge-case duplicates or NULLs exist. The performance is identical — SQLite uses the same B-tree structure for both.

## Risks, Trade-offs, and Mitigations (Required)

- Low risk — pure schema migration, no behavior change. The index is additive.
- Migration tested against v1, v2, and v3 starting schemas.
- Verified with `EXPLAIN QUERY PLAN` that SQLite uses the index after migration.

## Validation (Required)

- `test_migration_v3_to_v4`: creates a v3 database, runs migration, asserts version is 4 and the index exists.
- `test_migration_v1_to_v4` / `test_migration_v2_to_v4`: verify the full migration chain from older schemas still works.
- Manual `sqlite3` validation confirming query plan changes from `SCAN` to `SEARCH ... USING INDEX`.

## Rollback (Required for behavior or runtime changes; optional otherwise)

N/A — additive index only. Removing it would require a v4 → v5 migration dropping the index, but the index is harmless if unused.

## Blockers / Dependencies (Optional)

- Depends on #936 (adds the query that benefits from this index).

## Additional Info / Next Steps (Optional)

- Part 2/4 of the #931 split. Next: #941 (signature collector integration).