### PR TITLE
ci: bump Claude PR review to Opus 4.7

### DIFF
--- a/.github/workflows/claude-mentions.yml
+++ b/.github/workflows/claude-mentions.yml
@@ -98,5 +98,5 @@ jobs:
                   use_bedrock: "true"
                   claude_args: |
                       --max-turns 50
-                      --model us.anthropic.claude-opus-4-6-v1
+                      --model us.anthropic.claude-opus-4-7
                       --append-system-prompt "${{ steps.review-prompt.outputs.content }}"

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -126,7 +126,7 @@ jobs:
                       ${{ steps.review-prompt.outputs.content }}
                   claude_args: |
                       --max-turns 50
-                      --model us.anthropic.claude-opus-4-6-v1
+                      --model us.anthropic.claude-opus-4-7
                       --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Read,Grep"
 
             - name: Remove claude-recheck label if present


### PR DESCRIPTION
## Problem, Evidence, and Context (Required)

- The Claude PR review and `@claude` mention workflows pin Opus 4.6, which is now a legacy model per Anthropic's model overview.
- Opus 4.7 is the current generally available Opus model with better agentic coding performance — relevant for PR review quality.
- Ref: AWS Bedrock model card for Claude Opus 4.7 lists `us.anthropic.claude-opus-4-7` as the Geo (US) cross-region inference profile, available in us-west-2.

## Change Overview (Required)

- Two workflows (`claude-pr-review.yml`, `claude-mentions.yml`) switch `--model us.anthropic.claude-opus-4-6-v1` → `us.anthropic.claude-opus-4-7`.
- Note: no `-v1` suffix on 4.7, matching the Bedrock docs.
- Nothing else changes — prompts, permissions, action version, IAM role, and region are untouched.

## Risks, Trade-offs, and Mitigations (Required)

- Risk: IAM role must have Bedrock model access for Opus 4.7 in us-west-2. If not yet granted, the first run fails with an access error.
- Risk: Opus 4.7 only supports `thinking.type: "adaptive"` (not `"enabled"`) and drops `temperature`/`top_p`/`top_k`. The workflows don't set any of these, so no expected impact — but `claude-code-action@v1.0.52` internals are worth watching on the first run.
- Mitigation: revert is one-line per file.

## Validation (Required)

- YAML-only change; no runtime code paths touched.
- Real validation is the first PR triggering the workflow post-merge. If the Bedrock call fails, revert.

## Rollback (Required for behavior or runtime changes; optional otherwise)

- Revert the two one-line changes.
- No config, secrets, or data migration involved.