### PR TITLE
test: DutySpecTest

### DIFF
--- a/anchor/spec_tests/src/runner/types_dispatcher.rs
+++ b/anchor/spec_tests/src/runner/types_dispatcher.rs
@@ -70,6 +70,20 @@ fn dispatch_fixture_by_prefix(prefix: &str, path: &Path, contents: &str) -> Disp
             DispatchOutcome::Executed(run_test::<types::ConsensusDataProposerTest>(path, contents))
         }
 
+        // Lighthouse's VC drives Anchor through per-duty trait methods (`sign_block_proposal`,
+        // `sign_aggregate`, …), so Anchor always knows which duty it's in at the call site
+        // and hardcodes the wire `Role` there for parity with go-ssv. It never holds a
+        // `BeaconRole` and needs to dispatch on it.
+        //
+        // Go-ssv does need that dispatch — its `Validator` keeps `runners map[RunnerRole]Runner`
+        // and looks up the right runner per incoming duty, which is what `MapDutyToRunnerRole`
+        // (the function this spec test verifies) provides. Anchor has no equivalent and no
+        // caller for one. Not applicable.
+        "duty.DutySpecTest" => {
+            eprintln!("SKIP (known-inapplicable): {prefix}");
+            DispatchOutcome::SkippedKnown
+        }
+
         // TODO(spec-tests): Add more test types here as they are implemented.
         // This arm will be replaced with panic!() once all test types are added.
         _ => {


### PR DESCRIPTION
## Problem, Evidence, and Context

Closes #956 (parent #954). The issue asked to add `DutySpecTest` to the spec test suite by mirroring Go's `MapDutyToRunnerRole()`. After implementing it and reviewing, we concluded the test is **not applicable to Anchor's architecture** and is being skipped via `DispatchOutcome::SkippedKnown` instead — same precedent as `share.EncodingTest` (different `Share` type) already in the dispatcher.

The full architectural reasoning is inline in the dispatch arm — please read that comment as the source of truth. Summary:

- Go-ssv's `Validator` keeps `runners map[types.RunnerRole]Runner` and dispatches each incoming duty by role lookup at runtime. `MapDutyToRunnerRole` exists as the `BeaconRole → RunnerRole` bridge that lookup requires, and `DutySpecTest` exists to verify it.
- Anchor doesn't dispatch by role lookup. Lighthouse's VC drives Anchor through per-duty trait methods (`sign_block_proposal`, `sign_aggregate`, `sign_attestation`, …), so each handler in `validator_store` / `qbft_manager` already knows which duty it's in at the call site and writes the correct wire `Role` literal inline (for go-ssv parity on the wire). Anchor never holds a generic `BeaconRole` and asks "which `Role` goes with this?"
- There is no `RunnerRole` type in Anchor and no `BeaconRole → Role` function. We searched the codebase: zero production functions take `BeaconRole` as input. The mapping is distributed across handlers as hardcoded `(BeaconRole, Role)` pairs.
- Pre-Boole, those pairings deliberately diverge from the spec at the aggregator/sync-committee branches (legacy `Role::Aggregator` / `Role::SyncCommittee` instead of `Role::AggregatorCommittee`); post-Boole the wire roles converge but the bridge function still has no caller because the dispatch model doesn't change.

Implementing the test would mean writing a `MapDutyToRunnerRole` equivalent in the test file itself just to assert against the fixtures — a tautology, since the test author writes the mapping table the test verifies. It wouldn't catch any production Anchor bug because no production code performs the mapping.

## Change Overview

- One arm added to `runner/types_dispatcher.rs` for the prefix `"duty.DutySpecTest"`, returning `SkippedKnown` with the architectural rationale as a comment block above it.
- No new types, no new modules, no fixture handler.
- Reviewer: read the comment in `types_dispatcher.rs` first; that's the load-bearing artifact. The diff itself is +14 lines in one file.

## Risks, Trade-offs, and Mitigations

- **Trade-off**: declines an issue that asked for implementation. Mitigation: the architectural reason is documented in code, so anyone re-evaluating later (e.g., if Anchor refactors toward runtime role dispatch) has the context to revive the test.
- **Risk**: future maintainer adds the same arm with `Executed(...)` not knowing why it was skipped. Mitigation: the comment block is in the dispatch arm itself, not in a separate file, so it's hard to miss.
- No production behavior changes.

## Validation

- `cargo test -p spec_tests types_spec_tests`: passes. Fixture counts: `54 executed, 9 skipped (known-inapplicable), 51 skipped (not yet implemented)` (the 8 `duty.DutySpecTest_*` fixtures move from "not yet implemented" into the "known-inapplicable" bucket).
- `make cargo-fmt-check`: clean.
- `cargo clippy -p spec_tests --tests -- -D warnings`: clean.

## Rollback

Trivial — revert the single dispatcher edit. No runtime impact.

## Additional Info

If a reviewer disagrees with the skip-vs-implement decision, the conversation that led here is worth surfacing rather than just flipping the arm: the implementation we considered (and discarded) was a test-local `map_duty_to_runner_role` plus 6 i32 constants that mirrored Go's `RunnerRole` values. Either i32 constants or `Option<msgid::Role>` would work; both are tautologies. The real question is whether spec-conformance signaling is worth carrying a tautological test, and we're saying no in this case because Anchor's architecture makes the bridge function structurally meaningless, not just absent.
