### PR TITLE
feat: instruments proposer pre-QBFT fetch in randao_reveal step 

### DIFF
--- a/anchor/validator_store/src/instrumentation.rs
+++ b/anchor/validator_store/src/instrumentation.rs
@@ -9,6 +9,9 @@ pub fn outcome_from_result<T>(result: &Result<T, Error>) -> &'static str {
 }
 
 pub mod checkpoints {
+    pub const RANDAO_REVEAL_ENTERED: &str = "randao_reveal_entered";
+    pub const RANDAO_REVEAL_COMPLETED: &str = "randao_reveal_completed";
+    pub const RANDAO_REVEAL_FAILED: &str = "randao_reveal_failed";
     pub const DUTY_ENTRY: &str = "duty_entry";
     pub const PRE_CONSENSUS_HANDOFF: &str = "pre_consensus_handoff";
     pub const CONSENSUS_DECIDED: &str = "consensus_decided";
@@ -21,8 +24,13 @@ pub mod checkpoints {
 /// Common reasons for block signing failures.
 pub fn failure_reason(error: &Error) -> &'static str {
     match error {
+        Error::SpecificError(SpecificError::ArithError(_)) => "arith_error",
         Error::SpecificError(SpecificError::ClusterLiquidated) => "cluster_liquidated",
+        Error::SpecificError(SpecificError::DataTooLarge(_)) => "data_too_large",
         Error::SpecificError(SpecificError::InvalidQbftData(_)) => "invalid_qbft_data",
+        Error::SpecificError(SpecificError::KeyShareDecryptionFailed) => {
+            "key_share_decryption_failed"
+        }
         Error::SpecificError(SpecificError::MissingIndex) => "missing_index",
         Error::SpecificError(SpecificError::NoDataAgreed) => "no_data_agreed",
         Error::SpecificError(SpecificError::NotSynced) => "not_synced",
@@ -32,6 +40,9 @@ pub fn failure_reason(error: &Error) -> &'static str {
         }
         Error::SpecificError(SpecificError::SlotClock) => "slot_clock",
         Error::SpecificError(SpecificError::Timeout) => "timeout",
+        Error::SpecificError(SpecificError::ValidatorClusterMismatch { .. }) => {
+            "validator_cluster_mismatch"
+        }
         Error::Slashable(_) => "slashable",
         Error::SameData => "same_data",
         Error::SpecificError(_) => "other_specific_error",

--- a/anchor/validator_store/src/lib.rs
+++ b/anchor/validator_store/src/lib.rs
@@ -2,7 +2,6 @@ mod instrumentation;
 pub mod metadata_service;
 mod metrics;
 pub mod registration_service;
-
 use std::{
     collections::{HashMap, HashSet},
     fmt::Debug,
@@ -61,7 +60,7 @@ use tokio::{
     sync::{Barrier, RwLock, watch},
     time::{Instant, sleep},
 };
-use tracing::{Instrument, debug, error, info, info_span, trace, warn};
+use tracing::{Instrument, Span, debug, error, field, info, info_span, trace, warn};
 use types::{
     AbstractExecPayload, Address, AggregateAndProof, AggregateAndProofBase,
     AggregateAndProofElectra, Attestation, AttestationBase, AttestationElectra, BeaconBlock,
@@ -2249,14 +2248,14 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> ValidatorStore
     ) -> Result<Signature, Error> {
         let span = info_span!(
             "proposer_randao_reveal",
-            cluster_size = tracing::field::Empty,
-            clock_slot = tracing::field::Empty,
-            slot_elapsed_ms = tracing::field::Empty,
+            cluster_size = field::Empty,
+            clock_slot = field::Empty,
+            slot_elapsed_ms = field::Empty,
             signing_epoch = signing_epoch.as_u64(),
-            failure_reason = tracing::field::Empty,
-            outcome = tracing::field::Empty,
+            failure_reason = field::Empty,
+            outcome = field::Empty,
             validator_pubkey = %validator_pubkey,
-            validator_index = tracing::field::Empty,
+            validator_index = field::Empty,
         );
         let future = async {
             trace!(
@@ -2265,7 +2264,7 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> ValidatorStore
             );
             let result = async {
                 let clock_slot = self.slot_clock.now().ok_or(SpecificError::SlotClock)?;
-                tracing::Span::current().record("clock_slot", clock_slot.as_u64());
+                Span::current().record("clock_slot", clock_slot.as_u64());
 
                 let domain_hash = self.get_domain(signing_epoch, Domain::Randao);
                 let signing_root = signing_epoch.signing_root(domain_hash);
@@ -2273,11 +2272,11 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> ValidatorStore
                 let (validator, cluster) = self.get_validator_and_cluster(validator_pubkey)?;
 
                 if let Some(validator_idx) = validator.index {
-                    tracing::Span::current().record("validator_index", *validator_idx);
+                    Span::current().record("validator_index", *validator_idx);
                 }
 
                 let cluster_size = cluster.cluster_members.len();
-                tracing::Span::current().record("cluster_size", cluster_size);
+                Span::current().record("cluster_size", cluster_size);
 
                 self.collect_signature(
                     PartialSignatureKind::RandaoPartialSig,
@@ -2294,13 +2293,13 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> ValidatorStore
 
             match determine_slot_elapsed_ms(&self.slot_clock) {
                 Some(ms) => {
-                    tracing::Span::current().record("slot_elapsed_ms", ms);
+                    Span::current().record("slot_elapsed_ms", ms);
                 }
                 None => trace!("slot_elapsed_ms unavailable: clock returned None"),
             }
 
             let outcome = instrumentation::outcome_from_result(&result);
-            tracing::Span::current().record("outcome", outcome);
+            Span::current().record("outcome", outcome);
             match &result {
                 Ok(_) => trace!(
                     checkpoint = instrumentation::checkpoints::RANDAO_REVEAL_COMPLETED,
@@ -2313,7 +2312,7 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> ValidatorStore
                         outcome = &outcome,
                         failure_reason = &failure_reason
                     );
-                    tracing::Span::current().record("failure_reason", failure_reason);
+                    Span::current().record("failure_reason", failure_reason);
                 }
             }
 
@@ -2381,14 +2380,14 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> ValidatorStore
         let span = info_span!(
             "proposer_sign_block",
             block_type,
-            cluster_size = tracing::field::Empty,
+            cluster_size = field::Empty,
             clock_slot = current_slot.as_u64(),
-            failure_reason = tracing::field::Empty,
-            proposal_matched = tracing::field::Empty,
-            outcome = tracing::field::Empty,
+            failure_reason = field::Empty,
+            proposal_matched = field::Empty,
+            outcome = field::Empty,
             block_slot = block_slot.as_u64(),
             validator_pubkey = %validator_pubkey,
-            validator_index = tracing::field::Empty,
+            validator_index = field::Empty,
         );
         let future = async {
             trace!(
@@ -2402,10 +2401,10 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> ValidatorStore
                 let (validator, cluster) = self.get_validator_and_cluster(validator_pubkey)?;
 
                 let cluster_size = cluster.cluster_members.len();
-                tracing::Span::current().record("cluster_size", cluster_size);
+                Span::current().record("cluster_size", cluster_size);
 
                 if let Some(validator_idx) = validator.index {
-                    tracing::Span::current().record("validator_index", *validator_idx);
+                    Span::current().record("validator_index", *validator_idx);
                 }
 
                 let (blinded_block, local_full_block) = match block {
@@ -2457,8 +2456,7 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> ValidatorStore
 
                 let publish_decision =
                     select_publish_block(signed_block, &blinded_block, local_full_block);
-                tracing::Span::current()
-                    .record("proposal_matched", publish_decision.proposal_matched);
+                Span::current().record("proposal_matched", publish_decision.proposal_matched);
                 trace!(
                     checkpoint = instrumentation::checkpoints::PUBLISH_BLOCK,
                     publish_path = publish_decision.publish_path,
@@ -2470,7 +2468,7 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> ValidatorStore
             .await;
 
             let outcome = instrumentation::outcome_from_result(&result);
-            tracing::Span::current().record("outcome", outcome);
+            Span::current().record("outcome", outcome);
             match &result {
                 Ok(_) => trace!(
                     checkpoint = instrumentation::checkpoints::DUTY_COMPLETED,
@@ -2483,7 +2481,7 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> ValidatorStore
                         outcome = &outcome,
                         failure_reason = &failure_reason
                     );
-                    tracing::Span::current().record("failure_reason", failure_reason);
+                    Span::current().record("failure_reason", failure_reason);
                 }
             }
             result

--- a/anchor/validator_store/src/lib.rs
+++ b/anchor/validator_store/src/lib.rs
@@ -157,6 +157,13 @@ fn get_cluster_size(cluster: &Cluster) -> usize {
     cluster.cluster_members.len()
 }
 
+fn determine_slot_elapsed_ms(slot_clock: &impl SlotClock) -> Result<u128, SpecificError> {
+    let duration = slot_clock
+        .millis_from_current_slot_start()
+        .ok_or(SpecificError::SlotClock)?;
+    Ok(duration.as_millis())
+}
+
 pub struct AnchorValidatorStore<
     T: SlotClock + 'static,
     E: EthSpec,
@@ -2253,6 +2260,7 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> ValidatorStore
             clock_slot = clock_slot.as_u64(),
             slot_elapsed_ms = tracing::field::Empty,
             signing_epoch = signing_epoch.as_u64(),
+            failure_reason = tracing::field::Empty,
             outcome = tracing::field::Empty,
             validator_pubkey = %validator_pubkey,
             validator_index = tracing::field::Empty,
@@ -2288,6 +2296,10 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> ValidatorStore
             }
             .await;
 
+            if let Ok(millis_from_slot_start) = determine_slot_elapsed_ms(&self.slot_clock) {
+                tracing::Span::current().record("slot_elapsed_ms", millis_from_slot_start);
+            }
+
             let outcome = instrumentation::outcome_from_result(&result);
             tracing::Span::current().record("outcome", outcome);
             match &result {
@@ -2305,12 +2317,6 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> ValidatorStore
                     tracing::Span::current().record("failure_reason", failure_reason);
                 }
             }
-
-            let millis_from_slot_start = self
-                .slot_clock
-                .millis_from_current_slot_start()
-                .ok_or(SpecificError::SlotClock)?;
-            tracing::Span::current().record("slot_elapsed_ms", millis_from_slot_start.as_millis());
 
             result
         }

--- a/anchor/validator_store/src/lib.rs
+++ b/anchor/validator_store/src/lib.rs
@@ -2252,12 +2252,10 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> ValidatorStore
         validator_pubkey: PublicKeyBytes,
         signing_epoch: Epoch,
     ) -> Result<Signature, Error> {
-        let clock_slot = self.slot_clock.now().ok_or(SpecificError::SlotClock)?;
-
         let span = info_span!(
             "proposer_randao_reveal",
             cluster_size = tracing::field::Empty,
-            clock_slot = clock_slot.as_u64(),
+            clock_slot = tracing::field::Empty,
             slot_elapsed_ms = tracing::field::Empty,
             signing_epoch = signing_epoch.as_u64(),
             failure_reason = tracing::field::Empty,
@@ -2271,6 +2269,9 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> ValidatorStore
                 "Proposer randao reveal entered"
             );
             let result = async {
+                let clock_slot = self.slot_clock.now().ok_or(SpecificError::SlotClock)?;
+                tracing::Span::current().record("clock_slot", clock_slot.as_u64());
+
                 let domain_hash = self.get_domain(signing_epoch, Domain::Randao);
                 let signing_root = signing_epoch.signing_root(domain_hash);
 

--- a/anchor/validator_store/src/lib.rs
+++ b/anchor/validator_store/src/lib.rs
@@ -153,6 +153,10 @@ async fn run_committee_signing<T>(
     }
 }
 
+fn get_cluster_size(cluster: &Cluster) -> usize {
+    cluster.cluster_members.len()
+}
+
 pub struct AnchorValidatorStore<
     T: SlotClock + 'static,
     E: EthSpec,
@@ -2241,23 +2245,76 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> ValidatorStore
         validator_pubkey: PublicKeyBytes,
         signing_epoch: Epoch,
     ) -> Result<Signature, Error> {
+        let clock_slot = self.slot_clock.now().ok_or(SpecificError::SlotClock)?;
+
+        let span = info_span!(
+            "proposer_randao_reveal",
+            cluster_size = tracing::field::Empty,
+            clock_slot = clock_slot.as_u64(),
+            slot_elapsed_ms = tracing::field::Empty,
+            signing_epoch = signing_epoch.as_u64(),
+            outcome = tracing::field::Empty,
+            validator_pubkey = %validator_pubkey,
+            validator_index = tracing::field::Empty,
+        );
         let future = async {
-            let domain_hash = self.get_domain(signing_epoch, Domain::Randao);
-            let signing_root = signing_epoch.signing_root(domain_hash);
+            trace!(
+                checkpoint = instrumentation::checkpoints::RANDAO_REVEAL_ENTERED,
+                "Proposer randao reveal entered"
+            );
+            let result = async {
+                let domain_hash = self.get_domain(signing_epoch, Domain::Randao);
+                let signing_root = signing_epoch.signing_root(domain_hash);
 
-            let (validator, cluster) = self.get_validator_and_cluster(validator_pubkey)?;
+                let (validator, cluster) = self.get_validator_and_cluster(validator_pubkey)?;
 
-            self.collect_signature(
-                PartialSignatureKind::RandaoPartialSig,
-                Role::Proposer,
-                CollectionMode::SingleValidator,
-                &validator,
-                &cluster,
-                signing_root,
-                self.slot_clock.now().ok_or(SpecificError::SlotClock)?,
-            )
-            .await
-        };
+                if let Some(validator_idx) = validator.index {
+                    tracing::Span::current().record("validator_index", *validator_idx);
+                }
+
+                let cluster_size = get_cluster_size(&cluster);
+                tracing::Span::current().record("cluster_size", cluster_size);
+
+                self.collect_signature(
+                    PartialSignatureKind::RandaoPartialSig,
+                    Role::Proposer,
+                    CollectionMode::SingleValidator,
+                    &validator,
+                    &cluster,
+                    signing_root,
+                    clock_slot,
+                )
+                .await
+            }
+            .await;
+
+            let outcome = instrumentation::outcome_from_result(&result);
+            tracing::Span::current().record("outcome", outcome);
+            match &result {
+                Ok(_) => trace!(
+                    checkpoint = instrumentation::checkpoints::RANDAO_REVEAL_COMPLETED,
+                    outcome = &outcome
+                ),
+                Err(err) => {
+                    let failure_reason = instrumentation::failure_reason(err);
+                    warn!(
+                        checkpoint = instrumentation::checkpoints::RANDAO_REVEAL_FAILED,
+                        outcome = &outcome,
+                        failure_reason = &failure_reason
+                    );
+                    tracing::Span::current().record("failure_reason", failure_reason);
+                }
+            }
+
+            let millis_from_slot_start = self
+                .slot_clock
+                .millis_from_current_slot_start()
+                .ok_or(SpecificError::SlotClock)?;
+            tracing::Span::current().record("slot_elapsed_ms", millis_from_slot_start.as_millis());
+
+            result
+        }
+        .instrument(span);
 
         run_and_update_metrics(
             RANDAO_REVEAL_LOG_NAME,
@@ -2339,7 +2396,7 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> ValidatorStore
                 }
                 let (validator, cluster) = self.get_validator_and_cluster(validator_pubkey)?;
 
-                let cluster_size = cluster.cluster_members.len();
+                let cluster_size = get_cluster_size(&cluster);
                 tracing::Span::current().record("cluster_size", cluster_size);
 
                 if let Some(validator_idx) = validator.index {

--- a/anchor/validator_store/src/lib.rs
+++ b/anchor/validator_store/src/lib.rs
@@ -153,15 +153,10 @@ async fn run_committee_signing<T>(
     }
 }
 
-fn get_cluster_size(cluster: &Cluster) -> usize {
-    cluster.cluster_members.len()
-}
-
-fn determine_slot_elapsed_ms(slot_clock: &impl SlotClock) -> Result<u128, SpecificError> {
-    let duration = slot_clock
+fn determine_slot_elapsed_ms(slot_clock: &impl SlotClock) -> Option<u128> {
+    slot_clock
         .millis_from_current_slot_start()
-        .ok_or(SpecificError::SlotClock)?;
-    Ok(duration.as_millis())
+        .map(|d| d.as_millis())
 }
 
 pub struct AnchorValidatorStore<
@@ -2281,7 +2276,7 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> ValidatorStore
                     tracing::Span::current().record("validator_index", *validator_idx);
                 }
 
-                let cluster_size = get_cluster_size(&cluster);
+                let cluster_size = cluster.cluster_members.len();
                 tracing::Span::current().record("cluster_size", cluster_size);
 
                 self.collect_signature(
@@ -2297,8 +2292,11 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> ValidatorStore
             }
             .await;
 
-            if let Ok(millis_from_slot_start) = determine_slot_elapsed_ms(&self.slot_clock) {
-                tracing::Span::current().record("slot_elapsed_ms", millis_from_slot_start);
+            match determine_slot_elapsed_ms(&self.slot_clock) {
+                Some(ms) => {
+                    tracing::Span::current().record("slot_elapsed_ms", ms);
+                }
+                None => trace!("slot_elapsed_ms unavailable: clock returned None"),
             }
 
             let outcome = instrumentation::outcome_from_result(&result);
@@ -2403,7 +2401,7 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> ValidatorStore
                 }
                 let (validator, cluster) = self.get_validator_and_cluster(validator_pubkey)?;
 
-                let cluster_size = get_cluster_size(&cluster);
+                let cluster_size = cluster.cluster_members.len();
                 tracing::Span::current().record("cluster_size", cluster_size);
 
                 if let Some(validator_idx) = validator.index {


### PR DESCRIPTION
## Problem, Evidence, and Context (Required)

This change is the first of 2 PRs addressing #920 by adding an instrumentation span and start/end checkpoints to the `randao_reveal` function in `validator_store`.

It fulfils the following objectives:
- Checkpoints explicitly when `randao_reveal` starts and ends.
- Provides an indication of the slot budget remaining at the conclusion of `randao_reveal` ahead of Lighthouse fetching a beacon node block prior to signing.
- Allows reliable quantification of the time spent between `randao_reveal` and `sign_block` while Lighthouse performs that task.

This is worth doing now because a span and shallow checkpoints were added in #967 to the body of the main proposer duty signing flow. This change is required to begin reporting actionable information for pre-QBFT timing and slot budget expenditure.

## Change Overview (Required)
Another span was added to `randao_reveal` that instruments the pre-sign flow prior to Lighthouse performing the block fetch from the beacon node.

Specifics:
- Constants for entry, completion, and failure added to `checkpoints` module where existing checkpoints are defined.
- Relevant failure reasons from `randao_reveal` added to `failure_reason` function `match` body (+4).
- Helper functions `get_cluster_size` and `determine_slot_elapsed_ms` created for DRY implementation.
- Checkpoints added at randao reveal entry and upon conclusion of signature collection from committee peers.
- Slot budget also calculated post-signature collection and added to the trace.
- Trivial replacement of `cluster.cluster_members.len();` in `sign_block` with `get_cluster_size` call.

The span `proposer_randao_reveal` tracks the following values:
- `cluster_size`
- `clock_slot`
- `slot_elapsed_ms`
- `signing_epoch`
- `failure_reason`
- `outcome`
- `validator_pubkey`
- `validator_index`

What intentionally did not change?
- No changes were made to the block sign flow in `sign_block` as this was deferred to a follow-up to keep this PR concentrated on pre-block fetch.
- Decided against instrumenting within `decide_abstract_block` where in the case we receive a full-block from a non-Anchor operator, the block is still converted to a blinded block before entering `decide_abstract_block`. Otherwise the `as_ssz_bytes` function contains some work that could be expensive and worth considering.

## Risks, Trade-offs, and Mitigations (Required)

- What are the main risks or blast radius?
  - Similar in nature to #967 as traces added to `randao_reveal` function body with some light refactoring, however these are largely no-op and otherwise should not add any risk.
- What trade-offs are being made?
  - Not necessarily a trade-off, but no major refactoring or improvements are made here, just instrumentation and light cleanup.
- How are those risks being mitigated?
  - By small PRs to `unstable`, which will eventually be tested for correctness when traces are generated.

## Validation (Required)

`cargo test --workspace`
`cargo clippy`
`cargo check`

## Rollback (Required for behavior or runtime changes; optional otherwise)

It can be safely reverted. This would remove the trace and checkpoints, helper functions, and changes to instrumentation module.

## Additional Info / Next Steps (Optional)

Next steps in follow up PR are 
  Specifically, in sign_block the following additions are needed:
1. Add `slot_elapsed_ms` to the `proposer_sign_block` span declaration.
2. Record it at `DUTY_ENTRY` for _"time spent before block was available for signing"_ (i.e. randao + Lighthouse BN fetch).
3. Add `slot_remaining_ms` (or `pre_qbft_elapsed_ms`) at pre consensus handoff checkpoint to record the remaining budget at QBFT start.