### PR TITLE
fix(eth): skip duplicate-owner validator replay

### DIFF
--- a/anchor/eth/src/event_processor.rs
+++ b/anchor/eth/src/event_processor.rs
@@ -495,6 +495,8 @@ impl EventProcessor {
             ));
         }
 
+        self.validate_validator_added_conflict(&owner, &validator_pubkey, &cluster_id, tx)?;
+
         // Fetch the validator metadata
         let validator_metadata = construct_validator_metadata(&validator_pubkey, &cluster_id)
             .map_err(|e| {
@@ -541,6 +543,58 @@ impl EventProcessor {
         );
         metrics::inc_counter_vec(&metrics::EXECUTION_EVENTS_PROCESSED, &["validator_added"]);
         Ok(())
+    }
+
+    /// Rejects `ValidatorAdded` events that conflict with validator state already reconstructed by
+    /// Anchor.
+    ///
+    /// Anchor and the Go SSV node both key reconstructed validator state globally by validator
+    /// pubkey, even though the contract stores registrations per `(owner, pubkey)`. Until the
+    /// wider data model changes, treat a second owner for an existing pubkey as malformed and skip
+    /// it rather than aborting historical sync on a DB uniqueness error.
+    fn validate_validator_added_conflict(
+        &self,
+        owner: &Address,
+        validator_pubkey: &PublicKeyBytes,
+        computed_cluster_id: &ClusterId,
+        tx: &Transaction<'_>,
+    ) -> Result<(), ExecutionError> {
+        let Some(_) = self
+            .db
+            .get_validator_metadata_tx(validator_pubkey, tx)
+            .map_err(|e| ExecutionError::Database(e.to_string()))?
+        else {
+            return Ok(());
+        };
+
+        let Some(existing_cluster) = self
+            .db
+            .get_cluster_by_validator_tx(validator_pubkey, tx)
+            .map_err(|e| ExecutionError::Database(e.to_string()))?
+        else {
+            return Err(ExecutionError::MissingCommittedState(
+                "Failed to fetch cluster for existing validator metadata".to_string(),
+            ));
+        };
+
+        if existing_cluster.owner != *owner {
+            return Err(ExecutionError::InvalidEvent(format!(
+                "Validator already exists with different owner address. Expected {}. Got {}",
+                existing_cluster.owner, owner
+            )));
+        }
+
+        if existing_cluster.cluster_id != *computed_cluster_id {
+            return Err(ExecutionError::InvalidEvent(format!(
+                "Validator already exists with different cluster id. Expected {:?}. Got {:?}",
+                existing_cluster.cluster_id, computed_cluster_id
+            )));
+        }
+
+        Err(ExecutionError::Duplicate(format!(
+            "Validator already exists for owner {} and cluster {:?}",
+            owner, computed_cluster_id
+        )))
     }
 
     // A validator has been removed from the network and its respective cluster

--- a/anchor/eth/tests/common/mod.rs
+++ b/anchor/eth/tests/common/mod.rs
@@ -49,6 +49,25 @@ pub fn create_valid_shares_data_for_owner_and_nonce(
     owner: Address,
     nonce: u16,
 ) -> (Bytes, PublicKeyBytes) {
+    let validator_secret_key = SecretKey::random();
+    create_valid_shares_data_for_validator_owner_and_nonce(
+        operator_ids,
+        &validator_secret_key,
+        owner,
+        nonce,
+    )
+}
+
+/// Generate valid shares data for a specific validator key, owner, and nonce.
+///
+/// This lets integration tests reuse the same validator pubkey across multiple
+/// `ValidatorAdded` events while still producing owner-specific signatures.
+pub fn create_valid_shares_data_for_validator_owner_and_nonce(
+    operator_ids: &[u64],
+    validator_secret_key: &SecretKey,
+    owner: Address,
+    nonce: u16,
+) -> (Bytes, PublicKeyBytes) {
     let operator_count = operator_ids.len();
 
     // Calculate expected length: signature + (public_keys * count) + (encrypted_keys * count)
@@ -58,9 +77,7 @@ pub fn create_valid_shares_data_for_owner_and_nonce(
 
     let mut shares_bytes = Vec::with_capacity(expected_length);
 
-    // 1. Generate a validator keypair for this test
-    // For testing purposes, just generate a random key and use it
-    let validator_secret_key = SecretKey::random();
+    // 1. Reuse the provided validator keypair so tests can model duplicate-pubkey scenarios.
     let validator_public_key = validator_secret_key.public_key();
     let validator_pubkey_bytes = validator_public_key.serialize();
     let validator_pubkey = PublicKeyBytes::deserialize(&validator_pubkey_bytes)

--- a/anchor/eth/tests/integration.rs
+++ b/anchor/eth/tests/integration.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 use alloy::primitives::{Address, Bytes};
-use bls::PublicKeyBytes;
+use bls::{PublicKeyBytes, SecretKey};
 use database::test_utils::queries;
 use eth::{
     SlashingProtection,
@@ -293,6 +293,136 @@ async fn test_cross_block_operator_and_validator_processing_succeeds() {
         _ = tokio::time::sleep(tokio::time::Duration::from_millis(100)) => {
             panic!("validator should have been queued for index sync");
         }
+    }
+}
+
+/// Ensures a later `ValidatorAdded` for the same pubkey but a different owner does not abort the
+/// fetched batch.
+///
+/// The underlying schema mismatch predates the recent sync/refinery PRs: Anchor has always keyed
+/// validator state globally by pubkey. This test captures the user-visible regression boundary:
+/// historical sync must keep progressing even when the later block contains this contract-permitted
+/// edge case.
+#[tokio::test]
+async fn test_cross_owner_duplicate_validator_pubkey_is_skipped() {
+    setup_tracing();
+
+    // Arrange: one fetched batch contains operator setup, an initial validator registration, and
+    // then a second registration of the same validator pubkey under a different owner.
+    let mut test = ProcessorFixture::new_empty();
+    let operator_ids = vec![1u64, 2u64, 3u64, 4u64];
+    let operator_block = 12410;
+    let first_validator_block = 12411;
+    let duplicate_validator_block = 12412;
+    let first_owner = Address::from_str(TEST_CLUSTER_OWNER).expect("Invalid address");
+    let second_owner = Address::random();
+    let validator_secret_key = SecretKey::random();
+    let (first_shares, validator_pubkey_bytes) =
+        create_valid_shares_data_for_validator_owner_and_nonce(
+            &operator_ids,
+            &validator_secret_key,
+            first_owner,
+            0,
+        );
+    let (second_shares, _) = create_valid_shares_data_for_validator_owner_and_nonce(
+        &operator_ids,
+        &validator_secret_key,
+        second_owner,
+        0,
+    );
+    let validator_public_key = Bytes::from(validator_pubkey_bytes.serialize().to_vec());
+
+    let mut logs = Vec::new();
+    for (log_index, operator_id) in operator_ids.iter().enumerate() {
+        logs.push(create_operator_added_log_at_position(
+            *operator_id,
+            Address::random(),
+            create_valid_rsa_public_key_bytes(),
+            1000 + *operator_id,
+            operator_block,
+            0,
+            log_index as u64,
+        ));
+    }
+
+    logs.push(create_validator_added_log_at_position(
+        first_owner,
+        operator_ids.clone(),
+        validator_public_key.clone(),
+        first_shares,
+        first_validator_block,
+        0,
+        0,
+    ));
+    logs.push(create_validator_added_log_at_position(
+        second_owner,
+        operator_ids.clone(),
+        validator_public_key,
+        second_shares,
+        duplicate_validator_block,
+        0,
+        0,
+    ));
+
+    // Act: process the entire fetched batch in one call, matching historical sync behavior.
+    let result = test
+        .processor
+        .process_logs(logs, false, duplicate_validator_block);
+
+    // Assert: the later duplicate-owner event is skipped rather than aborting the batch.
+    assert!(
+        result.is_ok(),
+        "cross-owner duplicate validator pubkey should not abort batch processing"
+    );
+
+    let cluster_id = compute_cluster_id(first_owner, &operator_ids);
+    let duplicate_cluster_id = compute_cluster_id(second_owner, &operator_ids);
+    let validator_pubkey_str = format!("0x{}", hex::encode(validator_pubkey_bytes.serialize()));
+    let mut conn = test
+        .processor
+        .db
+        .connection()
+        .expect("Failed to get database connection");
+    let tx = conn.transaction().expect("Failed to start transaction");
+    let stored_validator =
+        queries::get_validator(&validator_pubkey_str, &tx).expect("validator should exist");
+
+    assert_eq!(
+        stored_validator.cluster_id, cluster_id,
+        "the first registration should remain authoritative"
+    );
+    assert!(
+        queries::get_cluster(cluster_id, &tx).is_some(),
+        "the original cluster should exist"
+    );
+    assert!(
+        queries::get_cluster(duplicate_cluster_id, &tx).is_none(),
+        "the duplicate-owner cluster should not be created"
+    );
+    assert_eq!(
+        test.processor.db.state().get_last_processed_block(),
+        duplicate_validator_block,
+        "historical sync should advance through the duplicate-owner block"
+    );
+
+    tokio::select! {
+        validator_key = test.index_sync_rx.recv() => {
+            assert_eq!(
+                validator_key,
+                Some(validator_pubkey_bytes),
+                "only the first registration should queue index sync"
+            );
+        }
+        _ = tokio::time::sleep(tokio::time::Duration::from_millis(100)) => {
+            panic!("the first registration should queue index sync");
+        }
+    }
+
+    tokio::select! {
+        validator_key = test.index_sync_rx.recv() => {
+            panic!("unexpected second index-sync enqueue for duplicate-owner event: {validator_key:?}");
+        }
+        _ = tokio::time::sleep(tokio::time::Duration::from_millis(100)) => {}
     }
 }
 


### PR DESCRIPTION
## Problem, Evidence, and Context (Required)

- Historical sync can halt on cross-owner duplicate validator pubkeys with `UNIQUE constraint failed: validators.validator_pubkey` instead of skipping the conflicting event.
- This is worth fixing now because it wedges historical sync on `unstable` once the old global-uniqueness assumption collides with valid on-chain history.
- Evidence: issue `#969`, the new regression test in this PR, and the existing issue discussion showing deterministic reproduction on Hoodi.
- Relevant links: `#969`, `#351`.

## Change Overview (Required)

- Add an explicit pre-insert conflict check in `process_validator_added`.
- Treat an existing validator pubkey under a different owner or cluster as malformed for Anchor's current data model, and skip it before validator-side effects or DB writes occur.
- Add a regression test that replays two `ValidatorAdded` logs with the same pubkey under different owners in one historical sync batch.
- Add a test helper that can reuse the same validator pubkey across owners while keeping signatures valid.
- Intentionally unchanged: schema, event-disposition enums, and `#351`'s abort-on-internal-failure direction.

## Risks, Trade-offs, and Mitigations (Required)

- Main risk: this keeps Anchor's current first-write-wins behavior for duplicate pubkeys instead of redesigning the validator schema.
- Trade-off: the fix is intentionally narrow and preserves the existing client data model rather than attempting a broader protocol-model change in this PR.
- Mitigation: the conflict is classified before slashing-protection registration or DB insertion, so the event is skipped without partial validator-side effects.

## Validation (Required)

- Targeted regression: `cargo test -p eth test_cross_owner_duplicate_validator_pubkey_is_skipped -- --nocapture`
- Full eth test suite: `cargo test -p eth --tests`
- Formatting: `cargo fmt --all --check`
- Linting: `cargo clippy -p eth --all-targets -- -D warnings`
- Fresh Hoodi replay: `cargo run --release -- node --network hoodi --data-dir /tmp/anchor-issue-969-hoodi-fresh --use-zero-ports --disable-upnp --beacon-nodes https://colo.sigp-dev.net/hoodi-bn/oxe3bah7tooF/ --execution-rpc https://colo.sigp-dev.net/hoodi-ee/oxe3bah7tooF/ --execution-ws wss://colo.sigp-dev.net/hoodi-ee/oxe3bah7toWS/`
- Result: the fresh replay advanced `/tmp/anchor-issue-969-hoodi-fresh/anchor_db.sqlite` `metadata.block_number` to `48996`, which is well past the old failing block `41163`, and no `validators.validator_pubkey` `UNIQUE` error appeared in `logs/anchor.log*`.
- The same run later stopped on a separate issue at block `48998`, outside the scope of this PR.

## Rollback (Required for behavior or runtime changes; optional otherwise)

- Safe rollback is a normal revert of this commit.
- No config, schema, or data migration impact.

## Blockers / Dependencies (Optional)

- N/A

## Additional Info / Next Steps (Optional)

- The underlying mismatch predates `#351`; that PR made it user-visible by aborting batch processing once the old assumption hit valid on-chain history.
- A broader contract/client data-model clarification can be handled separately; it is intentionally out of scope for this fix.

Closes #969
