### PR TITLE
feat: Creates directory in docs to contain CLI command usage documentation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -75,7 +75,12 @@ npm run preview
 
 ### Editing Existing Pages
 
-All documentation content is in `docs/pages/` as `.mdx` files. Edit these files directly.
+All documentation content is in `docs/pages/` as `.mdx` files.
+
+Specific CLI option detail is stored as separate imported components:
+
+- `docs/docs/generated/*.mdx` contain specific CLI option implementation details generated from Anchor CLI source code.
+- The `docs/docs/pages/cli*.mdx` pages remain hand-written and import those generated snippets.
 
 ### Page Structure
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -79,7 +79,7 @@ All documentation content is in `docs/pages/` as `.mdx` files.
 
 Specific CLI option detail is stored as separate imported components:
 
-- `docs/docs/generated/*.mdx` contain specific CLI option implementation details generated from Anchor CLI source code.
+- `docs/docs/generated/*.mdx` contain specific CLI option implementation details generated using the structure of Anchor CLI source code.
 - The `docs/docs/pages/cli*.mdx` pages remain hand-written and import those generated snippets.
 
 ### Page Structure

--- a/docs/docs/generated/cli-global-options.mdx
+++ b/docs/docs/generated/cli-global-options.mdx
@@ -1,0 +1,8 @@
+| Option | Description | Default               |
+| --- | --- |-----------------------|
+| `-d, --data-dir <DIR>` | Data directory for node files | `~/.anchor/{network}` |
+| `-t, --testnet-dir <DIR>` | Directory containing testnet specs | None                  |
+| `--network <NETWORK>` | Network to use (mainnet, holesky, hoodi) | `mainnet`               |
+| `--debug-level <DEBUG_LEVEL>` | Verbosity level for terminal logs | `INFO` |
+| `-h, --help` | Display help information | Unset                 |
+| `-V, --version` | Print version information | Unset |

--- a/docs/docs/generated/cli-keygen-options.mdx
+++ b/docs/docs/generated/cli-keygen-options.mdx
@@ -1,0 +1,10 @@
+| Option | Description | Default |
+| --- | --- | ---|
+| `-d, --data-dir <DIR>` | Directory to store generated keys | `~/.anchor/{network}` |
+| `--force` | Force overwrite of existing key files | Disabled |
+| `--encrypt` | Enable password encryption (password read from terminal or `--password-file`) | Disabled |
+| `--password-file <PATH>` | Path to a file containing the password to use | None |
+| `--network <NETWORK>` | Network to use (mainnet, holesky, hoodi) | `hoodi` |
+| `-t, --testnet-dir <DIR>` | Directory containing testnet specs | None |
+| `--debug-level <DEBUG_LEVEL>` | Verbosity level for terminal logs | `INFO` |
+| `-h, --help` | Display help information | |

--- a/docs/docs/generated/cli-keysplit-options.mdx
+++ b/docs/docs/generated/cli-keysplit-options.mdx
@@ -1,0 +1,37 @@
+| Option | Description | Default |
+| --- | --- | ---|
+| `--keystore-path <PATH>` | Path to validator keystore file | Required |
+| `--password-file <PATH>` | Path to a file containing the password for the validator keystore (if omitted, password will be prompted) | None |
+| `--owner <ADDRESS>` | EOA address that owns the validator | Required |
+| `--output-path <OUTPUT PATH>` | Path for output file | Required |
+| `--operators <IDS>` | Comma-separated list of operator IDs | Required|
+| `-d, --data-dir <DIR>` | Data directory for node files | `~/.anchor/{network}` |
+| `--network <NETWORK>` | Network to use (mainnet, holesky, hoodi) | `hoodi` |
+| `-t, --testnet-dir <DIR>` | Directory containing testnet specs | None |
+| `--debug-level <DEBUG_LEVEL>` | Verbosity level for terminal logs | `INFO` |
+| `-h, --help` | Display help information | |
+
+### Manual Keysplit Subcommand
+
+```bash
+anchor keysplit manual [OPTIONS]
+```
+
+Additional Options:
+
+| Option | Description | Default |
+| --- | --- | ---|
+| `--nonce <NONCE>` | Nonce for the owner address | Required |
+| `--public-keys <KEYS>...` | RSA public keys for the operators | Required|
+
+### Onchain Keysplit Subcommand
+
+```bash
+anchor keysplit onchain [OPTIONS]
+```
+
+Additional Options:
+
+| Option | Description | Default |
+| --- | --- | ---|
+| `--rpc <ENDPOINT>` | RPC endpoint to access L1 data | Required|

--- a/docs/docs/generated/cli-node-options.mdx
+++ b/docs/docs/generated/cli-node-options.mdx
@@ -1,0 +1,87 @@
+#### External APIs
+
+| Option | Description | Default |
+| --- | --- | ---|
+| `--beacon-nodes <NETWORK_ADDRESSES>` | Comma-separated beacon node HTTP URLs | `http://localhost:5052`|
+| `--execution-rpc <NETWORK_ADDRESSES>` | Comma-separated execution node RPC URLs | `http://localhost:8545` |
+| `--execution-ws <NETWORK_ADDRESSES>` | Execution node websocket URL | `ws://localhost:8546` |
+| `--beacon-nodes-tls-certs <CERTIFICATE-FILES>` | Comma-separated paths to custom TLS certificates for beacon nodes (PEM format) | None |
+| `--execution-nodes-tls-certs <CERTIFICATE-FILES>` | Comma-separated paths to custom TLS certificates for execution nodes (PEM format) | None |
+
+#### HTTP API
+
+| Option | Description | Default |
+| --- | --- | ---|
+| `--http` | Enable the HTTP API sever | Disabled |
+| `--http-address <ADDRESS>` | Listen address for HTTP API | None |
+| `--http-port <PORT>` | Listen port for HTTP API | `5062` if `--http` is set |
+| `--http-allow-origin <ORIGIN>` | Set CORS allowed origin | None |
+| `--unencrypted-http-transport` | Safety flag to acknowledge HTTP is unencrypted | Required if `--http-address` is set|
+
+#### Metrics Options
+
+| Option | Description | Default |
+| --- | --- | ---|
+| `--metrics` | Enable metrics server | Disabled |
+| `--metrics-address <ADDRESS>` | Listen address for metrics server | `127.0.0.1` if `--metrics` is set |
+| `--metrics-port <PORT>` | Listen port for metrics server | `5164` if `--metrics` is set |
+
+#### Network Options
+
+| Option | Description | Default |
+| --- | --- | ---|
+| `--listen-addresses [<ADDRESS>...]` | Network addresses to listen for UDP & TCP connections (can be set multiple times for IPv4 and IPv6) | `0.0.0.0` |
+| `--port <PORT>` | TCP/UDP ports for IPv4 (discovery and TCP will use this value, QUIC will use this + 1) | `12001` (discovery), `13001` (TCP) |
+| `--port6 <PORT>` | TCP/UDP ports for IPv6 when listening over both IPv4 and IPv6 (QUIC will use this + 1) | Same as `--port` |
+| `--discovery-port <PORT>` | UDP port for discovery | Same as `--port` if specified, otherwise `12001` |
+| `--discovery-port6 <PORT>` | UDP port for IPv6 discovery | Same as `--discovery-port` |
+| `--quic-port <PORT>` | UDP port for QUIC protocol | `--port` + 1 |
+| `--quic-port6 <PORT>` | UDP port for IPv6 QUIC protocol | `--port6` + 1 |
+| `--boot-nodes <BOOT_NODES>` | Comma-separated ENRs or Multiaddrs to bootstrap the network | None|
+| `--enr-address <ADDRESS>` | IPv4 address to broadcast in the node's ENR | None |
+| `--enr-address6 <ADDRESS>` | IPv6 address to broadcast in the node's ENR | None |
+| `--enr-udp-port <PORT>` | UDP port to advertise in the node's ENR | None |
+| `--enr-tcp-port <PORT>` | TCP port to advertise in the node's ENR | None |
+| `--enr-quic-port <PORT>` | QUIC port to advertise in the node's ENR | None |
+| `--enr-udp6-port <PORT>` | IPv6 UDP port to advertise in the node's ENR | None |
+| `--enr-tcp6-port <PORT>` | IPv6 TCP port to advertise in the node's ENR | None |
+| `--enr-quic6-port <PORT>` | IPv6 QUIC port to advertise in the node's ENR | None |
+| `--disable-enr-auto-update` | Disable discovery from automatically updating the ENR with external addresses | Disabled |
+| `--subscribe-all-subnets` | Subscribe to all subnets regardless of committee membership | Disabled|
+
+#### Security Options
+
+| Option | Description | Default |
+| --- | --- | ---|
+| `--key-file <PATH>` | Path to the operator key file (`.txt` for unencrypted, `.json` for encrypted) | Detected in data dir |
+| `--password-file <PATH>` | Path to a file containing the key password for decryption | None |
+
+#### Payload Building Options
+
+| Option | Description | Default |
+| --- | --- | ---|
+| `--builder-boost-factor <UINT64>` | Percentage multiplier to apply to builder's payload value | None |
+| `--prefer-builder-proposals` | Always prefer builder blocks regardless of payload value | Disabled |
+| `--gas-limit <INTEGER>` | Gas limit for all builder proposals for all validators | `36000000` |
+
+#### Logging Options
+
+| Option | Description | Default |
+| --- | --- | ---|
+| `--debug-level <DEBUG_LEVEL>` | Verbosity for terminal logs | `INFO` |
+| `--logfile-debug-level <LOGFILE_DEBUG_LEVEL>` | Verbosity for file logs | `DEBUG` |
+| `--logfile-max-size <SIZE>` | Maximum size of each log file in MB (set to 0 to disable) | `50` |
+| `--logfile-max-number <NUMBER>` | Maximum number of log files to keep (set to 0 to disable) | `10` |
+| `--logfile-dir <DIR>` | Directory to store log files | Same as `--data-dir` |
+| `--logfile-compression` | Compress old log files | Disabled |
+| `--logfile-color` | Enable colors in logfile | Disabled |
+| `--discv5-log-level <DISCV5_LOG_LEVEL>` | Verbosity level for discv5 dependency log file | `DEBUG` |
+| `--libp2p-log-level <LIBP2P_LOG_LEVEL>` | Verbosity level for libp2p dependency log file | `DEBUG` |
+
+#### Additional Network and Performance Options
+
+| Option | Description | Default |
+| --- | --- | ---|
+| `--disable-gossipsub-peer-scoring` | Disable gossipsub peer scoring | Enabled |
+| `--disable-latency-measurement-service` | Disable the latency measurement service | Enabled |
+| `--enable-high-validator-count-metrics` | Enable per validator metrics for > 64 validators | Auto-enabled for ≤ 64 validators |

--- a/docs/docs/pages/cli-keygen.mdx
+++ b/docs/docs/pages/cli-keygen.mdx
@@ -1,3 +1,5 @@
+import CliKeygenOptions from '../generated/cli-keygen-options.mdx'
+
 ## Keygen Command
 
 The `keygen` command generates RSA keys for SSV operator identification
@@ -8,16 +10,7 @@ anchor keygen [OPTIONS]
 
 ### Options
 
-| Option | Description | Default |
-| --- | --- | ---|
-| `-d, --data-dir <DIR>` | Directory to store generated keys | `~/.anchor/{network}` |
-| `--force` | Force overwrite of existing key files | Disabled |
-| `--encrypt` | Enable password encryption (password read from terminal or `--password-file`) | Disabled |
-| `--password-file <PATH>` | Path to a file containing the password to use | None |
-| `--network <NETWORK>` | Network to use (mainnet, holesky, hoodi) | `hoodi` |
-| `-t, --testnet-dir <DIR>` | Directory containing testnet specs | None |
-| `--debug-level <DEBUG_LEVEL>` | Verbosity level for terminal logs | `INFO` |
-| `-h, --help` | Display help information | |
+<CliKeygenOptions />
 
 ### Examples
 

--- a/docs/docs/pages/cli-keysplit.mdx
+++ b/docs/docs/pages/cli-keysplit.mdx
@@ -1,3 +1,5 @@
+import CliKeysplitOptions from '../generated/cli-keysplit-options.mdx'
+
 ## Keysplit Command
 
 The `keysplit` command is used to split validator keys for distributed validation on the SSV network.
@@ -13,43 +15,7 @@ Where `<SUBCOMMAND>` is one of:
 
 Both subcommands share these Options
 
-| Option | Description | Default |
-| --- | --- | ---|
-| `--keystore-path <PATH>` | Path to validator keystore file | Required |
-| `--password-file <PATH>` | Path to a file containing the password for the validator keystore (if omitted, password will be prompted) | None |
-| `--owner <ADDRESS>` | EOA address that owns the validator | Required |
-| `--output-path <OUTPUT PATH>` | Path for output file | Required |
-| `--operators <IDS>` | Comma-separated list of operator IDs | Required|
-| `-d, --data-dir <DIR>` | Data directory for node files | `~/.anchor/{network}` |
-| `--network <NETWORK>` | Network to use (mainnet, holesky, hoodi) | `hoodi` |
-| `-t, --testnet-dir <DIR>` | Directory containing testnet specs | None |
-| `--debug-level <DEBUG_LEVEL>` | Verbosity level for terminal logs | `INFO` |
-| `-h, --help` | Display help information | |
-
-### Manual Keysplit Subcommand
-
-```bash
-anchor keysplit manual [OPTIONS]
-```
-
-Additional Options:
-
-| Option | Description | Default |
-| --- | --- | ---|
-| `--nonce <NONCE>` | Nonce for the owner address | Required |
-| `--public-keys <KEYS>...` | RSA public keys for the operators | Required|
-
-### Onchain Keysplit Subcommand
-
-```bash
-anchor keysplit onchain [OPTIONS]
-```
-
-Additional Options:
-
-| Option | Description | Default |
-| --- | --- | ---|
-| `--rpc <ENDPOINT>` | RPC endpoint to access L1 data | Required|
+<CliKeysplitOptions />
 
 #### Examples
 

--- a/docs/docs/pages/cli-node.mdx
+++ b/docs/docs/pages/cli-node.mdx
@@ -1,3 +1,5 @@
+import CliNodeOptions from '../generated/cli-node-options.mdx'
+
 ## Node Command
 
 The `node` command starts the anchor client as a SSV operator node.
@@ -8,93 +10,7 @@ anchor node [OPTIONS]
 
 ### Options
 
-#### External APIs
-
-| Option | Description | Default |
-| --- | --- | ---|
-| `--beacon-nodes <NETWORK_ADDRESSES>` | Comma-separated beacon node HTTP URLs | `http://localhost:5052`|
-| `--execution-rpc <NETWORK_ADDRESSES>` | Comma-separated execution node RPC URLs | `http://localhost:8545` |
-| `--execution-ws <NETWORK_ADDRESSES>` | Execution node websocket URL | `ws://localhost:8546` |
-| `--beacon-nodes-tls-certs <CERTIFICATE-FILES>` | Comma-separated paths to custom TLS certificates for beacon nodes (PEM format) | None |
-| `--execution-nodes-tls-certs <CERTIFICATE-FILES>` | Comma-separated paths to custom TLS certificates for execution nodes (PEM format) | None |
-
-#### HTTP API
-
-| Option | Description | Default |
-| --- | --- | ---|
-| `--http` | Enable the HTTP API sever | Disabled |
-| `--http-address <ADDRESS>` | Listen address for HTTP API | None |
-| `--http-port <PORT>` | Listen port for HTTP API | `5062` if `--http` is set |
-| `--http-allow-origin <ORIGIN>` | Set CORS allowed origin | None |
-| `--unencrypted-http-transport` | Safety flag to acknowledge HTTP is unencrypted | Required if `--http-address` is set|
-
-#### Metrics Options
-
-| Option | Description | Default |
-| --- | --- | ---|
-| `--metrics` | Enable metrics server | Disabled |
-| `--metrics-address <ADDRESS>` | Listen address for metrics server | `127.0.0.1` if `--metrics` is set |
-| `--metrics-port <PORT>` | Listen port for metrics server | `5164` if `--metrics` is set |
-
-#### Network Options
-
-| Option | Description | Default |
-| --- | --- | ---|
-| `--listen-addresses [<ADDRESS>...]` | Network addresses to listen for UDP & TCP connections (can be set multiple times for IPv4 and IPv6) | `0.0.0.0` |
-| `--port <PORT>` | TCP/UDP ports for IPv4 (discovery and TCP will use this value, QUIC will use this + 1) | `12001` (discovery), `13001` (TCP) |
-| `--port6 <PORT>` | TCP/UDP ports for IPv6 when listening over both IPv4 and IPv6 (QUIC will use this + 1) | Same as `--port` |
-| `--discovery-port <PORT>` | UDP port for discovery | Same as `--port` if specified, otherwise `12001` |
-| `--discovery-port6 <PORT>` | UDP port for IPv6 discovery | Same as `--discovery-port` |
-| `--quic-port <PORT>` | UDP port for QUIC protocol | `--port` + 1 |
-| `--quic-port6 <PORT>` | UDP port for IPv6 QUIC protocol | `--port6` + 1 |
-| `--boot-nodes <BOOT_NODES>` | Comma-separated ENRs or Multiaddrs to bootstrap the network | None|
-| `--enr-address <ADDRESS>` | IPv4 address to broadcast in the node's ENR | None |
-| `--enr-address6 <ADDRESS>` | IPv6 address to broadcast in the node's ENR | None |
-| `--enr-udp-port <PORT>` | UDP port to advertise in the node's ENR | None |
-| `--enr-tcp-port <PORT>` | TCP port to advertise in the node's ENR | None |
-| `--enr-quic-port <PORT>` | QUIC port to advertise in the node's ENR | None |
-| `--enr-udp6-port <PORT>` | IPv6 UDP port to advertise in the node's ENR | None |
-| `--enr-tcp6-port <PORT>` | IPv6 TCP port to advertise in the node's ENR | None |
-| `--enr-quic6-port <PORT>` | IPv6 QUIC port to advertise in the node's ENR | None |
-| `--disable-enr-auto-update` | Disable discovery from automatically updating the ENR with external addresses | Disabled |
-| `--subscribe-all-subnets` | Subscribe to all subnets regardless of committee membership | Disabled|
-
-#### Security Options
-
-| Option | Description | Default |
-| --- | --- | ---|
-| `--key-file <PATH>` | Path to the operator key file (`.txt` for unencrypted, `.json` for encrypted) | Detected in data dir |
-| `--password-file <PATH>` | Path to a file containing the key password for decryption | None |
-
-#### Payload Building Options
-
-| Option | Description | Default |
-| --- | --- | ---|
-| `--builder-boost-factor <UINT64>` | Percentage multiplier to apply to builder's payload value | None |
-| `--prefer-builder-proposals` | Always prefer builder blocks regardless of payload value | Disabled |
-| `--gas-limit <INTEGER>` | Gas limit for all builder proposals for all validators | `36000000` |
-
-#### Logging Options
-
-| Option | Description | Default |
-| --- | --- | ---|
-| `--debug-level <DEBUG_LEVEL>` | Verbosity for terminal logs | `INFO` |
-| `--logfile-debug-level <LOGFILE_DEBUG_LEVEL>` | Verbosity for file logs | `DEBUG` |
-| `--logfile-max-size <SIZE>` | Maximum size of each log file in MB (set to 0 to disable) | `50` |
-| `--logfile-max-number <NUMBER>` | Maximum number of log files to keep (set to 0 to disable) | `10` |
-| `--logfile-dir <DIR>` | Directory to store log files | Same as `--data-dir` |
-| `--logfile-compression` | Compress old log files | Disabled |
-| `--logfile-color` | Enable colors in logfile | Disabled |
-| `--discv5-log-level <DISCV5_LOG_LEVEL>` | Verbosity level for discv5 dependency log file | `DEBUG` |
-| `--libp2p-log-level <LIBP2P_LOG_LEVEL>` | Verbosity level for libp2p dependency log file | `DEBUG` |
-
-#### Additional Network and Performance Options
-
-| Option | Description | Default |
-| --- | --- | ---|
-| `--disable-gossipsub-peer-scoring` | Disable gossipsub peer scoring | Enabled |
-| `--disable-latency-measurement-service` | Disable the latency measurement service | Enabled |
-| `--enable-high-validator-count-metrics` | Enable per validator metrics for > 64 validators | Auto-enabled for ≤ 64 validators |
+<CliNodeOptions />
 
 #### Examples
 
@@ -116,5 +32,3 @@ anchor node \
   --metrics-port 9300 \
   --password-file /path/to/your/password
 ```
-
-

--- a/docs/docs/pages/cli.mdx
+++ b/docs/docs/pages/cli.mdx
@@ -1,3 +1,5 @@
+import CliGlobalOptions from '../generated/cli-global-options.mdx'
+
 # Anchor CLI Reference
 
 This document provides a comprehensive reference for Anchor's command-line interface, including all available commands, subcommands, and options.
@@ -18,12 +20,4 @@ Where `<COMMAND>` is one of:
 
 ### Global Options
 
-| Option | Description | Default               |
-| --- | --- |-----------------------|
-| `-d, --data-dir <DIR>` | Data directory for node files | `~/.anchor/{network}` |
-| `-t, --testnet-dir <DIR>` | Directory containing testnet specs | None                  |
-| `--network <NETWORK>` | Network to use (mainnet, holesky, hoodi) | `mainnet`               |
-| `--debug-level <DEBUG_LEVEL>` | Verbosity level for terminal logs | `INFO` |
-| `-h, --help` | Display help information | Unset                 |
-| `-V, --version` | Print version information | Unset |
-
+<CliGlobalOptions />


### PR DESCRIPTION
## Problem, Evidence, and Context (Required)

- PR for #856 that separates source-code related CLI documentation from hand-written additional examples and usage directions.
- `generated` file content taken from current `unstable` state.
- A pre-condition for PR #939 to separate automated documentation generation from
    - project structure and destination of CLI documentation outputs,
    - distinction between ongoing hand-written documentation and what will be machine-generated,
    - actual content of CLI documentation.

#939 will no longer be concerned with documentation structure, only with how the documentation is generated.

## Change Overview (Required)

-  `docs/docs/generated` directory created to store `.mdx` files containing only CLI help documentation directly related to the structure of the Anchor CLI tree.
- `docs/docs/pages` now imports the CLI help documentation from `generated` instead of owning this information.
- `README` in `docs` [reflects the state of the project at this point in time](https://github.com/sigp/anchor/compare/unstable...jnhsigmap:anchor:feat/automated-pages?expand=1#diff-0b5ca119d2be595aa307d34512d9679e49186307ef94201e4b3dfa079aa89938R78). Removed mention of automation as this is yet to occur.

### Discussion Points

- Only the structure of this ownership model, as it allows neat separation of what could become machine generated and what will be hand-written.
- The contract between structure and indentation/heading level of machine-generated outputs and main `pages` documentation becomes less obvious with this change, however can still be enforced during review as it is clear when the heading levels would ever change in `generated`.

## Risks, Trade-offs, and Mitigations (Required)

No risks.

## Validation (Required)
n/a

## Rollback (Required for behavior or runtime changes; optional otherwise)

Remove references to `generated` from `pages`
