### PR TITLE
fix: claude-pr-review to be able to grep around forked branch

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -79,6 +79,7 @@ jobs:
               uses: actions/checkout@v4
               with:
                   token: ${{ steps.app-token.outputs.token }}
+                  ref: ${{ github.event.pull_request.head.sha }}
 
             - name: Configure AWS Credentials (OIDC)
               if: steps.check.outputs.is_member == 'true'


### PR DESCRIPTION
## Problem, Evidence, and Context (Required)

The Claude PR review bot has been posting inline comments that hallucinate missing symbols. Examples:

- [PR #973 discussion_r3124651371](https://github.com/sigp/anchor/pull/973#discussion_r3124651371) — claimed `ExecutionError::SkippedEvent` does not exist (it does, `anchor/eth/src/error.rs`).
- [PR #970 discussion_r3123361585](https://github.com/sigp/anchor/pull/970#discussion_r3123361585) — claimed `get_validator_metadata_tx`, `get_cluster_by_validator_tx`, and `ExecutionError::MissingCommittedState` don't exist. All exist.

**Root cause.** `.github/workflows/claude-pr-review.yml` calls `actions/checkout@v4` on a `pull_request_target` event with no `ref:`. On that event, checkout defaults to the repo's default branch, which is `stable`. PRs target `unstable`, which is currently **93 commits ahead of `stable`**. So the bot was reading files from `stable` while trying to sanity-check diffs that reference code only present on `unstable` (+ the PR head).

Proof from [runs/24783660685](https://github.com/sigp/anchor/actions/runs/24783660685):

```
[command]/usr/bin/git checkout --progress --force -B stable refs/remotes/origin/stable
```

`stable`'s `ExecutionError` enum is the exact list the bot quoted (`SyncError, InvalidEvent, RpcError, WsError, DecodeError, Misc, Duplicate, Database`) — including a `Misc` variant that no longer exists on `unstable`.

**Why now?** The bug is ~6 months old. It surfaced because PR [#351](https://github.com/sigp/anchor/pull/351) landed on `unstable` on 2026-04-07 and rewrote `ExecutionError` (added `SkippedEvent` and `MissingCommittedState`, removed `Misc`). PRs #970 and #973 are the first to reference those new symbols, which is when the stale-checkout gap finally started producing false positives.

**Diff vs. working tree distinction.** `gh pr diff` (what the bot uses to see the change) is a GitHub API call that returns PR head vs. PR base, so the diff itself was always correct. The bug was the *local working tree* the bot reads from when it uses `Read` / `Grep` to sanity-check the diff. After the fix, that working tree matches what the reviewer sees in the PR.

## Change Overview (Required)

One line added to the `Checkout repository` step in `.github/workflows/claude-pr-review.yml`:

```yaml
ref: ${{ github.event.pull_request.head.sha }}
```

That pins the working tree to the PR head commit, which equals `unstable` + whatever the PR adds on top — a strict superset of what checking out `unstable` alone would give (so new files added by the PR are also visible).

**Intentionally unchanged:**

- `claude-mentions.yml` — already correct. Uses a more verbose `repository` + `ref` pattern because its trigger (`issue_comment`) does not expose PR head info in the event payload; it has to `gh api` for it. `pull_request_target` exposes `github.event.pull_request.head.sha` directly, so a one-liner suffices.
- The review prompt loader (workflow lines 90–102) — already fetches `review.md` from the default branch via `git fetch`, so trusted-prompt loading is preserved regardless of what the working tree is checked out to.
- The trigger event. Staying on `pull_request_target` is load-bearing: per GitHub docs "with the exception of `GITHUB_TOKEN`, secrets are not passed to the runner when a workflow is triggered from a forked repository", and 13 of the last 15 PRs on this repo come from contributor forks. Switching to `pull_request` would make `secrets.APP_PRIVATE_KEY` and `secrets.AWS_ROLE_TO_ASSUME` resolve to empty strings, breaking both the GitHub App token and AWS OIDC steps.

## Risks, Trade-offs, and Mitigations (Required)

`pull_request_target` + checking out PR head is a known-risky combination ([GitHub Security Lab guidance](https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/)). Mitigations already in the workflow, none weakened by this change:

- `author_association` gate restricts to `MEMBER` / `OWNER` (workflow lines 50–61).
- `no-claude-review` label provides a per-PR escape hatch (lines 22–26).
- Review prompt fetched from the default branch via `git fetch`, not from the checked-out tree (lines 90–102) — PR content cannot influence the prompt.
- `--allowedTools` is restricted to `mcp__github_inline_comment__create_inline_comment`, read-only `gh pr` subcommands, `Read`, and `Grep` (line 129). No `cargo`, `npm`, or arbitrary shell execution.

PR head contents flow into the LLM as passive input only — the scenario GitHub Security Lab explicitly classifies as acceptable when PR content does not influence the build process.

## Validation (Required)

After merge:

1. Open or re-open any PR (or label an existing one with `claude-recheck` per the condition at workflow line 25).
2. In the new run's **Checkout repository** step logs, confirm the final `git checkout` now targets the PR head SHA (e.g. `refs/remotes/pull/<N>/merge` or a detached `HEAD` at `${{ head.sha }}`) instead of `refs/remotes/origin/stable`.
3. Re-trigger the review on PRs #970 and #973 with `claude-recheck`; the bot should no longer flag the symbols it previously hallucinated.

## Rollback (Required for behavior or runtime changes; optional otherwise)

Revert this one-line addition. No data migration, no state change, no dependency bump. The workflow returns to its prior (buggy) behavior of checking out the default branch.

## Additional Info / Next Steps (Optional)

- This targets `stable` so the fix is live on the default branch immediately — `pull_request_target` uses the workflow definition from the PR's base, so branches that target `stable` (rare, but possible) will also pick up the fix straight away.
- No change needed on `unstable` side beyond the normal sync; once this merges, the same one-liner will need to land there too (or be picked up by the next `stable → unstable` sync).
