### PR TITLE
fix: accept past-round QBFT decided messages

### DIFF
--- a/anchor/common/qbft/src/lib.rs
+++ b/anchor/common/qbft/src/lib.rs
@@ -275,6 +275,14 @@ where
         unique_operators.len() >= self.config.quorum_size()
     }
 
+    /// Checks if a message carries a quorum-backed decided commit.
+    fn is_decided_message(&self, wrapped_msg: &WrappedQbftMessage) -> bool {
+        matches!(
+            wrapped_msg.qbft_message.qbft_message_type,
+            QbftMessageType::Commit
+        ) && self.has_quorum([wrapped_msg])
+    }
+
     /// Checks if we have accepted a proposal
     fn is_proposal_accepted(&self) -> Result<(), QbftError> {
         if !self.proposal_accepted_for_current_round {
@@ -327,12 +335,16 @@ where
     ) -> Result<(MessageContent<D>, OperatorId), QbftError> {
         // Ensure that this message is for the correct round
         if wrapped_msg.qbft_message.round < self.current_round.into() {
-            debug!(
-                message_round = wrapped_msg.qbft_message.round,
-                current_round = *self.current_round,
-                "Message received for a previous round"
-            );
-            return Err(QbftError::PastRound);
+            // Decided messages carry all information needed to complete the height, even if the
+            // local round timer has already moved this instance forward.
+            if !self.is_decided_message(wrapped_msg) {
+                debug!(
+                    message_round = wrapped_msg.qbft_message.round,
+                    current_round = *self.current_round,
+                    "Message received for a previous round"
+                );
+                return Err(QbftError::PastRound);
+            }
         }
 
         // Check for future round
@@ -343,7 +355,7 @@ where
                 }
                 QbftMessageType::Commit => {
                     // Only decided messages (with quorum) are allowed from future rounds
-                    if !self.has_quorum([wrapped_msg]) {
+                    if !self.is_decided_message(wrapped_msg) {
                         return Err(QbftError::WrongRound);
                     }
                 }

--- a/anchor/common/qbft/src/lib.rs
+++ b/anchor/common/qbft/src/lib.rs
@@ -275,8 +275,8 @@ where
         unique_operators.len() >= self.config.quorum_size()
     }
 
-    /// Checks if a message carries a quorum-backed decided commit.
-    fn is_decided_message(&self, wrapped_msg: &WrappedQbftMessage) -> bool {
+    /// Checks if a message is a commit signed by a committee quorum.
+    fn is_quorum_commit(&self, wrapped_msg: &WrappedQbftMessage) -> bool {
         matches!(
             wrapped_msg.qbft_message.qbft_message_type,
             QbftMessageType::Commit
@@ -337,7 +337,7 @@ where
         if wrapped_msg.qbft_message.round < self.current_round.into() {
             // Decided messages carry all information needed to complete the height, even if the
             // local round timer has already moved this instance forward.
-            if !self.is_decided_message(wrapped_msg) {
+            if !self.is_quorum_commit(wrapped_msg) {
                 debug!(
                     message_round = wrapped_msg.qbft_message.round,
                     current_round = *self.current_round,
@@ -355,7 +355,7 @@ where
                 }
                 QbftMessageType::Commit => {
                     // Only decided messages (with quorum) are allowed from future rounds
-                    if !self.is_decided_message(wrapped_msg) {
+                    if !self.has_quorum([wrapped_msg]) {
                         return Err(QbftError::WrongRound);
                     }
                 }

--- a/anchor/common/qbft/src/lib.rs
+++ b/anchor/common/qbft/src/lib.rs
@@ -330,11 +330,12 @@ where
             // Decided messages carry all information needed to complete the height, even if the
             // local round timer has already moved this instance forward. In SSV QBFT, a decided
             // message is a Commit signed by a committee quorum.
-            if !matches!(
+            let is_decided_message = matches!(
                 wrapped_msg.qbft_message.qbft_message_type,
                 QbftMessageType::Commit
-            ) || !self.has_quorum([wrapped_msg])
-            {
+            ) && self.has_quorum([wrapped_msg]);
+
+            if !is_decided_message {
                 debug!(
                     message_round = wrapped_msg.qbft_message.round,
                     current_round = *self.current_round,

--- a/anchor/common/qbft/src/lib.rs
+++ b/anchor/common/qbft/src/lib.rs
@@ -275,14 +275,6 @@ where
         unique_operators.len() >= self.config.quorum_size()
     }
 
-    /// Checks if a message is a commit signed by a committee quorum.
-    fn is_quorum_commit(&self, wrapped_msg: &WrappedQbftMessage) -> bool {
-        matches!(
-            wrapped_msg.qbft_message.qbft_message_type,
-            QbftMessageType::Commit
-        ) && self.has_quorum([wrapped_msg])
-    }
-
     /// Checks if we have accepted a proposal
     fn is_proposal_accepted(&self) -> Result<(), QbftError> {
         if !self.proposal_accepted_for_current_round {
@@ -336,8 +328,13 @@ where
         // Ensure that this message is for the correct round
         if wrapped_msg.qbft_message.round < self.current_round.into() {
             // Decided messages carry all information needed to complete the height, even if the
-            // local round timer has already moved this instance forward.
-            if !self.is_quorum_commit(wrapped_msg) {
+            // local round timer has already moved this instance forward. In SSV QBFT, a decided
+            // message is a Commit signed by a committee quorum.
+            if !matches!(
+                wrapped_msg.qbft_message.qbft_message_type,
+                QbftMessageType::Commit
+            ) || !self.has_quorum([wrapped_msg])
+            {
                 debug!(
                     message_round = wrapped_msg.qbft_message.round,
                     current_round = *self.current_round,

--- a/anchor/common/qbft/src/tests.rs
+++ b/anchor/common/qbft/src/tests.rs
@@ -232,6 +232,93 @@ fn test_node_recovery() {
 }
 
 #[test]
+/// A decided message from an earlier round should complete the instance even after the local
+/// round timer has advanced.
+fn test_receive_accepts_past_round_decided_message_after_round_timeout() {
+    init_test_logging();
+
+    use ssv_types::{
+        consensus::QbftMessage,
+        message::{MsgType, SSVMessage},
+    };
+
+    // Arrange: create a round-1 instance, then simulate the local timer moving it to round 2.
+    let config = ConfigBuilder::<DefaultLeaderFunction>::new(
+        1.into(),
+        InstanceHeight::default(),
+        (1..=4).map(OperatorId::from).collect(),
+    )
+    .build()
+    .expect("config should be valid");
+
+    let decided_data = TestData(42);
+    let decided_root = decided_data.hash();
+    let mut qbft_instance = Qbft::new(
+        config,
+        decided_data.clone(),
+        Box::new(NoDataValidation),
+        MessageId::from([0; 56]),
+        |_| {},
+    );
+
+    qbft_instance.end_round();
+    assert_eq!(qbft_instance.current_round, 2.into());
+
+    let decided_commit = QbftMessage {
+        qbft_message_type: QbftMessageType::Commit,
+        height: 0,
+        round: 1,
+        identifier: VariableList::repeat_full(0),
+        root: decided_root,
+        data_round: 0,
+        round_change_justification: VariableList::empty(),
+        prepare_justification: VariableList::empty(),
+    };
+
+    let ssv_message = SSVMessage::new(
+        MsgType::SSVConsensusMsgType,
+        MessageId::from([0; 56]),
+        decided_commit.as_ssz_bytes(),
+    )
+    .expect("should create SSVMessage");
+
+    let signed_decided = SignedSSVMessage::new(
+        vec![[0; RSA_SIGNATURE_SIZE]; 3],
+        vec![
+            OperatorId::from(1),
+            OperatorId::from(2),
+            OperatorId::from(3),
+        ],
+        ssv_message,
+        decided_data.as_ssz_bytes(),
+    )
+    .expect("should create signed decided message");
+
+    let wrapped_decided = WrappedQbftMessage {
+        signed_message: signed_decided,
+        qbft_message: decided_commit,
+    };
+
+    // Act: deliver the round-1 decided message after the node has already moved to round 2.
+    let result = qbft_instance.receive(wrapped_decided);
+
+    // Assert: the decided certificate is stronger than the local liveness round cursor.
+    assert!(
+        result.is_ok(),
+        "past-round decided message should complete the instance, got {result:?}"
+    );
+    assert!(
+        matches!(
+            &qbft_instance.completed,
+            Some(Completed::Success(root)) if *root == decided_root
+        ),
+        "instance should complete with the decided root, got {:?}",
+        qbft_instance.completed
+    );
+    assert!(qbft_instance.aggregated_commit.is_some());
+}
+
+#[test]
 /// Test that FAILS if round change validation doesn't require prepare justifications for
 /// data_round=1
 ///

--- a/anchor/common/qbft/src/tests.rs
+++ b/anchor/common/qbft/src/tests.rs
@@ -316,6 +316,8 @@ fn test_receive_accepts_past_round_decided_message_after_round_timeout() {
         qbft_instance.completed
     );
     assert!(qbft_instance.aggregated_commit.is_some());
+    assert!(matches!(qbft_instance.state, InstanceState::Complete));
+    assert!(qbft_instance.data.contains_key(&decided_root));
 }
 
 #[test]


### PR DESCRIPTION
## Problem, Evidence, and Context (Required)

- Fixes #979.
- A mainnet proposer duty missed because an Anchor node advanced from round 1 to round 2, then rejected the cluster's quorum-backed round-1 decided message as `PastRound`.
- Anchor already has `received_decided`, and future-round decided commits already bypass the normal round check. The missing part was the same allowance for decided commits from earlier rounds.

## Change Overview (Required)

- Add a narrow past-round carve-out for decided messages, defined locally as `Commit` messages with committee quorum.
- Allow past-round decided messages through `validate_message` instead of returning `PastRound`.
- Leave the existing future-round `Commit` branch behavior unchanged: it still requires quorum.
- Keep the rest of validation unchanged: height, committee membership, full-data decoding, and data validation still run before the instance completes.
- Add a regression test that advances a QBFT instance to round 2, then delivers a quorum-signed round-1 decided commit and verifies the instance completes.

## Risks, Trade-offs, and Mitigations (Required)

- The behavior change is limited to quorum-backed `Commit` messages. Single-signer commits and non-commit messages from past rounds are still rejected.
- The main risk is accepting more messages after local round advancement. The helper keeps the acceptance rule narrow and still relies on the existing signer quorum and committee checks.

## Validation (Required)

- Confirmed the new regression test fails before the fix with `PastRound`.
- Confirmed the new regression test passes after the fix.
- Ran the full `qbft` crate test suite.
- Ran clippy for `qbft` tests.
- The commit hook also ran formatting, full workspace clippy, and Cargo.toml sort checks successfully.
- Checked the diff for whitespace errors.

## Rollback (Required for behavior or runtime changes; optional otherwise)

- Revert this PR. That restores the previous behavior where past-round decided commits are rejected by `validate_message`.
- No config, database, or operational migration is involved.

## Blockers / Dependencies (Optional)

N/A

## Additional Info / Next Steps (Optional)

N/A
