### PR TITLE
refactor(signature_collector): extract state struct

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7211,6 +7211,7 @@ dependencies = [
  "fork",
  "message_sender",
  "processor",
+ "rand 0.9.2",
  "slot_clock",
  "ssv_types",
  "thiserror 2.0.18",

--- a/anchor/signature_collector/Cargo.toml
+++ b/anchor/signature_collector/Cargo.toml
@@ -19,3 +19,6 @@ thiserror = { workspace = true }
 tokio = { workspace = true, features = ["sync"] }
 tracing = { workspace = true }
 types = { workspace = true }
+
+[dev-dependencies]
+rand = { workspace = true }

--- a/anchor/signature_collector/src/lib.rs
+++ b/anchor/signature_collector/src/lib.rs
@@ -2,6 +2,7 @@ use std::{
     collections::{HashMap, hash_map},
     future::Future,
     mem,
+    ops::ControlFlow,
     pin::Pin,
     sync::Arc,
 };
@@ -566,53 +567,65 @@ impl<S: SlotClock + Clone + 'static> SignatureCollecting for Arc<SignatureCollec
     }
 }
 
-/// The actual signature collector task, waiting for messages
+/// The actual signature collector task, waiting for messages.
 async fn signature_collector(mut rx: mpsc::UnboundedReceiver<CollectorMessage>) {
-    let mut notifiers = vec![];
-    let mut signature_share = HashMap::new();
-    let mut full_signature: Option<Arc<Signature>> = None;
-    let mut threshold = None;
-
+    let mut state = SignatureCollectorState::default();
     while let Some(message) = rx.recv().await {
         trace!(msg=?message.kind, "Signature collector received message");
-        match message.kind {
+        if state.process(message.kind).is_break() {
+            return;
+        }
+    }
+}
+
+/// Invariant: once `full_signature` is `Some`, both `signature_share` and
+/// `notifiers` are empty (drained by `try_reconstruct`).
+#[derive(Default)]
+struct SignatureCollectorState {
+    notifiers: Vec<oneshot::Sender<Arc<Signature>>>,
+    signature_share: HashMap<OperatorId, Signature>,
+    full_signature: Option<Arc<Signature>>,
+    threshold: Option<u64>,
+}
+
+impl SignatureCollectorState {
+    /// Returns `Break` when the collector should exit (conflicting thresholds,
+    /// unrecoverable reconstruction failure).
+    fn process(&mut self, kind: CollectorMessageKind) -> ControlFlow<()> {
+        match kind {
             CollectorMessageKind::RegisterNotifier {
                 notify,
                 threshold: new_threshold,
             } => {
-                if let Some(full_signature) = &full_signature {
-                    // We already got a reconstructed signature, send it immediately.
-                    if let Err(err) = notify.send(full_signature.clone()) {
+                if let Some(full_signature) = &self.full_signature {
+                    if let Err(err) = notify.send(Arc::clone(full_signature)) {
                         warn!(?err, "Failed to send recovered signature");
                     }
-                } else {
-                    // Register the notifier and threshold.
-                    notifiers.push(notify);
-                    if let Some(old_threshold) = threshold
-                        && new_threshold != old_threshold
-                    {
-                        // Different tasks expect different thresholds. We can not know which is
-                        // correct, so we exit this instance.
-                        error!(
-                            new_threshold,
-                            old_threshold, "Conflicting thresholds passed!"
-                        );
-                        return;
-                    }
-                    threshold = Some(new_threshold);
+                    return ControlFlow::Continue(());
                 }
+                self.notifiers.push(notify);
+                if let Some(old_threshold) = self.threshold
+                    && new_threshold != old_threshold
+                {
+                    // Different tasks expect different thresholds. We can not know which is
+                    // correct, so we exit this instance.
+                    error!(
+                        new_threshold,
+                        old_threshold, "Conflicting thresholds passed!"
+                    );
+                    return ControlFlow::Break(());
+                }
+                self.threshold = Some(new_threshold);
             }
             CollectorMessageKind::PartialSignature {
                 operator_id,
                 signature,
             } => {
-                if full_signature.is_some() {
-                    // Already got the full signature.
-                    continue;
+                if self.full_signature.is_some() {
+                    return ControlFlow::Continue(());
                 }
 
-                // Insert the signature into our map.
-                match signature_share.entry(operator_id) {
+                match self.signature_share.entry(operator_id) {
                     hash_map::Entry::Vacant(entry) => {
                         entry.insert(*signature);
                     }
@@ -630,26 +643,34 @@ async fn signature_collector(mut rx: mpsc::UnboundedReceiver<CollectorMessage>) 
             }
         }
 
-        if let Some(threshold) = threshold
-            && signature_share.len() as u64 >= threshold
-        {
-            let signature = match combine_signatures(mem::take(&mut signature_share)) {
-                Ok(signature) => Arc::new(signature),
-                Err(err) => {
-                    error!(?err, "Failed to recover signature");
-                    return;
-                }
-            };
+        self.try_reconstruct()
+    }
 
-            trace!(?signature, "Successfully recovered signature");
-
-            for notifier in mem::take(&mut notifiers) {
-                if notifier.send(Arc::clone(&signature)).is_err() {
-                    warn!("Callback dropped - signature is no longer relevant");
-                }
-            }
-            full_signature = Some(signature);
+    fn try_reconstruct(&mut self) -> ControlFlow<()> {
+        let Some(threshold) = self.threshold else {
+            return ControlFlow::Continue(());
+        };
+        if (self.signature_share.len() as u64) < threshold {
+            return ControlFlow::Continue(());
         }
+
+        let signature = match combine_signatures(mem::take(&mut self.signature_share)) {
+            Ok(signature) => Arc::new(signature),
+            Err(err) => {
+                error!(?err, "Failed to recover signature");
+                return ControlFlow::Break(());
+            }
+        };
+
+        trace!(?signature, "Successfully recovered signature");
+
+        for notifier in mem::take(&mut self.notifiers) {
+            if notifier.send(Arc::clone(&signature)).is_err() {
+                warn!("Callback dropped - signature is no longer relevant");
+            }
+        }
+        self.full_signature = Some(signature);
+        ControlFlow::Continue(())
     }
 }
 
@@ -663,3 +684,6 @@ fn combine_signatures(
 
     Ok(bls_lagrange::combine_signatures(&signatures, &ids)?)
 }
+
+#[cfg(test)]
+mod tests;

--- a/anchor/signature_collector/src/lib.rs
+++ b/anchor/signature_collector/src/lib.rs
@@ -568,11 +568,25 @@ impl<S: SlotClock + Clone + 'static> SignatureCollecting for Arc<SignatureCollec
 }
 
 /// The actual signature collector task, waiting for messages.
+///
+/// The recv loop is the only place that matches on [`CollectorMessageKind`];
+/// it dispatches each transport message to a typed method on
+/// [`SignatureCollectorState`] so the state machine never sees the channel
+/// shape (or the size-balancing `Box<Signature>` it carries).
 async fn signature_collector(mut rx: mpsc::UnboundedReceiver<CollectorMessage>) {
     let mut state = SignatureCollectorState::default();
     while let Some(message) = rx.recv().await {
         trace!(msg=?message.kind, "Signature collector received message");
-        if state.process(message.kind).is_break() {
+        let outcome = match message.kind {
+            CollectorMessageKind::RegisterNotifier { notify, threshold } => {
+                state.register_request(notify, threshold)
+            }
+            CollectorMessageKind::PartialSignature {
+                operator_id,
+                signature,
+            } => state.add_partial_signature(operator_id, *signature),
+        };
+        if outcome.is_break() {
             return;
         }
     }
@@ -589,56 +603,72 @@ struct SignatureCollectorState {
 }
 
 impl SignatureCollectorState {
-    /// Returns `Break` when the collector should exit (conflicting thresholds,
-    /// unrecoverable reconstruction failure).
-    fn process(&mut self, kind: CollectorMessageKind) -> ControlFlow<()> {
-        match kind {
-            CollectorMessageKind::RegisterNotifier {
-                notify,
-                threshold: new_threshold,
-            } => {
-                if let Some(full_signature) = &self.full_signature {
-                    if let Err(err) = notify.send(Arc::clone(full_signature)) {
-                        warn!(?err, "Failed to send recovered signature");
-                    }
-                    return ControlFlow::Continue(());
-                }
-                self.notifiers.push(notify);
-                if let Some(old_threshold) = self.threshold
-                    && new_threshold != old_threshold
-                {
-                    // Different tasks expect different thresholds. We can not know which is
-                    // correct, so we exit this instance.
-                    error!(
-                        new_threshold,
-                        old_threshold, "Conflicting thresholds passed!"
-                    );
-                    return ControlFlow::Break(());
-                }
-                self.threshold = Some(new_threshold);
+    /// Register a task waiting for the reconstructed signature.
+    ///
+    /// If reconstruction has already completed, the cached signature is
+    /// delivered immediately. Otherwise the notifier is queued and the
+    /// threshold is recorded; conflicting thresholds from concurrent
+    /// requests cause the collector to `Break` (the recv loop drops the
+    /// state, surfacing `RecvError` to every waiter).
+    ///
+    /// Returns `Break` when the collector should exit (conflicting
+    /// thresholds, unrecoverable reconstruction failure).
+    fn register_request(
+        &mut self,
+        notify: oneshot::Sender<Arc<Signature>>,
+        new_threshold: u64,
+    ) -> ControlFlow<()> {
+        if let Some(full_signature) = &self.full_signature {
+            if let Err(err) = notify.send(Arc::clone(full_signature)) {
+                warn!(?err, "Failed to send recovered signature");
             }
-            CollectorMessageKind::PartialSignature {
-                operator_id,
-                signature,
-            } => {
-                if self.full_signature.is_some() {
-                    return ControlFlow::Continue(());
-                }
+            return ControlFlow::Continue(());
+        }
+        self.notifiers.push(notify);
+        if let Some(old_threshold) = self.threshold
+            && new_threshold != old_threshold
+        {
+            // Different tasks expect different thresholds. We can not know which is
+            // correct, so we exit this instance.
+            error!(
+                new_threshold,
+                old_threshold, "Conflicting thresholds passed!"
+            );
+            return ControlFlow::Break(());
+        }
+        self.threshold = Some(new_threshold);
+        self.try_reconstruct()
+    }
 
-                match self.signature_share.entry(operator_id) {
-                    hash_map::Entry::Vacant(entry) => {
-                        entry.insert(*signature);
-                    }
-                    hash_map::Entry::Occupied(entry) => {
-                        if entry.get() != &*signature {
-                            // We can not know which signature is correct. This is serious
-                            // misbehaviour from the operator!
-                            error!(
-                                ?operator_id,
-                                "Received conflicting signatures from operator"
-                            );
-                        }
-                    }
+    /// Ingest a partial signature from one operator.
+    ///
+    /// Late shares arriving after reconstruction are silently dropped.
+    /// Conflicting shares from the same operator are logged but not fatal,
+    /// since the source of the discrepancy is not knowable here.
+    ///
+    /// Returns `Break` when the collector should exit (unrecoverable
+    /// reconstruction failure).
+    fn add_partial_signature(
+        &mut self,
+        operator_id: OperatorId,
+        signature: Signature,
+    ) -> ControlFlow<()> {
+        if self.full_signature.is_some() {
+            return ControlFlow::Continue(());
+        }
+
+        match self.signature_share.entry(operator_id) {
+            hash_map::Entry::Vacant(entry) => {
+                entry.insert(signature);
+            }
+            hash_map::Entry::Occupied(entry) => {
+                if entry.get() != &signature {
+                    // We can not know which signature is correct. This is serious
+                    // misbehaviour from the operator!
+                    error!(
+                        ?operator_id,
+                        "Received conflicting signatures from operator"
+                    );
                 }
             }
         }

--- a/anchor/signature_collector/src/tests.rs
+++ b/anchor/signature_collector/src/tests.rs
@@ -31,7 +31,7 @@ fn register_notifier(
     threshold: u64,
 ) -> oneshot::Receiver<Arc<Signature>> {
     let (notify, rx) = oneshot::channel();
-    let outcome = state.process(CollectorMessageKind::RegisterNotifier { notify, threshold });
+    let outcome = state.register_request(notify, threshold);
     assert!(
         outcome.is_continue(),
         "register_notifier should not break the collector"
@@ -44,10 +44,7 @@ fn feed_partial_sig(
     operator_id: OperatorId,
     signature: Signature,
 ) {
-    let outcome = state.process(CollectorMessageKind::PartialSignature {
-        operator_id,
-        signature: Box::new(signature),
-    });
+    let outcome = state.add_partial_signature(operator_id, signature);
     assert!(
         outcome.is_continue(),
         "feed_partial_sig should not break the collector"
@@ -87,10 +84,7 @@ fn state_breaks_on_conflicting_thresholds() {
     let _first_rx = register_notifier(&mut state, THRESHOLD);
 
     let (second_notify, mut second_rx) = oneshot::channel();
-    let outcome = state.process(CollectorMessageKind::RegisterNotifier {
-        notify: second_notify,
-        threshold: THRESHOLD + 1,
-    });
+    let outcome = state.register_request(second_notify, THRESHOLD + 1);
 
     assert!(
         outcome.is_break(),

--- a/anchor/signature_collector/src/tests.rs
+++ b/anchor/signature_collector/src/tests.rs
@@ -153,3 +153,51 @@ fn state_notifies_all_registrants_on_reconstruction() {
     expect_signature(&mut rx_b, "registrant b should be notified");
     expect_signature(&mut rx_c, "registrant c should be notified");
 }
+
+/// Partial signatures that arrive before any `RegisterNotifier` is buffered.
+/// Reconstruction triggers when a notifier and the threshold arrives.
+#[test]
+fn state_buffers_shares_arriving_before_first_notifier_register() {
+    let shares = split_random_master();
+    let mut state = SignatureCollectorState::default();
+
+    for (op_id, sk) in &shares[..THRESHOLD as usize] {
+        feed_partial_sig(&mut state, *op_id, sk.sign(SIGNING_ROOT));
+    }
+
+    assert!(
+        state.full_signature.is_none(),
+        "State should not reconstruct without a threshold"
+    );
+
+    let mut result_rx = register_notifier(&mut state, THRESHOLD);
+    expect_signature(
+        &mut result_rx,
+        "Notifier should receive the signature reconstructed from buffered shares",
+    );
+}
+
+/// Partial signatures that arrive after reconstruction are silently dropped:
+/// no panic, no Break, no re-buffering of the late share. This is the common
+/// case in production: slow operators' shares routinely arrive after a fast
+/// majority has already reconstructed the signature.
+#[test]
+fn state_drops_partial_signatures_after_reconstruction() {
+    let shares = split_random_master();
+    let mut state = SignatureCollectorState::default();
+
+    let mut rx = register_notifier(&mut state, THRESHOLD);
+    for (op_id, sk) in &shares[..THRESHOLD as usize] {
+        feed_partial_sig(&mut state, *op_id, sk.sign(SIGNING_ROOT));
+    }
+    expect_signature(&mut rx, "first registrant should be notified");
+
+    let (late_op, late_sk) = &shares[THRESHOLD as usize];
+    feed_partial_sig(&mut state, *late_op, late_sk.sign(SIGNING_ROOT));
+
+    assert!(state.full_signature.is_some(), "cached signature persists");
+    assert!(
+        state.signature_share.is_empty(),
+        "post-reconstruction shares are not buffered"
+    );
+}

--- a/anchor/signature_collector/src/tests.rs
+++ b/anchor/signature_collector/src/tests.rs
@@ -1,0 +1,155 @@
+use bls::{SecretKey, Signature};
+use bls_lagrange::{KeyId, split_with_rng};
+use rand::{prelude::*, rngs::StdRng};
+use tokio::sync::oneshot;
+
+use super::*;
+
+const TEST_RNG_SEED: u64 = 0xDEAD_BEEF_CAFE_0001;
+const TOTAL_SHARES: u64 = 4;
+const THRESHOLD: u64 = 3;
+const SIGNING_ROOT: Hash256 = Hash256::repeat_byte(0xAB);
+
+fn split_random_master() -> Vec<(OperatorId, SecretKey)> {
+    let rng = &mut StdRng::seed_from_u64(TEST_RNG_SEED);
+    let master = SecretKey::random();
+
+    split_with_rng(
+        &master,
+        THRESHOLD,
+        (1..=TOTAL_SHARES).map(|x| KeyId::try_from(x).unwrap()),
+        rng,
+    )
+    .expect("split should succeed")
+    .into_iter()
+    .map(|(kid, sk)| (OperatorId(u64::from(kid)), sk))
+    .collect()
+}
+
+fn register_notifier(
+    state: &mut SignatureCollectorState,
+    threshold: u64,
+) -> oneshot::Receiver<Arc<Signature>> {
+    let (notify, rx) = oneshot::channel();
+    let outcome = state.process(CollectorMessageKind::RegisterNotifier { notify, threshold });
+    assert!(
+        outcome.is_continue(),
+        "register_notifier should not break the collector"
+    );
+    rx
+}
+
+fn feed_partial_sig(
+    state: &mut SignatureCollectorState,
+    operator_id: OperatorId,
+    signature: Signature,
+) {
+    let outcome = state.process(CollectorMessageKind::PartialSignature {
+        operator_id,
+        signature: Box::new(signature),
+    });
+    assert!(
+        outcome.is_continue(),
+        "feed_partial_sig should not break the collector"
+    );
+}
+
+fn expect_signature(rx: &mut oneshot::Receiver<Arc<Signature>>, context: &str) {
+    rx.try_recv().expect(context);
+}
+
+/// Once `THRESHOLD` valid partial signatures have been fed in, the state
+/// reconstructs the master signature and delivers it to a registered notifier.
+#[test]
+fn state_processes_full_quorum_and_notifies() {
+    let shares = split_random_master();
+    let mut state = SignatureCollectorState::default();
+
+    let mut result_rx = register_notifier(&mut state, THRESHOLD);
+
+    for (op_id, sk) in &shares[..THRESHOLD as usize] {
+        feed_partial_sig(&mut state, *op_id, sk.sign(SIGNING_ROOT));
+    }
+
+    expect_signature(
+        &mut result_rx,
+        "Notifier should receive the reconstructed signature",
+    );
+}
+
+/// Two `RegisterNotifier` messages disagree on the threshold; the state must
+/// `Break`. In production, the recv loop drops the state on `Break`, which
+/// drops every queued notifier and surfaces `RecvError` to the callers. The
+/// test models that lifetime explicitly via `drop(state)`.
+#[test]
+fn state_breaks_on_conflicting_thresholds() {
+    let mut state = SignatureCollectorState::default();
+    let _first_rx = register_notifier(&mut state, THRESHOLD);
+
+    let (second_notify, mut second_rx) = oneshot::channel();
+    let outcome = state.process(CollectorMessageKind::RegisterNotifier {
+        notify: second_notify,
+        threshold: THRESHOLD + 1,
+    });
+
+    assert!(
+        outcome.is_break(),
+        "State should Break when a second notifier disagrees on threshold"
+    );
+
+    drop(state);
+
+    assert!(
+        matches!(
+            second_rx.try_recv(),
+            Err(oneshot::error::TryRecvError::Closed)
+        ),
+        "Conflicting notifier sender should be dropped, surfacing RecvError"
+    );
+}
+
+/// A notifier that registers after reconstruction has already completed should
+/// receive the cached signature immediately rather than waiting on a fresh
+/// quorum.
+#[test]
+fn state_delivers_cached_signature_to_late_registrant() {
+    let shares = split_random_master();
+    let mut state = SignatureCollectorState::default();
+
+    // Reach quorum on the first registrant.
+    let mut first_rx = register_notifier(&mut state, THRESHOLD);
+    for (op_id, sk) in &shares[..THRESHOLD as usize] {
+        feed_partial_sig(&mut state, *op_id, sk.sign(SIGNING_ROOT));
+    }
+    expect_signature(
+        &mut first_rx,
+        "First registrant should receive the reconstructed signature",
+    );
+
+    // Late registrant arrives after `full_signature` is set.
+    let mut late_rx = register_notifier(&mut state, THRESHOLD);
+    expect_signature(
+        &mut late_rx,
+        "Late registrant should receive the cached signature immediately",
+    );
+}
+
+/// Multiple notifiers registered before quorum should all be notified on a
+/// single reconstruction (the `Vec<oneshot::Sender>` fan-out).
+#[test]
+fn state_notifies_all_registrants_on_reconstruction() {
+    let shares = split_random_master();
+    let mut state = SignatureCollectorState::default();
+
+    let mut rx_a = register_notifier(&mut state, THRESHOLD);
+    let mut rx_b = register_notifier(&mut state, THRESHOLD);
+    let mut rx_c = register_notifier(&mut state, THRESHOLD);
+
+    for (op_id, sk) in &shares[..THRESHOLD as usize] {
+        feed_partial_sig(&mut state, *op_id, sk.sign(SIGNING_ROOT));
+    }
+
+    expect_signature(&mut rx_a, "registrant a should be notified");
+    expect_signature(&mut rx_b, "registrant b should be notified");
+    expect_signature(&mut rx_c, "registrant c should be notified");
+}


### PR DESCRIPTION
## Problem, Evidence, and Context (Required)

- This prepares the signature collector for the follow-up #933 work without mixing behavior changes into that PR.
- The current collector task keeps its state as several mutable locals inside the async receive loop, which makes the quorum/reconstruction behavior harder to test directly.
- This is worth doing now because #933 needs focused state-machine tests for verification/fallback paths.
- Related: #933.

## Change Overview (Required)

- Extracted the per-signature collector state into `SignatureCollectorState`.
- The async `signature_collector` task is now a thin receive loop that delegates each message to `state.process(...)`.
- Reconstruction logic moved into `SignatureCollectorState::try_reconstruct`, preserving the existing threshold/combine/notify behavior.
- Added direct state tests for quorum notification, conflicting thresholds, late notifier registration, and multiple waiting notifiers.
- Suggested reading order: start in `signature_collector/src/lib.rs` at `signature_collector`, then review `SignatureCollectorState`, then the tests in `signature_collector/src/tests.rs`.
- Intentionally did not add signature verification, fallback eviction, DB access, metrics, or validator pubkey plumbing. Those remain in the follow-up #933 PR.

## Risks, Trade-offs, and Mitigations (Required)

- Main risk is accidental behavior drift while moving logic out of the receive loop.
- Mitigation: this PR keeps the same message handling, same threshold conflict behavior, same duplicate-share behavior, and same reconstruction path.
- The tests drive the extracted state directly so the refactor has focused coverage without adding test-only production hooks.
- Trade-off: this adds a small internal struct before the feature PR, but keeps the later behavioral diff smaller and easier to review.

## Validation (Required)

- `cargo fmt --package signature_collector --check`
- `cargo test -p signature_collector`
- `git diff --cached --check`

## Rollback (Required for behavior or runtime changes; optional otherwise)

- Revert this PR. There are no config, database, or operational changes.

## Blockers / Dependencies (Optional)

- N/A

## Additional Info / Next Steps (Optional)

- Follow-up PR will implement post-reconstruction signature verification with fallback for #933.
