### PR TITLE
test: AggregatorCommitteeConsensusDataTest

### DIFF
--- a/anchor/spec_tests/src/runner/types_dispatcher.rs
+++ b/anchor/spec_tests/src/runner/types_dispatcher.rs
@@ -68,6 +68,13 @@ fn dispatch_fixture_by_prefix(prefix: &str, path: &Path, contents: &str) -> Disp
             DispatchOutcome::Executed(run_test::<types::ProposerConsensusDataTest>(path, contents))
         }
 
+        // Aggregator-committee consensus data validation tests
+        "aggregatorcommitteeconsensusdata.AggregatorCommitteeConsensusDataTest" => {
+            DispatchOutcome::Executed(run_test::<types::AggregatorCommitteeConsensusDataTest>(
+                path, contents,
+            ))
+        }
+
         // Proposer block data extraction tests
         "consensusdataproposer.ProposerSpecTest" => {
             DispatchOutcome::Executed(run_test::<types::ConsensusDataProposerTest>(path, contents))

--- a/anchor/spec_tests/src/types/aggregator_committee_consensus_data.rs
+++ b/anchor/spec_tests/src/types/aggregator_committee_consensus_data.rs
@@ -1,0 +1,47 @@
+use serde::Deserialize;
+use ssv_types::consensus::AggregatorCommitteeDataValidator;
+use types::MainnetEthSpec;
+
+use crate::{
+    SpecTest,
+    utils::{
+        dtos::RawAggregatorCommitteeConsensusData,
+        error_codes::{self, aggregator_committee_validation_error_code},
+    },
+};
+
+/// Mirrors Go's `AggregatorCommitteeConsensusData.Validate()`.
+///
+/// Exercises the production `AggregatorCommitteeDataValidator::do_validation` so any
+/// drift between Anchor's validator and ssv-spec's is caught by the fixtures.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct AggregatorCommitteeConsensusDataTest {
+    #[serde(rename = "AggCommConsensusData")]
+    consensus_data: RawAggregatorCommitteeConsensusData,
+    expected_error_code: i64,
+}
+
+impl SpecTest for AggregatorCommitteeConsensusDataTest {
+    fn run(&self) -> Result<(), String> {
+        let actual_code = match self.validate() {
+            Ok(()) => error_codes::NO_ERROR,
+            Err(code) => code,
+        };
+        error_codes::assert_error_code(self.expected_error_code, actual_code)
+    }
+}
+
+impl AggregatorCommitteeConsensusDataTest {
+    fn validate(&self) -> Result<(), i64> {
+        let consensus_data =
+            ssv_types::consensus::AggregatorCommitteeConsensusData::<MainnetEthSpec>::try_from(
+                &self.consensus_data,
+            )
+            .map_err(|_| error_codes::UNMAPPED_ERROR_CODE)?;
+
+        AggregatorCommitteeDataValidator::<MainnetEthSpec>::default()
+            .do_validation(&consensus_data)
+            .map_err(aggregator_committee_validation_error_code)
+    }
+}

--- a/anchor/spec_tests/src/types/mod.rs
+++ b/anchor/spec_tests/src/types/mod.rs
@@ -1,3 +1,4 @@
+mod aggregator_committee_consensus_data;
 mod aggregator_committee_consensus_data_encoding;
 mod beacon_vote_encoding;
 mod committee_member;
@@ -12,6 +13,7 @@ mod signed_ssv_msg_encoding;
 mod ssv_message_encoding;
 mod ssv_msg;
 
+pub use aggregator_committee_consensus_data::*;
 pub use aggregator_committee_consensus_data_encoding::*;
 pub use beacon_vote_encoding::*;
 pub use committee_member::*;

--- a/anchor/spec_tests/src/utils/deserializers.rs
+++ b/anchor/spec_tests/src/utils/deserializers.rs
@@ -49,6 +49,22 @@ pub fn deserialize_base64_list<'de, D: serde::Deserializer<'de>>(
         .collect()
 }
 
+/// Deserializes a vector of base64 strings that may be `null` into `Vec<Vec<u8>>`,
+/// treating `null` as an empty vector. Mirrors Go's marshaling of empty slices.
+pub fn deserialize_base64_list_or_null<'de, D: serde::Deserializer<'de>>(
+    deserializer: D,
+) -> Result<Vec<Vec<u8>>, D::Error> {
+    let opt: Option<Vec<String>> = Option::deserialize(deserializer)?;
+    opt.unwrap_or_default()
+        .into_iter()
+        .map(|s| {
+            STANDARD
+                .decode(&s)
+                .map_err(|e| serde::de::Error::custom(format!("Failed to decode base64: {e}")))
+        })
+        .collect()
+}
+
 /// Deserializes a base64-encoded string that may be `null` into `Option<Vec<u8>>`.
 ///
 /// Error fixtures have `null` while success fixtures have a base64 string.
@@ -84,6 +100,14 @@ pub fn deserialize_base64_or_empty<'de, D: serde::Deserializer<'de>>(
 }
 
 // ─── Hex ─────────────────────────────────────────────────────────────────────
+
+/// Deserializes a hex string (with or without `0x` prefix) into `Vec<u8>`.
+pub fn deserialize_hex<'de, D: serde::Deserializer<'de>>(
+    deserializer: D,
+) -> Result<Vec<u8>, D::Error> {
+    let hex_str = String::deserialize(deserializer)?;
+    decode_hex::<D::Error>(&hex_str)
+}
 
 /// Deserializes an optional hex string (with or without `0x` prefix) into `Option<Vec<u8>>`.
 pub fn deserialize_hex_option<'de, D: serde::Deserializer<'de>>(

--- a/anchor/spec_tests/src/utils/dtos.rs
+++ b/anchor/spec_tests/src/utils/dtos.rs
@@ -212,6 +212,7 @@ impl TryFrom<&RawConsensusData> for ProposerConsensusData {
 pub struct RawAssignedAggregator {
     pub validator_index: String,
     #[serde(deserialize_with = "deserialize_hex")]
+    // `AggregatorCommitteeDataValidator::do_validation()` does not currently read this field.
     pub selection_proof: Vec<u8>,
     pub committee_index: u64,
 }
@@ -233,9 +234,11 @@ impl TryFrom<&RawAssignedAggregator> for AssignedAggregator {
 
 /// DTO for Go's `AggregatorCommitteeConsensusData` fixture.
 ///
-/// Go marshals empty slices as JSON `null`, so list fields are `Option<Vec<_>>`
-/// (or use a null-tolerant deserializer). `SyncCommitteeContribution<E>` reuses
-/// Lighthouse's existing serde derive directly.
+/// Go marshals nil slices as JSON `null` (vs `[]` for non-nil empties); the
+/// `no_validators` fixture exercises this by leaving every list at its zero
+/// value. List fields therefore tolerate null via `Option<Vec<_>>` or a
+/// null-tolerant deserializer. `SyncCommitteeContribution<E>` reuses
+/// Lighthouse's existing `serde` derive directly.
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "PascalCase")]
 pub struct RawAggregatorCommitteeConsensusData {

--- a/anchor/spec_tests/src/utils/dtos.rs
+++ b/anchor/spec_tests/src/utils/dtos.rs
@@ -211,23 +211,24 @@ impl TryFrom<&RawConsensusData> for ProposerConsensusData {
 #[serde(rename_all = "PascalCase")]
 pub struct RawAssignedAggregator {
     pub validator_index: String,
+    /// Present in fixtures but unused: `AggregatorCommitteeDataValidator::do_validation()`
+    /// only reads `committee_index`. See `to_assigned_aggregator_for_validation()`.
     #[serde(deserialize_with = "deserialize_hex")]
-    // `AggregatorCommitteeDataValidator::do_validation()` does not currently read this field.
     pub selection_proof: Vec<u8>,
     pub committee_index: u64,
 }
 
-impl TryFrom<&RawAssignedAggregator> for AssignedAggregator {
-    type Error = String;
-
-    fn try_from(raw: &RawAssignedAggregator) -> Result<Self, String> {
-        let selection_proof = bls::Signature::deserialize(&raw.selection_proof)
-            .map_err(|e| format!("Invalid selection_proof BLS signature: {e:?}"))?;
-
+impl RawAssignedAggregator {
+    /// Builds an `AssignedAggregator` for `AggregatorCommitteeDataValidator::do_validation()`.
+    ///
+    /// `selection_proof` is replaced with `bls::Signature::empty()` because the validator does
+    /// not read it; this keeps the adapter focused on `Validate()` parity and avoids making BLS
+    /// proof validity an implicit precondition of these fixtures.
+    pub fn to_assigned_aggregator_for_validation(&self) -> Result<AssignedAggregator, String> {
         Ok(AssignedAggregator {
-            validator_index: parse_validator_index(&raw.validator_index)?,
-            selection_proof,
-            committee_index: raw.committee_index,
+            validator_index: parse_validator_index(&self.validator_index)?,
+            selection_proof: bls::Signature::empty(),
+            committee_index: self.committee_index,
         })
     }
 }
@@ -269,7 +270,7 @@ impl TryFrom<&RawAggregatorCommitteeConsensusData>
             .as_deref()
             .unwrap_or_default()
             .iter()
-            .map(AssignedAggregator::try_from)
+            .map(RawAssignedAggregator::to_assigned_aggregator_for_validation)
             .collect::<Result<Vec<_>, _>>()?;
         let aggregators =
             VariableList::new(aggregators).map_err(|_| "aggregators exceeds max length")?;
@@ -297,7 +298,7 @@ impl TryFrom<&RawAggregatorCommitteeConsensusData>
             .as_deref()
             .unwrap_or_default()
             .iter()
-            .map(AssignedAggregator::try_from)
+            .map(RawAssignedAggregator::to_assigned_aggregator_for_validation)
             .collect::<Result<Vec<_>, _>>()?;
         let contributors =
             VariableList::new(contributors).map_err(|_| "contributors exceeds max length")?;

--- a/anchor/spec_tests/src/utils/dtos.rs
+++ b/anchor/spec_tests/src/utils/dtos.rs
@@ -8,19 +8,30 @@ use std::str::FromStr;
 use serde::Deserialize;
 use ssv_types::{
     OperatorId, ValidatorIndex,
-    consensus::{BeaconRole, DataVersion, ProposerConsensusData, ValidatorDuty},
+    consensus::{
+        AggregatorCommitteeConsensusData, AssignedAggregator, BeaconRole, DataVersion,
+        ProposerConsensusData, ValidatorDuty,
+    },
     message::{MsgType, SSVMessage},
     msgid::MessageId,
     partial_sig::{PartialSignatureKind, PartialSignatureMessage},
 };
 use ssz::{Decode, DecodeError, Encode};
 use ssz_types::VariableList;
-use types::{ForkName, Hash256, Slot};
+use types::{ForkName, Hash256, MainnetEthSpec, Slot, SyncCommitteeContribution};
 
 use super::deserializers::{
-    deserialize_base64, deserialize_base64_or_empty, deserialize_hex_message_id,
-    deserialize_hex_option, deserialize_partial_signature_kind,
+    deserialize_base64, deserialize_base64_list_or_null, deserialize_base64_or_empty,
+    deserialize_hex, deserialize_hex_message_id, deserialize_hex_option,
+    deserialize_partial_signature_kind,
 };
+
+/// Parses a Go-marshaled `ValidatorIndex` (a quoted-uint string in JSON).
+fn parse_validator_index(s: &str) -> Result<ValidatorIndex, String> {
+    s.parse::<usize>()
+        .map(ValidatorIndex)
+        .map_err(|e| format!("Invalid validator_index: {e}"))
+}
 
 /// DTO for `SSVMessage`.
 #[derive(Debug, Deserialize)]
@@ -77,18 +88,17 @@ impl TryFrom<&RawPartialSignatureMessage> for PartialSignatureMessage {
         }
         let signing_root = Hash256::from_slice(root_bytes);
 
-        let validator_index = m
-            .validator_index
-            .as_ref()
-            .ok_or("Missing validator_index")?
-            .parse::<usize>()
-            .map_err(|e| format!("Invalid validator_index: {e}"))?;
+        let validator_index = parse_validator_index(
+            m.validator_index
+                .as_ref()
+                .ok_or("Missing validator_index")?,
+        )?;
 
         Ok(PartialSignatureMessage {
             partial_signature,
             signing_root,
             signer: OperatorId(m.signer),
-            validator_index: ValidatorIndex(validator_index),
+            validator_index,
         })
     }
 }
@@ -139,11 +149,7 @@ impl TryFrom<&RawDuty> for ValidatorDuty {
             .map(Slot::new)
             .map_err(|e| format!("Invalid slot: {e}"))?;
 
-        let validator_index = raw
-            .validator_index
-            .parse::<usize>()
-            .map(ValidatorIndex)
-            .map_err(|e| format!("Invalid validator_index: {e}"))?;
+        let validator_index = parse_validator_index(&raw.validator_index)?;
 
         let sync_indices: Vec<u64> = raw
             .validator_sync_committee_indices
@@ -196,6 +202,114 @@ impl TryFrom<&RawConsensusData> for ProposerConsensusData {
             duty,
             version: DataVersion::from(fork),
             data_ssz,
+        })
+    }
+}
+
+/// DTO for `AssignedAggregator`.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct RawAssignedAggregator {
+    pub validator_index: String,
+    #[serde(deserialize_with = "deserialize_hex")]
+    pub selection_proof: Vec<u8>,
+    pub committee_index: u64,
+}
+
+impl TryFrom<&RawAssignedAggregator> for AssignedAggregator {
+    type Error = String;
+
+    fn try_from(raw: &RawAssignedAggregator) -> Result<Self, String> {
+        let selection_proof = bls::Signature::deserialize(&raw.selection_proof)
+            .map_err(|e| format!("Invalid selection_proof BLS signature: {e:?}"))?;
+
+        Ok(AssignedAggregator {
+            validator_index: parse_validator_index(&raw.validator_index)?,
+            selection_proof,
+            committee_index: raw.committee_index,
+        })
+    }
+}
+
+/// DTO for Go's `AggregatorCommitteeConsensusData` fixture.
+///
+/// Go marshals empty slices as JSON `null`, so list fields are `Option<Vec<_>>`
+/// (or use a null-tolerant deserializer). `SyncCommitteeContribution<E>` reuses
+/// Lighthouse's existing serde derive directly.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct RawAggregatorCommitteeConsensusData {
+    pub version: String,
+    #[serde(default)]
+    pub aggregators: Option<Vec<RawAssignedAggregator>>,
+    #[serde(default)]
+    pub aggregators_committee_indexes: Option<Vec<u64>>,
+    #[serde(deserialize_with = "deserialize_base64_list_or_null", default)]
+    pub aggregated_attestations: Vec<Vec<u8>>,
+    #[serde(default)]
+    pub contributors: Option<Vec<RawAssignedAggregator>>,
+    #[serde(default)]
+    pub sync_committee_contributions: Option<Vec<SyncCommitteeContribution<MainnetEthSpec>>>,
+}
+
+impl TryFrom<&RawAggregatorCommitteeConsensusData>
+    for AggregatorCommitteeConsensusData<MainnetEthSpec>
+{
+    type Error = String;
+
+    fn try_from(raw: &RawAggregatorCommitteeConsensusData) -> Result<Self, String> {
+        let fork = ForkName::from_str(&raw.version)
+            .map_err(|e| format!("Invalid version '{}': {e}", raw.version))?;
+
+        let aggregators = raw
+            .aggregators
+            .as_deref()
+            .unwrap_or_default()
+            .iter()
+            .map(AssignedAggregator::try_from)
+            .collect::<Result<Vec<_>, _>>()?;
+        let aggregators =
+            VariableList::new(aggregators).map_err(|_| "aggregators exceeds max length")?;
+
+        let aggregator_committee_indexes = VariableList::new(
+            raw.aggregators_committee_indexes
+                .clone()
+                .unwrap_or_default(),
+        )
+        .map_err(|_| "aggregators_committee_indexes exceeds max length")?;
+
+        let aggregated_attestations = raw
+            .aggregated_attestations
+            .iter()
+            .map(|bytes| {
+                VariableList::new(bytes.clone())
+                    .map_err(|_| "aggregated attestation exceeds max length".to_string())
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        let aggregated_attestations = VariableList::new(aggregated_attestations)
+            .map_err(|_| "aggregated_attestations exceeds max length")?;
+
+        let contributors = raw
+            .contributors
+            .as_deref()
+            .unwrap_or_default()
+            .iter()
+            .map(AssignedAggregator::try_from)
+            .collect::<Result<Vec<_>, _>>()?;
+        let contributors =
+            VariableList::new(contributors).map_err(|_| "contributors exceeds max length")?;
+
+        let sync_committee_contributions =
+            VariableList::new(raw.sync_committee_contributions.clone().unwrap_or_default())
+                .map_err(|_| "sync_committee_contributions exceeds max length")?;
+
+        Ok(AggregatorCommitteeConsensusData {
+            version: DataVersion::from(fork),
+            aggregators,
+            aggregator_committee_indexes,
+            aggregated_attestations,
+            contributors,
+            sync_committee_contributions,
         })
     }
 }

--- a/anchor/spec_tests/src/utils/error_codes.rs
+++ b/anchor/spec_tests/src/utils/error_codes.rs
@@ -3,7 +3,7 @@
 //! Only codes relevant to currently implemented spec tests are included.
 //! Add new codes as new test types are implemented.
 
-use ssv_types::message::SignedSSVMessageError;
+use ssv_types::{consensus::AggregatorCommitteeValidationError, message::SignedSSVMessageError};
 
 /// No error — validation passed.
 pub const NO_ERROR: i64 = 0;
@@ -55,6 +55,35 @@ pub const UNKNOWN_DUTY_ROLE_DATA: i64 = 10;
 /// `UnknownBlockVersionErrorCode` (iota 10 → value 11) — unrecognized fork version.
 pub const UNKNOWN_BLOCK_VERSION: i64 = 11;
 
+// --- AggregatorCommitteeConsensusData.Validate() codes ---
+
+/// `AggCommAggCommIdxCntMismatchErrorCode` (iota 70 → value 71)
+pub const AGG_COMM_INDEX_COUNT_MISMATCH: i64 = 71;
+
+/// `AggCommCommIdxMismatchErrorCode` (iota 71 → value 72)
+pub const AGG_COMM_INDEX_MISSING: i64 = 72;
+
+/// `AggCommUnusedCommIdxErrorCode` (iota 72 → value 73)
+pub const AGG_COMM_INDEX_UNUSED: i64 = 73;
+
+/// `AggCommDuplicatedCommIdxErrorCode` (iota 73 → value 74)
+pub const AGG_COMM_INDEX_DUPLICATE: i64 = 74;
+
+/// `AggCommSubnetNotInSCSubnetsErrorCode` (iota 74 → value 75)
+pub const AGG_COMM_SC_SUBNET_MISSING: i64 = 75;
+
+/// `AggCommSCCSubnetDuplicateErrorCode` (iota 75 → value 76)
+pub const AGG_COMM_SC_SUBNET_DUPLICATE: i64 = 76;
+
+/// `AggCommUnusedSubnetErrorCode` (iota 76 → value 77)
+pub const AGG_COMM_SC_SUBNET_UNUSED: i64 = 77;
+
+/// `AggCommConsensusDataNoValidatorErrorCode` (iota 77 → value 78)
+pub const AGG_COMM_NO_VALIDATORS: i64 = 78;
+
+/// `AggCommAttestationDecodingErrorCode` (iota 83 → value 84)
+pub const AGG_COMM_ATTESTATION_DECODE: i64 = 84;
+
 // --- Sentinel ---
 
 /// Sentinel for Anchor-specific errors without Go equivalents.
@@ -83,6 +112,25 @@ pub fn signed_ssv_message_error_code(err: &SignedSSVMessageError) -> i64 {
         | SignedSSVMessageError::FullDataTooLong { .. }
         | SignedSSVMessageError::SignersNotSorted
         | SignedSSVMessageError::SSVMessageError(_) => UNMAPPED_ERROR_CODE,
+    }
+}
+
+/// Maps `AggregatorCommitteeValidationError` variants to Go's integer error codes.
+///
+/// Exhaustive match: a new variant on the production enum will fail to compile here,
+/// preventing silent drift to `UNMAPPED_ERROR_CODE`.
+pub fn aggregator_committee_validation_error_code(err: AggregatorCommitteeValidationError) -> i64 {
+    use AggregatorCommitteeValidationError as E;
+    match err {
+        E::CommitteeIndexCountMismatch { .. } => AGG_COMM_INDEX_COUNT_MISMATCH,
+        E::DuplicateCommitteeIndex(_) => AGG_COMM_INDEX_DUPLICATE,
+        E::AggregatorCommitteeIndexMissing(_) => AGG_COMM_INDEX_MISSING,
+        E::AggregatorCommitteeUnusedIndex => AGG_COMM_INDEX_UNUSED,
+        E::DuplicateSyncSubcommittee(_) => AGG_COMM_SC_SUBNET_DUPLICATE,
+        E::ContributorSubcommitteeMissing(_) => AGG_COMM_SC_SUBNET_MISSING,
+        E::SyncSubcommitteeUnusedIndex => AGG_COMM_SC_SUBNET_UNUSED,
+        E::NoValidatorsAssigned => AGG_COMM_NO_VALIDATORS,
+        E::AttestationDecodeError(_) => AGG_COMM_ATTESTATION_DECODE,
     }
 }
 


### PR DESCRIPTION
## Problem, Evidence, and Context

- Anchor's spec test suite lacks coverage for ssv-spec's `AggregatorCommitteeConsensusDataTest`. The companion `EncodingTest` for the same type is already on `unstable` (PR #835), so SSZ encode/decode parity is checked, but the 9 distinct error paths in `AggregatorCommitteeDataValidator::do_validation` are uncovered.
- Continues the type spec test rollout that PR #942 (proposer consensus data) and PR #968 (committee member) are part of. After this lands, only `maxmsgsize.StructureSizeTest` remains for full parity, after which the dispatcher's `_` arm can be replaced with `panic!()`.

## Change Overview

One new validation test type wired through the existing dispatcher:

1. **`AggregatorCommitteeConsensusDataTest`** — Mirrors Go's `AggregatorCommitteeConsensusData.Validate()` by exercising Anchor's production `AggregatorCommitteeDataValidator::do_validation` and mapping its 9 typed error variants to ssv-spec's integer error codes (71–78, 84). Drift between Anchor's validator and ssv-spec's would surface as a fixture mismatch.

Reading order:

- `types/aggregator_committee_consensus_data.rs` (new) — small test struct mirroring `proposer_consensus_data.rs`'s shape from PR #942.
- `utils/dtos.rs` — new `RawAssignedAggregator` and `RawAggregatorCommitteeConsensusData` DTOs with `TryFrom` impls into the production types. `SyncCommitteeContribution<E>` is deserialized directly through Lighthouse's existing serde derive — no DTO sub-type for the sync side. List fields use `Option<Vec<_>>` because Go marshals empty slices as JSON `null`.
- `utils/error_codes.rs` — 9 new constants and `aggregator_committee_validation_error_code` mapper. The match is exhaustive on `AggregatorCommitteeValidationError`, so a new variant on the production enum will fail to compile here rather than silently mapping to `UNMAPPED_ERROR_CODE`.
- `utils/deserializers.rs` — small additions (`deserialize_hex`, `deserialize_base64_list_or_null`) reused for the new DTO.
- `runner/types_dispatcher.rs` — one new match arm. `parse_validator_index` was extracted in `dtos.rs` and now backs `RawDuty`, `RawPartialSignatureMessage`, and `RawAssignedAggregator`.

What did **not** change: production validation logic. Anchor's `do_validation` is the source of truth and the test is the consumer. No production type gained `serde` derives.

## Risks, Trade-offs, and Mitigations

- **`fake_crypto` not required.** Selection-proof zeros short-circuit via `bls::Signature::deserialize`'s `NONE_SIGNATURE` handling; real proofs are valid blst points; aggregated attestations stay as raw SSZ bytes until decoded inside `do_validation`. All 16 new fixtures pass under both default and `--features fake_crypto`.
- **DTO conversion failure → `UNMAPPED_ERROR_CODE`** (matches the established `committee_member.rs` pattern). Loses the underlying error message on failure, but every fixture is well-formed today; a TryFrom failure indicates a real bug or fixture/spec drift and `assert_error_code` reports the unmapped sentinel loudly.
- **Variant order in the mapper** is aligned with `AggregatorCommitteeValidationError`'s declaration order in `consensus.rs`, so future variant changes are easy to audit.

## Validation

- `cargo test -p spec_tests --release` — 74 fixtures executed (was 58 on `unstable`, +16 matches the count of `aggregatorcommitteeconsensusdata.AggregatorCommitteeConsensusDataTest_*.json` fixtures).
- `cargo test -p spec_tests --release --features fake_crypto` — same 74 pass.
- `make cargo-fmt-check` and `make lint` clean.
- End-to-end sanity: temporarily flipping an `ExpectedErrorCode` in a fixture caused the runner to report the mismatch correctly; fixture restored.

## Rollback

N/A — test-only changes, no runtime impact.