### PR TITLE
feat(client): wire LH beacon head monitor

### DIFF
--- a/anchor/cli/src/cli.rs
+++ b/anchor/cli/src/cli.rs
@@ -537,6 +537,17 @@ pub struct Node {
 
     #[clap(
         long,
+        help = "Disable the beacon head monitor which tries to attest as soon as any of the \
+                configured beacon nodes sends a head event. Leaving the service enabled is \
+                recommended, but disabling it can lead to reduced bandwidth and more predictable \
+                usage of the primary beacon node (rather than the fastest BN).",
+        display_order = 0,
+        help_heading = FLAG_HEADER
+    )]
+    pub disable_beacon_head_monitor: bool,
+
+    #[clap(
+        long,
         help = "Disable slashing protection for all validator clients. DO NOT ENABLE THIS UNLESS YOU HAVE A MORE THAN SUFFICIENT REASON TO",
         hide = true,
         display_order = 0

--- a/anchor/cli/src/cli.rs
+++ b/anchor/cli/src/cli.rs
@@ -540,9 +540,7 @@ pub struct Node {
         help = "Disable the beacon head monitor which tries to attest as soon as any of the \
                 configured beacon nodes sends a head event. Leaving the service enabled is \
                 recommended, but disabling it can lead to reduced bandwidth and more predictable \
-                usage of the primary beacon node (rather than the fastest BN).",
-        display_order = 0,
-        help_heading = FLAG_HEADER
+                usage of the primary beacon node (rather than the fastest BN)."
     )]
     pub disable_beacon_head_monitor: bool,
 

--- a/anchor/client/src/config.rs
+++ b/anchor/client/src/config.rs
@@ -71,6 +71,8 @@ pub struct Config {
     pub prefer_builder_proposals: bool,
     /// Controls whether the latency measurement service is enabled
     pub disable_latency_measurement_service: bool,
+    /// Enables the beacon head monitor that reacts to head updates from connected beacon nodes.
+    pub enable_beacon_head_monitor: bool,
     /// Enable operator doppelgänger protection (blocks messages and monitors for twins)
     pub operator_dg: bool,
     /// Number of epochs to monitor for twins after grace period
@@ -124,6 +126,7 @@ impl Config {
             prefer_builder_proposals: false,
             gas_limit: 36_000_000,
             disable_latency_measurement_service: false,
+            enable_beacon_head_monitor: true,
             operator_dg: false,
             operator_dg_wait_epochs: 2,
             strict_mfp: false,
@@ -281,6 +284,7 @@ pub fn from_cli(mut cli_args: Node, global_config: GlobalConfig) -> Result<Confi
 
     config.impostor = cli_args.impostor.map(OperatorId);
     config.disable_latency_measurement_service = cli_args.disable_latency_measurement_service;
+    config.enable_beacon_head_monitor = !cli_args.disable_beacon_head_monitor;
 
     // Operator doppelgänger protection
     config.operator_dg = cli_args.operator_dg;

--- a/anchor/client/src/lib.rs
+++ b/anchor/client/src/lib.rs
@@ -18,7 +18,8 @@ use anchor_validator_store::{
     registration_service::RegistrationService,
 };
 use beacon_node_fallback::{
-    BeaconNodeFallback, CandidateBeaconNode, start_fallback_updater_service,
+    BeaconNodeFallback, CandidateBeaconNode, beacon_head_monitor::HeadEvent,
+    start_fallback_updater_service,
 };
 use config::Config;
 use database::{NetworkDatabase, OwnOperatorId};
@@ -45,7 +46,10 @@ use task_executor::TaskExecutor;
 use tokio::{
     net::TcpListener,
     select,
-    sync::{mpsc, mpsc::unbounded_channel},
+    sync::{
+        Mutex,
+        mpsc::{self, unbounded_channel},
+    },
     time::{Instant, interval, sleep},
 };
 use tracing::{debug, error, info, warn};
@@ -78,6 +82,7 @@ const HTTP_GET_DEBUG_BEACON_STATE_QUOTIENT: u32 = 4;
 const HTTP_GET_DEPOSIT_SNAPSHOT_QUOTIENT: u32 = 4;
 const HTTP_GET_VALIDATOR_BLOCK_TIMEOUT_QUOTIENT: u32 = 4;
 const HTTP_DEFAULT_TIMEOUT_QUOTIENT: u32 = 4;
+const MAX_HEAD_EVENT_QUEUE_LEN: usize = 1_024;
 
 pub struct Client {}
 
@@ -333,6 +338,17 @@ impl Client {
 
         beacon_nodes.set_slot_clock(slot_clock.clone());
         proposer_nodes.set_slot_clock(slot_clock.clone());
+
+        // Only the beacon_nodes are used for attestation duties, so proposer_nodes do not need a
+        // head_send ref.
+        let head_monitor_rx = if config.enable_beacon_head_monitor {
+            let (head_monitor_tx, head_monitor_rx) =
+                mpsc::channel::<HeadEvent>(MAX_HEAD_EVENT_QUEUE_LEN);
+            beacon_nodes.set_head_send(Arc::new(head_monitor_tx));
+            Some(Mutex::new(head_monitor_rx))
+        } else {
+            None
+        };
 
         let beacon_nodes = Arc::new(beacon_nodes);
         start_fallback_updater_service::<_, E>(executor.clone(), beacon_nodes.clone())?;
@@ -658,6 +674,7 @@ impl Client {
             .beacon_nodes(beacon_nodes.clone())
             .executor(executor.clone())
             .chain_spec(spec.clone())
+            .head_monitor_rx(head_monitor_rx)
             .build()?;
 
         let preparation_service = PreparationServiceBuilder::new()

--- a/anchor/client/src/lib.rs
+++ b/anchor/client/src/lib.rs
@@ -82,6 +82,7 @@ const HTTP_GET_DEBUG_BEACON_STATE_QUOTIENT: u32 = 4;
 const HTTP_GET_DEPOSIT_SNAPSHOT_QUOTIENT: u32 = 4;
 const HTTP_GET_VALIDATOR_BLOCK_TIMEOUT_QUOTIENT: u32 = 4;
 const HTTP_DEFAULT_TIMEOUT_QUOTIENT: u32 = 4;
+// Mirrors Lighthouse's value at `validator_client/src/lib.rs:75`.
 const MAX_HEAD_EVENT_QUEUE_LEN: usize = 1_024;
 
 pub struct Client {}
@@ -345,6 +346,7 @@ impl Client {
             let (head_monitor_tx, head_monitor_rx) =
                 mpsc::channel::<HeadEvent>(MAX_HEAD_EVENT_QUEUE_LEN);
             beacon_nodes.set_head_send(Arc::new(head_monitor_tx));
+            // Mutex required by `AttestationServiceBuilder::head_monitor_rx`'s signature.
             Some(Mutex::new(head_monitor_rx))
         } else {
             None

--- a/docs/docs/generated/cli-node-options.mdx
+++ b/docs/docs/generated/cli-node-options.mdx
@@ -317,6 +317,13 @@ Payload Building Options:
                epochs and head block proximity. Only useful with multiple
                beacon nodes.
 
+         --disable-beacon-head-monitor
+               Disable the beacon head monitor which tries to attest as soon as
+               any of the configured beacon nodes sends a head event. Leaving
+               the service enabled is recommended, but disabling it can lead to
+               reduced bandwidth and more predictable usage of the primary
+               beacon node (rather than the fastest BN).
+
 Logging Options:
          --logfile-debug-level <LOGFILE_DEBUG_LEVEL>
                Specifies the verbosity level used when emitting logs to the log


### PR DESCRIPTION
First in a series of PRs addressing #986 (end-to-end eager-attesting gap). This one only wires the LH 8.1.0 beacon head-monitor; follow-ups will cover MetadataService Phase 2 and any related plumbing.

## Problem, Evidence, and Context

LH 8.1.0 ships an SSE-driven eager-attest path (`set_head_send` + `AttestationServiceBuilder::head_monitor_rx`) that Anchor pulls in via the `4b3a9d3` pin but never opts into. The SSE polling task is gated on `head_monitor_send.is_some()` in `start_fallback_updater_service` and is never spawned today. See #986 for the full gap analysis.

## Change Overview

- New `--disable-beacon-head-monitor` CLI flag, mirroring LH (default: enabled).
- New `Config::enable_beacon_head_monitor` (defaults to `true`).
- In `Client::run`, after `set_slot_clock` and before `start_fallback_updater_service`, conditionally build the `mpsc::channel::<HeadEvent>`, call `beacon_nodes.set_head_send(...)` on the primary `BeaconNodeFallback` only, and pass `Option<Mutex<Receiver>>` into `AttestationServiceBuilder::head_monitor_rx`.
- Wiring structure mirrors LH's `validator_client/src/lib.rs:402-411 + 529`.

## Risks, Trade-offs, and Mitigations

- End-to-end eager attesting is still inert: `sign_committee_attestations` blocks on `get_voting_context`, which is filled by MetadataService Phase 2 on a fixed 1/3-slot timer. So this PR alone does not change attestation publish timing.
- New SSE stream per BN candidate (additional `/eth/v1/events?topics=head` subscription). Behind a flag and matches LH's default.

## Validation

- `make cargo-fmt-check`, `make lint` clean.
- `cargo test --release --workspace --exclude spec_tests` passes (spec_tests skip is a pre-existing missing-fixture issue, unrelated).

## Rollback

Revert the commit or pass `--disable-beacon-head-monitor` at runtime.

## Additional Info / Next Steps

Follow-up PR(s) will race MetadataService Phase 2 against head events so `VotingContext` is published early and `sign_committee_attestations` can actually start sooner.