### PR TITLE
test: split qbft aggregator rejection test

### DIFF
--- a/anchor/qbft_manager/src/tests.rs
+++ b/anchor/qbft_manager/src/tests.rs
@@ -39,6 +39,7 @@ use super::{
 };
 use crate::instance::qbft_instance;
 
+mod aggregator_tests;
 mod setup;
 mod timeout_tests;
 
@@ -841,82 +842,6 @@ mod manager_tests {
         .await;
 
         context.verify_consensus().await;
-    }
-
-    /// Test that AggregatorCommittee messages are rejected before the Boole fork.
-    /// This is a critical security test - the role should not be processed until Boole is active.
-    #[tokio::test]
-    async fn test_aggregator_committee_rejected_before_boole() {
-        use fork::ForkSchedule;
-        use message_sender::testing::MockMessageSender;
-        use ssv_types::{
-            RSA_SIGNATURE_SIZE,
-            consensus::{QbftMessage, QbftMessageType},
-            message::{MsgType, SSVMessage, SignedSSVMessage},
-        };
-        use ssz::Encode;
-
-        let setup = setup_test(1);
-
-        // Create QbftManager with default fork schedule (no Boole)
-        let config = processor::Config {
-            max_workers: 4,
-            queue_size: Default::default(),
-        };
-        let senders = processor::spawn(config, setup.executor);
-        let (network_tx, _network_rx) = mpsc::unbounded_channel();
-
-        let manager = QbftManager::<types::MainnetEthSpec, _>::new(
-            senders,
-            OperatorId(1).into(),
-            setup.clock,
-            Arc::new(MockMessageSender::new(network_tx, OperatorId(1))),
-            NonZeroU64::new(32).expect("slots_per_epoch is non-zero"),
-            Arc::new(ForkSchedule::new(Fork::Alan, DomainType::default(), "test")), // No Boole fork
-        )
-        .expect("Manager creation should succeed");
-
-        // Create an AggregatorCommittee message
-        let msg_id = MessageId::new(
-            &DomainType([0; 4]),
-            Role::AggregatorCommittee,
-            &DutyExecutor::Committee(CommitteeId([0; 32])),
-        );
-
-        let qbft_message = QbftMessage {
-            qbft_message_type: QbftMessageType::Proposal,
-            height: 100, // Slot 100, well before any Boole epoch
-            round: 1,
-            identifier: (&msg_id).into(),
-            root: Hash256::from([0u8; 32]),
-            data_round: 1,
-            round_change_justification: ssv_types::VariableList::empty(),
-            prepare_justification: ssv_types::VariableList::empty(),
-        };
-
-        let ssv_msg = SSVMessage::new(
-            MsgType::SSVConsensusMsgType,
-            msg_id,
-            qbft_message.as_ssz_bytes(),
-        )
-        .expect("SSVMessage creation should succeed");
-
-        let signed_msg = SignedSSVMessage::new(
-            vec![[0xAA; RSA_SIGNATURE_SIZE]],
-            vec![OperatorId(1)],
-            ssv_msg,
-            vec![],
-        )
-        .expect("SignedSSVMessage creation should succeed");
-
-        // Call receive_data - should return RoleNotActive
-        let result = manager.receive_data(signed_msg, qbft_message);
-
-        assert!(
-            matches!(result, Err(QbftError::RoleNotActive)),
-            "Expected RoleNotActive error before Boole fork, got: {:?}",
-            result
-        );
     }
 
     /// Test that AggregatorCommittee messages are accepted after the Boole fork.

--- a/anchor/qbft_manager/src/tests/aggregator_tests.rs
+++ b/anchor/qbft_manager/src/tests/aggregator_tests.rs
@@ -1,0 +1,77 @@
+use super::{setup::setup_test, *};
+
+/// Test that AggregatorCommittee messages are rejected before the Boole fork.
+/// This is a critical security test - the role should not be processed until Boole is active.
+#[tokio::test]
+async fn test_aggregator_committee_rejected_before_boole() {
+    use fork::ForkSchedule;
+    use message_sender::testing::MockMessageSender;
+    use ssv_types::{
+        RSA_SIGNATURE_SIZE,
+        consensus::{QbftMessage, QbftMessageType},
+        message::{MsgType, SSVMessage, SignedSSVMessage},
+    };
+    use ssz::Encode;
+
+    let setup = setup_test(1);
+
+    // Create QbftManager with default fork schedule (no Boole)
+    let config = processor::Config {
+        max_workers: 4,
+        queue_size: Default::default(),
+    };
+    let senders = processor::spawn(config, setup.executor);
+    let (network_tx, _network_rx) = mpsc::unbounded_channel();
+
+    let manager = QbftManager::<types::MainnetEthSpec, _>::new(
+        senders,
+        OperatorId(1).into(),
+        setup.clock,
+        Arc::new(MockMessageSender::new(network_tx, OperatorId(1))),
+        NonZeroU64::new(32).expect("slots_per_epoch is non-zero"),
+        Arc::new(ForkSchedule::new(Fork::Alan, DomainType::default(), "test")), // No Boole fork
+    )
+    .expect("Manager creation should succeed");
+
+    // Create an AggregatorCommittee message
+    let msg_id = MessageId::new(
+        &DomainType([0; 4]),
+        Role::AggregatorCommittee,
+        &DutyExecutor::Committee(CommitteeId([0; 32])),
+    );
+
+    let qbft_message = QbftMessage {
+        qbft_message_type: QbftMessageType::Proposal,
+        height: 100, // Slot 100, well before any Boole epoch
+        round: 1,
+        identifier: (&msg_id).into(),
+        root: Hash256::from([0u8; 32]),
+        data_round: 1,
+        round_change_justification: ssv_types::VariableList::empty(),
+        prepare_justification: ssv_types::VariableList::empty(),
+    };
+
+    let ssv_msg = SSVMessage::new(
+        MsgType::SSVConsensusMsgType,
+        msg_id,
+        qbft_message.as_ssz_bytes(),
+    )
+    .expect("SSVMessage creation should succeed");
+
+    let signed_msg = SignedSSVMessage::new(
+        vec![[0xAA; RSA_SIGNATURE_SIZE]],
+        vec![OperatorId(1)],
+        ssv_msg,
+        vec![],
+    )
+    .expect("SignedSSVMessage creation should succeed");
+
+    // Call receive_data - should return RoleNotActive
+    let result = manager.receive_data(signed_msg, qbft_message);
+
+    assert!(
+        matches!(result, Err(QbftError::RoleNotActive)),
+        "Expected RoleNotActive error before Boole fork, got: {:?}",
+        result
+    );
+}


### PR DESCRIPTION
## Problem, Evidence, and Context (Required)

- `anchor/qbft_manager/src/tests.rs` still contains some test groups that can be split out safely.
- This is the next small follow-up to #946 after #990 and #994.
- To keep the diff small, this PR moves only the AggregatorCommittee rejection test.

## Change Overview (Required)

- Added `anchor/qbft_manager/src/tests/aggregator_tests.rs`.
- Moved `test_aggregator_committee_rejected_before_boole` into that file.
- Left `test_aggregator_committee_accepted_after_boole` in `tests.rs` for the next small PR.
- Intentionally did not change production code or test behavior.

## Risks, Trade-offs, and Mitigations (Required)

- Main risk is an import or module wiring mistake while moving the test.
- The mitigation is keeping the move mechanical and running the existing `qbft_manager` tests.
- The trade-off is that the paired accepted-after-Boole test remains in the old module until the next slice.

## Validation (Required)

- Formatting passed.
- The `qbft_manager` test suite passed.
- The `qbft_manager` lint pass passed.
- The commit hook also passed workspace formatting, clippy, and cargo sort checks.

## Rollback (Required for behavior or runtime changes; optional otherwise)

- Revert the PR to move the test back into `tests.rs`.
- No config, data, or operational impact.

## Blockers / Dependencies (Optional)

- N/A

## Additional Info / Next Steps (Optional)

- The next PR can move `test_aggregator_committee_accepted_after_boole` into the same `aggregator_tests` module.
