### PR TITLE
chore: drop sigp libp2p fork patches, follow upstream

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -871,7 +871,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -882,7 +882,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1867,6 +1867,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
+
+[[package]]
 name = "compare_fields"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2268,7 +2278,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ab67060fc6b8ef687992d439ca0fa36e7ed17e9a0b16b25b601e8757df720de"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2438,7 +2448,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2751,18 +2761,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "enum-as-inner"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "enum-ordinalize"
 version = "4.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2795,7 +2793,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3639,24 +3637,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b07f60793ff0a4d9cef0f18e63b5357e06209987153a64648c972c1e5aff336f"
 
 [[package]]
-name = "hickory-proto"
-version = "0.25.2"
+name = "hickory-net"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8a6fe56c0038198998a6f217ca4e7ef3a5e51f46163bd6dd60b5c71ca6c6502"
+checksum = "e2295ed2f9c31e471e1428a8f88a3f0e1f4b27c15049592138d1eebe9c35b183"
 dependencies = [
  "async-trait",
  "cfg-if",
  "data-encoding",
- "enum-as-inner",
  "futures-channel",
  "futures-io",
  "futures-util",
+ "hickory-proto",
  "idna",
  "ipnet",
- "once_cell",
- "rand 0.9.2",
- "ring",
- "socket2 0.5.10",
+ "jni",
+ "rand 0.10.0",
  "thiserror 2.0.18",
  "tinyvec",
  "tokio",
@@ -3665,21 +3661,46 @@ dependencies = [
 ]
 
 [[package]]
-name = "hickory-resolver"
-version = "0.25.2"
+name = "hickory-proto"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc62a9a99b0bfb44d2ab95a7208ac952d31060efc16241c87eaf36406fecf87a"
+checksum = "0bab31817bfb44672a252e97fe81cd0c18d1b2cf892108922f6818820df8c643"
+dependencies = [
+ "data-encoding",
+ "idna",
+ "ipnet",
+ "jni",
+ "once_cell",
+ "prefix-trie",
+ "rand 0.10.0",
+ "ring",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "hickory-resolver"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d58d28879ceecde6607729660c2667a081ccdc082e082675042793960f178c"
 dependencies = [
  "cfg-if",
  "futures-util",
+ "hickory-net",
  "hickory-proto",
  "ipconfig",
+ "ipnet",
+ "jni",
  "moka",
+ "ndk-context",
  "once_cell",
  "parking_lot",
- "rand 0.9.2",
+ "rand 0.10.0",
  "resolv-conf",
  "smallvec",
+ "system-configuration",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -4143,6 +4164,9 @@ name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "iri-string"
@@ -4192,6 +4216,55 @@ name = "itoa"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+
+[[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.18",
+ "walkdir",
+ "windows-link",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version 0.4.1",
+ "simd_cesu8",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "js-sys"
@@ -4329,7 +4402,7 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 [[package]]
 name = "libp2p"
 version = "0.57.0"
-source = "git+https://github.com/libp2p/rust-libp2p.git?rev=22fb4c784fc55ad8b15d05fdc9f98d663107d4cb#22fb4c784fc55ad8b15d05fdc9f98d663107d4cb"
+source = "git+https://github.com/libp2p/rust-libp2p.git?rev=197663d7cd23c121db30b4cbe2557eb28e454142#197663d7cd23c121db30b4cbe2557eb28e454142"
 dependencies = [
  "bytes",
  "either",
@@ -4362,7 +4435,7 @@ dependencies = [
 [[package]]
 name = "libp2p-allow-block-list"
 version = "0.7.0"
-source = "git+https://github.com/libp2p/rust-libp2p.git?rev=22fb4c784fc55ad8b15d05fdc9f98d663107d4cb#22fb4c784fc55ad8b15d05fdc9f98d663107d4cb"
+source = "git+https://github.com/libp2p/rust-libp2p.git?rev=197663d7cd23c121db30b4cbe2557eb28e454142#197663d7cd23c121db30b4cbe2557eb28e454142"
 dependencies = [
  "libp2p-core",
  "libp2p-identity",
@@ -4372,7 +4445,7 @@ dependencies = [
 [[package]]
 name = "libp2p-connection-limits"
 version = "0.7.0"
-source = "git+https://github.com/libp2p/rust-libp2p.git?rev=22fb4c784fc55ad8b15d05fdc9f98d663107d4cb#22fb4c784fc55ad8b15d05fdc9f98d663107d4cb"
+source = "git+https://github.com/libp2p/rust-libp2p.git?rev=197663d7cd23c121db30b4cbe2557eb28e454142#197663d7cd23c121db30b4cbe2557eb28e454142"
 dependencies = [
  "libp2p-core",
  "libp2p-identity",
@@ -4382,7 +4455,7 @@ dependencies = [
 [[package]]
 name = "libp2p-core"
 version = "0.44.0"
-source = "git+https://github.com/libp2p/rust-libp2p.git?rev=22fb4c784fc55ad8b15d05fdc9f98d663107d4cb#22fb4c784fc55ad8b15d05fdc9f98d663107d4cb"
+source = "git+https://github.com/libp2p/rust-libp2p.git?rev=197663d7cd23c121db30b4cbe2557eb28e454142#197663d7cd23c121db30b4cbe2557eb28e454142"
 dependencies = [
  "either",
  "fnv",
@@ -4406,7 +4479,7 @@ dependencies = [
 [[package]]
 name = "libp2p-dns"
 version = "0.45.0"
-source = "git+https://github.com/libp2p/rust-libp2p.git?rev=22fb4c784fc55ad8b15d05fdc9f98d663107d4cb#22fb4c784fc55ad8b15d05fdc9f98d663107d4cb"
+source = "git+https://github.com/libp2p/rust-libp2p.git?rev=197663d7cd23c121db30b4cbe2557eb28e454142#197663d7cd23c121db30b4cbe2557eb28e454142"
 dependencies = [
  "futures",
  "hickory-resolver",
@@ -4420,7 +4493,7 @@ dependencies = [
 [[package]]
 name = "libp2p-gossipsub"
 version = "0.50.0"
-source = "git+https://github.com/libp2p/rust-libp2p.git?rev=22fb4c784fc55ad8b15d05fdc9f98d663107d4cb#22fb4c784fc55ad8b15d05fdc9f98d663107d4cb"
+source = "git+https://github.com/libp2p/rust-libp2p.git?rev=197663d7cd23c121db30b4cbe2557eb28e454142#197663d7cd23c121db30b4cbe2557eb28e454142"
 dependencies = [
  "async-channel 2.5.0",
  "asynchronous-codec",
@@ -4450,7 +4523,7 @@ dependencies = [
 [[package]]
 name = "libp2p-identify"
 version = "0.48.0"
-source = "git+https://github.com/libp2p/rust-libp2p.git?rev=22fb4c784fc55ad8b15d05fdc9f98d663107d4cb#22fb4c784fc55ad8b15d05fdc9f98d663107d4cb"
+source = "git+https://github.com/libp2p/rust-libp2p.git?rev=197663d7cd23c121db30b4cbe2557eb28e454142#197663d7cd23c121db30b4cbe2557eb28e454142"
 dependencies = [
  "asynchronous-codec",
  "either",
@@ -4490,7 +4563,7 @@ dependencies = [
 [[package]]
 name = "libp2p-mdns"
 version = "0.49.0"
-source = "git+https://github.com/libp2p/rust-libp2p.git?rev=22fb4c784fc55ad8b15d05fdc9f98d663107d4cb#22fb4c784fc55ad8b15d05fdc9f98d663107d4cb"
+source = "git+https://github.com/libp2p/rust-libp2p.git?rev=197663d7cd23c121db30b4cbe2557eb28e454142#197663d7cd23c121db30b4cbe2557eb28e454142"
 dependencies = [
  "futures",
  "hickory-proto",
@@ -4508,7 +4581,7 @@ dependencies = [
 [[package]]
 name = "libp2p-metrics"
 version = "0.18.0"
-source = "git+https://github.com/libp2p/rust-libp2p.git?rev=22fb4c784fc55ad8b15d05fdc9f98d663107d4cb#22fb4c784fc55ad8b15d05fdc9f98d663107d4cb"
+source = "git+https://github.com/libp2p/rust-libp2p.git?rev=197663d7cd23c121db30b4cbe2557eb28e454142#197663d7cd23c121db30b4cbe2557eb28e454142"
 dependencies = [
  "futures",
  "libp2p-core",
@@ -4525,7 +4598,7 @@ dependencies = [
 [[package]]
 name = "libp2p-noise"
 version = "0.47.0"
-source = "git+https://github.com/libp2p/rust-libp2p.git?rev=22fb4c784fc55ad8b15d05fdc9f98d663107d4cb#22fb4c784fc55ad8b15d05fdc9f98d663107d4cb"
+source = "git+https://github.com/libp2p/rust-libp2p.git?rev=197663d7cd23c121db30b4cbe2557eb28e454142#197663d7cd23c121db30b4cbe2557eb28e454142"
 dependencies = [
  "asynchronous-codec",
  "bytes",
@@ -4547,7 +4620,7 @@ dependencies = [
 [[package]]
 name = "libp2p-peer-store"
 version = "0.1.0"
-source = "git+https://github.com/libp2p/rust-libp2p.git?rev=22fb4c784fc55ad8b15d05fdc9f98d663107d4cb#22fb4c784fc55ad8b15d05fdc9f98d663107d4cb"
+source = "git+https://github.com/libp2p/rust-libp2p.git?rev=197663d7cd23c121db30b4cbe2557eb28e454142#197663d7cd23c121db30b4cbe2557eb28e454142"
 dependencies = [
  "hashlink 0.11.0",
  "libp2p-core",
@@ -4557,7 +4630,7 @@ dependencies = [
 [[package]]
 name = "libp2p-ping"
 version = "0.48.0"
-source = "git+https://github.com/libp2p/rust-libp2p.git?rev=22fb4c784fc55ad8b15d05fdc9f98d663107d4cb#22fb4c784fc55ad8b15d05fdc9f98d663107d4cb"
+source = "git+https://github.com/libp2p/rust-libp2p.git?rev=197663d7cd23c121db30b4cbe2557eb28e454142#197663d7cd23c121db30b4cbe2557eb28e454142"
 dependencies = [
  "futures",
  "futures-timer",
@@ -4572,7 +4645,7 @@ dependencies = [
 [[package]]
 name = "libp2p-plaintext"
 version = "0.44.0"
-source = "git+https://github.com/libp2p/rust-libp2p.git?rev=22fb4c784fc55ad8b15d05fdc9f98d663107d4cb#22fb4c784fc55ad8b15d05fdc9f98d663107d4cb"
+source = "git+https://github.com/libp2p/rust-libp2p.git?rev=197663d7cd23c121db30b4cbe2557eb28e454142#197663d7cd23c121db30b4cbe2557eb28e454142"
 dependencies = [
  "asynchronous-codec",
  "bytes",
@@ -4587,7 +4660,7 @@ dependencies = [
 [[package]]
 name = "libp2p-quic"
 version = "0.14.0"
-source = "git+https://github.com/libp2p/rust-libp2p.git?rev=22fb4c784fc55ad8b15d05fdc9f98d663107d4cb#22fb4c784fc55ad8b15d05fdc9f98d663107d4cb"
+source = "git+https://github.com/libp2p/rust-libp2p.git?rev=197663d7cd23c121db30b4cbe2557eb28e454142#197663d7cd23c121db30b4cbe2557eb28e454142"
 dependencies = [
  "futures",
  "futures-timer",
@@ -4608,7 +4681,7 @@ dependencies = [
 [[package]]
 name = "libp2p-request-response"
 version = "0.30.0"
-source = "git+https://github.com/libp2p/rust-libp2p.git?rev=22fb4c784fc55ad8b15d05fdc9f98d663107d4cb#22fb4c784fc55ad8b15d05fdc9f98d663107d4cb"
+source = "git+https://github.com/libp2p/rust-libp2p.git?rev=197663d7cd23c121db30b4cbe2557eb28e454142#197663d7cd23c121db30b4cbe2557eb28e454142"
 dependencies = [
  "futures",
  "futures-bounded",
@@ -4623,7 +4696,7 @@ dependencies = [
 [[package]]
 name = "libp2p-swarm"
 version = "0.48.0"
-source = "git+https://github.com/libp2p/rust-libp2p.git?rev=22fb4c784fc55ad8b15d05fdc9f98d663107d4cb#22fb4c784fc55ad8b15d05fdc9f98d663107d4cb"
+source = "git+https://github.com/libp2p/rust-libp2p.git?rev=197663d7cd23c121db30b4cbe2557eb28e454142#197663d7cd23c121db30b4cbe2557eb28e454142"
 dependencies = [
  "either",
  "fnv",
@@ -4646,7 +4719,7 @@ dependencies = [
 [[package]]
 name = "libp2p-swarm-derive"
 version = "0.36.0"
-source = "git+https://github.com/libp2p/rust-libp2p.git?rev=22fb4c784fc55ad8b15d05fdc9f98d663107d4cb#22fb4c784fc55ad8b15d05fdc9f98d663107d4cb"
+source = "git+https://github.com/libp2p/rust-libp2p.git?rev=197663d7cd23c121db30b4cbe2557eb28e454142#197663d7cd23c121db30b4cbe2557eb28e454142"
 dependencies = [
  "heck",
  "quote",
@@ -4656,7 +4729,7 @@ dependencies = [
 [[package]]
 name = "libp2p-swarm-test"
 version = "0.7.0"
-source = "git+https://github.com/libp2p/rust-libp2p.git?rev=22fb4c784fc55ad8b15d05fdc9f98d663107d4cb#22fb4c784fc55ad8b15d05fdc9f98d663107d4cb"
+source = "git+https://github.com/libp2p/rust-libp2p.git?rev=197663d7cd23c121db30b4cbe2557eb28e454142#197663d7cd23c121db30b4cbe2557eb28e454142"
 dependencies = [
  "async-trait",
  "futures",
@@ -4673,7 +4746,7 @@ dependencies = [
 [[package]]
 name = "libp2p-tcp"
 version = "0.45.0"
-source = "git+https://github.com/libp2p/rust-libp2p.git?rev=22fb4c784fc55ad8b15d05fdc9f98d663107d4cb#22fb4c784fc55ad8b15d05fdc9f98d663107d4cb"
+source = "git+https://github.com/libp2p/rust-libp2p.git?rev=197663d7cd23c121db30b4cbe2557eb28e454142#197663d7cd23c121db30b4cbe2557eb28e454142"
 dependencies = [
  "futures",
  "futures-timer",
@@ -4688,7 +4761,7 @@ dependencies = [
 [[package]]
 name = "libp2p-tls"
 version = "0.7.0"
-source = "git+https://github.com/libp2p/rust-libp2p.git?rev=22fb4c784fc55ad8b15d05fdc9f98d663107d4cb#22fb4c784fc55ad8b15d05fdc9f98d663107d4cb"
+source = "git+https://github.com/libp2p/rust-libp2p.git?rev=197663d7cd23c121db30b4cbe2557eb28e454142#197663d7cd23c121db30b4cbe2557eb28e454142"
 dependencies = [
  "futures",
  "futures-rustls",
@@ -4706,7 +4779,7 @@ dependencies = [
 [[package]]
 name = "libp2p-upnp"
 version = "0.7.0"
-source = "git+https://github.com/libp2p/rust-libp2p.git?rev=22fb4c784fc55ad8b15d05fdc9f98d663107d4cb#22fb4c784fc55ad8b15d05fdc9f98d663107d4cb"
+source = "git+https://github.com/libp2p/rust-libp2p.git?rev=197663d7cd23c121db30b4cbe2557eb28e454142#197663d7cd23c121db30b4cbe2557eb28e454142"
 dependencies = [
  "futures",
  "futures-timer",
@@ -4720,7 +4793,7 @@ dependencies = [
 [[package]]
 name = "libp2p-yamux"
 version = "0.48.0"
-source = "git+https://github.com/libp2p/rust-libp2p.git?rev=22fb4c784fc55ad8b15d05fdc9f98d663107d4cb#22fb4c784fc55ad8b15d05fdc9f98d663107d4cb"
+source = "git+https://github.com/libp2p/rust-libp2p.git?rev=197663d7cd23c121db30b4cbe2557eb28e454142#197663d7cd23c121db30b4cbe2557eb28e454142"
 dependencies = [
  "either",
  "futures",
@@ -5159,7 +5232,7 @@ dependencies = [
 [[package]]
 name = "multistream-select"
 version = "0.14.0"
-source = "git+https://github.com/libp2p/rust-libp2p.git?rev=22fb4c784fc55ad8b15d05fdc9f98d663107d4cb#22fb4c784fc55ad8b15d05fdc9f98d663107d4cb"
+source = "git+https://github.com/libp2p/rust-libp2p.git?rev=197663d7cd23c121db30b4cbe2557eb28e454142#197663d7cd23c121db30b4cbe2557eb28e454142"
 dependencies = [
  "bytes",
  "futures",
@@ -5185,6 +5258,12 @@ dependencies = [
  "security-framework-sys",
  "tempfile",
 ]
+
+[[package]]
+name = "ndk-context"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
 
 [[package]]
 name = "netlink-packet-core"
@@ -5336,7 +5415,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5836,6 +5915,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "prefix-trie"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f561214012d3fc240a1f9c817cc4d57f5310910d066069c1b093f766bb5966"
+dependencies = [
+ "either",
+ "ipnet",
+ "num-traits",
+]
+
+[[package]]
 name = "pretty_reqwest_error"
 version = "0.1.0"
 source = "git+https://github.com/sigp/lighthouse?rev=4b3a9d3#4b3a9d3d10a6181a1a1588880de133457eb90816"
@@ -6088,7 +6178,7 @@ dependencies = [
 [[package]]
 name = "quick-protobuf-codec"
 version = "0.4.0"
-source = "git+https://github.com/libp2p/rust-libp2p.git?rev=22fb4c784fc55ad8b15d05fdc9f98d663107d4cb#22fb4c784fc55ad8b15d05fdc9f98d663107d4cb"
+source = "git+https://github.com/libp2p/rust-libp2p.git?rev=197663d7cd23c121db30b4cbe2557eb28e454142#197663d7cd23c121db30b4cbe2557eb28e454142"
 dependencies = [
  "asynchronous-codec",
  "bytes",
@@ -6150,7 +6240,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.3",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6730,7 +6820,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6789,7 +6879,7 @@ dependencies = [
 [[package]]
 name = "rw-stream-sink"
 version = "0.5.0"
-source = "git+https://github.com/libp2p/rust-libp2p.git?rev=22fb4c784fc55ad8b15d05fdc9f98d663107d4cb#22fb4c784fc55ad8b15d05fdc9f98d663107d4cb"
+source = "git+https://github.com/libp2p/rust-libp2p.git?rev=197663d7cd23c121db30b4cbe2557eb28e454142#197663d7cd23c121db30b4cbe2557eb28e454142"
 dependencies = [
  "futures",
  "pin-project",
@@ -7239,6 +7329,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
 
 [[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version 0.4.1",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
 name = "siphasher"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7323,7 +7429,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7644,7 +7750,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8674,7 +8780,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -871,7 +871,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -882,7 +882,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1995,15 +1995,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
-name = "core2"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49ba7ef1ad6107f8824dbe97de947cbaac53c44e7f9756a1fba0d37c1eec505"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2447,7 +2438,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2804,7 +2795,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3272,12 +3263,12 @@ dependencies = [
 
 [[package]]
 name = "futures-bounded"
-version = "0.2.4"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91f328e7fb845fc832912fb6a34f40cf6d1888c92f974d1893a54e97b5ff542e"
+checksum = "b604752cefc5aa3ab98992a107a8bd99465d2825c1584e0b60cb6957b21e19d7"
 dependencies = [
- "futures-timer",
  "futures-util",
+ "tokio",
 ]
 
 [[package]]
@@ -3362,6 +3353,10 @@ name = "futures-timer"
 version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
+dependencies = [
+ "gloo-timers",
+ "send_wrapper 0.4.0",
+]
 
 [[package]]
 name = "futures-util"
@@ -3484,6 +3479,18 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tracing",
+]
+
+[[package]]
+name = "gloo-timers"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b995a66bb87bebce9a0f4a95aed01daca4872c050bfcb21653361c03bc35e5c"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -3859,7 +3866,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -4309,9 +4316,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.183"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libm"
@@ -4321,8 +4328,8 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libp2p"
-version = "0.56.1"
-source = "git+https://github.com/sigp/rust-libp2p.git?rev=defcaf1a78cf5b70a723b3fee0e0be051c1dbd88#defcaf1a78cf5b70a723b3fee0e0be051c1dbd88"
+version = "0.57.0"
+source = "git+https://github.com/libp2p/rust-libp2p.git#22fb4c784fc55ad8b15d05fdc9f98d663107d4cb"
 dependencies = [
  "bytes",
  "either",
@@ -4354,8 +4361,8 @@ dependencies = [
 
 [[package]]
 name = "libp2p-allow-block-list"
-version = "0.6.0"
-source = "git+https://github.com/sigp/rust-libp2p.git?rev=defcaf1a78cf5b70a723b3fee0e0be051c1dbd88#defcaf1a78cf5b70a723b3fee0e0be051c1dbd88"
+version = "0.7.0"
+source = "git+https://github.com/libp2p/rust-libp2p.git#22fb4c784fc55ad8b15d05fdc9f98d663107d4cb"
 dependencies = [
  "libp2p-core",
  "libp2p-identity",
@@ -4364,8 +4371,8 @@ dependencies = [
 
 [[package]]
 name = "libp2p-connection-limits"
-version = "0.6.0"
-source = "git+https://github.com/sigp/rust-libp2p.git?rev=defcaf1a78cf5b70a723b3fee0e0be051c1dbd88#defcaf1a78cf5b70a723b3fee0e0be051c1dbd88"
+version = "0.7.0"
+source = "git+https://github.com/libp2p/rust-libp2p.git#22fb4c784fc55ad8b15d05fdc9f98d663107d4cb"
 dependencies = [
  "libp2p-core",
  "libp2p-identity",
@@ -4374,8 +4381,8 @@ dependencies = [
 
 [[package]]
 name = "libp2p-core"
-version = "0.43.2"
-source = "git+https://github.com/sigp/rust-libp2p.git?rev=defcaf1a78cf5b70a723b3fee0e0be051c1dbd88#defcaf1a78cf5b70a723b3fee0e0be051c1dbd88"
+version = "0.44.0"
+source = "git+https://github.com/libp2p/rust-libp2p.git#22fb4c784fc55ad8b15d05fdc9f98d663107d4cb"
 dependencies = [
  "either",
  "fnv",
@@ -4399,7 +4406,7 @@ dependencies = [
 [[package]]
 name = "libp2p-dns"
 version = "0.45.0"
-source = "git+https://github.com/sigp/rust-libp2p.git?rev=defcaf1a78cf5b70a723b3fee0e0be051c1dbd88#defcaf1a78cf5b70a723b3fee0e0be051c1dbd88"
+source = "git+https://github.com/libp2p/rust-libp2p.git#22fb4c784fc55ad8b15d05fdc9f98d663107d4cb"
 dependencies = [
  "futures",
  "hickory-resolver",
@@ -4413,7 +4420,7 @@ dependencies = [
 [[package]]
 name = "libp2p-gossipsub"
 version = "0.50.0"
-source = "git+https://github.com/sigp/rust-libp2p.git?rev=defcaf1a78cf5b70a723b3fee0e0be051c1dbd88#defcaf1a78cf5b70a723b3fee0e0be051c1dbd88"
+source = "git+https://github.com/libp2p/rust-libp2p.git#22fb4c784fc55ad8b15d05fdc9f98d663107d4cb"
 dependencies = [
  "async-channel 2.5.0",
  "asynchronous-codec",
@@ -4442,8 +4449,8 @@ dependencies = [
 
 [[package]]
 name = "libp2p-identify"
-version = "0.47.0"
-source = "git+https://github.com/sigp/rust-libp2p.git?rev=defcaf1a78cf5b70a723b3fee0e0be051c1dbd88#defcaf1a78cf5b70a723b3fee0e0be051c1dbd88"
+version = "0.48.0"
+source = "git+https://github.com/libp2p/rust-libp2p.git#22fb4c784fc55ad8b15d05fdc9f98d663107d4cb"
 dependencies = [
  "asynchronous-codec",
  "either",
@@ -4482,8 +4489,8 @@ dependencies = [
 
 [[package]]
 name = "libp2p-mdns"
-version = "0.48.0"
-source = "git+https://github.com/sigp/rust-libp2p.git?rev=defcaf1a78cf5b70a723b3fee0e0be051c1dbd88#defcaf1a78cf5b70a723b3fee0e0be051c1dbd88"
+version = "0.49.0"
+source = "git+https://github.com/libp2p/rust-libp2p.git#22fb4c784fc55ad8b15d05fdc9f98d663107d4cb"
 dependencies = [
  "futures",
  "hickory-proto",
@@ -4500,8 +4507,8 @@ dependencies = [
 
 [[package]]
 name = "libp2p-metrics"
-version = "0.17.1"
-source = "git+https://github.com/sigp/rust-libp2p.git?rev=defcaf1a78cf5b70a723b3fee0e0be051c1dbd88#defcaf1a78cf5b70a723b3fee0e0be051c1dbd88"
+version = "0.18.0"
+source = "git+https://github.com/libp2p/rust-libp2p.git#22fb4c784fc55ad8b15d05fdc9f98d663107d4cb"
 dependencies = [
  "futures",
  "libp2p-core",
@@ -4517,8 +4524,8 @@ dependencies = [
 
 [[package]]
 name = "libp2p-noise"
-version = "0.46.1"
-source = "git+https://github.com/sigp/rust-libp2p.git?rev=defcaf1a78cf5b70a723b3fee0e0be051c1dbd88#defcaf1a78cf5b70a723b3fee0e0be051c1dbd88"
+version = "0.47.0"
+source = "git+https://github.com/libp2p/rust-libp2p.git#22fb4c784fc55ad8b15d05fdc9f98d663107d4cb"
 dependencies = [
  "asynchronous-codec",
  "bytes",
@@ -4540,7 +4547,7 @@ dependencies = [
 [[package]]
 name = "libp2p-peer-store"
 version = "0.1.0"
-source = "git+https://github.com/sigp/rust-libp2p.git?rev=defcaf1a78cf5b70a723b3fee0e0be051c1dbd88#defcaf1a78cf5b70a723b3fee0e0be051c1dbd88"
+source = "git+https://github.com/libp2p/rust-libp2p.git#22fb4c784fc55ad8b15d05fdc9f98d663107d4cb"
 dependencies = [
  "hashlink 0.11.0",
  "libp2p-core",
@@ -4549,8 +4556,8 @@ dependencies = [
 
 [[package]]
 name = "libp2p-ping"
-version = "0.47.0"
-source = "git+https://github.com/sigp/rust-libp2p.git?rev=defcaf1a78cf5b70a723b3fee0e0be051c1dbd88#defcaf1a78cf5b70a723b3fee0e0be051c1dbd88"
+version = "0.48.0"
+source = "git+https://github.com/libp2p/rust-libp2p.git#22fb4c784fc55ad8b15d05fdc9f98d663107d4cb"
 dependencies = [
  "futures",
  "futures-timer",
@@ -4564,9 +4571,8 @@ dependencies = [
 
 [[package]]
 name = "libp2p-plaintext"
-version = "0.43.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e659439578fc6d305da8303834beb9d62f155f40e7f5b9d81c9f2b2c69d1926"
+version = "0.44.0"
+source = "git+https://github.com/libp2p/rust-libp2p.git#22fb4c784fc55ad8b15d05fdc9f98d663107d4cb"
 dependencies = [
  "asynchronous-codec",
  "bytes",
@@ -4580,8 +4586,8 @@ dependencies = [
 
 [[package]]
 name = "libp2p-quic"
-version = "0.13.0"
-source = "git+https://github.com/sigp/rust-libp2p.git?rev=defcaf1a78cf5b70a723b3fee0e0be051c1dbd88#defcaf1a78cf5b70a723b3fee0e0be051c1dbd88"
+version = "0.14.0"
+source = "git+https://github.com/libp2p/rust-libp2p.git#22fb4c784fc55ad8b15d05fdc9f98d663107d4cb"
 dependencies = [
  "futures",
  "futures-timer",
@@ -4602,7 +4608,7 @@ dependencies = [
 [[package]]
 name = "libp2p-request-response"
 version = "0.30.0"
-source = "git+https://github.com/sigp/rust-libp2p.git?rev=defcaf1a78cf5b70a723b3fee0e0be051c1dbd88#defcaf1a78cf5b70a723b3fee0e0be051c1dbd88"
+source = "git+https://github.com/libp2p/rust-libp2p.git#22fb4c784fc55ad8b15d05fdc9f98d663107d4cb"
 dependencies = [
  "futures",
  "futures-bounded",
@@ -4616,13 +4622,14 @@ dependencies = [
 
 [[package]]
 name = "libp2p-swarm"
-version = "0.47.1"
-source = "git+https://github.com/sigp/rust-libp2p.git?rev=defcaf1a78cf5b70a723b3fee0e0be051c1dbd88#defcaf1a78cf5b70a723b3fee0e0be051c1dbd88"
+version = "0.48.0"
+source = "git+https://github.com/libp2p/rust-libp2p.git#22fb4c784fc55ad8b15d05fdc9f98d663107d4cb"
 dependencies = [
  "either",
  "fnv",
  "futures",
  "futures-timer",
+ "getrandom 0.2.17",
  "hashlink 0.11.0",
  "libp2p-core",
  "libp2p-identity",
@@ -4632,13 +4639,14 @@ dependencies = [
  "smallvec",
  "tokio",
  "tracing",
+ "wasm-bindgen-futures",
  "web-time",
 ]
 
 [[package]]
 name = "libp2p-swarm-derive"
-version = "0.35.1"
-source = "git+https://github.com/sigp/rust-libp2p.git?rev=defcaf1a78cf5b70a723b3fee0e0be051c1dbd88#defcaf1a78cf5b70a723b3fee0e0be051c1dbd88"
+version = "0.36.0"
+source = "git+https://github.com/libp2p/rust-libp2p.git#22fb4c784fc55ad8b15d05fdc9f98d663107d4cb"
 dependencies = [
  "heck",
  "quote",
@@ -4647,9 +4655,8 @@ dependencies = [
 
 [[package]]
 name = "libp2p-swarm-test"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b149112570d507efe305838c7130835955a0b1147aa8051c1c3867a83175cf6"
+version = "0.7.0"
+source = "git+https://github.com/libp2p/rust-libp2p.git#22fb4c784fc55ad8b15d05fdc9f98d663107d4cb"
 dependencies = [
  "async-trait",
  "futures",
@@ -4665,8 +4672,8 @@ dependencies = [
 
 [[package]]
 name = "libp2p-tcp"
-version = "0.44.1"
-source = "git+https://github.com/sigp/rust-libp2p.git?rev=defcaf1a78cf5b70a723b3fee0e0be051c1dbd88#defcaf1a78cf5b70a723b3fee0e0be051c1dbd88"
+version = "0.45.0"
+source = "git+https://github.com/libp2p/rust-libp2p.git#22fb4c784fc55ad8b15d05fdc9f98d663107d4cb"
 dependencies = [
  "futures",
  "futures-timer",
@@ -4680,8 +4687,8 @@ dependencies = [
 
 [[package]]
 name = "libp2p-tls"
-version = "0.6.2"
-source = "git+https://github.com/sigp/rust-libp2p.git?rev=defcaf1a78cf5b70a723b3fee0e0be051c1dbd88#defcaf1a78cf5b70a723b3fee0e0be051c1dbd88"
+version = "0.7.0"
+source = "git+https://github.com/libp2p/rust-libp2p.git#22fb4c784fc55ad8b15d05fdc9f98d663107d4cb"
 dependencies = [
  "futures",
  "futures-rustls",
@@ -4698,8 +4705,8 @@ dependencies = [
 
 [[package]]
 name = "libp2p-upnp"
-version = "0.6.0"
-source = "git+https://github.com/sigp/rust-libp2p.git?rev=defcaf1a78cf5b70a723b3fee0e0be051c1dbd88#defcaf1a78cf5b70a723b3fee0e0be051c1dbd88"
+version = "0.7.0"
+source = "git+https://github.com/libp2p/rust-libp2p.git#22fb4c784fc55ad8b15d05fdc9f98d663107d4cb"
 dependencies = [
  "futures",
  "futures-timer",
@@ -4712,8 +4719,8 @@ dependencies = [
 
 [[package]]
 name = "libp2p-yamux"
-version = "0.47.0"
-source = "git+https://github.com/sigp/rust-libp2p.git?rev=defcaf1a78cf5b70a723b3fee0e0be051c1dbd88#defcaf1a78cf5b70a723b3fee0e0be051c1dbd88"
+version = "0.48.0"
+source = "git+https://github.com/libp2p/rust-libp2p.git#22fb4c784fc55ad8b15d05fdc9f98d663107d4cb"
 dependencies = [
  "either",
  "futures",
@@ -5077,9 +5084,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
  "wasi",
@@ -5142,18 +5149,17 @@ dependencies = [
 
 [[package]]
 name = "multihash"
-version = "0.19.3"
+version = "0.19.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b430e7953c29dd6a09afc29ff0bb69c6e306329ee6794700aee27b76a1aea8d"
+checksum = "577c63b00ad74d57e8c9aa870b5fccebf2fd64a308a5aee9f1bb88e4aea19447"
 dependencies = [
- "core2",
  "unsigned-varint",
 ]
 
 [[package]]
 name = "multistream-select"
-version = "0.13.0"
-source = "git+https://github.com/sigp/rust-libp2p.git?rev=defcaf1a78cf5b70a723b3fee0e0be051c1dbd88#defcaf1a78cf5b70a723b3fee0e0be051c1dbd88"
+version = "0.14.0"
+source = "git+https://github.com/libp2p/rust-libp2p.git#22fb4c784fc55ad8b15d05fdc9f98d663107d4cb"
 dependencies = [
  "bytes",
  "futures",
@@ -5330,7 +5336,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6081,8 +6087,8 @@ dependencies = [
 
 [[package]]
 name = "quick-protobuf-codec"
-version = "0.3.1"
-source = "git+https://github.com/sigp/rust-libp2p.git?rev=defcaf1a78cf5b70a723b3fee0e0be051c1dbd88#defcaf1a78cf5b70a723b3fee0e0be051c1dbd88"
+version = "0.4.0"
+source = "git+https://github.com/libp2p/rust-libp2p.git#22fb4c784fc55ad8b15d05fdc9f98d663107d4cb"
 dependencies = [
  "asynchronous-codec",
  "bytes",
@@ -6105,7 +6111,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -6142,9 +6148,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6724,7 +6730,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6782,8 +6788,8 @@ dependencies = [
 
 [[package]]
 name = "rw-stream-sink"
-version = "0.4.0"
-source = "git+https://github.com/sigp/rust-libp2p.git?rev=defcaf1a78cf5b70a723b3fee0e0be051c1dbd88#defcaf1a78cf5b70a723b3fee0e0be051c1dbd88"
+version = "0.5.0"
+source = "git+https://github.com/libp2p/rust-libp2p.git#22fb4c784fc55ad8b15d05fdc9f98d663107d4cb"
 dependencies = [
  "futures",
  "pin-project",
@@ -6965,6 +6971,12 @@ checksum = "9900206b54a3527fdc7b8a938bffd94a568bac4f4aa8113b209df75a09c0dec2"
 dependencies = [
  "pest",
 ]
+
+[[package]]
+name = "send_wrapper"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f638d531eccd6e23b980caf34876660d38e265409d8e99b397ab71eb3612fad0"
 
 [[package]]
 name = "send_wrapper"
@@ -7311,7 +7323,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7632,7 +7644,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7785,9 +7797,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.50.0"
+version = "1.52.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
 dependencies = [
  "bytes",
  "libc",
@@ -7801,9 +7813,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.1"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8662,7 +8674,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -9169,7 +9181,7 @@ dependencies = [
  "log",
  "pharos",
  "rustc_version 0.4.1",
- "send_wrapper",
+ "send_wrapper 0.6.0",
  "thiserror 2.0.18",
  "wasm-bindgen",
  "wasm-bindgen-futures",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -871,7 +871,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -882,7 +882,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2268,7 +2268,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ab67060fc6b8ef687992d439ca0fa36e7ed17e9a0b16b25b601e8757df720de"
 dependencies = [
  "data-encoding",
- "syn 2.0.117",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2438,7 +2438,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2795,7 +2795,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3866,7 +3866,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -4329,7 +4329,7 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 [[package]]
 name = "libp2p"
 version = "0.57.0"
-source = "git+https://github.com/libp2p/rust-libp2p.git#22fb4c784fc55ad8b15d05fdc9f98d663107d4cb"
+source = "git+https://github.com/libp2p/rust-libp2p.git?rev=22fb4c784fc55ad8b15d05fdc9f98d663107d4cb#22fb4c784fc55ad8b15d05fdc9f98d663107d4cb"
 dependencies = [
  "bytes",
  "either",
@@ -4362,7 +4362,7 @@ dependencies = [
 [[package]]
 name = "libp2p-allow-block-list"
 version = "0.7.0"
-source = "git+https://github.com/libp2p/rust-libp2p.git#22fb4c784fc55ad8b15d05fdc9f98d663107d4cb"
+source = "git+https://github.com/libp2p/rust-libp2p.git?rev=22fb4c784fc55ad8b15d05fdc9f98d663107d4cb#22fb4c784fc55ad8b15d05fdc9f98d663107d4cb"
 dependencies = [
  "libp2p-core",
  "libp2p-identity",
@@ -4372,7 +4372,7 @@ dependencies = [
 [[package]]
 name = "libp2p-connection-limits"
 version = "0.7.0"
-source = "git+https://github.com/libp2p/rust-libp2p.git#22fb4c784fc55ad8b15d05fdc9f98d663107d4cb"
+source = "git+https://github.com/libp2p/rust-libp2p.git?rev=22fb4c784fc55ad8b15d05fdc9f98d663107d4cb#22fb4c784fc55ad8b15d05fdc9f98d663107d4cb"
 dependencies = [
  "libp2p-core",
  "libp2p-identity",
@@ -4382,7 +4382,7 @@ dependencies = [
 [[package]]
 name = "libp2p-core"
 version = "0.44.0"
-source = "git+https://github.com/libp2p/rust-libp2p.git#22fb4c784fc55ad8b15d05fdc9f98d663107d4cb"
+source = "git+https://github.com/libp2p/rust-libp2p.git?rev=22fb4c784fc55ad8b15d05fdc9f98d663107d4cb#22fb4c784fc55ad8b15d05fdc9f98d663107d4cb"
 dependencies = [
  "either",
  "fnv",
@@ -4406,7 +4406,7 @@ dependencies = [
 [[package]]
 name = "libp2p-dns"
 version = "0.45.0"
-source = "git+https://github.com/libp2p/rust-libp2p.git#22fb4c784fc55ad8b15d05fdc9f98d663107d4cb"
+source = "git+https://github.com/libp2p/rust-libp2p.git?rev=22fb4c784fc55ad8b15d05fdc9f98d663107d4cb#22fb4c784fc55ad8b15d05fdc9f98d663107d4cb"
 dependencies = [
  "futures",
  "hickory-resolver",
@@ -4420,7 +4420,7 @@ dependencies = [
 [[package]]
 name = "libp2p-gossipsub"
 version = "0.50.0"
-source = "git+https://github.com/libp2p/rust-libp2p.git#22fb4c784fc55ad8b15d05fdc9f98d663107d4cb"
+source = "git+https://github.com/libp2p/rust-libp2p.git?rev=22fb4c784fc55ad8b15d05fdc9f98d663107d4cb#22fb4c784fc55ad8b15d05fdc9f98d663107d4cb"
 dependencies = [
  "async-channel 2.5.0",
  "asynchronous-codec",
@@ -4450,7 +4450,7 @@ dependencies = [
 [[package]]
 name = "libp2p-identify"
 version = "0.48.0"
-source = "git+https://github.com/libp2p/rust-libp2p.git#22fb4c784fc55ad8b15d05fdc9f98d663107d4cb"
+source = "git+https://github.com/libp2p/rust-libp2p.git?rev=22fb4c784fc55ad8b15d05fdc9f98d663107d4cb#22fb4c784fc55ad8b15d05fdc9f98d663107d4cb"
 dependencies = [
  "asynchronous-codec",
  "either",
@@ -4490,7 +4490,7 @@ dependencies = [
 [[package]]
 name = "libp2p-mdns"
 version = "0.49.0"
-source = "git+https://github.com/libp2p/rust-libp2p.git#22fb4c784fc55ad8b15d05fdc9f98d663107d4cb"
+source = "git+https://github.com/libp2p/rust-libp2p.git?rev=22fb4c784fc55ad8b15d05fdc9f98d663107d4cb#22fb4c784fc55ad8b15d05fdc9f98d663107d4cb"
 dependencies = [
  "futures",
  "hickory-proto",
@@ -4508,7 +4508,7 @@ dependencies = [
 [[package]]
 name = "libp2p-metrics"
 version = "0.18.0"
-source = "git+https://github.com/libp2p/rust-libp2p.git#22fb4c784fc55ad8b15d05fdc9f98d663107d4cb"
+source = "git+https://github.com/libp2p/rust-libp2p.git?rev=22fb4c784fc55ad8b15d05fdc9f98d663107d4cb#22fb4c784fc55ad8b15d05fdc9f98d663107d4cb"
 dependencies = [
  "futures",
  "libp2p-core",
@@ -4525,7 +4525,7 @@ dependencies = [
 [[package]]
 name = "libp2p-noise"
 version = "0.47.0"
-source = "git+https://github.com/libp2p/rust-libp2p.git#22fb4c784fc55ad8b15d05fdc9f98d663107d4cb"
+source = "git+https://github.com/libp2p/rust-libp2p.git?rev=22fb4c784fc55ad8b15d05fdc9f98d663107d4cb#22fb4c784fc55ad8b15d05fdc9f98d663107d4cb"
 dependencies = [
  "asynchronous-codec",
  "bytes",
@@ -4547,7 +4547,7 @@ dependencies = [
 [[package]]
 name = "libp2p-peer-store"
 version = "0.1.0"
-source = "git+https://github.com/libp2p/rust-libp2p.git#22fb4c784fc55ad8b15d05fdc9f98d663107d4cb"
+source = "git+https://github.com/libp2p/rust-libp2p.git?rev=22fb4c784fc55ad8b15d05fdc9f98d663107d4cb#22fb4c784fc55ad8b15d05fdc9f98d663107d4cb"
 dependencies = [
  "hashlink 0.11.0",
  "libp2p-core",
@@ -4557,7 +4557,7 @@ dependencies = [
 [[package]]
 name = "libp2p-ping"
 version = "0.48.0"
-source = "git+https://github.com/libp2p/rust-libp2p.git#22fb4c784fc55ad8b15d05fdc9f98d663107d4cb"
+source = "git+https://github.com/libp2p/rust-libp2p.git?rev=22fb4c784fc55ad8b15d05fdc9f98d663107d4cb#22fb4c784fc55ad8b15d05fdc9f98d663107d4cb"
 dependencies = [
  "futures",
  "futures-timer",
@@ -4572,7 +4572,7 @@ dependencies = [
 [[package]]
 name = "libp2p-plaintext"
 version = "0.44.0"
-source = "git+https://github.com/libp2p/rust-libp2p.git#22fb4c784fc55ad8b15d05fdc9f98d663107d4cb"
+source = "git+https://github.com/libp2p/rust-libp2p.git?rev=22fb4c784fc55ad8b15d05fdc9f98d663107d4cb#22fb4c784fc55ad8b15d05fdc9f98d663107d4cb"
 dependencies = [
  "asynchronous-codec",
  "bytes",
@@ -4587,7 +4587,7 @@ dependencies = [
 [[package]]
 name = "libp2p-quic"
 version = "0.14.0"
-source = "git+https://github.com/libp2p/rust-libp2p.git#22fb4c784fc55ad8b15d05fdc9f98d663107d4cb"
+source = "git+https://github.com/libp2p/rust-libp2p.git?rev=22fb4c784fc55ad8b15d05fdc9f98d663107d4cb#22fb4c784fc55ad8b15d05fdc9f98d663107d4cb"
 dependencies = [
  "futures",
  "futures-timer",
@@ -4608,7 +4608,7 @@ dependencies = [
 [[package]]
 name = "libp2p-request-response"
 version = "0.30.0"
-source = "git+https://github.com/libp2p/rust-libp2p.git#22fb4c784fc55ad8b15d05fdc9f98d663107d4cb"
+source = "git+https://github.com/libp2p/rust-libp2p.git?rev=22fb4c784fc55ad8b15d05fdc9f98d663107d4cb#22fb4c784fc55ad8b15d05fdc9f98d663107d4cb"
 dependencies = [
  "futures",
  "futures-bounded",
@@ -4623,7 +4623,7 @@ dependencies = [
 [[package]]
 name = "libp2p-swarm"
 version = "0.48.0"
-source = "git+https://github.com/libp2p/rust-libp2p.git#22fb4c784fc55ad8b15d05fdc9f98d663107d4cb"
+source = "git+https://github.com/libp2p/rust-libp2p.git?rev=22fb4c784fc55ad8b15d05fdc9f98d663107d4cb#22fb4c784fc55ad8b15d05fdc9f98d663107d4cb"
 dependencies = [
  "either",
  "fnv",
@@ -4646,7 +4646,7 @@ dependencies = [
 [[package]]
 name = "libp2p-swarm-derive"
 version = "0.36.0"
-source = "git+https://github.com/libp2p/rust-libp2p.git#22fb4c784fc55ad8b15d05fdc9f98d663107d4cb"
+source = "git+https://github.com/libp2p/rust-libp2p.git?rev=22fb4c784fc55ad8b15d05fdc9f98d663107d4cb#22fb4c784fc55ad8b15d05fdc9f98d663107d4cb"
 dependencies = [
  "heck",
  "quote",
@@ -4656,7 +4656,7 @@ dependencies = [
 [[package]]
 name = "libp2p-swarm-test"
 version = "0.7.0"
-source = "git+https://github.com/libp2p/rust-libp2p.git#22fb4c784fc55ad8b15d05fdc9f98d663107d4cb"
+source = "git+https://github.com/libp2p/rust-libp2p.git?rev=22fb4c784fc55ad8b15d05fdc9f98d663107d4cb#22fb4c784fc55ad8b15d05fdc9f98d663107d4cb"
 dependencies = [
  "async-trait",
  "futures",
@@ -4673,7 +4673,7 @@ dependencies = [
 [[package]]
 name = "libp2p-tcp"
 version = "0.45.0"
-source = "git+https://github.com/libp2p/rust-libp2p.git#22fb4c784fc55ad8b15d05fdc9f98d663107d4cb"
+source = "git+https://github.com/libp2p/rust-libp2p.git?rev=22fb4c784fc55ad8b15d05fdc9f98d663107d4cb#22fb4c784fc55ad8b15d05fdc9f98d663107d4cb"
 dependencies = [
  "futures",
  "futures-timer",
@@ -4688,7 +4688,7 @@ dependencies = [
 [[package]]
 name = "libp2p-tls"
 version = "0.7.0"
-source = "git+https://github.com/libp2p/rust-libp2p.git#22fb4c784fc55ad8b15d05fdc9f98d663107d4cb"
+source = "git+https://github.com/libp2p/rust-libp2p.git?rev=22fb4c784fc55ad8b15d05fdc9f98d663107d4cb#22fb4c784fc55ad8b15d05fdc9f98d663107d4cb"
 dependencies = [
  "futures",
  "futures-rustls",
@@ -4706,7 +4706,7 @@ dependencies = [
 [[package]]
 name = "libp2p-upnp"
 version = "0.7.0"
-source = "git+https://github.com/libp2p/rust-libp2p.git#22fb4c784fc55ad8b15d05fdc9f98d663107d4cb"
+source = "git+https://github.com/libp2p/rust-libp2p.git?rev=22fb4c784fc55ad8b15d05fdc9f98d663107d4cb#22fb4c784fc55ad8b15d05fdc9f98d663107d4cb"
 dependencies = [
  "futures",
  "futures-timer",
@@ -4720,7 +4720,7 @@ dependencies = [
 [[package]]
 name = "libp2p-yamux"
 version = "0.48.0"
-source = "git+https://github.com/libp2p/rust-libp2p.git#22fb4c784fc55ad8b15d05fdc9f98d663107d4cb"
+source = "git+https://github.com/libp2p/rust-libp2p.git?rev=22fb4c784fc55ad8b15d05fdc9f98d663107d4cb#22fb4c784fc55ad8b15d05fdc9f98d663107d4cb"
 dependencies = [
  "either",
  "futures",
@@ -5159,7 +5159,7 @@ dependencies = [
 [[package]]
 name = "multistream-select"
 version = "0.14.0"
-source = "git+https://github.com/libp2p/rust-libp2p.git#22fb4c784fc55ad8b15d05fdc9f98d663107d4cb"
+source = "git+https://github.com/libp2p/rust-libp2p.git?rev=22fb4c784fc55ad8b15d05fdc9f98d663107d4cb#22fb4c784fc55ad8b15d05fdc9f98d663107d4cb"
 dependencies = [
  "bytes",
  "futures",
@@ -5336,7 +5336,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6088,7 +6088,7 @@ dependencies = [
 [[package]]
 name = "quick-protobuf-codec"
 version = "0.4.0"
-source = "git+https://github.com/libp2p/rust-libp2p.git#22fb4c784fc55ad8b15d05fdc9f98d663107d4cb"
+source = "git+https://github.com/libp2p/rust-libp2p.git?rev=22fb4c784fc55ad8b15d05fdc9f98d663107d4cb#22fb4c784fc55ad8b15d05fdc9f98d663107d4cb"
 dependencies = [
  "asynchronous-codec",
  "bytes",
@@ -6111,7 +6111,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -6148,9 +6148,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6730,7 +6730,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6789,7 +6789,7 @@ dependencies = [
 [[package]]
 name = "rw-stream-sink"
 version = "0.5.0"
-source = "git+https://github.com/libp2p/rust-libp2p.git#22fb4c784fc55ad8b15d05fdc9f98d663107d4cb"
+source = "git+https://github.com/libp2p/rust-libp2p.git?rev=22fb4c784fc55ad8b15d05fdc9f98d663107d4cb#22fb4c784fc55ad8b15d05fdc9f98d663107d4cb"
 dependencies = [
  "futures",
  "pin-project",
@@ -7323,7 +7323,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7644,7 +7644,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8674,7 +8674,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,7 +117,7 @@ futures = "0.3.30"
 hex = "0.4.3"
 hyper = "1.4"
 indexmap = "2.7.0"
-libp2p = { git = "https://github.com/libp2p/rust-libp2p.git", rev = "22fb4c784fc55ad8b15d05fdc9f98d663107d4cb", default-features = false, features = [
+libp2p = { git = "https://github.com/libp2p/rust-libp2p.git", rev = "197663d7cd23c121db30b4cbe2557eb28e454142", default-features = false, features = [
     "identify",
     "yamux",
     "noise",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,7 +117,7 @@ futures = "0.3.30"
 hex = "0.4.3"
 hyper = "1.4"
 indexmap = "2.7.0"
-libp2p = { git = "https://github.com/libp2p/rust-libp2p.git", default-features = false, features = [
+libp2p = { git = "https://github.com/libp2p/rust-libp2p.git", rev = "22fb4c784fc55ad8b15d05fdc9f98d663107d4cb", default-features = false, features = [
     "identify",
     "yamux",
     "noise",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,7 +117,7 @@ futures = "0.3.30"
 hex = "0.4.3"
 hyper = "1.4"
 indexmap = "2.7.0"
-libp2p = { version = "0.56", default-features = false, features = [
+libp2p = { git = "https://github.com/libp2p/rust-libp2p.git", default-features = false, features = [
     "identify",
     "yamux",
     "noise",
@@ -176,12 +176,6 @@ zeroize = "1.8.1"
 
 [patch.crates-io]
 quick-protobuf = { git = "https://github.com/sigp/quick-protobuf.git", rev = "87c4ccb9bb2af494de375f5f6c62850badd26304" }
-libp2p = { git = "https://github.com/sigp/rust-libp2p.git", rev = "defcaf1a78cf5b70a723b3fee0e0be051c1dbd88" }
-libp2p-core = { git = "https://github.com/sigp/rust-libp2p.git", rev = "defcaf1a78cf5b70a723b3fee0e0be051c1dbd88" }
-libp2p-swarm = { git = "https://github.com/sigp/rust-libp2p.git", rev = "defcaf1a78cf5b70a723b3fee0e0be051c1dbd88" }
-libp2p-tcp = { git = "https://github.com/sigp/rust-libp2p.git", rev = "defcaf1a78cf5b70a723b3fee0e0be051c1dbd88" }
-libp2p-yamux = { git = "https://github.com/sigp/rust-libp2p.git", rev = "defcaf1a78cf5b70a723b3fee0e0be051c1dbd88" }
-quick-protobuf-codec = { git = "https://github.com/sigp/rust-libp2p.git", rev = "defcaf1a78cf5b70a723b3fee0e0be051c1dbd88" }
 
 [profile.maxperf]
 inherits = "release"

--- a/Makefile
+++ b/Makefile
@@ -144,11 +144,8 @@ audit: install-audit audit-CI
 install-audit:
 	cargo install --force cargo-audit
 
-# Tracked in sigp/anchor#989. Drop the hickory-proto ignores once libp2p ships
-# a release with hickory >= 0.26.1 (libp2p/rust-libp2p#6395) and we bump our
-# libp2p dep. See the tracking issue for the reachability analysis.
 audit-CI:
-	cargo audit --ignore RUSTSEC-2026-0118 --ignore RUSTSEC-2026-0119
+	cargo audit
 
 # Runs `cargo vendor` to make sure dependencies can be vendored for packaging, reproducibility and archival purpose.
 vendor:

--- a/anchor/network/Cargo.toml
+++ b/anchor/network/Cargo.toml
@@ -16,7 +16,7 @@ libp2p = { workspace = true }
 message_receiver = { workspace = true }
 metrics = { workspace = true }
 network_utils = { workspace = true }
-peer-store = { package = "libp2p-peer-store", git = "https://github.com/libp2p/rust-libp2p.git", rev = "22fb4c784fc55ad8b15d05fdc9f98d663107d4cb" }
+peer-store = { package = "libp2p-peer-store", git = "https://github.com/libp2p/rust-libp2p.git", rev = "197663d7cd23c121db30b4cbe2557eb28e454142" }
 prometheus-client = { workspace = true }
 quick-protobuf = "0.8.1"
 rand = { workspace = true }
@@ -35,7 +35,7 @@ types = { workspace = true }
 version = { workspace = true }
 
 [dev-dependencies]
-libp2p-swarm-test = { git = "https://github.com/libp2p/rust-libp2p.git", rev = "22fb4c784fc55ad8b15d05fdc9f98d663107d4cb" }
+libp2p-swarm-test = { git = "https://github.com/libp2p/rust-libp2p.git", rev = "197663d7cd23c121db30b4cbe2557eb28e454142" }
 message_receiver = { workspace = true }
 tokio = { workspace = true, features = ["rt", "macros", "time", "test-util"] }
 tracing-subscriber = { workspace = true }

--- a/anchor/network/Cargo.toml
+++ b/anchor/network/Cargo.toml
@@ -16,7 +16,7 @@ libp2p = { workspace = true }
 message_receiver = { workspace = true }
 metrics = { workspace = true }
 network_utils = { workspace = true }
-peer-store = { package = "libp2p-peer-store", git = "https://github.com/sigp/rust-libp2p.git", rev = "defcaf1a78cf5b70a723b3fee0e0be051c1dbd88" }
+peer-store = { package = "libp2p-peer-store", git = "https://github.com/libp2p/rust-libp2p.git" }
 prometheus-client = { workspace = true }
 quick-protobuf = "0.8.1"
 rand = { workspace = true }
@@ -35,7 +35,7 @@ types = { workspace = true }
 version = { workspace = true }
 
 [dev-dependencies]
-libp2p-swarm-test = "0.6.0"
+libp2p-swarm-test = { git = "https://github.com/libp2p/rust-libp2p.git" }
 message_receiver = { workspace = true }
 tokio = { workspace = true, features = ["rt", "macros", "time", "test-util"] }
 tracing-subscriber = { workspace = true }

--- a/anchor/network/Cargo.toml
+++ b/anchor/network/Cargo.toml
@@ -16,7 +16,7 @@ libp2p = { workspace = true }
 message_receiver = { workspace = true }
 metrics = { workspace = true }
 network_utils = { workspace = true }
-peer-store = { package = "libp2p-peer-store", git = "https://github.com/libp2p/rust-libp2p.git" }
+peer-store = { package = "libp2p-peer-store", git = "https://github.com/libp2p/rust-libp2p.git", rev = "22fb4c784fc55ad8b15d05fdc9f98d663107d4cb" }
 prometheus-client = { workspace = true }
 quick-protobuf = "0.8.1"
 rand = { workspace = true }
@@ -35,7 +35,7 @@ types = { workspace = true }
 version = { workspace = true }
 
 [dev-dependencies]
-libp2p-swarm-test = { git = "https://github.com/libp2p/rust-libp2p.git" }
+libp2p-swarm-test = { git = "https://github.com/libp2p/rust-libp2p.git", rev = "22fb4c784fc55ad8b15d05fdc9f98d663107d4cb" }
 message_receiver = { workspace = true }
 tokio = { workspace = true, features = ["rt", "macros", "time", "test-util"] }
 tracing-subscriber = { workspace = true }

--- a/anchor/network/src/behaviour.rs
+++ b/anchor/network/src/behaviour.rs
@@ -123,8 +123,8 @@ impl AnchorBehaviour {
             .heartbeat_interval(Duration::from_millis(GOSSIPSUB_HEARTBEAT_INTERVAL_MILLIS))
             .history_length(GOSSIPSUB_HISTORY_LENGTH)
             .history_gossip(4)
-            .max_ihave_length(1500)
-            .max_ihave_messages(32)
+            .max_control_messages(1500)
+            .max_ihave_messages_heartbeat(32)
             // `SignedSSVMessage` has a full data field with max 4,194,532 bytes, so 5M bytes seems
             // like a reasonable upper bound for that and the rest of the message.
             .max_transmit_size(MAX_TRANSMIT_SIZE_BYTES)


### PR DESCRIPTION
## Problem

Anchor's `[patch.crates-io]` redirected `libp2p` + 5 sub-crates to sigp's `rust-libp2p@defcaf1a` fork. Maintaining a fork rev is friction, and we can drop it now.

## Why we can drop the patches

All four gossipsub deltas the fork carried are now upstream:

- PRUNE backoff `Duration` overflow ([GHSA-gc42-3jg7-rxr2](https://github.com/libp2p/rust-libp2p/security/advisories/GHSA-gc42-3jg7-rxr2)) → upstream gossipsub 0.49.3.
- PRUNE backoff `Instant` overflow ([GHSA-xqmp-fxgv-xvq5](https://github.com/libp2p/rust-libp2p/security/advisories/GHSA-xqmp-fxgv-xvq5)) → upstream gossipsub 0.49.4 via [`libp2p/rust-libp2p#6359`](https://github.com/libp2p/rust-libp2p/pull/6359).
- IWANT and IDONTWANT control-message bounds → upstream via [`libp2p/rust-libp2p#6409`](https://github.com/libp2p/rust-libp2p/pull/6409) (merged 2026-05-05). Replaces the fork's per-IWANT/IDONTWANT handler-time inner caps with a unified codec-time `max_control_messages` cap covering all five control types. Sigma Prime classifies the residual inner-id gap as low-severity defense-in-depth (see [`sigp/rust-libp2p#578`](https://github.com/sigp/rust-libp2p/pull/578)).

The new pin (`197663d7`, master tip) also includes the hickory 0.26 bump from [`libp2p/rust-libp2p#6395`](https://github.com/libp2p/rust-libp2p/pull/6395), making RUSTSEC-2026-0118 / RUSTSEC-2026-0119 unreachable in our resolved graph. Closes #989.

Lighthouse made the equivalent migration in [`sigp/lighthouse#8314`](https://github.com/sigp/lighthouse/pull/8314).

## Change Overview

- Drop the six `libp2p*` entries from `[patch.crates-io]` (keep `quick-protobuf`).
- Pin `libp2p`, `libp2p-peer-store`, and `libp2p-swarm-test` to upstream `197663d7`.
- Builder rename in `network` per PR #6409: `max_ihave_length(1500)` → `max_control_messages(1500)`, `max_ihave_messages(32)` → `max_ihave_messages_heartbeat(32)`.
- Drop the two `--ignore` flags (and stale comment) from `Makefile` `audit-CI`.

## Validation

- `cargo check --workspace`, `cargo test -p network --lib` (52/52), `cargo clippy -p network --all-targets -- -D warnings`, `make cargo-fmt-check`, `make audit-CI` — all clean.
- Zero `sigp/rust-libp2p` refs in `Cargo.lock`.

## Rollback

Pure revert. No config, database, or operational impact.

## Blockers / Dependencies

N/A
