### PR TITLE
ci: run spec_tests with fake_crypto

### DIFF
--- a/.claude/rules/commands.md
+++ b/.claude/rules/commands.md
@@ -12,6 +12,7 @@ Use project Make targets by default.
 - `make test` - all tests, release mode (standard)
 - `make test-debug` - all tests, debug mode
 - `make nextest-release` / `make nextest-debug` - nextest runner
+- `make test-spec-tests` / `make nextest-spec-tests` - `spec_tests` with `fake_crypto` (full proposer block coverage)
 - `cargo test -p <crate>` - specific crate
 - `make check-benches` - compile benchmarks without running
 

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -101,6 +101,26 @@ jobs:
     - name: Show cache stats
       if: env.SELF_HOSTED_RUNNERS == 'true'
       run: sccache --show-stats
+  spec-tests-fake-crypto:
+    name: spec-tests-fake-crypto
+    needs: [check-labels]
+    if: needs.check-labels.outputs.skip_ci != 'true'
+    runs-on: ubuntu-22.04
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: 'recursive'
+    - name: Get latest version of stable Rust
+      if: env.SELF_HOSTED_RUNNERS == 'false'
+      uses: moonrepo/setup-rust@v1
+      with:
+          cache: false
+          cache-target: release
+          bins: cargo-nextest
+      env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - name: Run spec_tests with fake_crypto
+      run: make nextest-spec-tests
   check-fmt:
     name: check-fmt
     runs-on: ubuntu-22.04
@@ -224,6 +244,7 @@ jobs:
       'check-labels',
       'release-tests-ubuntu',
       'debug-tests-ubuntu',
+      'spec-tests-fake-crypto',
       'check-fmt',
       'check-code',
       'check-msrv',

--- a/Makefile
+++ b/Makefile
@@ -97,6 +97,15 @@ coverage:
 coverage-html:
 	cargo llvm-cov nextest --workspace --features "$(TEST_FEATURES)" --html
 
+# Runs `spec_tests` with `fake_crypto` for full proposer block coverage
+# (workspace run already covers the BLS-rejection path).
+test-spec-tests:
+	cargo test --release -p spec_tests --features fake_crypto
+
+# Same as `test-spec-tests`, using nextest.
+nextest-spec-tests:
+	cargo nextest run --release -p spec_tests --features fake_crypto
+
 # Runs cargo-fmt (linter).
 cargo-fmt:
 	cargo +$(PINNED_NIGHTLY) fmt --all
@@ -133,7 +142,7 @@ mdlint:
 	./scripts/mdlint.sh
 
 # Runs the entire test suite
-test-full: cargo-fmt test-release test-debug
+test-full: cargo-fmt test-release test-debug test-spec-tests
 
 # Lints the code for bad style and potentially unsafe arithmetic using Clippy.
 # Clippy lints are opt-in per-crate for now. By default, everything is allowed except for performance and correctness lints.


### PR DESCRIPTION
## Problem, Evidence, and Context

- PR #942 added `ConsensusDataProposerTest` whose success-path assertions (block blinded state, block root, block SSZ roundtrip) only run when `bls/fake_crypto` is enabled. Without it, success fixtures fall through to a weaker BLS-rejection branch because Lighthouse validates BLS during SSZ decode while Go's `fastssz` does not.
- Today nothing in the Makefile or CI runs `spec_tests` with `fake_crypto`, so the branch can stay green while bypassing the strongest assertions of the new proposer test.
- Closes #938.

## Change Overview

Test-infra only, two additions:

- **Makefile**: new `test-spec-tests` / `nextest-spec-tests` targets that run `spec_tests` with `--features fake_crypto`; `test-full` extended to include them. Mirrors Lighthouse's `ef_tests` pattern.
- **CI**: new `spec-tests-fake-crypto` job in `test-suite.yml` that runs `make nextest-spec-tests`, gated by `test-suite-success`. Runs in parallel with the existing release-tests job.

What did **not** change: no production code; no edits to the BLS-fallback heuristic in `consensus_data_proposer.rs` or `is_bls_validation_error`. Both paths remain valuable — the workspace test run continues to exercise the realistic BLS-rejection branch, and the new job covers the full-coverage path.

## Risks, Trade-offs, and Mitigations

- Adds a CI job with ~1–2 min compile + run; runs in parallel so it does not extend the critical path materially.
- `fake_crypto` cannot be enabled at the workspace level (the `anchor` root crate does not declare it), so the target is scoped to `-p spec_tests`.
- Trade-off vs folding inline into `release-tests-ubuntu`: separate job preserves independent failure visibility and parallel execution; cost is ~30–60s of duplicate Rust setup, accepted.

## Validation

- `make nextest-spec-tests`: 1 test, 114 fixtures, 0.06s runtime (after ~1m48s cold compile). Success fixtures now exercise `verify_block` (block root + SSZ roundtrip) instead of falling through to the BLS-rejection branch.
- `cargo nextest run --release -p spec_tests` (no `fake_crypto`): still passes via the existing BLS-fallback path — confirms the workspace test run is unaffected.
- `.github/scripts/check_success_job.sh ./.github/workflows/test-suite.yml test-suite-success` reports `COMPLETENESS CHECK PASSED`; `yq` parses the workflow YAML cleanly.

## Rollback

N/A — test-infrastructure-only change.

## Blockers / Dependencies

None.