### PR TITLE
test: committee member test

### DIFF
--- a/anchor/spec_tests/src/runner/types_dispatcher.rs
+++ b/anchor/spec_tests/src/runner/types_dispatcher.rs
@@ -45,6 +45,9 @@ fn dispatch_fixture_by_prefix(prefix: &str, path: &Path, contents: &str) -> Disp
         }
 
         // Validation tests
+        "committeemember.CommitteeMemberTest" => {
+            DispatchOutcome::Executed(run_test::<types::CommitteeMemberTest>(path, contents))
+        }
         "signedssvmsg.SignedSSVMessageTest" => {
             DispatchOutcome::Executed(run_test::<types::SignedSSVMessageTest>(path, contents))
         }

--- a/anchor/spec_tests/src/types/committee_member.rs
+++ b/anchor/spec_tests/src/types/committee_member.rs
@@ -50,22 +50,13 @@ pub struct CommitteeMemberTest {
 
 impl SpecTest for CommitteeMemberTest {
     fn run(&self) -> Result<(), String> {
-        // Arrange + Act: build the `SignedSSVMessage` through the production constructor,
-        // capturing either success or a mapped Go error code.
         let actual_code = self
             .build_signed_message()
             .err()
             .unwrap_or(error_codes::NO_ERROR);
+        error_codes::assert_error_code(self.expected_error_code, actual_code)?;
 
-        // Assert: validation error code matches the fixture's expectation.
-        if actual_code != self.expected_error_code {
-            return Err(format!(
-                "Expected error code {}, got {actual_code}",
-                self.expected_error_code,
-            ));
-        }
-
-        // Assert: quorum thresholds use deduplicated signers (matches Go's
+        // Quorum thresholds use deduplicated signers (matches Go's
         // `GetUniqueMessageSignersCount` behavior).
         let unique_signers: HashSet<u64> = self.message.operator_ids.iter().copied().collect();
         let unique_count = unique_signers.len();

--- a/anchor/spec_tests/src/types/committee_member.rs
+++ b/anchor/spec_tests/src/types/committee_member.rs
@@ -1,0 +1,131 @@
+use std::collections::HashSet;
+
+use serde::{Deserialize, de::IgnoredAny};
+use ssv_types::{OperatorId, message::SignedSSVMessage, quorum_size};
+
+use crate::{
+    SpecTest,
+    utils::{
+        deserializers::{deserialize_base64_list, deserialize_base64_or_null},
+        dtos::RawSSVMessage,
+        error_codes,
+    },
+};
+
+/// Fixture container for the signed message in `CommitteeMemberTest`.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+struct FixtureMessage {
+    #[serde(deserialize_with = "deserialize_base64_list")]
+    signatures: Vec<Vec<u8>>,
+    #[serde(rename = "OperatorIDs")]
+    operator_ids: Vec<u64>,
+    #[serde(rename = "SSVMessage")]
+    ssv_message: RawSSVMessage,
+    #[serde(deserialize_with = "deserialize_base64_or_null", default)]
+    full_data: Option<Vec<u8>>,
+}
+
+/// Only the length of `Committee` is exercised; quorum is derived from committee size
+/// via `ssv_types::quorum_size` (matches production QBFT behavior, see struct docs).
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+struct FixtureCommitteeMember {
+    committee: Vec<IgnoredAny>,
+}
+
+/// Mirrors Go's `CommitteeMemberTest`. Quorum check reuses `ssv_types::quorum_size`
+/// (the same helper `ConfigBuilder::new` seeds `Config::quorum_size()` with, which
+/// production `Qbft::has_quorum` compares against). For canonical SSV committees
+/// (`N ∈ {4, 7, 10, 13}`) this equals Go's `2f + 1`.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct CommitteeMemberTest {
+    committee_member: FixtureCommitteeMember,
+    message: FixtureMessage,
+    expected_has_quorum: bool,
+    expected_full_committee: bool,
+    expected_error_code: i64,
+}
+
+impl SpecTest for CommitteeMemberTest {
+    fn run(&self) -> Result<(), String> {
+        // Arrange + Act: build the `SignedSSVMessage` through the production constructor,
+        // capturing either success or a mapped Go error code.
+        let actual_code = self
+            .build_signed_message()
+            .err()
+            .unwrap_or(error_codes::NO_ERROR);
+
+        // Assert: validation error code matches the fixture's expectation.
+        if actual_code != self.expected_error_code {
+            return Err(format!(
+                "Expected error code {}, got {actual_code}",
+                self.expected_error_code,
+            ));
+        }
+
+        // Assert: quorum thresholds use deduplicated signers (matches Go's
+        // `GetUniqueMessageSignersCount` behavior).
+        let unique_signers: HashSet<u64> = self.message.operator_ids.iter().copied().collect();
+        let unique_count = unique_signers.len();
+        let committee_size = self.committee_member.committee.len();
+        let required_quorum = quorum_size(committee_size);
+
+        let has_quorum = unique_count >= required_quorum;
+        if has_quorum != self.expected_has_quorum {
+            return Err(format!(
+                "has_quorum: expected {}, got {has_quorum} \
+                 (unique={unique_count}, committee_size={committee_size}, \
+                 required={required_quorum})",
+                self.expected_has_quorum,
+            ));
+        }
+
+        let full_committee = unique_count == committee_size;
+        if full_committee != self.expected_full_committee {
+            return Err(format!(
+                "full_committee: expected {}, got {full_committee} \
+                 (unique={unique_count}, committee={committee_size})",
+                self.expected_full_committee,
+            ));
+        }
+
+        Ok(())
+    }
+}
+
+impl CommitteeMemberTest {
+    /// Run the fixture through the production `SignedSSVMessage::new()` validator.
+    /// Returns the mapped Go error code on failure.
+    fn build_signed_message(&self) -> Result<SignedSSVMessage, i64> {
+        let ssv_message = (&self.message.ssv_message)
+            .try_into()
+            .map_err(|_: String| error_codes::UNMAPPED_ERROR_CODE)?;
+
+        let signatures = self
+            .message
+            .signatures
+            .iter()
+            .map(|sig| {
+                <[u8; 256]>::try_from(sig.as_slice()).map_err(|_| error_codes::EMPTY_SIGNATURE)
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+
+        let operator_ids = self
+            .message
+            .operator_ids
+            .iter()
+            .copied()
+            .map(OperatorId)
+            .collect();
+
+        SignedSSVMessage::new(
+            signatures,
+            operator_ids,
+            ssv_message,
+            self.message.full_data.clone().unwrap_or_default(),
+        )
+        .map_err(|e| error_codes::signed_ssv_message_error_code(&e))
+    }
+}

--- a/anchor/spec_tests/src/types/committee_member.rs
+++ b/anchor/spec_tests/src/types/committee_member.rs
@@ -1,7 +1,7 @@
 use std::collections::HashSet;
 
 use serde::{Deserialize, de::IgnoredAny};
-use ssv_types::{OperatorId, message::SignedSSVMessage, quorum_size};
+use ssv_types::{OperatorId, get_f, message::SignedSSVMessage, quorum_size};
 
 use crate::{
     SpecTest,
@@ -26,12 +26,15 @@ struct FixtureMessage {
     full_data: Option<Vec<u8>>,
 }
 
-/// Only the length of `Committee` is exercised; quorum is derived from committee size
-/// via `ssv_types::quorum_size` (matches production QBFT behavior, see struct docs).
+/// `committee` is deserialized only for its length; per-operator data isn't needed
+/// because quorum is derived from `committee.len()` via `ssv_types::quorum_size`.
+/// `faulty_nodes` is asserted equal to `ssv_types::get_f(committee.len())` to detect
+/// drift between Anchor's `get_f` and Go's `ComputeF`.
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "PascalCase")]
 struct FixtureCommitteeMember {
     committee: Vec<IgnoredAny>,
+    faulty_nodes: usize,
 }
 
 /// Mirrors Go's `CommitteeMemberTest`. Quorum check reuses `ssv_types::quorum_size`
@@ -61,6 +64,18 @@ impl SpecTest for CommitteeMemberTest {
         let unique_signers: HashSet<u64> = self.message.operator_ids.iter().copied().collect();
         let unique_count = unique_signers.len();
         let committee_size = self.committee_member.committee.len();
+
+        // Verify the fixture's stored `FaultyNodes` agrees with Anchor's derivation.
+        // Go's `CommitteeMember.HasQuorum` uses the stored field directly, so this
+        // catches drift between `ssv_types::get_f` and Go's `ComputeF`.
+        let derived_f = get_f(committee_size);
+        if self.committee_member.faulty_nodes != derived_f {
+            return Err(format!(
+                "FaultyNodes mismatch: fixture={}, get_f({committee_size})={derived_f}",
+                self.committee_member.faulty_nodes,
+            ));
+        }
+
         let required_quorum = quorum_size(committee_size);
 
         let has_quorum = unique_count >= required_quorum;

--- a/anchor/spec_tests/src/types/committee_member.rs
+++ b/anchor/spec_tests/src/types/committee_member.rs
@@ -35,9 +35,9 @@ struct FixtureCommitteeMember {
 }
 
 /// Mirrors Go's `CommitteeMemberTest`. Quorum check reuses `ssv_types::quorum_size`
-/// (the same helper `ConfigBuilder::new` seeds `Config::quorum_size()` with, which
-/// production `Qbft::has_quorum` compares against). For canonical SSV committees
-/// (`N ∈ {4, 7, 10, 13}`) this equals Go's `2f + 1`.
+/// (`2f + 1`), the same helper `Config::quorum_size()` returns and production
+/// `Qbft::has_quorum` compares against. This matches Go's `CommitteeMember.GetQuorum`
+/// byte-for-byte at all committee sizes.
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "PascalCase")]
 pub struct CommitteeMemberTest {

--- a/anchor/spec_tests/src/types/mod.rs
+++ b/anchor/spec_tests/src/types/mod.rs
@@ -1,5 +1,6 @@
 mod aggregator_committee_consensus_data_encoding;
 mod beacon_vote_encoding;
+mod committee_member;
 mod consensus_data_proposer;
 mod encryption;
 mod partial_sig_message;
@@ -13,6 +14,7 @@ mod ssv_msg;
 
 pub use aggregator_committee_consensus_data_encoding::*;
 pub use beacon_vote_encoding::*;
+pub use committee_member::*;
 pub use consensus_data_proposer::*;
 pub use encryption::*;
 pub use partial_sig_message::*;

--- a/anchor/spec_tests/src/types/signed_ssv_msg.rs
+++ b/anchor/spec_tests/src/types/signed_ssv_msg.rs
@@ -47,13 +47,7 @@ impl SpecTest for SignedSSVMessageTest {
                 Ok(()) => error_codes::NO_ERROR,
                 Err(code) => code,
             };
-
-            if actual_code != self.expected_error_code {
-                return Err(format!(
-                    "Expected error code {}, got {actual_code}",
-                    self.expected_error_code,
-                ));
-            }
+            error_codes::assert_error_code(self.expected_error_code, actual_code)?;
         }
         Ok(())
     }

--- a/anchor/spec_tests/src/types/signed_ssv_msg.rs
+++ b/anchor/spec_tests/src/types/signed_ssv_msg.rs
@@ -2,7 +2,7 @@ use openssl::{hash::MessageDigest, pkey::PKey, sign::Verifier};
 use serde::Deserialize;
 use ssv_types::{
     OperatorId,
-    message::{SSVMessage, SignedSSVMessage, SignedSSVMessageError},
+    message::{SSVMessage, SignedSSVMessage},
 };
 use ssz::Encode;
 
@@ -81,7 +81,7 @@ impl SignedSSVMessageTest {
             ssv_message.clone(),
             msg.full_data.clone().unwrap_or_default(),
         )
-        .map_err(|e| Self::error_code_for(&e))?;
+        .map_err(|e| error_codes::signed_ssv_message_error_code(&e))?;
 
         self.verify_rsa_signatures(&signed_msg, &ssv_message)
     }
@@ -143,29 +143,5 @@ impl SignedSSVMessageTest {
             return Err("RSA signature verification failed".into());
         }
         Ok(())
-    }
-
-    /// Map Anchor's `SignedSSVMessageError` variants to Go's integer error codes.
-    fn error_code_for(error: &SignedSSVMessageError) -> i64 {
-        match error {
-            SignedSSVMessageError::NoSigners => error_codes::NO_SIGNERS,
-            SignedSSVMessageError::NoSignatures => error_codes::NO_SIGNATURES,
-            SignedSSVMessageError::ZeroSigner => error_codes::ZERO_SIGNER_NOT_ALLOWED,
-            SignedSSVMessageError::DuplicatedSigner => error_codes::NON_UNIQUE_SIGNER,
-            SignedSSVMessageError::SignersAndSignaturesWithDifferentLength => {
-                error_codes::INCORRECT_NUMBER_OF_SIGNATURES
-            }
-            // Unreachable: `prepare_signatures()` pads all sigs to exactly `[u8; 256]`
-            // before `new()` runs, so the size check inside `new()` always passes.
-            SignedSSVMessageError::WrongRSASignatureSize { .. } => error_codes::EMPTY_SIGNATURE,
-            SignedSSVMessageError::TooManySignatures { .. }
-            | SignedSSVMessageError::TooManyOperatorIDs { .. }
-            | SignedSSVMessageError::FullDataTooLong { .. }
-            | SignedSSVMessageError::SignersNotSorted
-            | SignedSSVMessageError::SSVMessageError(_) => {
-                // No Go error code equivalent —> sentinel forces test failure on mismatch.
-                error_codes::UNMAPPED_ERROR_CODE
-            }
-        }
     }
 }

--- a/anchor/spec_tests/src/utils/error_codes.rs
+++ b/anchor/spec_tests/src/utils/error_codes.rs
@@ -85,3 +85,24 @@ pub fn signed_ssv_message_error_code(err: &SignedSSVMessageError) -> i64 {
         | SignedSSVMessageError::SSVMessageError(_) => UNMAPPED_ERROR_CODE,
     }
 }
+
+// --- Assertions ---
+
+/// Mirrors ssv-spec's `tests.AssertErrorCode` (`types/spectest/tests/error.go`):
+/// `expected_error_code == NO_ERROR` requires `actual_code == NO_ERROR`;
+/// `actual_code == UNMAPPED_ERROR_CODE` always fails loudly (matches Go's
+/// `errors.As(err, &types.Error)` guard, which fails with "unknown error" when
+/// the error isn't a typed spec error); otherwise the codes are compared for equality.
+pub fn assert_error_code(expected_error_code: i64, actual_code: i64) -> Result<(), String> {
+    if actual_code == UNMAPPED_ERROR_CODE {
+        return Err(format!(
+            "Unknown error: validation returned a variant not mapped to a Go error code (expected {expected_error_code})"
+        ));
+    }
+    if actual_code != expected_error_code {
+        return Err(format!(
+            "Expected error code {expected_error_code}, got {actual_code}"
+        ));
+    }
+    Ok(())
+}

--- a/anchor/spec_tests/src/utils/error_codes.rs
+++ b/anchor/spec_tests/src/utils/error_codes.rs
@@ -3,6 +3,8 @@
 //! Only codes relevant to currently implemented spec tests are included.
 //! Add new codes as new test types are implemented.
 
+use ssv_types::message::SignedSSVMessageError;
+
 /// No error — validation passed.
 pub const NO_ERROR: i64 = 0;
 
@@ -57,3 +59,29 @@ pub const UNKNOWN_BLOCK_VERSION: i64 = 11;
 
 /// Sentinel for Anchor-specific errors without Go equivalents.
 pub const UNMAPPED_ERROR_CODE: i64 = -1;
+
+// --- Mappers ---
+
+/// Maps `SignedSSVMessageError` variants to Go's integer error codes from ssv-spec.
+///
+/// Variants without a Go equivalent map to `UNMAPPED_ERROR_CODE` so tests fail loudly
+/// on mismatch rather than silently matching some unrelated code.
+pub fn signed_ssv_message_error_code(err: &SignedSSVMessageError) -> i64 {
+    match err {
+        SignedSSVMessageError::NoSigners => NO_SIGNERS,
+        SignedSSVMessageError::NoSignatures => NO_SIGNATURES,
+        SignedSSVMessageError::ZeroSigner => ZERO_SIGNER_NOT_ALLOWED,
+        SignedSSVMessageError::DuplicatedSigner => NON_UNIQUE_SIGNER,
+        SignedSSVMessageError::SignersAndSignaturesWithDifferentLength => {
+            INCORRECT_NUMBER_OF_SIGNATURES
+        }
+        // Unreachable when callers pad all sigs to exactly `[u8; 256]` before
+        // `SignedSSVMessage::new()`, so the size check inside `new()` always passes.
+        SignedSSVMessageError::WrongRSASignatureSize { .. } => EMPTY_SIGNATURE,
+        SignedSSVMessageError::TooManySignatures { .. }
+        | SignedSSVMessageError::TooManyOperatorIDs { .. }
+        | SignedSSVMessageError::FullDataTooLong { .. }
+        | SignedSSVMessageError::SignersNotSorted
+        | SignedSSVMessageError::SSVMessageError(_) => UNMAPPED_ERROR_CODE,
+    }
+}


### PR DESCRIPTION
## Problem, Evidence, and Context (Required)

- Closes #958: adds the `CommitteeMemberTest` spec test from ssv-spec, validating Anchor's quorum and signed-message semantics against the Go reference.
- Worth doing now because the helper it depends on (`ssv_types::quorum_size`) was just aligned with Go's `2f + 1` formula in #966, so a spec test of the surrounding contract naturally fits.
- Anchor has no `CommitteeMember` type, but both contracts the Go test exercises (`SignedSSVMessage.Validate` and `CommitteeMember.HasQuorum`) map directly to production helpers (`SignedSSVMessage::new` and `ssv_types::quorum_size`).
- Relevant links: issue #958; ssv-spec `types/spectest/tests/committeemember/test.go`; depended on #966 (now merged).

## Change Overview (Required)

- One new spec-test type registered with the dispatcher: deserializes the Go fixture, runs it through the production `SignedSSVMessage` constructor for error-code parity, then evaluates quorum via the production helper and full-committee via deduplicated signer count.
- Read order: start with the new test module to see fixture shape and assertions; the diff in `signed_ssv_msg.rs` is a pure DRY refactor that promotes the existing error-code mapper into a shared utility now used by both spec tests.
- What intentionally did not change: production code (test-harness only); the crate's `Result<_, i64>` error-code convention; the older spec test's signature-padding policy (committee-member fixtures ship fixed 256-byte sigs and use strict size checks instead).

## Risks, Trade-offs, and Mitigations (Required)

- Blast radius: spec-tests crate only; no on-wire, runtime, config, or storage impact.
- Strict signature size (`<[u8; 256]>::try_from`) rejects non-256-byte sigs with `EMPTY_SIGNATURE`. All four current fixtures ship exactly-256-byte RSA sigs (verified); a future fixture with shorter sigs would need to adopt the existing padding helper.
- The shared error-code mapper is now used by two call sites, so any drift between Anchor's error variants and Go's error codes surfaces in both spec tests at once.

## Validation (Required)

- `cargo test -p spec_tests --lib`: dispatcher passes; four committee-member fixtures registered and exercised (`has_quorum`, `has_quorum_3f1`, `no_quorum_duplicate`, `quorum_with_duplicate`).
- `make cargo-fmt-check` and `make lint` clean.
- Fixture properties verified: signature sizes all `[256]`; committee sizes all `N=4`.

## Rollback (Required for behavior or runtime changes; optional otherwise)

- Test-harness only; revert the commit to remove. No config, data, or operational impact.

## Blockers / Dependencies (Optional)

- Originally blocked on #966; now merged. Branch is rebased onto current `unstable` and reduced to a single commit.

## Additional Info / Next Steps (Optional)

- The Go fixture's `FaultyNodes` field is deserialized and asserted equal to `ssv_types::get_f(committee.len())` before the quorum check. This catches drift between Anchor's `get_f` and Go's `ComputeF` with an explicit error message, rather than letting it surface only through a `has_quorum` mismatch.

