### PR TITLE
fix: prioritize urgent processor work

### DIFF
--- a/anchor/processor/src/receivers.rs
+++ b/anchor/processor/src/receivers.rs
@@ -79,3 +79,60 @@ impl Receivers {
         })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use tokio::sync::{Semaphore, mpsc};
+
+    use super::{Receiver, Receivers};
+    use crate::{QueueKind, work::WorkItem};
+
+    const PERMITLESS_WORK_NAME: &str = "permitless_test_work";
+    const URGENT_WORK_NAME: &str = "urgent_consensus_test_work";
+
+    #[tokio::test]
+    async fn test_next_work_item_prioritizes_urgent_consensus_over_ready_permitless() {
+        // Arrange: both queues are ready, and urgent consensus has worker capacity available.
+        let (permitless_tx, permitless_rx) = mpsc::channel(1);
+        let (urgent_consensus_tx, urgent_consensus_rx) = mpsc::channel(1);
+        let mut receivers = Receivers {
+            permitless: Receiver {
+                rx: permitless_rx,
+                queue: QueueKind::Permitless,
+            },
+            urgent_consensus: Receiver {
+                rx: urgent_consensus_rx,
+                queue: QueueKind::UrgentConsensus,
+            },
+        };
+        let semaphore = Arc::new(Semaphore::new(1));
+
+        permitless_tx
+            .send(WorkItem::new_immediate(PERMITLESS_WORK_NAME, |_| {}))
+            .await
+            .expect("permitless receiver should be open");
+        urgent_consensus_tx
+            .send(WorkItem::new_immediate(URGENT_WORK_NAME, |_| {}))
+            .await
+            .expect("urgent consensus receiver should be open");
+
+        // Act: select the next item from the scheduler.
+        let received = receivers
+            .next_work_item(&semaphore)
+            .await
+            .expect("at least one queue should have work");
+
+        // Assert: urgent consensus should not be delayed behind ready permitless work.
+        assert_eq!(
+            received.queue,
+            QueueKind::UrgentConsensus,
+            "BUG: ready permitless work is selected before ready urgent consensus work"
+        );
+        assert!(
+            received.permit.is_some(),
+            "urgent consensus work should hold a worker permit"
+        );
+    }
+}

--- a/anchor/processor/src/receivers.rs
+++ b/anchor/processor/src/receivers.rs
@@ -47,17 +47,17 @@ pub struct Receivers {
 }
 
 impl Receivers {
-    /// Retrieves the next work item from the permitless queue, or acquires a permit and delegates
-    /// to `next_work_item_with_permit`.
+    /// Acquires a permit and delegates to `next_work_item_with_permit`, or retrieves the next work
+    /// item from the permitless queue if no permit is available.
     ///
     /// Returns `None` if all queues are closed.
     pub async fn next_work_item(&mut self, semaphore: &Arc<Semaphore>) -> Option<ReceivedWork> {
         select! {
             biased;
-            Some(work_item) = self.permitless.recv() => Some(work_item),
             Ok(permit) = semaphore.clone().acquire_owned() => {
                 self.next_work_item_with_permit(permit).await
             },
+            Some(work_item) = self.permitless.recv() => Some(work_item),
             else => None,
         }
     }

--- a/anchor/processor/src/receivers.rs
+++ b/anchor/processor/src/receivers.rs
@@ -50,11 +50,16 @@ impl Receivers {
     /// Acquires a permit and delegates to `next_work_item_with_permit`, or retrieves the next work
     /// item from the permitless queue if no permit is available.
     ///
+    /// The permit branch is biased first so permit-bound work can win when capacity exists.
+    ///
     /// Returns `None` if all queues are closed.
     pub async fn next_work_item(&mut self, semaphore: &Arc<Semaphore>) -> Option<ReceivedWork> {
         select! {
             biased;
             Ok(permit) = semaphore.clone().acquire_owned() => {
+                // If only permitless work is ready, the permit is dropped before returning.
+                // This is harmless while the processor has a single receiver loop; revisit it if
+                // processor polling becomes concurrent.
                 self.next_work_item_with_permit(permit).await
             },
             Some(work_item) = self.permitless.recv() => Some(work_item),
@@ -92,12 +97,10 @@ mod tests {
     const PERMITLESS_WORK_NAME: &str = "permitless_test_work";
     const URGENT_WORK_NAME: &str = "urgent_consensus_test_work";
 
-    #[tokio::test]
-    async fn test_next_work_item_prioritizes_urgent_consensus_over_ready_permitless() {
-        // Arrange: both queues are ready, and urgent consensus has worker capacity available.
+    fn new_receivers() -> (mpsc::Sender<WorkItem>, mpsc::Sender<WorkItem>, Receivers) {
         let (permitless_tx, permitless_rx) = mpsc::channel(1);
         let (urgent_consensus_tx, urgent_consensus_rx) = mpsc::channel(1);
-        let mut receivers = Receivers {
+        let receivers = Receivers {
             permitless: Receiver {
                 rx: permitless_rx,
                 queue: QueueKind::Permitless,
@@ -107,16 +110,30 @@ mod tests {
                 queue: QueueKind::UrgentConsensus,
             },
         };
-        let semaphore = Arc::new(Semaphore::new(1));
 
-        permitless_tx
-            .send(WorkItem::new_immediate(PERMITLESS_WORK_NAME, |_| {}))
+        (permitless_tx, urgent_consensus_tx, receivers)
+    }
+
+    async fn send_permitless(tx: &mpsc::Sender<WorkItem>) {
+        tx.send(WorkItem::new_immediate(PERMITLESS_WORK_NAME, |_| {}))
             .await
             .expect("permitless receiver should be open");
-        urgent_consensus_tx
-            .send(WorkItem::new_immediate(URGENT_WORK_NAME, |_| {}))
+    }
+
+    async fn send_urgent_consensus(tx: &mpsc::Sender<WorkItem>) {
+        tx.send(WorkItem::new_immediate(URGENT_WORK_NAME, |_| {}))
             .await
             .expect("urgent consensus receiver should be open");
+    }
+
+    #[tokio::test]
+    async fn test_next_work_item_prioritizes_urgent_consensus_over_ready_permitless() {
+        // Arrange: both queues are ready, and urgent consensus has worker capacity available.
+        let (permitless_tx, urgent_consensus_tx, mut receivers) = new_receivers();
+        let semaphore = Arc::new(Semaphore::new(1));
+
+        send_permitless(&permitless_tx).await;
+        send_urgent_consensus(&urgent_consensus_tx).await;
 
         // Act: select the next item from the scheduler.
         let received = receivers
@@ -133,6 +150,57 @@ mod tests {
         assert!(
             received.permit.is_some(),
             "urgent consensus work should hold a worker permit"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_next_work_item_returns_permitless_without_permit_when_capacity_is_available() {
+        // Arrange: permitless work is ready, and worker capacity is available.
+        let (permitless_tx, _, mut receivers) = new_receivers();
+        let semaphore = Arc::new(Semaphore::new(1));
+        send_permitless(&permitless_tx).await;
+
+        // Act: select the next item from the scheduler.
+        let received = receivers
+            .next_work_item(&semaphore)
+            .await
+            .expect("permitless work should be selected");
+
+        // Assert: permitless work is not charged against the worker permit budget.
+        assert_eq!(received.queue, QueueKind::Permitless);
+        assert!(
+            received.permit.is_none(),
+            "permitless work should not hold a worker permit"
+        );
+        assert_eq!(
+            semaphore.available_permits(),
+            1,
+            "temporary permit acquisition should be released before returning permitless work"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_next_work_item_returns_permitless_when_worker_permits_are_saturated() {
+        // Arrange: permitless work is ready, and the worker permit is already held.
+        let (permitless_tx, _, mut receivers) = new_receivers();
+        let semaphore = Arc::new(Semaphore::new(1));
+        let _held_permit = semaphore
+            .clone()
+            .try_acquire_owned()
+            .expect("test should be able to saturate the semaphore");
+        send_permitless(&permitless_tx).await;
+
+        // Act: select the next item from the scheduler.
+        let received = receivers
+            .next_work_item(&semaphore)
+            .await
+            .expect("permitless work should still drain while permits are saturated");
+
+        // Assert: permitless fallback still works when no worker permits are available.
+        assert_eq!(received.queue, QueueKind::Permitless);
+        assert!(
+            received.permit.is_none(),
+            "permitless work should not hold a worker permit"
         );
     }
 }


### PR DESCRIPTION
## Problem, Evidence, and Context (Required)

The processor scheduler could select ready permitless work before ready urgent consensus work, even when a worker permit was immediately available. That made the permitless lane capable of delaying work that is supposed to have higher priority.

The regression coverage now captures the main priority case and the two permitless boundary cases: permitless-only work with capacity available, and permitless-only work while worker permits are saturated.

Relevant context: this PR fixes the scheduler selection order in the processor only. It does not redesign queue capacity, expiry, or network backpressure.

## Change Overview (Required)

- Adds focused processor tests for urgent consensus priority and permitless fallback behavior.
- Changes the outer receiver selection so the processor first acquires an available worker permit, then lets the existing permit-aware selector prefer urgent consensus.
- Keeps permitless fallback behavior for the case where no worker permit is available.
- Documents the transient permit acquisition when only permitless work is ready, including the assumption that the processor has a single receiver loop.

Reviewer reading order: start with the tests in `anchor/processor/src/receivers.rs`, then read the small selection-order change in the same file.

## Risks, Trade-offs, and Mitigations (Required)

The main behavior change is scheduling priority when a worker permit is available. Urgent consensus now wins over permitless in that case. Permitless work still runs without a worker permit when all permits are occupied, so the existing bypass behavior is preserved for saturated worker pools.

When capacity exists but only permitless work is ready, the scheduler briefly acquires and releases a permit before returning permitless work. That is harmless with the current single receiver loop and is now documented near the selection logic.

## Validation (Required)

- Format check passed.
- Targeted processor lint check passed.
- Processor tests passed, including the new regression and boundary tests plus the existing max-worker test.
- The repo commit hook passed its formatter, clippy, and dependency sort checks before committing.

## Rollback (Required for behavior or runtime changes; optional otherwise)

Revert the commits in this PR. There is no config, data, or migration impact.

## Blockers / Dependencies (Optional)

N/A

## Additional Info / Next Steps (Optional)

This only fixes the immediate priority inversion. Separate follow-up work is still needed for broader overload policy, such as bounded per-key mailboxes, TTLs for stale work, and reserved capacity for critical classes.
