### PR TITLE
chore: ignore hickory-proto audit advisories

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -144,8 +144,12 @@ audit: install-audit audit-CI
 install-audit:
 	cargo install --force cargo-audit
 
+# TODO: drop the hickory-proto ignores once libp2p picks up hickory >= 0.26.1
+# (libp2p/rust-libp2p#6395). Hickory is a transitive dep of libp2p, so the bump
+# happens by updating the libp2p source in workspace Cargo.toml (version bump
+# and/or the [patch] rev), then refreshing the lockfile.
 audit-CI:
-	cargo audit
+	cargo audit --ignore RUSTSEC-2026-0118 --ignore RUSTSEC-2026-0119
 
 # Runs `cargo vendor` to make sure dependencies can be vendored for packaging, reproducibility and archival purpose.
 vendor:

--- a/Makefile
+++ b/Makefile
@@ -144,10 +144,9 @@ audit: install-audit audit-CI
 install-audit:
 	cargo install --force cargo-audit
 
-# TODO: drop the hickory-proto ignores once libp2p picks up hickory >= 0.26.1
-# (libp2p/rust-libp2p#6395). Hickory is a transitive dep of libp2p, so the bump
-# happens by updating the libp2p source in workspace Cargo.toml (version bump
-# and/or the [patch] rev), then refreshing the lockfile.
+# Tracked in sigp/anchor#989. Drop the hickory-proto ignores once libp2p ships
+# a release with hickory >= 0.26.1 (libp2p/rust-libp2p#6395) and we bump our
+# libp2p dep. See the tracking issue for the reachability analysis.
 audit-CI:
 	cargo audit --ignore RUSTSEC-2026-0118 --ignore RUSTSEC-2026-0119
 


### PR DESCRIPTION
## Problem, Evidence, and Context

CI's `audit-CI` step fails on two advisories against `hickory-proto 0.25.2`, pulled in transitively via `libp2p-dns`:

- [RUSTSEC-2026-0118](https://rustsec.org/advisories/RUSTSEC-2026-0118.html) — NSEC3 unbounded loop
- [RUSTSEC-2026-0119](https://rustsec.org/advisories/RUSTSEC-2026-0119.html) — O(n²) name-compression CPU DoS

Both clear once libp2p picks up hickory ≥ 0.26.1 (tracked upstream in [libp2p/rust-libp2p#6395](https://github.com/libp2p/rust-libp2p/pull/6395)). Until then, CI is blocked. Mirrors [sigp/lighthouse#9257](https://github.com/sigp/lighthouse/pull/9257).

Anchor tracking issue (reachability analysis, removal condition, review date): #989

## Change Overview

Adds `--ignore` flags for both advisories to the `audit-CI` target, plus a TODO comment pointing at the tracking issue so the ignores get removed when the libp2p bump lands.

## Risks, Trade-offs, and Mitigations

Verified non-reachability via `cargo tree -e features -i hickory-proto`. The only `hickory-proto` features active in Anchor's resolved graph are `futures-io`, `std`, `tokio`; `dnssec-ring`/`dnssec-aws-lc-rs` are not enabled because `libp2p-dns` declares `hickory-resolver` with `default-features = false, features = ["system-config"]`.

- **RUSTSEC-2026-0118** (NSEC3 unbounded loop in `DnssecDnsHandle`) — unreachable. The advisory states the bug requires `dnssec-ring` or `dnssec-aws-lc-rs` plus DNSSEC validation configured. Neither feature is enabled, so `DnssecDnsHandle` is `cfg`'d out and the vulnerable code is not compiled.
- **RUSTSEC-2026-0119** (O(n²) name-compression in encoder) — not practically reachable. The bug is in DNS message encoding and triggers on messages with many compressible names. `libp2p-dns` uses hickory as a stub client: it encodes single-question outbound queries (one hostname per multiaddr) and decodes responses. Stub queries don't construct the multi-name messages the bug needs.

Tracking issue #989 captures the removal condition and a 2026-05-25 review date so the ignores don't go stale.

## Validation

`make audit-CI` exits 0 locally; remaining output is the standard non-fatal `unmaintained`/`yanked` warnings.

## Rollback

Revert the Makefile change.