### PR TITLE
fix(keysplit): replace unsafe unwrap with proper error handling in build_db

### DIFF
--- a/anchor/keysplit/src/split.rs
+++ b/anchor/keysplit/src/split.rs
@@ -44,7 +44,7 @@ pub fn onchain_split<'a>(
     secret_keys: impl IntoIterator<Item = &'a SecretKey>,
 ) -> Result<Vec<Split<KeyShare>>, KeysplitError> {
     // Construct DB and perform sync
-    let db = build_db();
+    let db = build_db()?;
     let mut syncer =
         SsvEventSyncer::new_keysplit(db.clone(), onchain.rpc, global_config.ssv_network);
 
@@ -113,19 +113,27 @@ fn create_keyshares_for_key(
 }
 
 // Build a network database for the keysplit
-fn build_db() -> Arc<NetworkDatabase> {
+fn build_db() -> Result<Arc<NetworkDatabase>, KeysplitError> {
     // We do not care about the public key here, so just generate a random one to prevent having to
     // use option
     let rsa = Rsa::generate(2048).expect("Keygen will not fail");
-    let public_key =
-        Rsa::from_public_components(rsa.n().to_owned().unwrap(), rsa.e().to_owned().unwrap())
-            .expect("Keygen will not fail");
+    
+    // Extract RSA components with proper error handling
+    let n = rsa.n().to_owned().map_err(|e| {
+        KeysplitError::Misc(format!("Failed to extract RSA modulus: {e}"))
+    })?;
+    let e = rsa.e().to_owned().map_err(|e| {
+        KeysplitError::Misc(format!("Failed to extract RSA exponent: {e}"))
+    })?;
+    
+    let public_key = Rsa::from_public_components(n, e)
+        .expect("Keygen will not fail");
     let path = Path::new("keysplit.sqlite");
     // TODO: The way the keysplit currently is implemented, we do not have easy access to the domain
     // type. This is easier once https://github.com/sigp/anchor/pull/347 is merged and irrelevant
     // if we implement https://github.com/sigp/anchor/issues/386.
-    Arc::new(
+    Ok(Arc::new(
         NetworkDatabase::new(path, &public_key, DomainType([0xff; 4]))
             .expect("Database construction will not fail"),
-    )
+    ))
 }


### PR DESCRIPTION


Keep this concise. Use bullets where helpful. Write `N/A` if not applicable.

## Problem, Evidence, and Context (Required)

There some unsafe .unwrap() calls in code.

## Change Overview (Required)

Replaced unsafe .unwrap() calls in the build_db() function with proper error handling using Result and map_err, providing meaningful error messages when RSA modulus or exponent extraction fails.

## Risks, Trade-offs, and Mitigations (Required)

- What are the main risks or blast radius?
- What trade-offs are being made?
- How are those risks being mitigated?

## Validation (Required)

- What proves the change does what it must do?
- Examples: targeted tests, manual repro, benchmark/profiling result, before/after behavior, spec-parity check.

## Rollback (Required for behavior or runtime changes; optional otherwise)

- How can this be safely reverted?
- Any config, data, or operational impact?

## Blockers / Dependencies (Optional)

- Anything that must happen before or after merge.

## Additional Info / Next Steps (Optional)

- Anything else reviewers should know.
