### PR TITLE
fix(qbft): align quorum rule with ssv-spec (2f + 1)

### DIFF
--- a/anchor/common/qbft/src/config.rs
+++ b/anchor/common/qbft/src/config.rs
@@ -221,9 +221,10 @@ where
             return Err(ConfigBuilderError::OperatorNotParticipant);
         }
 
-        // Validate `quorum_size`: must fall in `[2f + 1, quorum_size(N)]`.
+        // Validate `quorum_size`: must fall in `[2f + 1, N − f]`.
         let f = get_f(committee_size);
-        if self.quorum_size < f * 2 + 1 || self.quorum_size > quorum_size(committee_size) {
+        let max_quorum = quorum_size(committee_size);
+        if self.quorum_size < f * 2 + 1 || self.quorum_size > max_quorum {
             return Err(ConfigBuilderError::InvalidQuorumSize);
         }
 

--- a/anchor/common/qbft/src/config.rs
+++ b/anchor/common/qbft/src/config.rs
@@ -1,7 +1,7 @@
 use std::{fmt::Debug, time::Duration};
 
 use indexmap::IndexSet;
-use ssv_types::{OperatorId, Round, get_f, quorum_size};
+use ssv_types::{OperatorId, Round, is_valid_committee_size, quorum_size};
 
 use super::error::ConfigBuilderError;
 use crate::qbft_types::{DefaultLeaderFunction, InstanceHeight, LeaderFunction};
@@ -15,7 +15,6 @@ where
     instance_height: InstanceHeight,
     round: Round,
     committee_members: IndexSet<OperatorId>,
-    quorum_size: usize,
     round_time: Duration,
     max_rounds: usize,
     leader_fn: F,
@@ -43,7 +42,7 @@ impl<F: Clone + LeaderFunction> Config<F> {
     }
 
     pub fn quorum_size(&self) -> usize {
-        self.quorum_size
+        quorum_size(self.committee_members.len())
     }
 
     /// How long the round will last
@@ -70,7 +69,6 @@ impl<F: Clone + LeaderFunction> Config<F> {
             round: builder.round,
             round_time: builder.round_time,
             max_rounds: builder.max_rounds,
-            quorum_size: builder.quorum_size,
             leader_fn: builder.leader_fn.clone(),
         }
     }
@@ -92,7 +90,6 @@ where
     round: Round,
     round_time: Duration,
     max_rounds: usize,
-    quorum_size: usize,
 }
 
 impl<F> ConfigBuilder<F>
@@ -104,8 +101,6 @@ where
         instance_height: InstanceHeight,
         committee_members: IndexSet<OperatorId>,
     ) -> Self {
-        let default_quorum = quorum_size(committee_members.len());
-
         ConfigBuilder {
             operator_id,
             instance_height,
@@ -113,7 +108,6 @@ where
             round: Round::default(),
             round_time: Duration::new(2, 0),
             max_rounds: 4,
-            quorum_size: default_quorum,
             leader_fn: F::default(),
         }
     }
@@ -129,8 +123,6 @@ where
         committee_members: IndexSet<OperatorId>,
         leader_fn: F,
     ) -> Self {
-        let default_quorum = quorum_size(committee_members.len());
-
         ConfigBuilder {
             operator_id,
             instance_height,
@@ -138,7 +130,6 @@ where
             round: Round::default(),
             round_time: Duration::new(2, 0),
             max_rounds: 4,
-            quorum_size: default_quorum,
             leader_fn,
         }
     }
@@ -164,7 +155,7 @@ where
     }
 
     pub fn quorum_size(&self) -> usize {
-        self.quorum_size
+        quorum_size(self.committee_members.len())
     }
 
     pub fn max_rounds(&self) -> usize {
@@ -221,11 +212,9 @@ where
             return Err(ConfigBuilderError::OperatorNotParticipant);
         }
 
-        // Validate `quorum_size`: must fall in `[2f + 1, N − f]`.
-        let f = get_f(committee_size);
-        let max_quorum = quorum_size(committee_size);
-        if self.quorum_size < f * 2 + 1 || self.quorum_size > max_quorum {
-            return Err(ConfigBuilderError::InvalidQuorumSize);
+        // Validate `quorum_size`
+        if !is_valid_committee_size(committee_size) {
+            return Err(ConfigBuilderError::InvalidCommitteeSize);
         }
 
         // Validate `max_rounds`
@@ -240,5 +229,63 @@ where
 
         // If everything is okay, build and return a `Config`.
         Ok(Config::from_builder(&self))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn committee_members(size: usize) -> IndexSet<OperatorId> {
+        (1..=size as u64).map(OperatorId::from).collect()
+    }
+
+    fn builder(size: usize) -> ConfigBuilder<DefaultLeaderFunction> {
+        ConfigBuilder::new(
+            OperatorId::from(1),
+            InstanceHeight::default(),
+            committee_members(size),
+        )
+    }
+
+    #[test]
+    fn build_accepts_canonical_committee_sizes() {
+        for size in [4, 7, 10, 13] {
+            let config = builder(size)
+                .build()
+                .expect("canonical committee size should build");
+
+            assert_eq!(config.quorum_size(), quorum_size(size), "size={size}");
+        }
+    }
+
+    #[test]
+    fn build_rejects_empty_committee() {
+        let result = builder(0).build();
+
+        assert!(matches!(result, Err(ConfigBuilderError::NoParticipants)));
+    }
+
+    #[test]
+    fn build_rejects_non_canonical_committee_sizes() {
+        for size in [1, 2, 3, 5, 6, 8, 9, 11, 12, 14] {
+            let result = builder(size).build();
+
+            assert!(
+                matches!(result, Err(ConfigBuilderError::InvalidCommitteeSize)),
+                "size={size}: {result:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn builder_quorum_size_is_derived_from_committee_size() {
+        assert_eq!(builder(4).quorum_size(), 3);
+        assert_eq!(
+            builder(4)
+                .with_committee_members(committee_members(7))
+                .quorum_size(),
+            5
+        );
     }
 }

--- a/anchor/common/qbft/src/config.rs
+++ b/anchor/common/qbft/src/config.rs
@@ -1,7 +1,7 @@
 use std::{fmt::Debug, time::Duration};
 
 use indexmap::IndexSet;
-use ssv_types::{OperatorId, Round};
+use ssv_types::{OperatorId, Round, get_f, quorum_size};
 
 use super::error::ConfigBuilderError;
 use crate::qbft_types::{DefaultLeaderFunction, InstanceHeight, LeaderFunction};
@@ -61,11 +61,6 @@ impl<F: Clone + LeaderFunction> Config<F> {
         &self.leader_fn
     }
 
-    /// Obtains the maximum number of faulty nodes that this consensus can tolerate
-    pub fn get_f(&self) -> usize {
-        get_f(self.committee_members.len())
-    }
-
     /// Private constructor so it can only be built by our `ConfigBuilder`.
     fn from_builder(builder: &ConfigBuilder<F>) -> Self {
         Self {
@@ -79,10 +74,6 @@ impl<F: Clone + LeaderFunction> Config<F> {
             leader_fn: builder.leader_fn.clone(),
         }
     }
-}
-
-fn get_f(members: usize) -> usize {
-    (members - 1) / 3
 }
 
 /// Builder struct for constructing the QBFT instance configuration
@@ -113,9 +104,7 @@ where
         instance_height: InstanceHeight,
         committee_members: IndexSet<OperatorId>,
     ) -> Self {
-        let committee_size = committee_members.len();
-        let f = get_f(committee_size);
-        let default_quorum = committee_size.saturating_sub(f);
+        let default_quorum = quorum_size(committee_members.len());
 
         ConfigBuilder {
             operator_id,
@@ -140,9 +129,7 @@ where
         committee_members: IndexSet<OperatorId>,
         leader_fn: F,
     ) -> Self {
-        let committee_size = committee_members.len();
-        let f = get_f(committee_size);
-        let default_quorum = committee_size.saturating_sub(f);
+        let default_quorum = quorum_size(committee_members.len());
 
         ConfigBuilder {
             operator_id,
@@ -234,9 +221,9 @@ where
             return Err(ConfigBuilderError::OperatorNotParticipant);
         }
 
-        // Validate `quorum_size`
+        // Validate `quorum_size`: must fall in `[2f + 1, quorum_size(N)]`.
         let f = get_f(committee_size);
-        if self.quorum_size < f * 2 + 1 || self.quorum_size > committee_size - f {
+        if self.quorum_size < f * 2 + 1 || self.quorum_size > quorum_size(committee_size) {
             return Err(ConfigBuilderError::InvalidQuorumSize);
         }
 

--- a/anchor/common/qbft/src/config.rs
+++ b/anchor/common/qbft/src/config.rs
@@ -212,7 +212,7 @@ where
             return Err(ConfigBuilderError::OperatorNotParticipant);
         }
 
-        // Validate `quorum_size`
+        // Validate canonical SSV committee size
         if !is_valid_committee_size(committee_size) {
             return Err(ConfigBuilderError::InvalidCommitteeSize);
         }

--- a/anchor/common/qbft/src/error.rs
+++ b/anchor/common/qbft/src/error.rs
@@ -1,7 +1,7 @@
 use ssv_types::message::SignedSSVMessageError;
 
 /// Error associated with Config building.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ConfigBuilderError {
     /// No participants were specified
     NoParticipants,
@@ -9,8 +9,8 @@ pub enum ConfigBuilderError {
     ZeroMaxRounds,
     /// Starting round exceeds maximum rounds
     ExceedingStartingRound,
-    /// Quorum must be in \[2f+1, participants-f\]
-    InvalidQuorumSize,
+    /// Committee size must be canonical for SSV QBFT
+    InvalidCommitteeSize,
     /// Operator ID must be specified
     MissingOperatorId,
     /// Operator ID must be contained in participants
@@ -33,8 +33,11 @@ impl std::fmt::Display for ConfigBuilderError {
             Self::ExceedingStartingRound => {
                 write!(f, "Starting round exceeds maximum rounds")
             }
-            Self::InvalidQuorumSize => {
-                write!(f, "Quorum must be in [2f+1, participants-f]")
+            Self::InvalidCommitteeSize => {
+                write!(
+                    f,
+                    "Committee size must be of the form 3f + 1 (4, 7, 10, or 13)"
+                )
             }
             Self::MissingOperatorId => {
                 write!(f, "Operator ID must be specified")

--- a/anchor/common/qbft/src/lib.rs
+++ b/anchor/common/qbft/src/lib.rs
@@ -16,6 +16,7 @@ use ssv_types::{
         PrepareJustificationLength, QbftData, QbftDataValidator, QbftMessage, QbftMessageType,
         RoundChangeJustificationLength, UnsignedSSVMessage,
     },
+    get_f,
     message::{MsgType, SSVMessage, SignedSSVMessage},
     msgid::MessageId,
     try_to_variable_list,
@@ -1149,7 +1150,10 @@ where
             //    message
             let round = self
                 .round_change_container
-                .lowest_partial_quorum_above_round(self.current_round, self.config.get_f() + 1);
+                .lowest_partial_quorum_above_round(
+                    self.current_round,
+                    get_f(self.config.committee_members().len()) + 1,
+                );
             if let Some(round) = round
                 && round > self.current_round
             {

--- a/anchor/common/qbft/src/tests.rs
+++ b/anchor/common/qbft/src/tests.rs
@@ -85,7 +85,7 @@ impl Default for TestQBFTCommitteeBuilder {
             config: ConfigBuilder::new(
                 1.into(),
                 InstanceHeight::default(),
-                (1..6).map(OperatorId::from).collect(),
+                (1..=4).map(OperatorId::from).collect(),
             ),
         }
     }
@@ -202,7 +202,7 @@ fn test_basic_committee() {
 
     // Wait until consensus is reached or all the instances have ended
     let num_consensus = test_instance.wait_until_end();
-    assert!(num_consensus == 5);
+    assert_eq!(num_consensus, 4);
 }
 
 #[test]
@@ -214,7 +214,7 @@ fn test_consensus_with_f_faulty_operators() {
 
     // Wait until consensus is reached or all the instances have ended
     let num_consensus = test_instance.wait_until_end();
-    assert!(num_consensus == 4);
+    assert_eq!(num_consensus, 3);
 }
 
 #[test]
@@ -228,7 +228,7 @@ fn test_node_recovery() {
     test_instance.restart_instance(&OperatorId::from(2));
 
     let num_consensus = test_instance.wait_until_end();
-    assert_eq!(num_consensus, 5); // Should reach full consensus after recovery
+    assert_eq!(num_consensus, 4); // Should reach full consensus after recovery
 }
 
 #[test]
@@ -256,7 +256,7 @@ fn test_round_change_validation_skips_round_one_prepared_values() {
     let config = ConfigBuilder::<DefaultLeaderFunction>::new(
         1.into(),
         InstanceHeight::default(),
-        (1..4).map(OperatorId::from).collect(), // 3 nodes, quorum = 3
+        (1..=4).map(OperatorId::from).collect(), // 4 nodes, quorum = 3
     )
     .with_operator_id(OperatorId::from(1))
     .build()
@@ -287,7 +287,7 @@ fn test_round_change_validation_skips_round_one_prepared_values() {
                                                        * preparation! */
     };
 
-    // Create signed round change messages (need quorum of 3 for 3-node committee)
+    // Create signed round change messages (need quorum of 3 for 4-node committee)
     let mut signed_round_changes = vec![];
     for operator_id in [1, 2, 3] {
         // Create the SSVMessage properly
@@ -399,11 +399,11 @@ fn test_leader_waits_when_highest_prepared_data_missing() {
 
     // Create QBFT instance that will be leader for round 2
     // Leader for round R: committee[(R-1 + height) % committee_size]
-    // Round 2: (2-1+0) % 3 = 1 -> operator 2 (index 1 in [1,2,3])
+    // Round 2: (2-1+0) % 4 = 1 -> operator 2 (index 1 in [1,2,3,4])
     let config = ConfigBuilder::<DefaultLeaderFunction>::new(
         1.into(),
         InstanceHeight::default(),
-        (1..4).map(OperatorId::from).collect(), // [1, 2, 3]
+        (1..=4).map(OperatorId::from).collect(), // [1, 2, 3, 4]
     )
     .with_operator_id(OperatorId::from(2)) // This node is leader for round 2
     .build()

--- a/anchor/common/ssv_types/src/cluster.rs
+++ b/anchor/common/ssv_types/src/cluster.rs
@@ -48,7 +48,7 @@ impl Cluster {
     ///
     /// Exception: Returns 0 if there are no cluster members
     pub fn get_f(&self) -> u64 {
-        (self.cluster_members.len().saturating_sub(1) / 3) as u64
+        crate::get_f(self.cluster_members.len()) as u64
     }
 
     pub fn committee_id(&self) -> CommitteeId {

--- a/anchor/common/ssv_types/src/lib.rs
+++ b/anchor/common/ssv_types/src/lib.rs
@@ -26,6 +26,20 @@ pub use types::{Epoch, Slot};
 pub const RSA_SIGNATURE_SIZE: usize = 256;
 pub const MAX_SIGNATURES: usize = 13;
 
+/// Maximum Byzantine/faulty members a committee of `members` can tolerate:
+/// `f = ⌊(N − 1) / 3⌋`. Returns 0 for empty committees.
+pub fn get_f(members: usize) -> usize {
+    members.saturating_sub(1) / 3
+}
+
+/// Default QBFT quorum: `N − f`. Safe for any `N ≥ 1`; equivalent to `2f + 1`
+/// for canonical SSV sizes (`N = 3f + 1`: 4, 7, 10, 13) and strictly larger
+/// otherwise. Callers may override via `ConfigBuilder::with_quorum_size`
+/// within the valid range `[2f + 1, N − f]`.
+pub fn quorum_size(committee_size: usize) -> usize {
+    committee_size.saturating_sub(get_f(committee_size))
+}
+
 /// Converts a Vec to VariableList, returning a custom error on failure.
 pub fn try_to_variable_list<T, N, E, F>(vec: Vec<T>, error_fn: F) -> Result<VariableList<T, N>, E>
 where

--- a/anchor/common/ssv_types/src/lib.rs
+++ b/anchor/common/ssv_types/src/lib.rs
@@ -51,3 +51,48 @@ where
 
     VariableList::new(vec).map_err(|_| error_fn(vec_len, max_len))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Regression targets: `N / 3` vs `(N − 1) / 3` (at N=3), `saturating_sub(1)` revert (at N=0).
+    #[test]
+    fn get_f_matches_byzantine_formula() {
+        let cases = [
+            (0, 0),  // empty committee: `saturating_sub` contract
+            (3, 0),  // smallest N where `(N − 1) / 3` diverges from `N / 3`
+            (4, 1),  // canonical SSV (`N = 3f + 1`)
+            (7, 2),  // canonical SSV
+            (10, 3), // canonical SSV
+            (13, 4), // canonical SSV
+        ];
+        for (n, expected) in cases {
+            assert_eq!(get_f(n), expected, "get_f({n})");
+        }
+    }
+
+    // Regression targets: silent `2f + 1` substitution for `N − f`.
+    #[test]
+    fn quorum_size_is_n_minus_f() {
+        let cases = [
+            (3, 3),  // non-canonical: `N − f` = 3, `2f + 1` = 1
+            (4, 3),  // canonical SSV
+            (6, 5),  // non-canonical: `N − f` = 5, `2f + 1` = 3
+            (7, 5),  // canonical SSV
+            (10, 7), // canonical SSV
+            (13, 9), // canonical SSV
+        ];
+        for (n, expected) in cases {
+            assert_eq!(quorum_size(n), expected, "quorum_size({n})");
+        }
+    }
+
+    // Catches a refactor that inlines `quorum_size` and decouples it from `get_f`.
+    #[test]
+    fn quorum_size_composes_with_get_f() {
+        for n in 0..=MAX_SIGNATURES {
+            assert_eq!(quorum_size(n), n - get_f(n), "n={n}");
+        }
+    }
+}

--- a/anchor/common/ssv_types/src/lib.rs
+++ b/anchor/common/ssv_types/src/lib.rs
@@ -32,10 +32,10 @@ pub fn get_f(members: usize) -> usize {
     members.saturating_sub(1) / 3
 }
 
-/// Default QBFT quorum: `N − f`. Safe for any `N ≥ 1`; equivalent to `2f + 1`
-/// for canonical SSV sizes (`N = 3f + 1`: 4, 7, 10, 13) and strictly larger
-/// otherwise. Callers may override via `ConfigBuilder::with_quorum_size`
-/// within the valid range `[2f + 1, N − f]`.
+/// Default QBFT quorum: `N − f`. Equivalent to `2f + 1` when `N = 3f + 1`
+/// (SSV canonical sizes: 4, 7, 10, 13) and strictly larger for all other `N`.
+/// Uses `saturating_sub` so `N = 0` returns 0 without panicking; small committees
+/// (`N ≤ 3`) yield trivial unanimity quorums with `f = 0` (no Byzantine tolerance).
 pub fn quorum_size(committee_size: usize) -> usize {
     committee_size.saturating_sub(get_f(committee_size))
 }

--- a/anchor/common/ssv_types/src/lib.rs
+++ b/anchor/common/ssv_types/src/lib.rs
@@ -32,12 +32,27 @@ pub fn get_f(members: usize) -> usize {
     members.saturating_sub(1) / 3
 }
 
-/// Default QBFT quorum: `N − f`. Equivalent to `2f + 1` when `N = 3f + 1`
-/// (SSV canonical sizes: 4, 7, 10, 13) and strictly larger for all other `N`.
-/// Uses `saturating_sub` so `N = 0` returns 0 without panicking; small committees
-/// (`N ≤ 3`) yield trivial unanimity quorums with `f = 0` (no Byzantine tolerance).
+/// QBFT quorum threshold, matching Go SSV's `ComputeQuorumAndPartialQuorum`
+/// and ssv-spec's `CommitteeMember.GetQuorum`: `2f + 1`.
+///
+/// This is equal to `N - f` for canonical SSV committee sizes (`N = 3f + 1`),
+/// while non-canonical committee sizes should be rejected at config/event
+/// boundaries.
 pub fn quorum_size(committee_size: usize) -> usize {
-    committee_size.saturating_sub(get_f(committee_size))
+    get_f(committee_size) * 2 + 1
+}
+
+/// Returns true if `committee_size` is a canonical SSV committee size.
+///
+/// Matches Go SSV's `ValidCommitteeSize` and the SSV Network contract operator
+/// length rule: `N = 3f + 1`, with `f` in `1..=4`, i.e. 4, 7, 10, or 13.
+pub fn is_valid_committee_size(committee_size: usize) -> bool {
+    if committee_size == 0 {
+        return false;
+    }
+
+    let f = get_f(committee_size);
+    (committee_size - 1).is_multiple_of(3) && (1..=get_f(MAX_SIGNATURES)).contains(&f)
 }
 
 /// Converts a Vec to VariableList, returning a custom error on failure.
@@ -72,13 +87,15 @@ mod tests {
         }
     }
 
-    // Regression targets: silent `2f + 1` substitution for `N − f`.
+    // Regression targets: accidental `N - f` substitution for `2f + 1`.
     #[test]
-    fn quorum_size_is_n_minus_f() {
+    fn quorum_size_is_two_f_plus_one() {
         let cases = [
-            (3, 3),  // non-canonical: `N − f` = 3, `2f + 1` = 1
-            (4, 3),  // canonical SSV
-            (6, 5),  // non-canonical: `N − f` = 5, `2f + 1` = 3
+            (0, 1),  // empty committees are invalid, but the arithmetic stays `2f + 1`
+            (1, 1),  // non-canonical: f = 0
+            (3, 1),  // non-canonical: `N - f` = 3, `2f + 1` = 1
+            (4, 3),  // canonical SSV: `N - f` = `2f + 1`
+            (6, 3),  // non-canonical: `N - f` = 5, `2f + 1` = 3
             (7, 5),  // canonical SSV
             (10, 7), // canonical SSV
             (13, 9), // canonical SSV
@@ -92,7 +109,18 @@ mod tests {
     #[test]
     fn quorum_size_composes_with_get_f() {
         for n in 0..=MAX_SIGNATURES {
-            assert_eq!(quorum_size(n), n - get_f(n), "n={n}");
+            assert_eq!(quorum_size(n), get_f(n) * 2 + 1, "n={n}");
+        }
+    }
+
+    #[test]
+    fn valid_committee_size_matches_ssv_canonical_sizes() {
+        for n in [4, 7, 10, 13] {
+            assert!(is_valid_committee_size(n), "committee size {n}");
+        }
+
+        for n in [0, 1, 2, 3, 5, 6, 8, 9, 11, 12, 14, 15, 16] {
+            assert!(!is_valid_committee_size(n), "committee size {n}");
         }
     }
 }

--- a/anchor/common/ssv_types/src/lib.rs
+++ b/anchor/common/ssv_types/src/lib.rs
@@ -47,12 +47,8 @@ pub fn quorum_size(committee_size: usize) -> usize {
 /// Matches Go SSV's `ValidCommitteeSize` and the SSV Network contract operator
 /// length rule: `N = 3f + 1`, with `f` in `1..=4`, i.e. 4, 7, 10, or 13.
 pub fn is_valid_committee_size(committee_size: usize) -> bool {
-    if committee_size == 0 {
-        return false;
-    }
-
     let f = get_f(committee_size);
-    (committee_size - 1).is_multiple_of(3) && (1..=get_f(MAX_SIGNATURES)).contains(&f)
+    committee_size.saturating_sub(1).is_multiple_of(3) && (1..=get_f(MAX_SIGNATURES)).contains(&f)
 }
 
 /// Converts a Vec to VariableList, returning a custom error on failure.
@@ -91,7 +87,6 @@ mod tests {
     #[test]
     fn quorum_size_is_two_f_plus_one() {
         let cases = [
-            (0, 1),  // empty committees are invalid, but the arithmetic stays `2f + 1`
             (1, 1),  // non-canonical: f = 0
             (3, 1),  // non-canonical: `N - f` = 3, `2f + 1` = 1
             (4, 3),  // canonical SSV: `N - f` = `2f + 1`

--- a/anchor/eth/src/util.rs
+++ b/anchor/eth/src/util.rs
@@ -11,7 +11,9 @@ use database::NetworkDatabase;
 use reqwest::Client;
 use rusqlite::Transaction;
 use sensitive_url::SensitiveUrl;
-use ssv_types::{ClusterId, ENCRYPTED_KEY_LENGTH, OperatorId, Share, ValidatorMetadata};
+use ssv_types::{
+    ClusterId, ENCRYPTED_KEY_LENGTH, OperatorId, Share, ValidatorMetadata, is_valid_committee_size,
+};
 use tower::ServiceBuilder;
 use tracing::trace;
 use types::Graffiti;
@@ -151,8 +153,7 @@ pub fn validate_operators(
     }
 
     // make sure count is valid
-    let threshold = (num_operators - 1) / 3;
-    if !(num_operators - 1).is_multiple_of(3) || !(1..=4).contains(&threshold) {
+    if !is_valid_committee_size(num_operators) {
         return Err(ExecutionError::InvalidEvent(format!(
             "Given {num_operators} operators. Cannot build a 3f+1 quorum"
         )));

--- a/anchor/message_validator/src/consensus_message.rs
+++ b/anchor/message_validator/src/consensus_message.rs
@@ -9,15 +9,16 @@ use ssv_types::{
     consensus::{QbftMessage, QbftMessageType},
     message::SignedSSVMessage,
     msgid::Role,
+    quorum_size,
 };
 use ssz::Decode;
 use typenum::{U13, Unsigned};
 use types::Epoch;
 
 use crate::{
-    FIRST_ROUND, ValidatedSSVMessage, ValidationContext, ValidationFailure, compute_quorum_size,
-    duty_state::DutyState, hash_data, slot_start_time, validate_beacon_duty, validate_duty_count,
-    validate_role_for_fork, validate_slot_time, verify_message_signatures,
+    FIRST_ROUND, ValidatedSSVMessage, ValidationContext, ValidationFailure, duty_state::DutyState,
+    hash_data, slot_start_time, validate_beacon_duty, validate_duty_count, validate_role_for_fork,
+    validate_slot_time, verify_message_signatures,
 };
 
 pub(crate) fn validate_consensus_message(
@@ -77,7 +78,7 @@ pub(crate) fn validate_consensus_message_semantics(
 ) -> Result<(), ValidationFailure> {
     let signers = signed_ssv_message.operator_ids().len();
 
-    let quorum_size = compute_quorum_size(committee_info.committee_members.len());
+    let required_quorum = quorum_size(committee_info.committee_members.len());
     let msg_type = consensus_message.qbft_message_type;
 
     if signers > 1 {
@@ -90,10 +91,10 @@ pub(crate) fn validate_consensus_message_semantics(
         }
 
         // Rule: Number of signers must be >= quorum size
-        if signers < quorum_size {
+        if signers < required_quorum {
             return Err(ValidationFailure::DecidedNotEnoughSigners {
                 got: signers,
-                want: quorum_size,
+                want: required_quorum,
             });
         }
     }

--- a/anchor/message_validator/src/lib.rs
+++ b/anchor/message_validator/src/lib.rs
@@ -26,6 +26,7 @@ use slot_clock::SlotClock;
 use ssv_types::{
     CommitteeInfo, IndexSet, OperatorId, ValidatorIndex,
     consensus::QbftMessage,
+    get_f,
     message::{MsgType, SSVMessageError, SignedSSVMessage, SignedSSVMessageError},
     msgid::{DutyExecutor, MessageId, Role},
     partial_sig::PartialSignatureMessages,
@@ -1059,8 +1060,7 @@ pub fn sync_committee_period(
 }
 
 pub(crate) fn compute_quorum_size(committee_size: usize) -> usize {
-    let f = get_f(committee_size);
-    f * 2 + 1
+    get_f(committee_size) * 2 + 1
 }
 
 fn get_operator_pub_keys(
@@ -1075,11 +1075,6 @@ fn get_operator_pub_keys(
                 .map(|operator| (*id, operator.rsa_pubkey))
         })
         .collect()
-}
-
-// # TODO centralize this and the one in the qbft crate
-pub(crate) fn get_f(committee_size: usize) -> usize {
-    (committee_size - 1) / 3
 }
 
 pub(crate) fn hash_data(full_data: &[u8]) -> [u8; 32] {

--- a/anchor/message_validator/src/lib.rs
+++ b/anchor/message_validator/src/lib.rs
@@ -26,7 +26,6 @@ use slot_clock::SlotClock;
 use ssv_types::{
     CommitteeInfo, IndexSet, OperatorId, ValidatorIndex,
     consensus::QbftMessage,
-    get_f,
     message::{MsgType, SSVMessageError, SignedSSVMessage, SignedSSVMessageError},
     msgid::{DutyExecutor, MessageId, Role},
     partial_sig::PartialSignatureMessages,
@@ -1059,10 +1058,6 @@ pub fn sync_committee_period(
         .as_u64())
 }
 
-pub(crate) fn compute_quorum_size(committee_size: usize) -> usize {
-    get_f(committee_size) * 2 + 1
-}
-
 fn get_operator_pub_keys(
     network_state: &NetworkState,
     operator_ids: &IndexSet<OperatorId>,
@@ -1107,12 +1102,11 @@ mod tests {
     use ssz::Encode;
     use types::{Epoch, Slot};
 
-    use crate::{ValidationFailure, compute_quorum_size, hash_data};
+    use crate::{ValidationFailure, hash_data};
 
-    // Constants for committee sizes in tests to improve readability
+    // Constants for committee sizes in tests to improve readability.
     pub(crate) const SINGLE_NODE_COMMITTEE: usize = 1;
     pub(crate) const FOUR_NODE_COMMITTEE: usize = 4;
-    pub(crate) const SEVEN_NODE_COMMITTEE: usize = 7;
 
     // Helper struct for directly creating consensus messages for tests
     pub(crate) struct QbftMessageBuilder {
@@ -1356,28 +1350,6 @@ mod tests {
     // ---------------------------------------------------------------------
     // Utility function tests
     // ---------------------------------------------------------------------
-
-    #[test]
-    fn test_compute_quorum_size() {
-        // For committee_size=4 -> f=1 -> quorum=3.
-        assert_eq!(
-            compute_quorum_size(FOUR_NODE_COMMITTEE),
-            3,
-            "Expected quorum=3 for committee of 4"
-        );
-        // For committee_size=7 -> f=2 -> quorum=5.
-        assert_eq!(
-            compute_quorum_size(SEVEN_NODE_COMMITTEE),
-            5,
-            "Expected quorum=5 for committee of 7"
-        );
-        // For committee_size=1 -> f=0 -> quorum=1.
-        assert_eq!(
-            compute_quorum_size(SINGLE_NODE_COMMITTEE),
-            1,
-            "Expected quorum=1 for committee of 1"
-        );
-    }
 
     #[test]
     fn test_hash_data_root() {

--- a/anchor/qbft_manager/src/tests.rs
+++ b/anchor/qbft_manager/src/tests.rs
@@ -14,8 +14,10 @@ use ssv_types::{
     Cluster, ClusterId, CommitteeId, IndexSet, OperatorId,
     consensus::{BeaconVote, NoDataValidation, QbftMessage, QbftMessageType},
     domain_type::DomainType,
+    get_f,
     message::SignedSSVMessage,
     msgid::{DutyExecutor, MessageId, Role},
+    quorum_size,
 };
 use ssz::Decode;
 use task_executor::{ShutdownReason, TaskExecutor};
@@ -153,7 +155,7 @@ where
                         .expect("If consensus was reached, this must exist");
                     assert!(
                         aggregated_commit.signatures().len() as u64
-                            >= (self.tester.size as u64 - self.tester.size.get_f())
+                            >= quorum_size(self.tester.size as usize) as u64
                     );
                 },
                 _ = &mut timeout => {
@@ -177,18 +179,6 @@ pub enum CommitteeSize {
     Seven = 7,
     Ten = 10,
     Thirteen = 13,
-}
-
-impl CommitteeSize {
-    // The number of fault nodes that the committee can tolerate
-    fn get_f(&self) -> u64 {
-        match self {
-            CommitteeSize::Four => 1,
-            CommitteeSize::Seven => 2,
-            CommitteeSize::Ten => 3,
-            CommitteeSize::Thirteen => 4,
-        }
-    }
 }
 
 /// The main test coordinator that manages multiple QBFT instances
@@ -362,7 +352,7 @@ where
             self.identifiers.insert(height, data_id.clone());
 
             // Track the consensus results
-            let min_for_consensus = self.size as u64 - self.size.get_f();
+            let min_for_consensus = quorum_size(self.size as usize) as u64;
             self.results.write().unwrap().insert(
                 data.hash(),
                 ConsensusResult {
@@ -512,7 +502,7 @@ where
         let mut finished = true;
         // Make sure there are no more running instances
         for running in self.num_running.read().unwrap().values() {
-            finished &= *running <= self.size.get_f();
+            finished &= *running <= get_f(self.size as usize) as u64;
         }
 
         // Make sure we have received all of the aggregated commit message. There is race condition


### PR DESCRIPTION
## Problem, Evidence, and Context

Anchor's QBFT quorum used `N - f`, diverging from ssv-spec and Go-SSV (`2f + 1`). The formulas coincide at canonical SSV sizes (`N = 3f + 1`: `{4, 7, 10, 13}`) and diverge elsewhere. `message_validator::compute_quorum_size` already used `2f + 1`, so Anchor's two quorum rules disagreed internally on non-canonical input.

## Change Overview

- `ssv_types`: `quorum_size` now `2f + 1`; new `is_valid_committee_size` helper.
- `qbft::config`: `ConfigBuilder::build` rejects non-canonical sizes; removes the old `[2f + 1, N - f]` range validation; `quorum_size()` is a derived getter (no cached field).
- `message_validator`: duplicate `compute_quorum_size` wrapper deleted; call site uses the shared helper.
- `eth::util::validate_operators`: inline canonical check replaced with the shared helper.

## Risks, Trade-offs, and Mitigations

Non-canonical committee sizes are now rejected at `ConfigBuilder::build` (previously accepted); the quorum formula changes from `N - f` to `2f + 1` at those sizes. No production impact: the SSV Network contract already enforces canonical sizes on-chain.

## Validation

`cargo test` + `cargo clippy --all-targets -- -D warnings` + `make cargo-fmt-check`: clean on all touched crates.

## Rollback

`git revert` reverses all changes cleanly. No on-wire, config, or storage impact.

## Blockers / Dependencies

Unblocks #958 (CommitteeMemberTest spec test).

<details>
<summary>Background: spec references, defense-in-depth, why <code>N - f</code> was wrong</summary>

### Why `N - f` was wrong

`N - f` had no comment, design note, or spec citation. It coincides with `2f + 1` at canonical sizes but differs elsewhere (e.g., `N=6`: `N - f = 5`, `2f + 1 = 3`). Since `message_validator::compute_quorum_size` already used `2f + 1`, Anchor had two quorum rules that agreed on all production inputs but would silently disagree on anything non-canonical.

### Spec references

- ssv-spec `types/operator.go:27-33`: `CommitteeMember.GetQuorum` returns `2 * FaultyNodes + 1`; `HasQuorum` compares signers against that.
- Go-SSV `protocol/v2/types/ssvshare.go:228-267`: `ComputeQuorumAndPartialQuorum` returns `(f*2 + 1, f + 1)`; `ValidCommitteeSize` accepts `(N-1) % 3 == 0 && f in [1, 4]`.
- SSV Network contract (`ssvlabs/ssv-network` at `stage-v2.0.0-upgrade7`): `ValidatorLib.validateOperatorsLength` enforces canonical sizes at `registerValidator`.

### Defense-in-depth

Non-canonical sizes are rejected at three layers: the SSV Network contract on-chain, eth event ingestion (`eth::util::validate_operators`), and the qbft config builder. Production is already all-canonical; this PR makes the invariant explicit in Rust as well as on-chain.

### Intentionally unchanged

- `get_f` formula and its `saturating_sub` guard.
- `Cluster::get_f` (used by `validator_store` for the BLS Lagrange reconstruction threshold; separate contract, same value at canonical sizes).
- On-wire behaviour; event format; runtime semantics at canonical sizes.

</details>