### PR TITLE
fix: clippy useless conversion attestation zip

### DIFF
--- a/anchor/src/environment.rs
+++ b/anchor/src/environment.rs
@@ -131,7 +131,7 @@ impl Environment {
                 Err(e) => error!(error = ?e, "Could not register SIGHUP handler"),
             }
 
-            future::select(inner_shutdown, future::select_all(handles.into_iter())).await
+            future::select(inner_shutdown, future::select_all(handles)).await
         };
 
         match self.runtime().block_on(register_handlers) {

--- a/anchor/validator_store/src/lib.rs
+++ b/anchor/validator_store/src/lib.rs
@@ -1770,7 +1770,7 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> AnchorValidator
             .collect();
 
         for ((validator_index, attestation, validator_pubkey), slashing_status) in
-            attestations.into_iter().zip(results.into_iter())
+            attestations.into_iter().zip(results)
         {
             match slashing_status {
                 Ok(()) => {


### PR DESCRIPTION
## Problem, Evidence, and Context

CI lint job is failing on `clippy::useless_conversion` for two pre-existing call sites. The repo doesn't pin a Rust toolchain, so CI picked up rustc 1.95.0 / clippy 0.1.95 (released 2026-04-14), which extended this lint to flag `.into_iter()` calls passed into `impl IntoIterator` parameters even when the receiver is already an `Iterator`.

Failing CI run: <https://github.com/sigp/anchor/actions/runs/24529318414/job/71708041784?pr=962>.

## Change Overview

Two one-line edits, same mechanical pattern (drop redundant `.into_iter()` inside `IntoIterator` argument):

- `anchor/validator_store/src/lib.rs:1773` — inside `Iterator::zip(...)`.
- `anchor/src/environment.rs:134` — inside `futures::future::select_all(...)`.

No behavior change; the explicit `.into_iter()` is a no-op in both cases.

## Risks, Trade-offs, and Mitigations

None of substance. Workspace audit (`cargo clippy --workspace --tests --benches`) confirms these are the only two sites; nothing else hides behind the toolchain bump.

Pinning the toolchain (the root cause of "CI advanced past local") is intentionally out of scope — separate policy decision.

## Validation

- `make lint` clean locally on rustc 1.95.0.
- Reverted each fix individually and re-ran clippy 1.95 → both lints reproduce; reapplied → both clear.

## Rollback

Revert the two-line patch.
