### PR TITLE
ci: address cargo audit failure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6753,9 +6753,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/Makefile
+++ b/Makefile
@@ -144,8 +144,16 @@ audit: install-audit audit-CI
 install-audit:
 	cargo install --force cargo-audit
 
+# Keep real vulnerabilities failing CI while suppressing reviewed warning-only
+# advisories from current upstream transitive dependencies.
+AUDIT_IGNORES = \
+	--ignore RUSTSEC-2024-0388 \
+	--ignore RUSTSEC-2024-0436 \
+	--ignore RUSTSEC-2026-0002 \
+	--ignore RUSTSEC-2026-0097
+
 audit-CI:
-	cargo audit
+	cargo audit $(AUDIT_IGNORES)
 
 # Runs `cargo vendor` to make sure dependencies can be vendored for packaging, reproducibility and archival purpose.
 vendor:

--- a/Makefile
+++ b/Makefile
@@ -144,16 +144,8 @@ audit: install-audit audit-CI
 install-audit:
 	cargo install --force cargo-audit
 
-# Keep real vulnerabilities failing CI while suppressing reviewed warning-only
-# advisories from current upstream transitive dependencies.
-AUDIT_IGNORES = \
-	--ignore RUSTSEC-2024-0388 \
-	--ignore RUSTSEC-2024-0436 \
-	--ignore RUSTSEC-2026-0002 \
-	--ignore RUSTSEC-2026-0097
-
 audit-CI:
-	cargo audit $(AUDIT_IGNORES)
+	cargo audit
 
 # Runs `cargo vendor` to make sure dependencies can be vendored for packaging, reproducibility and archival purpose.
 vendor:


### PR DESCRIPTION
## Problem, Evidence, and Context (Required)

- `check-code` is failing at the `cargo audit` step because `Cargo.lock` still contains `rustls-webpki 0.103.12`, which is flagged by `RUSTSEC-2026-0104`.
- This is worth fixing now because it blocks unrelated PRs on the shared audit gate.
- Evidence: the failing Actions job for `#970` reported `RUSTSEC-2026-0104` on `rustls-webpki 0.103.12`.
- Relevant links: `#970`

## Change Overview (Required)

- Bump `rustls-webpki` in `Cargo.lock` from `0.103.12` to `0.103.13`.
- Review the diff as a lockfile-only dependency update.
- Intentionally unchanged: `Cargo.toml` manifests, runtime code, and broader dependency refreshes.

## Risks, Trade-offs, and Mitigations (Required)

- Risk is limited to the transitive behavior change from the patched `rustls-webpki` release.
- Trade-off: this keeps the fix narrow instead of doing a wider dependency upgrade.
- Mitigation: validation is limited to the audit gate plus targeted compile/test checks on the affected crates.

## Validation (Required)

- `make cargo-fmt-check`
- `env CARGO_HOME=/private/tmp/anchor-audit-home make audit-CI`
- `env CARGO_HOME=/private/tmp/anchor-audit-home cargo clippy -p eth -p network --all-targets -- -D warnings`
- `env CARGO_HOME=/private/tmp/anchor-audit-home cargo test -p eth -p network --tests`

## Rollback (Required for behavior or runtime changes; optional otherwise)

- Safe rollback is a normal revert of the two commits in this PR branch.
- No schema, config, or operational migration impact.

## Blockers / Dependencies (Optional)

- N/A

## Additional Info / Next Steps (Optional)

- `cargo audit` still reports warning-level upstream advisories, but after this lockfile bump the audit command exits successfully without changing CI policy.
