### PR TITLE
test: split qbft test setup

### DIFF
--- a/anchor/qbft_manager/src/tests.rs
+++ b/anchor/qbft_manager/src/tests.rs
@@ -39,6 +39,7 @@ use super::{
 };
 use crate::instance::qbft_instance;
 
+mod setup;
 mod timeout_tests;
 
 /// The time we wait at most for consensus results until the test times out. Note that this is not
@@ -627,70 +628,7 @@ pub struct ConsensusResult {
 
 #[cfg(test)]
 mod manager_tests {
-    use super::*;
-
-    // Provides test setup
-    struct Setup {
-        executor: TaskExecutor,
-        _signal: async_channel::Sender<()>,
-        _shutdown: futures::channel::mpsc::Sender<ShutdownReason>,
-        clock: ManualSlotClock,
-        all_data: Vec<(BeaconVote, CommitteeInstanceId)>,
-    }
-
-    // Generate unique test data
-    pub(crate) fn generate_test_data(id: usize) -> (BeaconVote, CommitteeInstanceId) {
-        // setup mock data
-        let id = CommitteeInstanceId {
-            committee: CommitteeId([0; 32]),
-            instance_height: id.into(),
-        };
-
-        let data = BeaconVote {
-            block_root: Hash256::random(),
-            source: types::Checkpoint::default(),
-            target: types::Checkpoint::default(),
-        };
-
-        (data, id)
-    }
-
-    // Setup env for the test
-    fn setup_test(num_instances: usize) -> Setup {
-        *TRACING;
-
-        // setup the executor
-        let handle = tokio::runtime::Handle::current();
-        let (signal, exit) = async_channel::bounded(1);
-        let (shutdown, _) = futures::channel::mpsc::channel(1);
-        let executor = TaskExecutor::new(handle, exit, shutdown.clone());
-
-        // setup the slot clock
-        let slot_duration = Duration::from_secs(12);
-        let genesis_time = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap()
-            .as_secs();
-
-        let clock = ManualSlotClock::new(
-            Slot::new(0),
-            Duration::from_secs(genesis_time),
-            slot_duration,
-        );
-
-        let mut all_data = vec![];
-        for id in 1..num_instances + 1 {
-            all_data.push(generate_test_data(id))
-        }
-
-        Setup {
-            executor,
-            _signal: signal,
-            _shutdown: shutdown,
-            clock,
-            all_data,
-        }
-    }
+    use super::{setup::setup_test, *};
 
     #[tokio::test]
     // Test running a single instance and confirm that it reaches consensus

--- a/anchor/qbft_manager/src/tests/setup.rs
+++ b/anchor/qbft_manager/src/tests/setup.rs
@@ -1,0 +1,64 @@
+use super::*;
+
+// Provides test setup
+pub(super) struct Setup {
+    pub(super) executor: TaskExecutor,
+    pub(super) _signal: async_channel::Sender<()>,
+    pub(super) _shutdown: futures::channel::mpsc::Sender<ShutdownReason>,
+    pub(super) clock: ManualSlotClock,
+    pub(super) all_data: Vec<(BeaconVote, CommitteeInstanceId)>,
+}
+
+// Generate unique test data
+pub(crate) fn generate_test_data(id: usize) -> (BeaconVote, CommitteeInstanceId) {
+    // setup mock data
+    let id = CommitteeInstanceId {
+        committee: CommitteeId([0; 32]),
+        instance_height: id.into(),
+    };
+
+    let data = BeaconVote {
+        block_root: Hash256::random(),
+        source: types::Checkpoint::default(),
+        target: types::Checkpoint::default(),
+    };
+
+    (data, id)
+}
+
+// Setup env for the test
+pub(super) fn setup_test(num_instances: usize) -> Setup {
+    *TRACING;
+
+    // setup the executor
+    let handle = tokio::runtime::Handle::current();
+    let (signal, exit) = async_channel::bounded(1);
+    let (shutdown, _) = futures::channel::mpsc::channel(1);
+    let executor = TaskExecutor::new(handle, exit, shutdown.clone());
+
+    // setup the slot clock
+    let slot_duration = Duration::from_secs(12);
+    let genesis_time = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_secs();
+
+    let clock = ManualSlotClock::new(
+        Slot::new(0),
+        Duration::from_secs(genesis_time),
+        slot_duration,
+    );
+
+    let mut all_data = vec![];
+    for id in 1..num_instances + 1 {
+        all_data.push(generate_test_data(id))
+    }
+
+    Setup {
+        executor,
+        _signal: signal,
+        _shutdown: shutdown,
+        clock,
+        all_data,
+    }
+}

--- a/anchor/qbft_manager/src/tests/timeout_tests.rs
+++ b/anchor/qbft_manager/src/tests/timeout_tests.rs
@@ -33,7 +33,7 @@ async fn test_timeout(round_timeout_to_test: usize) {
     message_tx
         .send(crate::QbftMessage {
             kind: QbftMessageKind::Initialize(QbftInitialization {
-                initial: manager_tests::generate_test_data(0).0,
+                initial: setup::generate_test_data(0).0,
                 validator: Box::new(NoDataValidation),
                 message_id: MessageId::new(
                     &DomainType::default(),
@@ -102,7 +102,7 @@ async fn test_relative_mode_timeout() {
     message_tx
         .send(crate::QbftMessage {
             kind: QbftMessageKind::Initialize(QbftInitialization {
-                initial: manager_tests::generate_test_data(0).0,
+                initial: setup::generate_test_data(0).0,
                 validator: Box::new(NoDataValidation),
                 message_id: MessageId::new(
                     &DomainType::default(),
@@ -181,7 +181,7 @@ async fn test_relative_vs_slottime_timing_difference() {
         message_tx
             .send(crate::QbftMessage {
                 kind: QbftMessageKind::Initialize(QbftInitialization {
-                    initial: manager_tests::generate_test_data(0).0,
+                    initial: setup::generate_test_data(0).0,
                     validator: Box::new(NoDataValidation),
                     message_id: MessageId::new(
                         &DomainType::default(),


### PR DESCRIPTION
## Problem, Evidence, and Context (Required)

- `anchor/qbft_manager/src/tests.rs` still owns shared setup helpers that are used by more than one test group.
- This is the next small follow-up to #946 after #990: move only the shared test setup into its own file.
- Keeping this PR narrow makes the next test-module splits easier without creating another large review.

## Change Overview (Required)

- Added `anchor/qbft_manager/src/tests/setup.rs`.
- Moved the existing `Setup`, `setup_test`, and `generate_test_data` helpers there.
- Updated the timeout tests to use `setup::generate_test_data` instead of reaching through `manager_tests`.
- Intentionally did not move the remaining manager tests or change production code.

## Risks, Trade-offs, and Mitigations (Required)

- Main risk is a visibility or import mistake while moving helpers between test modules.
- The mitigation is keeping the move mechanical and running the existing `qbft_manager` tests.
- This leaves more cleanup for later PRs, but keeps this slice small.

## Validation (Required)

- Formatting passed.
- The `qbft_manager` test suite passed.
- The `qbft_manager` lint pass passed.
- The commit hook also passed workspace formatting, clippy, and cargo sort checks.

## Rollback (Required for behavior or runtime changes; optional otherwise)

- Revert the PR to move the setup helpers back into `tests.rs`.
- No config, data, or operational impact.

## Blockers / Dependencies (Optional)

- N/A

## Additional Info / Next Steps (Optional)

- Follow-up PRs can now move the remaining manager test groups without depending on helpers nested under `manager_tests`.
