### PR TITLE
test: SszSpecTest

### DIFF
--- a/anchor/spec_tests/src/runner/types_dispatcher.rs
+++ b/anchor/spec_tests/src/runner/types_dispatcher.rs
@@ -100,6 +100,11 @@ fn dispatch_fixture_by_prefix(prefix: &str, path: &Path, contents: &str) -> Disp
             DispatchOutcome::SkippedKnown
         }
 
+        // SSZ merkleization tests
+        "ssz.SSZSpecTest" => {
+            DispatchOutcome::Executed(run_test::<types::SSZSpecTest>(path, contents))
+        }
+
         // TODO(spec-tests): Add more test types here as they are implemented.
         // This arm will be replaced with panic!() once all test types are added.
         _ => {

--- a/anchor/spec_tests/src/types/mod.rs
+++ b/anchor/spec_tests/src/types/mod.rs
@@ -11,6 +11,7 @@ mod signed_ssv_msg;
 mod signed_ssv_msg_encoding;
 mod ssv_message_encoding;
 mod ssv_msg;
+mod ssz_spec_test;
 
 pub use aggregator_committee_consensus_data_encoding::*;
 pub use beacon_vote_encoding::*;
@@ -25,3 +26,4 @@ pub use signed_ssv_msg::*;
 pub use signed_ssv_msg_encoding::*;
 pub use ssv_message_encoding::*;
 pub use ssv_msg::*;
+pub use ssz_spec_test::*;

--- a/anchor/spec_tests/src/types/ssz_spec_test.rs
+++ b/anchor/spec_tests/src/types/ssz_spec_test.rs
@@ -1,0 +1,74 @@
+use serde::Deserialize;
+use ssz::Decode;
+use types::{ExecPayload, Hash256, MainnetEthSpec};
+
+use crate::{
+    SpecTest,
+    utils::{
+        deserializers::{deserialize_base64, deserialize_hex_hash256},
+        is_bls_validation_error,
+    },
+};
+
+/// Mirrors Go's `SSZSpecTest.Run()`. Verifies withdrawals `HashTreeRoot`.
+///
+/// Fixtures contain synthetic BLS; Anchor rejects these during SSZ decode
+/// (Go's `fastssz` doesn't validate BLS), so BLS failures pass silently.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct SSZSpecTest {
+    #[serde(deserialize_with = "deserialize_base64")]
+    data: Vec<u8>,
+    #[serde(deserialize_with = "deserialize_hex_hash256")]
+    expected_root: Hash256,
+}
+
+impl SpecTest for SSZSpecTest {
+    fn run(&self) -> Result<(), String> {
+        let cd = ssv_types::consensus::ProposerConsensusData::from_ssz_bytes(&self.data)
+            .map_err(|e| format!("Failed to decode ProposerConsensusData: {e:?}"))?;
+
+        // Try blinded then full (same order as Go).
+        let withdrawals_root = match cd.decode_blinded_block::<MainnetEthSpec>() {
+            Ok(blinded) => blinded
+                .body()
+                .execution_payload()
+                .and_then(|p| p.withdrawals_root())
+                .map_err(|e| format!("Failed to get withdrawals root from blinded block: {e:?}"))?,
+            Err(blinded_err) => match cd.decode_block_contents::<MainnetEthSpec>() {
+                Ok(full) => full
+                    .block()
+                    .body()
+                    .execution_payload()
+                    .and_then(|p| p.withdrawals_root())
+                    .map_err(|e| {
+                        format!("Failed to get withdrawals root from full block: {e:?}")
+                    })?,
+                // Both decoders failed. Go fixtures use synthetic BLS points that Go's
+                // fastssz accepts but Lighthouse rejects (`BLST_BAD_ENCODING`). Without
+                // `fake_crypto`, the withdrawals root check is unreachable — the test
+                // passes by skipping it. With `fake_crypto` enabled
+                // (`cargo test -p spec_tests --features fake_crypto`), BLS validation is
+                // skipped, the full block decodes successfully above, and the withdrawals
+                // root is actually verified. Tracked by ssvlabs/ssv-spec#622.
+                Err(full_err) => {
+                    if is_bls_validation_error(&blinded_err) || is_bls_validation_error(&full_err) {
+                        return Ok(());
+                    }
+                    return Err(format!(
+                        "Both block decoders failed: blinded={blinded_err:?}, full={full_err:?}"
+                    ));
+                }
+            },
+        };
+
+        if withdrawals_root != self.expected_root {
+            return Err(format!(
+                "Withdrawals root mismatch: got {withdrawals_root}, expected {}",
+                self.expected_root,
+            ));
+        }
+
+        Ok(())
+    }
+}

--- a/anchor/spec_tests/src/types/ssz_spec_test.rs
+++ b/anchor/spec_tests/src/types/ssz_spec_test.rs
@@ -10,10 +10,12 @@ use crate::{
     },
 };
 
-/// Mirrors Go's `SSZSpecTest.Run()`. Verifies withdrawals `HashTreeRoot`.
+/// Mirrors Go's `SSZSpecTest.Run()`. Verifies the withdrawals root from the
+/// execution payload when block decode succeeds.
 ///
-/// Fixtures contain synthetic BLS; Anchor rejects these during SSZ decode
-/// (Go's `fastssz` doesn't validate BLS), so BLS failures pass silently.
+/// Fixtures contain synthetic BLS; Lighthouse rejects these during SSZ decode
+/// (Go's `fastssz` doesn't validate BLS), so withdrawals root verification is
+/// only exercised with `fake_crypto` enabled.
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "PascalCase")]
 pub struct SSZSpecTest {
@@ -46,8 +48,9 @@ impl SpecTest for SSZSpecTest {
                     })?,
                 // Both decoders failed. Go fixtures use synthetic BLS points that Go's
                 // fastssz accepts but Lighthouse rejects (`BLST_BAD_ENCODING`). Without
-                // `fake_crypto`, the withdrawals root check is unreachable — the test
-                // passes by skipping it. With `fake_crypto` enabled
+                // `fake_crypto`, the withdrawals root check is unreachable and this
+                // returns `Ok(())` to preserve parity with the current Go `SSZSpecTest`.
+                // With `fake_crypto` enabled
                 // (`cargo test -p spec_tests --features fake_crypto`), BLS validation is
                 // skipped, the full block decodes successfully above, and the withdrawals
                 // root is actually verified. Tracked by ssvlabs/ssv-spec#622.


### PR DESCRIPTION
## Problem, Evidence, and Context (Required)

Anchor is missing the `SSZSpecTest` type from `ssv-spec`, leaving SSZ-level parity with the Go reference unverified for proposer consensus data. Regressions in withdrawals merkleization or `ProposerConsensusData` decoding are currently uncovered by the spec-test suite.

Part of the spec-test expansion in #954 (split from #840); sub-issue #955.

## Change Overview (Required)

Adds an `SSZSpecTest` runner that mirrors Go's `SSZSpecTest.Run()`: decode `ProposerConsensusData` from SSZ, extract the beacon block (blinded first, then full), and assert the execution-payload withdrawals root matches the fixture's expected root. Wired into the type dispatcher under `"ssz.SSZSpecTest"` with one fixture.

Intentional non-changes:
- Test-harness only; no production paths touched.
- `ExpectedErrorCode` is not asserted, matching the upstream Go runner. The generator emits only success fixtures today; Anchor-only enforcement would diverge from the reference contract.

## Risks, Trade-offs, and Mitigations (Required)

The Capella fixture uses placeholder BLS values that Lighthouse rejects during SSZ decode (`BLST_BAD_ENCODING`) but Go's `fastssz` accepts. So the default `cargo test -p spec_tests` path fails decode and never reaches the withdrawals-root assertion; it is kept only for parity with the current `ssv-spec` runner. The meaningful coverage path is `--features fake_crypto`, which skips BLS validation and verifies the withdrawals root end-to-end. #938 tracks making the `fake_crypto` invocation explicit in the Makefile / CI. Upstream fixture fix is [ssvlabs/ssv-spec#622](https://github.com/ssvlabs/ssv-spec/issues/622); once bumped, the fallback becomes dead code (cleanup #953).

## Validation (Required)

- `cargo test -p spec_tests`: 55 passed (parity path).
- `cargo test -p spec_tests --features fake_crypto`: 55 passed (full withdrawals-root verification).
- `cargo clippy`, `cargo +nightly fmt --check`: clean.

## Rollback

N/A, test-only.

## Additional Info

Remaining spec test types from #954: #956, #957, #958.
