### PR TITLE
refactor: ProposerConsensusDataTest uses assert_error_code helper

### DIFF
--- a/anchor/spec_tests/src/types/proposer_consensus_data.rs
+++ b/anchor/spec_tests/src/types/proposer_consensus_data.rs
@@ -21,15 +21,7 @@ impl SpecTest for ProposerConsensusDataTest {
             Ok(()) => error_codes::NO_ERROR,
             Err(code) => code,
         };
-
-        if actual_code != self.expected_error_code {
-            return Err(format!(
-                "Expected error code {}, got {actual_code}",
-                self.expected_error_code,
-            ));
-        }
-
-        Ok(())
+        error_codes::assert_error_code(self.expected_error_code, actual_code)
     }
 }
 


### PR DESCRIPTION
## Problem, Evidence, and Context

`ProposerConsensusDataTest::run()` was the only spec test type still doing
inline `expected != actual` comparison instead of going through
`error_codes::assert_error_code`. Five sibling tests already use the
helper (`CommitteeMemberTest`, `AggregatorCommitteeConsensusDataTest`,
`SignedSSVMessageTest`, `SSVMessageTest`, `PartialSigMsgSpecTest`), so the
inline copy was the odd one out.

Flagged in [#984 review](https://github.com/sigp/anchor/pull/984#issuecomment-4355870543) as a follow-up.

## Change Overview

One-file refactor: replace the 7-line inline `if`/`format!`/`return` block
in `proposer_consensus_data.rs:25-31` with a single
`error_codes::assert_error_code(...)` call. Net: +1 / -9.

Behavior is identical. The helper produces the same `Expected error code
X, got Y` string and additionally guards against `UNMAPPED_ERROR_CODE`
(currently unreachable in this test, since `validate()` only returns
`UNKNOWN_DUTY_ROLE_DATA` or `UNMARSHAL_SSZ` — but the guard is
defensively in place if a future code path adds an UNMAPPED route).

What did **not** change: `validate()` logic, error codes returned,
fixture coverage.

## Risks, Trade-offs, and Mitigations

- **Risk:** none beyond test-harness mechanics. Output strings are
  byte-for-byte equivalent for the currently reachable codes.
- **Mitigation:** existing fixtures continue to exercise the same paths;
  no fixture-side change.

## Validation

- `make cargo-fmt-check` — clean.
- `make lint` — clean.
- `cargo test -p spec_tests --release` — all proposer-consensus-data
  fixtures pass.

## Rollback

`git revert <sha>` is safe — single mechanical change, no data or
runtime impact.