### PR TITLE
test: skip DepositDataSpecTest

### DIFF
--- a/anchor/spec_tests/src/runner/types_dispatcher.rs
+++ b/anchor/spec_tests/src/runner/types_dispatcher.rs
@@ -70,6 +70,19 @@ fn dispatch_fixture_by_prefix(prefix: &str, path: &Path, contents: &str) -> Disp
             DispatchOutcome::Executed(run_test::<types::ConsensusDataProposerTest>(path, contents))
         }
 
+        // Go's spec test pins ssv-spec's historical deposit-data primitive
+        // (used when DKG lived in ssv-spec pre-2023; now in ssvlabs/ssv-dkg
+        // which uses its own Go primitives). No Anchor production path generates
+        // or verifies deposit data: deposit signing is ssv-dkg's responsibility,
+        // on-chain verification is Ethereum's, and Anchor only consumes RSA-
+        // encrypted shares from `ValidatorAdded` events. Lighthouse drift in
+        // deposit primitives cannot affect Anchor or its ssv-dkg interop.
+        // Not applicable.
+        "beacon.DepositDataSpecTest" => {
+            eprintln!("SKIP (known-inapplicable): {prefix}");
+            DispatchOutcome::SkippedKnown
+        }
+
         // Lighthouse's VC drives Anchor through per-duty trait methods (`sign_block_proposal`,
         // `sign_aggregate`, …), so Anchor always knows which duty it's in at the call site
         // and hardcodes the wire `Role` there for parity with go-ssv. It never holds a


### PR DESCRIPTION
## Problem, Evidence, and Context (Required)

Closes #957 (part of #954).

[Diego flagged](https://github.com/sigp/anchor/pull/965#pullrequestreview-4169958615) that the prior revision executes a fixture with no SSV client runtime subject. Verified: no Go SSV production use, no Anchor production use, and ssv-dkg (which does use these primitives) is Go and independent of Lighthouse. `SkippedKnown` matches the existing convention for `share.EncodingTest` and `duty.DutySpecTest`. Full trail in `<details>` below.

## Change Overview (Required)

+13 lines in `anchor/spec_tests/src/runner/types_dispatcher.rs`: one `SkippedKnown` arm with rationale comment. No new helper/type/module.

**Intentionally did not change:** no production code.

## Risks, Trade-offs, and Mitigations (Required)

- Blast radius: `spec_tests` only.
- Trade-off: forgoes a Lighthouse-pin drift sentinel on deposit-domain signing. Accepted — Anchor uses none of those primitives, and shared-infrastructure drift (`signing_root`, `compute_domain`) fails the attestation/block/sync-committee tests that exercise production paths.

## Validation (Required)

- `make cargo-fmt-check`, `cargo clippy -p spec_tests --tests --all-features -- -D warnings`: clean.
- `cargo test -p spec_tests --release`: 1 passed.
- Dispatch confirmed via `--nocapture`: `SKIP (known-inapplicable): beacon.DepositDataSpecTest`. Fixture moved from `SkippedUnknown` (pre-PR baseline) to `SkippedKnown`.

## Rollback (Required for behavior or runtime changes; optional otherwise)

N/A — test-only.

## Blockers / Dependencies (Optional)

N/A.

## Additional Info / Next Steps (Optional)

<details>
<summary>Research trail behind the SkippedKnown call</summary>

### Is the fixture backed by SSV production code?

`gh search code` against `ssvlabs/ssv` — zero production hits for every primitive the fixture exercises:

- `GenerateETHDepositData`: 0
- `DepositMessage`: 0
- `DomainDeposit`: 0
- `ComputeETHDomain`: 0
- `phase0.DepositData`: 0

Only trace: `ssvsigner/web3signer/types.go:43` defines `TypeDeposit SignedObjectType = "DEPOSIT"` — a Web3Signer enum constant with no other references. Dead.

### Why the fixture exists in ssv-spec

Git archaeology on `types/spectest/tests/beacon/deposit_data.go`:

- `2022-06-22` (`f9bd13b`, "eth deposit data + spec test") — landed while ssv-spec still contained `dkg/`. `DKGRunner.prepareAndBroadcastDepositData()` called `types.GenerateETHDepositData(...)` as production code (see `RockX-SG/ssv-spec:dkg/runner.go`, a pre-extraction snapshot).
- `2022-12-13` — last commit to ssv-spec's `dkg/` directory.
- Post-2023 — DKG extracted to `ssvlabs/ssv-dkg` + `ssvlabs/dkg-spec`. The `eth1_deposit.go` primitive was demoted from `types/` to `types/testingutils/`. The spec test was retained and is now orphaned.

### Where deposit signing actually lives today

`ssvlabs/ssv-dkg` (actively maintained, last push 2026-04-23):

- `pkgs/crypto/beacon.go::SignDepositMessage` calls
- `ssvlabs/dkg-spec/crypto/beacon.go::ComputeDepositMessageSigningRoot` (uses `phase0.DepositMessage`, `DomainDeposit`, zero genesis root).

Go primitives, structurally equivalent to `GenerateETHDepositData`, parallel repo tree, independent of Lighthouse.

### Why this doesn't matter for ssv-dkg interop (#950)

Dataflow traced from ssv-dkg ceremony output through Anchor's consumption path:

- `deposit_data.json` — submitted by initiator to the Ethereum deposit contract; verified on-chain by Ethereum consensus. Anchor never touches it.
- `keyshares.json` — contains RSA-encrypted BLS shares; submitted to the SSV contract; surfaced to Anchor as `ValidatorAdded` events.
- Anchor consumption: `validator_store/src/lib.rs:1866-1900` RSA-PKCS1v15-decrypts the share. Uses `rsa` + Lighthouse's `bls` crate. Zero `DepositMessage`, zero `Domain::Deposit`, zero `compute_domain`.

Any Lighthouse drift in deposit primitives cannot affect ssv-dkg (which doesn't use Lighthouse) or Anchor (which doesn't use those primitives).

### Why not keep as a Lighthouse-pin drift sentinel?

Redundant. Any drift that would break the deposit fixture and matter to Anchor also fails existing tests that exercise production paths:

- `signing_root(obj, domain)` framework — caught by attestation/block/sync-committee spec tests.
- `compute_domain` — caught by every domain Anchor computes each slot (`BeaconAttester`, `BeaconProposer`, `SyncCommittee`, `Randao`, etc.).
- `max_effective_balance` — caught by balance/effective-balance paths.

The deposit-specific parts (`Domain::Deposit = 0x03000000`, `DepositMessage` SSZ layout) are the only things this fixture uniquely pins, and Anchor uses neither.

### Why `SkippedKnown` rather than silent fallthrough

Without this PR, the fixture falls through to `SkippedUnknown`. The existing `TODO(spec-tests)` at `types_dispatcher.rs:87-93` says that arm will be replaced with `panic!()` once all test types are mapped. `SkippedKnown` with a rationale comment is the honest categorization: we know what it is, we know why it doesn't apply, and the comment documents the reasoning for future maintainers.

</details>
