### PR TITLE
fix(eth): replay duplicate operator keys

### DIFF
--- a/anchor/database/src/migrations/V2__upgrade_production_v1_to_current.sql
+++ b/anchor/database/src/migrations/V2__upgrade_production_v1_to_current.sql
@@ -5,3 +5,7 @@
 ALTER TABLE metadata ADD COLUMN max_operator_id_seen INTEGER;
 ALTER TABLE metadata ADD COLUMN network_name TEXT;
 CREATE INDEX IF NOT EXISTS idx_validators_validator_index ON validators(validator_index);
+CREATE TABLE skipped_operator_adds (
+    operator_id INTEGER PRIMARY KEY,
+    reason TEXT NOT NULL
+);

--- a/anchor/database/src/operator_operations.rs
+++ b/anchor/database/src/operator_operations.rs
@@ -1,5 +1,6 @@
 use base64::prelude::*;
-use rusqlite::{Transaction, params};
+use openssl::{pkey::Public, rsa::Rsa};
+use rusqlite::{OptionalExtension, Transaction, params};
 use ssv_types::{Operator, OperatorId};
 use tracing::trace;
 
@@ -49,6 +50,58 @@ impl NetworkDatabase {
             ])?;
         state_updates.insert_operator(operator.to_owned(), is_own_operator);
         Ok(())
+    }
+
+    /// Record that an `OperatorAdded` log was intentionally skipped after consuming its
+    /// monotonically-increasing operator id.
+    pub fn insert_skipped_operator_add_tx(
+        &self,
+        id: OperatorId,
+        reason: &str,
+        tx: &Transaction<'_>,
+    ) -> Result<(), DatabaseError> {
+        tx.prepare_cached(sql_operations::INSERT_SKIPPED_OPERATOR_ADD)?
+            .execute(params![id, reason])?;
+        Ok(())
+    }
+
+    /// Delete a previously recorded skipped `OperatorAdded` marker.
+    pub fn delete_skipped_operator_add_tx(
+        &self,
+        id: OperatorId,
+        tx: &Transaction<'_>,
+    ) -> Result<bool, DatabaseError> {
+        let rows = tx
+            .prepare_cached(sql_operations::DELETE_SKIPPED_OPERATOR_ADD)?
+            .execute(params![id])?;
+        Ok(rows > 0)
+    }
+
+    /// Check if an `OperatorAdded` log for this id was previously skipped.
+    pub fn was_operator_add_skipped_tx(
+        &self,
+        id: OperatorId,
+        tx: &Transaction<'_>,
+    ) -> Result<bool, DatabaseError> {
+        tx.prepare_cached(sql_operations::GET_SKIPPED_OPERATOR_ADD_REASON)?
+            .query_row(params![id], |row| row.get::<_, String>(0))
+            .optional()
+            .map(|reason| reason.is_some())
+            .map_err(DatabaseError::from)
+    }
+
+    /// Resolve any operator id that already owns this canonical public key, including soft-deleted
+    /// rows that still occupy the schema-level uniqueness slot.
+    pub fn get_any_operator_id_by_public_key_tx(
+        &self,
+        public_key: &Rsa<Public>,
+        tx: &Transaction<'_>,
+    ) -> Result<Option<OperatorId>, DatabaseError> {
+        let encoded = BASE64_STANDARD.encode(public_key.public_key_to_pem()?);
+        tx.prepare_cached(sql_operations::GET_ANY_OPERATOR_ID)?
+            .query_row(params![encoded], |row| row.get(0))
+            .optional()
+            .map_err(DatabaseError::from)
     }
 
     /// Delete an operator in the active transaction and queue the matching state update.

--- a/anchor/database/src/operator_operations.rs
+++ b/anchor/database/src/operator_operations.rs
@@ -78,6 +78,7 @@ impl NetworkDatabase {
     }
 
     /// Check if an `OperatorAdded` log for this id was previously skipped.
+    #[cfg(any(test, feature = "test-utils"))]
     pub fn was_operator_add_skipped_tx(
         &self,
         id: OperatorId,

--- a/anchor/database/src/sql_operations.rs
+++ b/anchor/database/src/sql_operations.rs
@@ -30,6 +30,7 @@ pub const INSERT_SKIPPED_OPERATOR_ADD: &str = r#"
 "#;
 pub const DELETE_SKIPPED_OPERATOR_ADD: &str =
     r#"DELETE FROM skipped_operator_adds WHERE operator_id = ?1"#;
+#[cfg(any(test, feature = "test-utils"))]
 pub const GET_SKIPPED_OPERATOR_ADD_REASON: &str =
     r#"SELECT reason FROM skipped_operator_adds WHERE operator_id = ?1"#;
 pub const MARK_OPERATOR_REMOVED: &str =

--- a/anchor/database/src/sql_operations.rs
+++ b/anchor/database/src/sql_operations.rs
@@ -21,12 +21,25 @@ pub const INSERT_OPERATOR: &str = r#"
     VALUES
         (?1, ?2, ?3)
 "#;
+pub const INSERT_SKIPPED_OPERATOR_ADD: &str = r#"
+    INSERT INTO skipped_operator_adds
+        (operator_id, reason)
+    VALUES
+        (?1, ?2)
+    ON CONFLICT (operator_id) DO UPDATE SET reason = excluded.reason
+"#;
+pub const DELETE_SKIPPED_OPERATOR_ADD: &str =
+    r#"DELETE FROM skipped_operator_adds WHERE operator_id = ?1"#;
+pub const GET_SKIPPED_OPERATOR_ADD_REASON: &str =
+    r#"SELECT reason FROM skipped_operator_adds WHERE operator_id = ?1"#;
 pub const MARK_OPERATOR_REMOVED: &str =
     r#"UPDATE operators SET removed = TRUE WHERE operator_id = ?1"#;
 pub const DELETE_OPERATOR: &str = r#"DELETE FROM operators WHERE operator_id = ?1"#;
 pub const GET_OPERATOR_STATUS: &str = r#"SELECT removed FROM operators WHERE operator_id = ?1"#;
 pub const GET_OPERATOR_ID: &str =
     r#"SELECT operator_id FROM operators WHERE public_key = ?1 AND removed = FALSE"#;
+pub const GET_ANY_OPERATOR_ID: &str =
+    r#"SELECT operator_id FROM operators WHERE public_key = ?1 LIMIT 1"#;
 pub const GET_OPERATOR_KEY: &str =
     r#"SELECT public_key FROM operators WHERE operator_id = ?1 AND removed = FALSE"#;
 pub const GET_ALL_OPERATORS: &str = r#"SELECT * FROM operators WHERE removed = FALSE"#;

--- a/anchor/database/src/tests/metadata_tests.rs
+++ b/anchor/database/src/tests/metadata_tests.rs
@@ -112,6 +112,7 @@ mod tests {
             has_validator_index(&conn),
             "the first refinery migration should create the validator index"
         );
+        assert_skipped_operator_add_round_trip(&conn, 7);
     }
 
     #[test]
@@ -147,6 +148,7 @@ mod tests {
             has_validator_index(&conn),
             "the resumed cutover should still create the validator index"
         );
+        assert_skipped_operator_add_round_trip(&conn, 8);
     }
 
     #[test]
@@ -338,5 +340,28 @@ mod tests {
             |_| Ok(()),
         )
         .is_ok()
+    }
+
+    fn assert_skipped_operator_add_round_trip(conn: &Connection, operator_id: u64) {
+        let expected_reason = "migration coverage";
+
+        conn.execute(
+            "INSERT INTO skipped_operator_adds (operator_id, reason) VALUES (?1, ?2)",
+            params![operator_id, expected_reason],
+        )
+        .expect("Failed to insert skipped operator marker");
+
+        let actual_reason: String = conn
+            .query_row(
+                "SELECT reason FROM skipped_operator_adds WHERE operator_id = ?1",
+                params![operator_id],
+                |row| row.get(0),
+            )
+            .expect("Failed to read skipped operator marker");
+
+        assert_eq!(
+            actual_reason, expected_reason,
+            "the V2 migration should materialize a writable skipped_operator_adds table"
+        );
     }
 }

--- a/anchor/database/src/tests/operator_tests.rs
+++ b/anchor/database/src/tests/operator_tests.rs
@@ -158,4 +158,43 @@ mod operator_database_tests {
                 .is_err()
         )
     }
+
+    #[test]
+    fn test_skipped_operator_add_round_trip() {
+        let fixture = InMemoryTestFixture::new_empty();
+        let mut conn = fixture.db.connection().unwrap();
+        let tx = conn.transaction().unwrap();
+
+        assert!(
+            !fixture
+                .db
+                .was_operator_add_skipped_tx(OperatorId(7), &tx)
+                .expect("Failed to query skipped operator marker")
+        );
+
+        fixture
+            .db
+            .insert_skipped_operator_add_tx(OperatorId(7), "duplicate key", &tx)
+            .expect("Failed to insert skipped operator marker");
+
+        assert!(
+            fixture
+                .db
+                .was_operator_add_skipped_tx(OperatorId(7), &tx)
+                .expect("Failed to query skipped operator marker")
+        );
+
+        assert!(
+            fixture
+                .db
+                .delete_skipped_operator_add_tx(OperatorId(7), &tx)
+                .expect("Failed to delete skipped operator marker")
+        );
+        assert!(
+            !fixture
+                .db
+                .was_operator_add_skipped_tx(OperatorId(7), &tx)
+                .expect("Failed to query skipped operator marker")
+        );
+    }
 }

--- a/anchor/database/src/tests/operator_tests.rs
+++ b/anchor/database/src/tests/operator_tests.rs
@@ -161,10 +161,12 @@ mod operator_database_tests {
 
     #[test]
     fn test_skipped_operator_add_round_trip() {
+        // Arrange: start from an empty in-memory database and an operator id with no marker.
         let fixture = InMemoryTestFixture::new_empty();
         let mut conn = fixture.db.connection().unwrap();
         let tx = conn.transaction().unwrap();
 
+        // Act/Assert: the marker should be absent before insertion.
         assert!(
             !fixture
                 .db
@@ -172,11 +174,13 @@ mod operator_database_tests {
                 .expect("Failed to query skipped operator marker")
         );
 
+        // Act: insert a skipped-operator marker.
         fixture
             .db
             .insert_skipped_operator_add_tx(OperatorId(7), "duplicate key", &tx)
             .expect("Failed to insert skipped operator marker");
 
+        // Assert: the inserted marker is visible through the typed helper.
         assert!(
             fixture
                 .db
@@ -184,12 +188,15 @@ mod operator_database_tests {
                 .expect("Failed to query skipped operator marker")
         );
 
+        // Act: delete the skipped-operator marker.
         assert!(
             fixture
                 .db
                 .delete_skipped_operator_add_tx(OperatorId(7), &tx)
                 .expect("Failed to delete skipped operator marker")
         );
+
+        // Assert: the marker is gone again after deletion.
         assert!(
             !fixture
                 .db

--- a/anchor/database/src/tests/utils.rs
+++ b/anchor/database/src/tests/utils.rs
@@ -360,8 +360,6 @@ pub mod queries {
     const GET_VALIDATOR: &str = "SELECT validator_pubkey, cluster_id, validator_index,  graffiti FROM validators WHERE validator_pubkey = ?1";
     const GET_MEMBERS: &str = "SELECT operator_id FROM cluster_members WHERE cluster_id = ?1";
     const GET_METADATA: &str = "SELECT network_name, block_number FROM metadata";
-    const GET_SKIPPED_OPERATOR_REASON: &str =
-        "SELECT reason FROM skipped_operator_adds WHERE operator_id = ?1";
 
     // Get an operator from the database
     pub fn get_operator(id: OperatorId, tx: &Transaction<'_>) -> Option<Operator> {
@@ -476,9 +474,11 @@ pub mod queries {
         operator_id: OperatorId,
         tx: &Transaction<'_>,
     ) -> Option<String> {
-        tx.query_row(GET_SKIPPED_OPERATOR_REASON, params![operator_id], |row| {
-            row.get(0)
-        })
+        tx.query_row(
+            crate::sql_operations::GET_SKIPPED_OPERATOR_ADD_REASON,
+            params![operator_id],
+            |row| row.get(0),
+        )
         .ok()
     }
 }

--- a/anchor/database/src/tests/utils.rs
+++ b/anchor/database/src/tests/utils.rs
@@ -360,6 +360,8 @@ pub mod queries {
     const GET_VALIDATOR: &str = "SELECT validator_pubkey, cluster_id, validator_index,  graffiti FROM validators WHERE validator_pubkey = ?1";
     const GET_MEMBERS: &str = "SELECT operator_id FROM cluster_members WHERE cluster_id = ?1";
     const GET_METADATA: &str = "SELECT network_name, block_number FROM metadata";
+    const GET_SKIPPED_OPERATOR_REASON: &str =
+        "SELECT reason FROM skipped_operator_adds WHERE operator_id = ?1";
 
     // Get an operator from the database
     pub fn get_operator(id: OperatorId, tx: &Transaction<'_>) -> Option<Operator> {
@@ -468,6 +470,16 @@ pub mod queries {
                 block_number: row.get("block_number")?,
             })
         })
+    }
+
+    pub fn get_skipped_operator_reason(
+        operator_id: OperatorId,
+        tx: &Transaction<'_>,
+    ) -> Option<String> {
+        tx.query_row(GET_SKIPPED_OPERATOR_REASON, params![operator_id], |row| {
+            row.get(0)
+        })
+        .ok()
     }
 }
 

--- a/anchor/eth/Cargo.toml
+++ b/anchor/eth/Cargo.toml
@@ -7,6 +7,7 @@ authors = ["Sigma Prime <contact@sigmaprime.io>"]
 [dependencies]
 alloy = { workspace = true }
 anchor_validator_store = { workspace = true }
+base64 = { workspace = true }
 beacon_node_fallback = { workspace = true }
 bls = { workspace = true }
 database = { workspace = true }
@@ -31,7 +32,6 @@ tracing = { workspace = true }
 types = { workspace = true }
 
 [dev-dependencies]
-base64 = { workspace = true }
 bls = { workspace = true }
 database = { workspace = true, features = ["test-utils"] }
 tracing-subscriber = "0.3"

--- a/anchor/eth/src/event_processor.rs
+++ b/anchor/eth/src/event_processor.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use alloy::{primitives::Address, rpc::types::Log, sol_types::SolEvent};
+use base64::prelude::*;
 use bls::PublicKeyBytes;
 use database::{NetworkDatabase, PendingStateUpdates, SlashingProtection};
 use indexmap::IndexSet;
@@ -380,24 +381,29 @@ impl EventProcessor {
             .set_max_operator_id_seen_tx(operatorId, tx, state_updates)
             .map_err(|e| ExecutionError::Database(e.to_string()))?;
 
-        let data = publicKey.as_ref();
-
-        // If the data is 704 bytes, remove the ssv encoding. Else, just parse the key
-        let data = if data.len() == 704 {
-            let mut data = &data[64..];
-            // while there is a 0 at the end of the data, remove it
-            while let [rest @ .., 0] = data {
-                data = rest;
+        let operator = match parse_operator_public_key(publicKey.as_ref(), operator_id, owner) {
+            Ok(operator) => operator,
+            Err(reason) => {
+                self.db
+                    .insert_skipped_operator_add_tx(operator_id, &reason, tx)
+                    .map_err(|e| ExecutionError::Database(e.to_string()))?;
+                return Err(ExecutionError::InvalidEvent(reason));
             }
-            data
-        } else {
-            data
         };
 
-        // Construct the Operator and insert it into the database
-        let operator = Operator::new(data, operator_id, owner).map_err(|e| {
-            ExecutionError::InvalidEvent(format!("Failed to construct operator: {e}"))
-        })?;
+        if let Some(existing_operator_id) = self
+            .db
+            .get_any_operator_id_by_public_key_tx(&operator.rsa_pubkey, tx)
+            .map_err(|e| ExecutionError::Database(e.to_string()))?
+        {
+            let reason =
+                format!("Operator public key already exists as operator {existing_operator_id}");
+            self.db
+                .insert_skipped_operator_add_tx(operator_id, &reason, tx)
+                .map_err(|e| ExecutionError::Database(e.to_string()))?;
+            return Err(ExecutionError::InvalidEvent(reason));
+        }
+
         self.db
             .insert_operator_tx(&operator, tx, state_updates)
             .map_err(|e| {
@@ -425,6 +431,19 @@ impl EventProcessor {
             SSVContract::OperatorRemoved::decode_from_log(log)?;
         let operator_id = OperatorId(operatorId);
         trace!(operator_id = ?operator_id, "Processing operator removed");
+
+        if self
+            .db
+            .was_operator_add_skipped_tx(operator_id, tx)
+            .map_err(|e| ExecutionError::Database(e.to_string()))?
+        {
+            self.db
+                .delete_skipped_operator_add_tx(operator_id, tx)
+                .map_err(|e| ExecutionError::Database(e.to_string()))?;
+            return Err(ExecutionError::SkippedEvent(format!(
+                "Operator {operator_id} was previously skipped during registration"
+            )));
+        }
 
         // Delete the operator from database and in memory
         self.db
@@ -905,4 +924,78 @@ impl EventProcessor {
 
         Ok(())
     }
+}
+
+fn parse_operator_public_key(
+    data: &[u8],
+    operator_id: OperatorId,
+    owner: Address,
+) -> Result<Operator, String> {
+    let data = unwrap_operator_public_key(data);
+    let data = normalize_operator_public_key_bytes(data)?;
+    Operator::new(&data, operator_id, owner)
+        .map_err(|e| format!("Failed to construct operator: {e}"))
+}
+
+fn unwrap_operator_public_key(data: &[u8]) -> &[u8] {
+    abi_decode_single_dynamic_bytes(data).unwrap_or(data)
+}
+
+fn normalize_operator_public_key_bytes(data: &[u8]) -> Result<Vec<u8>, String> {
+    if let Some(pem_base64) = decode_hex_encoded_operator_pem(data)? {
+        return Ok(pem_base64);
+    }
+
+    Ok(data.to_vec())
+}
+
+fn decode_hex_encoded_operator_pem(data: &[u8]) -> Result<Option<Vec<u8>>, String> {
+    let text = match std::str::from_utf8(data) {
+        Ok(text) => text,
+        Err(_) => return Ok(None),
+    };
+    let text = text.strip_prefix("0x").unwrap_or(text);
+
+    if text.is_empty() || !text.len().is_multiple_of(2) {
+        return Ok(None);
+    }
+    if !text.as_bytes().iter().all(u8::is_ascii_hexdigit) {
+        return Ok(None);
+    }
+
+    let pem = hex::decode(text)
+        .map_err(|e| format!("Failed to decode hex-encoded operator public key: {e}"))?;
+    if !pem.starts_with(b"-----BEGIN") {
+        return Err("Hex-encoded operator public key did not decode to PEM".to_string());
+    }
+
+    Ok(Some(BASE64_STANDARD.encode(pem).into_bytes()))
+}
+
+fn abi_decode_single_dynamic_bytes(data: &[u8]) -> Option<&[u8]> {
+    if data.len() < 64 || !data.len().is_multiple_of(32) {
+        return None;
+    }
+
+    let offset = abi_word_to_usize(&data[..32])?;
+    if offset != 32 {
+        return None;
+    }
+
+    let len = abi_word_to_usize(&data[32..64])?;
+    let padded_len = len.checked_add(31)?.checked_div(32)?.checked_mul(32)?;
+    let end = 64usize.checked_add(len)?;
+    if data.len() != 64 + padded_len || end > data.len() {
+        return None;
+    }
+
+    Some(&data[64..end])
+}
+
+fn abi_word_to_usize(word: &[u8]) -> Option<usize> {
+    if word.len() != 32 || word[..24].iter().any(|byte| *byte != 0) {
+        return None;
+    }
+
+    usize::try_from(u64::from_be_bytes(word[24..].try_into().ok()?)).ok()
 }

--- a/anchor/eth/src/event_processor.rs
+++ b/anchor/eth/src/event_processor.rs
@@ -434,12 +434,9 @@ impl EventProcessor {
 
         if self
             .db
-            .was_operator_add_skipped_tx(operator_id, tx)
+            .delete_skipped_operator_add_tx(operator_id, tx)
             .map_err(|e| ExecutionError::Database(e.to_string()))?
         {
-            self.db
-                .delete_skipped_operator_add_tx(operator_id, tx)
-                .map_err(|e| ExecutionError::Database(e.to_string()))?;
             return Err(ExecutionError::SkippedEvent(format!(
                 "Operator {operator_id} was previously skipped during registration"
             )));

--- a/anchor/eth/src/event_processor.rs
+++ b/anchor/eth/src/event_processor.rs
@@ -1131,6 +1131,33 @@ mod tests {
     }
 
     #[test]
+    fn decode_hex_encoded_operator_pem_accepts_0x_prefixed_hex_payload() {
+        let base64_public_key = create_base64_operator_public_key();
+        let pem_bytes = BASE64_STANDARD
+            .decode(&base64_public_key)
+            .expect("Failed to decode base64 operator key");
+        let hex_payload = format!("0x{}", hex::encode(pem_bytes));
+
+        let decoded = decode_hex_encoded_operator_pem(hex_payload.as_bytes())
+            .expect("0x-prefixed PEM hex should parse")
+            .expect("0x-prefixed PEM hex should normalize to base64 PEM");
+
+        assert_eq!(decoded, base64_public_key);
+    }
+
+    #[test]
+    fn decode_hex_encoded_operator_pem_returns_none_for_non_hex_like_inputs() {
+        for input in [&b""[..], b"abc", b"zzzz", &[0xff, 0xfe]] {
+            assert!(
+                decode_hex_encoded_operator_pem(input)
+                    .expect("Malformed non-hex inputs should not error")
+                    .is_none(),
+                "Input {input:?} should not be treated as hex-encoded PEM"
+            );
+        }
+    }
+
+    #[test]
     fn abi_decode_single_dynamic_bytes_rejects_invalid_offset() {
         let mut encoded = wrap_dynamic_bytes(b"test");
         encoded[31] = 0;
@@ -1139,6 +1166,17 @@ mod tests {
         assert!(
             abi_decode_single_dynamic_bytes(&encoded).is_none(),
             "ABI payload with a non-standard offset should be rejected"
+        );
+    }
+
+    #[test]
+    fn abi_decode_single_dynamic_bytes_rejects_length_mismatch_buffer() {
+        let mut encoded = wrap_dynamic_bytes(b"test");
+        encoded[56..64].copy_from_slice(&40u64.to_be_bytes());
+
+        assert!(
+            abi_decode_single_dynamic_bytes(&encoded).is_none(),
+            "ABI payloads whose declared length does not match the padded buffer should be rejected"
         );
     }
 

--- a/anchor/eth/src/event_processor.rs
+++ b/anchor/eth/src/event_processor.rs
@@ -1081,6 +1081,7 @@ mod tests {
 
     #[test]
     fn parse_operator_public_key_normalizes_wrapped_base64_and_hex_payloads() {
+        // Arrange: encode the same PEM key once as wrapped base64 and once as wrapped ASCII hex.
         let base64_public_key = create_base64_operator_public_key();
         let pem_bytes = BASE64_STANDARD
             .decode(&base64_public_key)
@@ -1088,6 +1089,7 @@ mod tests {
         let wrapped_base64 = wrap_dynamic_bytes(&base64_public_key);
         let wrapped_hex = wrap_dynamic_bytes(hex::encode(pem_bytes).as_bytes());
 
+        // Act: parse both payload shapes through the operator-key normalization path.
         let base64_operator =
             parse_operator_public_key(&wrapped_base64, OperatorId(1), Address::random())
                 .expect("Wrapped base64 operator key should parse");
@@ -1095,6 +1097,7 @@ mod tests {
             parse_operator_public_key(&wrapped_hex, OperatorId(2), Address::random())
                 .expect("Wrapped hex operator key should parse");
 
+        // Assert: both payloads normalize to the same canonical RSA key.
         assert_eq!(
             base64_operator
                 .rsa_pubkey
@@ -1109,8 +1112,10 @@ mod tests {
 
     #[test]
     fn unwrap_operator_public_key_returns_original_bytes_for_non_abi_input() {
+        // Arrange: build a plain base64 operator key without the outer ABI wrapper.
         let public_key = create_base64_operator_public_key();
 
+        // Act/Assert: non-ABI input should pass through unchanged.
         assert_eq!(
             unwrap_operator_public_key(&public_key),
             public_key.as_slice()
@@ -1119,11 +1124,14 @@ mod tests {
 
     #[test]
     fn decode_hex_encoded_operator_pem_rejects_non_pem_hex_payload() {
+        // Arrange: build hex text that decodes successfully but does not contain PEM bytes.
         let hex_payload = hex::encode("not a pem");
 
+        // Act: attempt to normalize it as a hex-encoded operator key.
         let error = decode_hex_encoded_operator_pem(hex_payload.as_bytes())
             .expect_err("Non-PEM hex should be rejected");
 
+        // Assert: the helper rejects it explicitly rather than silently accepting garbage.
         assert!(
             error.contains("did not decode to PEM"),
             "Unexpected error: {error}"
@@ -1132,22 +1140,27 @@ mod tests {
 
     #[test]
     fn decode_hex_encoded_operator_pem_accepts_0x_prefixed_hex_payload() {
+        // Arrange: encode a valid PEM payload as hex and add the optional 0x prefix.
         let base64_public_key = create_base64_operator_public_key();
         let pem_bytes = BASE64_STANDARD
             .decode(&base64_public_key)
             .expect("Failed to decode base64 operator key");
         let hex_payload = format!("0x{}", hex::encode(pem_bytes));
 
+        // Act: normalize the prefixed hex payload.
         let decoded = decode_hex_encoded_operator_pem(hex_payload.as_bytes())
             .expect("0x-prefixed PEM hex should parse")
             .expect("0x-prefixed PEM hex should normalize to base64 PEM");
 
+        // Assert: the normalized bytes match the canonical base64 PEM form.
         assert_eq!(decoded, base64_public_key);
     }
 
     #[test]
     fn decode_hex_encoded_operator_pem_returns_none_for_non_hex_like_inputs() {
+        // Arrange: gather malformed inputs that should be ignored as "not hex", not rejected.
         for input in [&b""[..], b"abc", b"zzzz", &[0xff, 0xfe]] {
+            // Act/Assert: all of them should fall back to the non-hex path.
             assert!(
                 decode_hex_encoded_operator_pem(input)
                     .expect("Malformed non-hex inputs should not error")
@@ -1159,10 +1172,12 @@ mod tests {
 
     #[test]
     fn abi_decode_single_dynamic_bytes_rejects_invalid_offset() {
+        // Arrange: encode a valid payload, then corrupt the ABI offset word.
         let mut encoded = wrap_dynamic_bytes(b"test");
         encoded[31] = 0;
         encoded[30] = 64;
 
+        // Act/Assert: non-standard offsets should be rejected.
         assert!(
             abi_decode_single_dynamic_bytes(&encoded).is_none(),
             "ABI payload with a non-standard offset should be rejected"
@@ -1171,9 +1186,11 @@ mod tests {
 
     #[test]
     fn abi_decode_single_dynamic_bytes_rejects_length_mismatch_buffer() {
+        // Arrange: encode a short payload, then lie about the dynamic length word.
         let mut encoded = wrap_dynamic_bytes(b"test");
         encoded[56..64].copy_from_slice(&40u64.to_be_bytes());
 
+        // Act/Assert: buffers whose declared length does not match the padded body are rejected.
         assert!(
             abi_decode_single_dynamic_bytes(&encoded).is_none(),
             "ABI payloads whose declared length does not match the padded buffer should be rejected"
@@ -1182,10 +1199,12 @@ mod tests {
 
     #[test]
     fn abi_word_to_usize_rejects_non_zero_high_bytes() {
+        // Arrange: create a 32-byte ABI word with non-zero high-order bytes.
         let mut word = [0u8; 32];
         word[0] = 1;
         word[31] = 32;
 
+        // Act/Assert: values that do not fit the narrow ABI decoding contract are rejected.
         assert!(
             abi_word_to_usize(&word).is_none(),
             "ABI words with non-zero high-order bytes should be rejected"

--- a/anchor/eth/src/event_processor.rs
+++ b/anchor/eth/src/event_processor.rs
@@ -996,3 +996,107 @@ fn abi_word_to_usize(word: &[u8]) -> Option<usize> {
 
     usize::try_from(u64::from_be_bytes(word[24..].try_into().ok()?)).ok()
 }
+
+#[cfg(test)]
+mod tests {
+    use base64::Engine;
+
+    use super::*;
+
+    fn create_base64_operator_public_key() -> Vec<u8> {
+        let rsa_key = database::test_utils::generators::pubkey::random_rsa();
+        BASE64_STANDARD
+            .encode(
+                rsa_key
+                    .public_key_to_pem()
+                    .expect("Failed to serialize RSA public key"),
+            )
+            .into_bytes()
+    }
+
+    fn wrap_dynamic_bytes(data: &[u8]) -> Vec<u8> {
+        let padded_len = data.len().div_ceil(32) * 32;
+        let mut encoded = vec![0u8; 64 + padded_len];
+
+        encoded[31] = 32;
+        encoded[56..64].copy_from_slice(&(data.len() as u64).to_be_bytes());
+        encoded[64..64 + data.len()].copy_from_slice(data);
+
+        encoded
+    }
+
+    #[test]
+    fn parse_operator_public_key_normalizes_wrapped_base64_and_hex_payloads() {
+        let base64_public_key = create_base64_operator_public_key();
+        let pem_bytes = BASE64_STANDARD
+            .decode(&base64_public_key)
+            .expect("Failed to decode base64 operator key");
+        let wrapped_base64 = wrap_dynamic_bytes(&base64_public_key);
+        let wrapped_hex = wrap_dynamic_bytes(hex::encode(pem_bytes).as_bytes());
+
+        let base64_operator =
+            parse_operator_public_key(&wrapped_base64, OperatorId(1), Address::random())
+                .expect("Wrapped base64 operator key should parse");
+        let hex_operator =
+            parse_operator_public_key(&wrapped_hex, OperatorId(2), Address::random())
+                .expect("Wrapped hex operator key should parse");
+
+        assert_eq!(
+            base64_operator
+                .rsa_pubkey
+                .public_key_to_pem()
+                .expect("Failed to serialize parsed base64 operator key"),
+            hex_operator
+                .rsa_pubkey
+                .public_key_to_pem()
+                .expect("Failed to serialize parsed hex operator key"),
+        );
+    }
+
+    #[test]
+    fn unwrap_operator_public_key_returns_original_bytes_for_non_abi_input() {
+        let public_key = create_base64_operator_public_key();
+
+        assert_eq!(
+            unwrap_operator_public_key(&public_key),
+            public_key.as_slice()
+        );
+    }
+
+    #[test]
+    fn decode_hex_encoded_operator_pem_rejects_non_pem_hex_payload() {
+        let hex_payload = hex::encode("not a pem");
+
+        let error = decode_hex_encoded_operator_pem(hex_payload.as_bytes())
+            .expect_err("Non-PEM hex should be rejected");
+
+        assert!(
+            error.contains("did not decode to PEM"),
+            "Unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn abi_decode_single_dynamic_bytes_rejects_invalid_offset() {
+        let mut encoded = wrap_dynamic_bytes(b"test");
+        encoded[31] = 0;
+        encoded[30] = 64;
+
+        assert!(
+            abi_decode_single_dynamic_bytes(&encoded).is_none(),
+            "ABI payload with a non-standard offset should be rejected"
+        );
+    }
+
+    #[test]
+    fn abi_word_to_usize_rejects_non_zero_high_bytes() {
+        let mut word = [0u8; 32];
+        word[0] = 1;
+        word[31] = 32;
+
+        assert!(
+            abi_word_to_usize(&word).is_none(),
+            "ABI words with non-zero high-order bytes should be rejected"
+        );
+    }
+}

--- a/anchor/eth/tests/common/mod.rs
+++ b/anchor/eth/tests/common/mod.rs
@@ -55,12 +55,6 @@ pub fn wrap_operator_public_key_bytes(public_key: &[u8]) -> Bytes {
     Bytes::from(encoded)
 }
 
-/// Generate a valid operator key wrapped in the nested ABI string encoding used on-chain.
-pub fn create_wrapped_base64_operator_public_key_bytes() -> Bytes {
-    let public_key = create_valid_rsa_public_key_bytes();
-    wrap_operator_public_key_bytes(public_key.as_ref())
-}
-
 /// Re-encode the same PEM key as ASCII hex and wrap it in the nested ABI string encoding used
 /// on-chain.
 pub fn create_wrapped_hex_operator_public_key_bytes(public_key: &Bytes) -> Bytes {

--- a/anchor/eth/tests/common/mod.rs
+++ b/anchor/eth/tests/common/mod.rs
@@ -42,6 +42,35 @@ pub fn create_valid_rsa_public_key_bytes() -> Bytes {
     Bytes::from(base64_pem.as_bytes().to_vec())
 }
 
+/// Wrap operator key bytes the same way the SDK currently submits `string` into the contract's
+/// `bytes publicKey` field.
+pub fn wrap_operator_public_key_bytes(public_key: &[u8]) -> Bytes {
+    let padded_len = public_key.len().div_ceil(32) * 32;
+    let mut encoded = vec![0u8; 64 + padded_len];
+
+    encoded[31] = 32;
+    encoded[56..64].copy_from_slice(&(public_key.len() as u64).to_be_bytes());
+    encoded[64..64 + public_key.len()].copy_from_slice(public_key);
+
+    Bytes::from(encoded)
+}
+
+/// Generate a valid operator key wrapped in the nested ABI string encoding used on-chain.
+pub fn create_wrapped_base64_operator_public_key_bytes() -> Bytes {
+    let public_key = create_valid_rsa_public_key_bytes();
+    wrap_operator_public_key_bytes(public_key.as_ref())
+}
+
+/// Re-encode the same PEM key as ASCII hex and wrap it in the nested ABI string encoding used
+/// on-chain.
+pub fn create_wrapped_hex_operator_public_key_bytes(public_key: &Bytes) -> Bytes {
+    let pem_bytes = BASE64_STANDARD
+        .decode(public_key.as_ref())
+        .expect("Failed to decode test operator public key");
+    let hex_pem = hex::encode(pem_bytes);
+    wrap_operator_public_key_bytes(hex_pem.as_bytes())
+}
+
 /// Generate valid shares data with correct signature verification
 /// Returns (shares_data, validator_public_key) - both are needed for the test
 pub fn create_valid_shares_data_for_owner_and_nonce(

--- a/anchor/eth/tests/integration.rs
+++ b/anchor/eth/tests/integration.rs
@@ -167,6 +167,81 @@ async fn test_wrapped_hex_duplicate_operator_add_is_skipped_and_later_remove_doe
 }
 
 #[tokio::test]
+async fn test_malformed_operator_add_is_skipped_and_later_remove_does_not_abort() {
+    setup_tracing();
+
+    let test = ProcessorFixture::new_empty();
+    let owner = Address::random();
+    let add_block = 12345;
+    let remove_block = 12346;
+    let malformed_wrapped_public_key =
+        wrap_operator_public_key_bytes(hex::encode("not a pem").as_bytes());
+
+    let add = create_operator_added_log_at_position(
+        1,
+        owner,
+        malformed_wrapped_public_key,
+        1000,
+        add_block,
+        0,
+        0,
+    );
+    assert!(
+        test.processor
+            .process_logs(vec![add], true, add_block)
+            .is_ok(),
+        "An unparseable operator key should be skipped without aborting the block"
+    );
+
+    let mut conn = test
+        .processor
+        .db
+        .connection()
+        .expect("Failed to get database connection");
+    let tx = conn.transaction().expect("Failed to start transaction");
+
+    assert!(
+        queries::get_operator(OperatorId(1), &tx).is_none(),
+        "A malformed operator should not be inserted"
+    );
+    let skip_reason = queries::get_skipped_operator_reason(OperatorId(1), &tx)
+        .expect("Skipped operator marker should be recorded");
+    assert!(
+        skip_reason.contains("did not decode to PEM"),
+        "Skip reason should record the parse failure: {skip_reason}"
+    );
+    drop(tx);
+    drop(conn);
+
+    let remove = create_operator_removed_log_at_position(1, remove_block, 0, 0);
+    assert!(
+        test.processor
+            .process_logs(vec![remove], true, remove_block)
+            .is_ok(),
+        "Removing a previously skipped malformed operator should no longer abort replay"
+    );
+
+    let mut conn = test
+        .processor
+        .db
+        .connection()
+        .expect("Failed to get database connection");
+    let tx = conn.transaction().expect("Failed to start transaction");
+    assert!(
+        queries::get_skipped_operator_reason(OperatorId(1), &tx).is_none(),
+        "The skipped operator marker should be consumed by the later remove"
+    );
+    drop(tx);
+    drop(conn);
+
+    assert_eq!(
+        test.processor.db.state().get_last_processed_block(),
+        remove_block,
+        "Replay should advance past the later operator removal"
+    );
+}
+
+#[tokio::test]
 async fn test_validator_added_event_processing() {
     setup_tracing();
 

--- a/anchor/eth/tests/integration.rs
+++ b/anchor/eth/tests/integration.rs
@@ -75,6 +75,8 @@ async fn test_operator_added_event_processing() {
 async fn test_wrapped_hex_duplicate_operator_add_is_skipped_and_later_remove_does_not_abort() {
     setup_tracing();
 
+    // Arrange: register one operator normally, then replay the same canonical RSA key under a
+    // different operator id using the wrapped-hex payload shape seen on-chain.
     let test = ProcessorFixture::new_empty();
     let owner = Address::random();
     let first_block = 12345;
@@ -94,12 +96,16 @@ async fn test_wrapped_hex_duplicate_operator_add_is_skipped_and_later_remove_doe
         0,
         0,
     );
+
+    // Act: process the initial add and then the duplicate-key add in separate replay steps.
     assert!(
         test.processor
             .process_logs(vec![first_add], true, first_block)
             .is_ok(),
         "Wrapped base64 operator keys should still decode successfully"
     );
+
+    // Assert: the first operator is committed normally.
     verify_operator_stored(&test.processor, OperatorId(1));
 
     let second_add = create_operator_added_log_at_position(
@@ -118,6 +124,7 @@ async fn test_wrapped_hex_duplicate_operator_add_is_skipped_and_later_remove_doe
         "A duplicate canonical operator key should be skipped without aborting the block"
     );
 
+    // Assert: the duplicate operator is skipped and leaves a marker behind.
     let mut conn = test
         .processor
         .db
@@ -138,6 +145,7 @@ async fn test_wrapped_hex_duplicate_operator_add_is_skipped_and_later_remove_doe
     drop(tx);
     drop(conn);
 
+    // Act: process the later remove for the skipped operator id.
     let remove = create_operator_removed_log_at_position(2, third_block, 0, 0);
     assert!(
         test.processor
@@ -145,6 +153,8 @@ async fn test_wrapped_hex_duplicate_operator_add_is_skipped_and_later_remove_doe
             .is_ok(),
         "Removing a previously skipped operator should no longer abort replay"
     );
+
+    // Assert: the original operator remains, the marker is consumed, and replay keeps advancing.
     verify_operator_stored(&test.processor, OperatorId(1));
 
     let mut conn = test
@@ -170,6 +180,7 @@ async fn test_wrapped_hex_duplicate_operator_add_is_skipped_and_later_remove_doe
 async fn test_malformed_operator_add_is_skipped_and_later_remove_does_not_abort() {
     setup_tracing();
 
+    // Arrange: replay an operator add whose wrapped payload decodes as hex text but not PEM.
     let test = ProcessorFixture::new_empty();
     let owner = Address::random();
     let add_block = 12345;
@@ -186,6 +197,8 @@ async fn test_malformed_operator_add_is_skipped_and_later_remove_does_not_abort(
         0,
         0,
     );
+
+    // Act: process the malformed add and let replay classify it as skipped.
     assert!(
         test.processor
             .process_logs(vec![add], true, add_block)
@@ -193,6 +206,7 @@ async fn test_malformed_operator_add_is_skipped_and_later_remove_does_not_abort(
         "An unparseable operator key should be skipped without aborting the block"
     );
 
+    // Assert: the operator is not inserted and the skip marker records the parse failure.
     let mut conn = test
         .processor
         .db
@@ -213,6 +227,7 @@ async fn test_malformed_operator_add_is_skipped_and_later_remove_does_not_abort(
     drop(tx);
     drop(conn);
 
+    // Act: process the later remove for that skipped operator id.
     let remove = create_operator_removed_log_at_position(1, remove_block, 0, 0);
     assert!(
         test.processor
@@ -221,6 +236,7 @@ async fn test_malformed_operator_add_is_skipped_and_later_remove_does_not_abort(
         "Removing a previously skipped malformed operator should no longer abort replay"
     );
 
+    // Assert: the skip marker is consumed and replay advances through the remove.
     let mut conn = test
         .processor
         .db

--- a/anchor/eth/tests/integration.rs
+++ b/anchor/eth/tests/integration.rs
@@ -72,6 +72,101 @@ async fn test_operator_added_event_processing() {
 }
 
 #[tokio::test]
+async fn test_wrapped_hex_duplicate_operator_add_is_skipped_and_later_remove_does_not_abort() {
+    setup_tracing();
+
+    let test = ProcessorFixture::new_empty();
+    let owner = Address::random();
+    let first_block = 12345;
+    let second_block = 12346;
+    let third_block = 12347;
+
+    let base64_public_key = create_valid_rsa_public_key_bytes();
+    let wrapped_base64_public_key = wrap_operator_public_key_bytes(base64_public_key.as_ref());
+    let wrapped_hex_public_key = create_wrapped_hex_operator_public_key_bytes(&base64_public_key);
+
+    let first_add = create_operator_added_log_at_position(
+        1,
+        owner,
+        wrapped_base64_public_key,
+        1000,
+        first_block,
+        0,
+        0,
+    );
+    assert!(
+        test.processor
+            .process_logs(vec![first_add], true, first_block)
+            .is_ok(),
+        "Wrapped base64 operator keys should still decode successfully"
+    );
+    verify_operator_stored(&test.processor, OperatorId(1));
+
+    let second_add = create_operator_added_log_at_position(
+        2,
+        owner,
+        wrapped_hex_public_key,
+        1001,
+        second_block,
+        0,
+        0,
+    );
+    assert!(
+        test.processor
+            .process_logs(vec![second_add], true, second_block)
+            .is_ok(),
+        "A duplicate canonical operator key should be skipped without aborting the block"
+    );
+
+    let mut conn = test
+        .processor
+        .db
+        .connection()
+        .expect("Failed to get database connection");
+    let tx = conn.transaction().expect("Failed to start transaction");
+
+    assert!(
+        queries::get_operator(OperatorId(2), &tx).is_none(),
+        "The duplicate operator should not be inserted"
+    );
+    let skip_reason = queries::get_skipped_operator_reason(OperatorId(2), &tx)
+        .expect("Skipped operator marker should be recorded");
+    assert!(
+        skip_reason.contains("already exists as operator 1"),
+        "Skip reason should explain the canonical key conflict: {skip_reason}"
+    );
+    drop(tx);
+    drop(conn);
+
+    let remove = create_operator_removed_log_at_position(2, third_block, 0, 0);
+    assert!(
+        test.processor
+            .process_logs(vec![remove], true, third_block)
+            .is_ok(),
+        "Removing a previously skipped operator should no longer abort replay"
+    );
+    verify_operator_stored(&test.processor, OperatorId(1));
+
+    let mut conn = test
+        .processor
+        .db
+        .connection()
+        .expect("Failed to get database connection");
+    let tx = conn.transaction().expect("Failed to start transaction");
+    assert!(
+        queries::get_skipped_operator_reason(OperatorId(2), &tx).is_none(),
+        "The skipped operator marker should be consumed by the later remove"
+    );
+    drop(tx);
+    drop(conn);
+    assert_eq!(
+        test.processor.db.state().get_last_processed_block(),
+        third_block,
+        "Replay should advance past the later operator removal"
+    );
+}
+
+#[tokio::test]
 async fn test_validator_added_event_processing() {
     setup_tracing();
 


### PR DESCRIPTION
## Problem, Evidence, and Context (Required)

- Closes #972.
- Historical replay can encounter `OperatorAdded` events whose nested `publicKey` bytes either resolve to a canonical RSA key Anchor already knows under another operator id, or use operator-key payloads Anchor cannot interpret at all. Before this PR, either case could leave Anchor without committed operator state for that id and later abort replay on `OperatorRemoved`.
- This is worth fixing now because `#351` correctly made replay inconsistencies batch-fatal instead of silently continuing with partial state. The underlying operator replay bug already existed; it is now visible as a hard sync stop.
- Relevant links: #972.

## Change Overview (Required)

- `eth` now ABI-unpacks operator `publicKey`, accepts the two on-chain encodings already observed during replay, normalizes them to a canonical RSA key, and classifies canonical duplicates before any DB writes.
- `database` now persists a skipped-operator marker keyed by operator id so a later `OperatorRemoved` for a previously skipped add is treated as an expected skip instead of `NotFound`.
- That skipped-marker policy is intentionally broader than canonical duplicates alone: it also covers operator-key payloads Anchor cannot interpret, so replay can consume the add/remove lifecycle symmetrically instead of wedging on the later remove.
- Start with `event_processor.rs` for the replay behavior, then the small DB helper and migration changes, then the regression tests.
- This does not change validator handling, upstream contract semantics, or Anchor's operator identity model. Anchor still treats the canonical decoded RSA key as the operator identity, not the raw submitted bytes.

## Risks, Trade-offs, and Mitigations (Required)

- Main trade-off: Anchor remains intentionally stricter than the contract and raw-bytes client model. If upstream decides that differently encoded raw values should be distinct operators, or that uninterpretable payloads should be preserved differently, Anchor will still treat canonical duplicates and unparseable operator keys as malformed.
- Blast radius is limited to operator add/remove replay. Normal operator registration and unrelated event paths are unchanged.
- Mitigations: duplicate classification happens before insert side effects, skipped ids are durably recorded and consumed on remove, and the regression tests cover both duplicate-key and malformed-add lifecycle shapes.

## Validation (Required)

- `cargo fmt --all --check`
- `cargo clippy -p eth -p database --tests -- -D warnings`
- `cargo test -p database --features test-utils test_skipped_operator_add_round_trip -- --nocapture`
- `cargo test -p eth test_wrapped_hex_duplicate_operator_add_is_skipped_and_later_remove_does_not_abort -- --nocapture`
- `cargo test -p eth test_malformed_operator_add_is_skipped_and_later_remove_does_not_abort -- --nocapture`
- `cargo test -p eth event_processor::tests -- --nocapture`
- `cargo test -p eth --tests`
- Manual Hoodi replay on the updated PR branch completed historical sync, entered live sync, and continued processing new blocks.

## Rollback (Required for behavior or runtime changes; optional otherwise)

- Safe code revert.
- Data impact is limited to the unreleased `V2` migration addition for skipped replay markers. If this branch is tested locally and then reverted before release, recreate local DBs created with this `V2` checksum.

## Blockers / Dependencies (Optional)

- N/A

## Additional Info / Next Steps (Optional)

- This PR only makes Anchor replay resilient to the historical operator encodings and malformed operator-key payloads already observed in replay.
- Any broader upstream identity or normalization change should be handled separately in the SSV contract and client repos.
