### PR TITLE
feat: instruments proposer block sign duty pre-QBFT fetch

### DIFF
--- a/anchor/validator_store/src/lib.rs
+++ b/anchor/validator_store/src/lib.rs
@@ -2385,15 +2385,19 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> ValidatorStore
             failure_reason = field::Empty,
             proposal_matched = field::Empty,
             outcome = field::Empty,
+            slot_elapsed_ms = field::Empty,
             block_slot = block_slot.as_u64(),
             validator_pubkey = %validator_pubkey,
             validator_index = field::Empty,
         );
+
         let future = async {
             trace!(
                 checkpoint = instrumentation::checkpoints::DUTY_ENTRY,
+                slot_elapsed_ms = determine_slot_elapsed_ms(&self.slot_clock),
                 "Proposer block signing duty entered"
             );
+
             let result = async {
                 if !*self.is_synced.borrow() {
                     return Err(Error::SpecificError(SpecificError::NotSynced));
@@ -2420,6 +2424,7 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> ValidatorStore
 
                 trace!(
                     checkpoint = instrumentation::checkpoints::PRE_CONSENSUS_HANDOFF,
+                    slot_elapsed_ms = determine_slot_elapsed_ms(&self.slot_clock),
                     "Handing block to consensus process"
                 );
 
@@ -2466,6 +2471,13 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> ValidatorStore
                 Ok(publish_decision.signed_block)
             }
             .await;
+
+            match determine_slot_elapsed_ms(&self.slot_clock) {
+                Some(ms) => {
+                    Span::current().record("slot_elapsed_ms", ms);
+                }
+                None => trace!("slot_elapsed_ms unavailable: clock returned None"),
+            }
 
             let outcome = instrumentation::outcome_from_result(&result);
             Span::current().record("outcome", outcome);

--- a/anchor/validator_store/src/lib.rs
+++ b/anchor/validator_store/src/lib.rs
@@ -152,10 +152,10 @@ async fn run_committee_signing<T>(
     }
 }
 
-fn determine_slot_elapsed_ms(slot_clock: &impl SlotClock) -> Option<u128> {
+fn determine_slot_elapsed_ms(slot_clock: &impl SlotClock) -> Option<u64> {
     slot_clock
         .millis_from_current_slot_start()
-        .map(|d| d.as_millis())
+        .map(|d| d.as_millis() as u64)
 }
 
 pub struct AnchorValidatorStore<
@@ -2291,13 +2291,10 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> ValidatorStore
             }
             .await;
 
-            match determine_slot_elapsed_ms(&self.slot_clock) {
-                Some(ms) => {
-                    Span::current().record("slot_elapsed_ms", ms);
-                }
-                None => trace!("slot_elapsed_ms unavailable: clock returned None"),
-            }
-
+            Span::current().record(
+                "slot_elapsed_ms",
+                determine_slot_elapsed_ms(&self.slot_clock),
+            );
             let outcome = instrumentation::outcome_from_result(&result);
             Span::current().record("outcome", outcome);
             match &result {
@@ -2472,13 +2469,10 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> ValidatorStore
             }
             .await;
 
-            match determine_slot_elapsed_ms(&self.slot_clock) {
-                Some(ms) => {
-                    Span::current().record("slot_elapsed_ms", ms);
-                }
-                None => trace!("slot_elapsed_ms unavailable: clock returned None"),
-            }
-
+            Span::current().record(
+                "slot_elapsed_ms",
+                determine_slot_elapsed_ms(&self.slot_clock),
+            );
             let outcome = instrumentation::outcome_from_result(&result);
             Span::current().record("outcome", outcome);
             match &result {


### PR DESCRIPTION
## Problem, Evidence, and Context (Required)

A follow up to #999 addressing the remaining components of #920:
1. Adds `slot_elapsed_ms` to the `proposer_sign_block` span declaration.
2. Records it at `DUTY_ENTRY` for _"time spent before block was available for signing"_ (i.e. randao + Lighthouse BN fetch).
3. Adds `slot_elapsed_ms` at pre consensus handoff checkpoint to record the remaining budget at QBFT start.

Additionally, the current `match` statement determining recording of `slot_elapsed_ms` in `randao_reveal` (from #999) had scope for improvement as `.record` of `None` results in a no-op and `slot_elapsed_ms` remains `empty`. This enabled a more concise expression than the existing verbose `match` statement: 
```
match determine_slot_elapsed_ms(&self.slot_clock) {
    Some(ms) => {
        Span::current().record("slot_elapsed_ms", ms);
     }
     None => trace!("slot_elapsed_ms unavailable: clock returned None"),
}
```

becomes
```
Span::current().record(
    "slot_elapsed_ms",
    determine_slot_elapsed_ms(&self.slot_clock),
);
```
This is worth doing now to follow from instrumenting `randao_reveal` and complete the stated objective of #920 to instrument the pre-QBFT proposer path and quantify slot budget spent prior to QBFT starting.

## Change Overview (Required)

Specific changes:
- `slot_elapsed_ms` added to `sign_block` span.
- Added `slot_elapsed_ms` field to existing traces at duty entry and pre-consensus handoff checkpoints.
- Reported `slot_elapsed_ms` in the final span prior to the sign block future returning.

## Risks, Trade-offs, and Mitigations (Required)

No new failure modes or behavioural changes were made as `determine_slot_elapsed_ms` returns `Option<u128>` and no side effects from the application's perspective. There were also no distinct trade offs made as this change was narrow and specific.

## Validation (Required)

`make cargo-fmt`
`cargo clippy`
`cargo check`

## Rollback (Required for behavior or runtime changes; optional otherwise)

This change can be safely reverted without any impacts.