### PR TITLE
fix(eth): force WS reconnect when live block stream goes idle

### DIFF
--- a/anchor/eth/Cargo.toml
+++ b/anchor/eth/Cargo.toml
@@ -34,4 +34,5 @@ types = { workspace = true }
 [dev-dependencies]
 bls = { workspace = true }
 database = { workspace = true, features = ["test-utils"] }
+tokio = { workspace = true, features = ["test-util"] }
 tracing-subscriber = "0.3"

--- a/anchor/eth/src/sync.rs
+++ b/anchor/eth/src/sync.rs
@@ -179,8 +179,6 @@ impl SsvEventSyncer {
         );
         debug!("Created event processor - done");
 
-        metrics::set_gauge(&metrics::EXECUTION_SYNC_STATUS, 0);
-
         Ok(Self {
             rpc_client,
             ws_client,
@@ -265,6 +263,7 @@ impl SsvEventSyncer {
                 Err(e) => {
                     error!(?e, "Sync failed, attempting recovery");
                     self.is_synced.send_replace(false);
+                    metrics::set_gauge(&metrics::EXECUTION_SYNC_STATUS, 0);
 
                     match e {
                         ExecutionError::WsError(e) => {
@@ -773,7 +772,6 @@ impl SsvEventSyncer {
 
             // If we get here, the stream ended (likely due to disconnect)
             error!("WebSocket stream ended, reconnecting...");
-            metrics::set_gauge(&metrics::EXECUTION_SYNC_STATUS, 0);
         }
     }
 }

--- a/anchor/eth/src/sync.rs
+++ b/anchor/eth/src/sync.rs
@@ -85,19 +85,22 @@ const FOLLOW_DISTANCE: u64 = 8;
 // before assuming the WebSocket has gone stale and forcing a full reconnect.
 const STREAM_IDLE_TIMEOUT: Duration = Duration::from_secs(60);
 
-// Awaits the next item from `stream`, returning `Err(WsError)` if no item arrives
-// within `STREAM_IDLE_TIMEOUT`. Caller is responsible for any metric updates.
+// Sole producer of the idle-timeout `WsError` so a unit test can pin the variant.
+fn record_idle_timeout() -> ExecutionError {
+    metrics::inc_counter_vec(&metrics::EXECUTION_CONNECTION_ERRORS, &["ws_idle_timeout"]);
+    ExecutionError::WsError(format!(
+        "WebSocket idle for more than {}s, forcing full reconnect",
+        STREAM_IDLE_TIMEOUT.as_secs()
+    ))
+}
+
 async fn next_block_or_timeout<S>(stream: &mut S) -> Result<Option<Header>, ExecutionError>
 where
     S: Stream<Item = Header> + Unpin,
 {
-    match timeout(STREAM_IDLE_TIMEOUT, stream.next()).await {
-        Ok(item) => Ok(item),
-        Err(_) => Err(ExecutionError::WsError(format!(
-            "WebSocket idle for more than {}s, forcing full reconnect",
-            STREAM_IDLE_TIMEOUT.as_secs()
-        ))),
-    }
+    timeout(STREAM_IDLE_TIMEOUT, stream.next())
+        .await
+        .map_err(|_| record_idle_timeout())
 }
 
 // Connection timeout duration
@@ -707,16 +710,9 @@ impl SsvEventSyncer {
             info!("Successfully subscribed to block stream");
 
             loop {
-                let block_header = match next_block_or_timeout(&mut stream).await {
-                    Ok(Some(header)) => header,
-                    Ok(None) => break,
-                    Err(e) => {
-                        metrics::inc_counter_vec(
-                            &metrics::EXECUTION_CONNECTION_ERRORS,
-                            &["ws_idle_timeout"],
-                        );
-                        return Err(e);
-                    }
+                let block_header = match next_block_or_timeout(&mut stream).await? {
+                    Some(header) => header,
+                    None => break,
                 };
 
                 // Guard against integer underflow when calculating relevant_block.

--- a/anchor/eth/src/sync.rs
+++ b/anchor/eth/src/sync.rs
@@ -8,16 +8,21 @@ use alloy::{
     eips::BlockNumberOrTag,
     primitives::Address,
     providers::{Provider, ProviderBuilder, RootProvider, WsConnect},
-    rpc::types::{Filter, Log, SyncStatus},
+    rpc::types::{Filter, Header, Log, SyncStatus},
     sol_types::SolEvent,
     transports::{RpcError, TransportErrorKind},
 };
 use database::{NetworkDatabase, SlashingProtection};
-use futures::{FutureExt, StreamExt, stream::FuturesOrdered};
+use futures::{FutureExt, Stream, StreamExt, stream::FuturesOrdered};
 use reqwest::Url;
 use sensitive_url::SensitiveUrl;
 use ssv_network_config::SsvNetworkConfig;
-use tokio::{select, sync::watch, task::spawn_blocking, time::Duration};
+use tokio::{
+    select,
+    sync::watch,
+    task::spawn_blocking,
+    time::{Duration, timeout},
+};
 use tracing::{debug, error, info, instrument, trace, warn};
 
 use crate::{
@@ -75,6 +80,25 @@ const MAX_BACKOFF_MS: u64 = 30_000; // Don't wait longer than 30 seconds
 
 // Block follow distance
 const FOLLOW_DISTANCE: u64 = 8;
+
+// Maximum time to wait for the next block on the live `subscribe_blocks` stream
+// before assuming the WebSocket has gone stale and forcing a full reconnect.
+const STREAM_IDLE_TIMEOUT: Duration = Duration::from_secs(60);
+
+// Awaits the next item from `stream`, returning `Err(WsError)` if no item arrives
+// within `STREAM_IDLE_TIMEOUT`. Caller is responsible for any metric updates.
+async fn next_block_or_timeout<S>(stream: &mut S) -> Result<Option<Header>, ExecutionError>
+where
+    S: Stream<Item = Header> + Unpin,
+{
+    match timeout(STREAM_IDLE_TIMEOUT, stream.next()).await {
+        Ok(item) => Ok(item),
+        Err(_) => Err(ExecutionError::WsError(format!(
+            "WebSocket idle for more than {}s, forcing full reconnect",
+            STREAM_IDLE_TIMEOUT.as_secs()
+        ))),
+    }
+}
 
 // Connection timeout duration
 pub const CONNECT_TIMEOUT: u64 = 10;
@@ -682,8 +706,19 @@ impl SsvEventSyncer {
 
             info!("Successfully subscribed to block stream");
 
-            // If we have a connection, continuously stream in blocks
-            while let Some(block_header) = stream.next().await {
+            loop {
+                let block_header = match next_block_or_timeout(&mut stream).await {
+                    Ok(Some(header)) => header,
+                    Ok(None) => break,
+                    Err(e) => {
+                        metrics::inc_counter_vec(
+                            &metrics::EXECUTION_CONNECTION_ERRORS,
+                            &["ws_idle_timeout"],
+                        );
+                        return Err(e);
+                    }
+                };
+
                 // Guard against integer underflow when calculating relevant_block.
                 if block_header.number < self.network.ssv_contract_block + FOLLOW_DISTANCE {
                     warn!(
@@ -695,11 +730,9 @@ impl SsvEventSyncer {
                     continue;
                 }
 
-                // Block we are interested in is the current block number - follow distance
                 let relevant_block = block_header.number - FOLLOW_DISTANCE;
 
-                // If the relevant block was already processed, do not process it again. This can
-                // happen if `block_header.number` was seen before due to a reorg.
+                // Skip blocks already processed (e.g. due to a reorg replaying numbers).
                 let last_processed_block =
                     self.event_processor.db.state().get_last_processed_block();
                 if relevant_block <= last_processed_block {
@@ -774,5 +807,59 @@ mod provider_tests {
         let provider = http_with_timeout_and_fallback(&urls);
         let block_number = provider.get_block_number().await;
         assert!(block_number.is_ok());
+    }
+}
+
+#[cfg(test)]
+mod live_sync_tests {
+    use futures::stream;
+
+    use super::*;
+
+    #[tokio::test(start_paused = true)]
+    async fn next_block_or_timeout_returns_ws_error_when_stream_is_idle() {
+        let mut idle_stream = stream::pending::<Header>();
+        let outer = STREAM_IDLE_TIMEOUT + Duration::from_secs(10);
+
+        let result = timeout(outer, next_block_or_timeout(&mut idle_stream)).await;
+
+        match result {
+            Ok(Err(ExecutionError::WsError(msg))) => {
+                assert!(
+                    msg.contains(&STREAM_IDLE_TIMEOUT.as_secs().to_string()),
+                    "WsError message should mention the idle timeout, got: {msg}"
+                );
+            }
+            Ok(other) => panic!("expected Err(WsError), got {other:?}"),
+            Err(_) => panic!(
+                "next_block_or_timeout hung past {}s — timeout guard missing?",
+                outer.as_secs()
+            ),
+        }
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn next_block_or_timeout_returns_header_when_stream_yields() {
+        let header: Header = Header::default();
+        let mut live_stream = stream::iter(vec![header]);
+
+        let result = next_block_or_timeout(&mut live_stream).await;
+
+        assert!(
+            matches!(result, Ok(Some(_))),
+            "expected Ok(Some(header)), got {result:?}"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn next_block_or_timeout_returns_none_when_stream_ends() {
+        let mut empty_stream = stream::empty::<Header>();
+
+        let result = next_block_or_timeout(&mut empty_stream).await;
+
+        assert!(
+            matches!(result, Ok(None)),
+            "expected Ok(None), got {result:?}"
+        );
     }
 }


### PR DESCRIPTION
## Problem, Evidence, and Context

- `live_sync` awaits `stream.next()` on the EL WebSocket subscription with no timeout. If the underlying connection silently goes stale (proxy idles it out, NAT keepalive too lax, server-side stale connection), the stream neither yields a new item nor returns `None`, and the await blocks indefinitely. SSV event sync stops advancing, no error is logged, and `sync()`'s recovery handler never runs.
- Reproduced live during the mixed-client e2e for #950: Anchor sat at the same `metadata.block_number` for ~48h on Hoodi and never observed the on-chain `ValidatorAdded` for our test validator. Restarting Anchor immediately resumed sync.
- Static analysis trace + reproduction details: #993.
- Closes #993.
- Closes #1004.

## Change Overview

- Extract `next_block_or_timeout` helper that wraps `stream.next()` in `tokio::time::timeout(STREAM_IDLE_TIMEOUT, ...)`.
- New constant `STREAM_IDLE_TIMEOUT = 60s` (5x Ethereum slot time, generous enough to ride out transient slowness, tight enough to catch a stale subscription within ~1 minute).
- `live_sync` calls the helper. On `Ok(Some(header))` processes the block (existing logic unchanged). On `Ok(None)` (clean stream end) breaks to re-subscribe on the same `ws_client`, preserves existing behavior. On `Err(_)` (idle timeout) bumps `EXECUTION_CONNECTION_ERRORS["ws_idle_timeout"]` and returns `WsError`, which routes through `sync()`'s existing `troubleshoot_ws` recovery for a full client rebuild with backoff.

## Risks, Trade-offs, and Mitigations

- **Risk:** spurious reconnects on healthy connections during chains with > 60s effective inter-block periods. Mitigation: 60s is 5x Ethereum's 12s slot, well past any realistic transient slowness; if needed, the constant is trivial to lift to a CLI/config flag in a follow-up.
- **Trade-off:** extra reconnect adds a brief gap during which live events aren't observed; on resume, `historical_sync` is invoked first and replays missed blocks before live mode resumes. Net behavior is "eventually consistent within seconds" rather than "permanently stalled."
- **Blast radius:** scoped to `live_sync` recovery path; existing `historical_sync`, event-processing, and DB code paths are untouched.

## Validation

- Three new unit tests in `live_sync_tests` covering idle, yielding, and ended streams. Use `tokio::test(start_paused = true)` virtual-time so a 60s+ wait runs in sub-millisecond wall time. The idle test wraps the helper call in an outer `timeout` guard so a future regression panics with a clear message instead of hanging the suite.
- Verified the regression test fails meaningfully when the helper is reverted to `Ok(stream.next().await)` (panic with `timeout guard missing?` rather than infinite hang).
- `cargo test -p eth --lib`, 19/19 pass (debug + release).
- `cargo clippy -p eth --all-targets --no-deps -- -D warnings`, clean.
- `cargo fmt -p eth -- --check`, clean.
- The original failure mode was reproduced on Hoodi during the #950 e2e; this fix would have surfaced as a clean reconnect rather than a 48h silent stall.

## Rollback

Revert this commit. Pure code change, no migrations, no config impact, no DB schema change. Operators on the prior behavior would just regain the silent-stall vulnerability, a pure functional regression.

## Additional Info / Next Steps

- The `STREAM_IDLE_TIMEOUT` value could later be exposed as a CLI/config flag if operators want to tune it for slower chains; not done here per "simple solutions first."
- The `ws_idle_timeout` metric label is intentionally distinct from `troubleshoot_ws`'s `websocket` label so dashboards can attribute reconnects to silent-stall versus subscribe-time failures.