### PR TITLE
chore(deps): bump rustls-webpki to 0.103.12

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6709,9 +6709,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "ring",
  "rustls-pki-types",


### PR DESCRIPTION
## Summary
- bump rustls-webpki in Cargo.lock from 0.103.10 to 0.103.12 to address the current cargo audit failure
- keep the change lockfile-only
- avoid any actual crate version downgrades

## Notes
- the only version change in this PR is rustls-webpki 0.103.10 -> 0.103.12
- Cargo.lock also rewrites data-encoding-macro-internal to reference syn 1.0.109; cargo tree -p data-encoding-macro-internal confirms that is the resolved dependency already in use, not a crate downgrade

## Verification
- env CARGO_HOME=/tmp/cargo-home make audit-CI
