### PR TITLE
ci: add coverage workflow

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - stable
+      - unstable
       - 'pr/*'
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,56 @@
+name: coverage
+
+on:
+  push:
+    branches:
+      - stable
+      - 'pr/*'
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+  merge_group:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_INCREMENTAL: 0
+  CARGO_TERM_COLOR: always
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  RUSTFLAGS: "-D warnings"
+
+jobs:
+  coverage:
+    name: coverage
+    if: github.event_name != 'pull_request' || !contains(github.event.pull_request.labels.*.name, 'skip-ci')
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: 'recursive'
+    - name: Get latest version of stable Rust
+      uses: moonrepo/setup-rust@v1
+      with:
+        cache: false
+        channel: stable
+        bins: cargo-nextest, cargo-llvm-cov
+    - name: Generate coverage report
+      run: make coverage
+    - name: Upload lcov report artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: lcov-report
+        path: lcov.info
+        if-no-files-found: error
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v6
+      with:
+        files: lcov.info
+        flags: rust
+        name: anchor-rust
+        use_oidc: true
+        fail_ci_if_error: false

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: tests
+.PHONY: tests coverage coverage-html
 
 GIT_TAG := $(shell git describe --tags --candidates 1)
 BIN_DIR = "bin"
@@ -88,6 +88,14 @@ test-debug:
 # vectors, using nextest.
 nextest-debug:
 	cargo nextest run --workspace --features "$(TEST_FEATURES)"
+
+# Generates an lcov coverage report using the nextest runner.
+coverage:
+	cargo llvm-cov nextest --workspace --features "$(TEST_FEATURES)" --lcov --output-path lcov.info
+
+# Generates a local HTML coverage report in `target/llvm-cov/html`.
+coverage-html:
+	cargo llvm-cov nextest --workspace --features "$(TEST_FEATURES)" --html
 
 # Runs cargo-fmt (linter).
 cargo-fmt:


### PR DESCRIPTION
## Problem, Evidence, and Context (Required)

Anchor runs Rust tests in CI with `cargo nextest`, but there is no coverage workflow. This adds a free coverage path that uses the same test runner shape as the existing CI jobs and publishes a standard lcov report for Codecov.

Evidence: `cargo-llvm-cov` supports `nextest` directly, and a targeted smoke run produced an lcov report for the `version` crate.

## Change Overview (Required)

- Add `make coverage` for generating `lcov.info` through `cargo llvm-cov nextest`.
- Add `make coverage-html` for local HTML reports.
- Add a dedicated `coverage` GitHub Actions workflow that installs `cargo-nextest` and `cargo-llvm-cov`, runs the Make target, uploads `lcov.info` as an artifact, and uploads the report to Codecov.

Reviewers can start with `.github/workflows/coverage.yml`, then check the two Make targets. This does not add coverage thresholds or change the existing test-suite workflow.

## Risks, Trade-offs, and Mitigations (Required)

The main risk is extra CI runtime from an instrumented test run. Keeping this in a separate workflow makes that cost visible and easy to tune independently.

The Codecov upload is non-blocking for the first version, so missing Codecov-side setup will not block CI. The lcov artifact still gives reviewers access to the generated report.

## Validation (Required)

- The new Make coverage target expands to the expected `cargo-llvm-cov nextest` command.
- The workflow YAML parses successfully.
- A targeted coverage smoke run against the `version` crate passed and produced an lcov report.
- The repo commit hook completed successfully, including formatting, clippy, and Cargo.toml sorting checks.

Full workspace coverage was not run locally.

## Rollback (Required for behavior or runtime changes; optional otherwise)

Revert this PR to remove the workflow and Make targets. There is no runtime, schema, or configuration impact.

## Blockers / Dependencies (Optional)

Codecov may need repository or organization setup for OIDC uploads before hosted reporting appears in the Codecov UI.

## Additional Info / Next Steps (Optional)

After the first few reports establish a baseline, a follow-up can decide whether to add Codecov status checks or explicit coverage thresholds.
