### PR TITLE
chore(deps): bump Lighthouse to unstable HEAD 1a6863118

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -871,7 +871,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -882,7 +882,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1402,7 +1402,7 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 [[package]]
 name = "beacon_node_fallback"
 version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?rev=4b3a9d3#4b3a9d3d10a6181a1a1588880de133457eb90816"
+source = "git+https://github.com/sigp/lighthouse?rev=1a6863118#1a686311803c7a8123c4fa576f2ea7c0283005dc"
 dependencies = [
  "bls",
  "clap",
@@ -1502,7 +1502,7 @@ dependencies = [
 [[package]]
 name = "bls"
 version = "0.2.0"
-source = "git+https://github.com/sigp/lighthouse?rev=4b3a9d3#4b3a9d3d10a6181a1a1588880de133457eb90816"
+source = "git+https://github.com/sigp/lighthouse?rev=1a6863118#1a686311803c7a8123c4fa576f2ea7c0283005dc"
 dependencies = [
  "alloy-primitives 1.5.7",
  "blst",
@@ -2447,7 +2447,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2606,7 +2606,7 @@ dependencies = [
 [[package]]
 name = "eip_3076"
 version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?rev=4b3a9d3#4b3a9d3d10a6181a1a1588880de133457eb90816"
+source = "git+https://github.com/sigp/lighthouse?rev=1a6863118#1a686311803c7a8123c4fa576f2ea7c0283005dc"
 dependencies = [
  "bls",
  "ethereum_serde_utils 0.8.0",
@@ -2804,7 +2804,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2842,7 +2842,7 @@ dependencies = [
 [[package]]
 name = "eth2"
 version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?rev=4b3a9d3#4b3a9d3d10a6181a1a1588880de133457eb90816"
+source = "git+https://github.com/sigp/lighthouse?rev=1a6863118#1a686311803c7a8123c4fa576f2ea7c0283005dc"
 dependencies = [
  "bls",
  "context_deserialize",
@@ -2871,7 +2871,7 @@ dependencies = [
 [[package]]
 name = "eth2_config"
 version = "0.2.0"
-source = "git+https://github.com/sigp/lighthouse?rev=4b3a9d3#4b3a9d3d10a6181a1a1588880de133457eb90816"
+source = "git+https://github.com/sigp/lighthouse?rev=1a6863118#1a686311803c7a8123c4fa576f2ea7c0283005dc"
 dependencies = [
  "paste",
  "types",
@@ -2880,20 +2880,20 @@ dependencies = [
 [[package]]
 name = "eth2_interop_keypairs"
 version = "0.2.0"
-source = "git+https://github.com/sigp/lighthouse?rev=4b3a9d3#4b3a9d3d10a6181a1a1588880de133457eb90816"
+source = "git+https://github.com/sigp/lighthouse?rev=1a6863118#1a686311803c7a8123c4fa576f2ea7c0283005dc"
 dependencies = [
  "bls",
  "ethereum_hashing 0.8.0",
  "hex",
  "num-bigint",
  "serde",
- "serde_yaml",
+ "yaml_serde",
 ]
 
 [[package]]
 name = "eth2_key_derivation"
 version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?rev=4b3a9d3#4b3a9d3d10a6181a1a1588880de133457eb90816"
+source = "git+https://github.com/sigp/lighthouse?rev=1a6863118#1a686311803c7a8123c4fa576f2ea7c0283005dc"
 dependencies = [
  "bls",
  "num-bigint-dig",
@@ -2905,7 +2905,7 @@ dependencies = [
 [[package]]
 name = "eth2_keystore"
 version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?rev=4b3a9d3#4b3a9d3d10a6181a1a1588880de133457eb90816"
+source = "git+https://github.com/sigp/lighthouse?rev=1a6863118#1a686311803c7a8123c4fa576f2ea7c0283005dc"
 dependencies = [
  "aes",
  "bls",
@@ -2929,7 +2929,7 @@ dependencies = [
 [[package]]
 name = "eth2_network_config"
 version = "0.2.0"
-source = "git+https://github.com/sigp/lighthouse?rev=4b3a9d3#4b3a9d3d10a6181a1a1588880de133457eb90816"
+source = "git+https://github.com/sigp/lighthouse?rev=1a6863118#1a686311803c7a8123c4fa576f2ea7c0283005dc"
 dependencies = [
  "bytes",
  "discv5",
@@ -2939,11 +2939,11 @@ dependencies = [
  "pretty_reqwest_error",
  "reqwest",
  "sensitive_url",
- "serde_yaml",
  "sha2",
  "tracing",
  "types",
  "url",
+ "yaml_serde",
  "zip",
 ]
 
@@ -3141,7 +3141,7 @@ dependencies = [
 [[package]]
 name = "filesystem"
 version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?rev=4b3a9d3#4b3a9d3d10a6181a1a1588880de133457eb90816"
+source = "git+https://github.com/sigp/lighthouse?rev=1a6863118#1a686311803c7a8123c4fa576f2ea7c0283005dc"
 dependencies = [
  "winapi",
  "windows-acl",
@@ -3168,7 +3168,7 @@ dependencies = [
 [[package]]
 name = "fixed_bytes"
 version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?rev=4b3a9d3#4b3a9d3d10a6181a1a1588880de133457eb90816"
+source = "git+https://github.com/sigp/lighthouse?rev=1a6863118#1a686311803c7a8123c4fa576f2ea7c0283005dc"
 dependencies = [
  "alloy-primitives 1.5.7",
  "safe_arith",
@@ -3489,7 +3489,7 @@ dependencies = [
 [[package]]
 name = "graffiti_file"
 version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?rev=4b3a9d3#4b3a9d3d10a6181a1a1588880de133457eb90816"
+source = "git+https://github.com/sigp/lighthouse?rev=1a6863118#1a686311803c7a8123c4fa576f2ea7c0283005dc"
 dependencies = [
  "bls",
  "serde",
@@ -3590,7 +3590,7 @@ dependencies = [
 [[package]]
 name = "health_metrics"
 version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?rev=4b3a9d3#4b3a9d3d10a6181a1a1588880de133457eb90816"
+source = "git+https://github.com/sigp/lighthouse?rev=1a6863118#1a686311803c7a8123c4fa576f2ea7c0283005dc"
 dependencies = [
  "eth2",
  "metrics",
@@ -4114,7 +4114,7 @@ dependencies = [
 [[package]]
 name = "int_to_bytes"
 version = "0.2.0"
-source = "git+https://github.com/sigp/lighthouse?rev=4b3a9d3#4b3a9d3d10a6181a1a1588880de133457eb90816"
+source = "git+https://github.com/sigp/lighthouse?rev=1a6863118#1a686311803c7a8123c4fa576f2ea7c0283005dc"
 dependencies = [
  "bytes",
 ]
@@ -4276,7 +4276,7 @@ dependencies = [
 [[package]]
 name = "kzg"
 version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?rev=4b3a9d3#4b3a9d3d10a6181a1a1588880de133457eb90816"
+source = "git+https://github.com/sigp/lighthouse?rev=1a6863118#1a686311803c7a8123c4fa576f2ea7c0283005dc"
 dependencies = [
  "educe",
  "ethereum_hashing 0.8.0",
@@ -4745,6 +4745,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "libyaml-rs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e126dda6f34391ab7b444f9922055facc83c07a910da3eb16f1e4d9c45dc777"
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4791,7 +4797,7 @@ dependencies = [
 [[package]]
 name = "logging"
 version = "0.2.0"
-source = "git+https://github.com/sigp/lighthouse?rev=4b3a9d3#4b3a9d3d10a6181a1a1588880de133457eb90816"
+source = "git+https://github.com/sigp/lighthouse?rev=1a6863118#1a686311803c7a8123c4fa576f2ea7c0283005dc"
 dependencies = [
  "chrono",
  "logroller",
@@ -4846,7 +4852,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 [[package]]
 name = "lru_cache"
 version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?rev=4b3a9d3#4b3a9d3d10a6181a1a1588880de133457eb90816"
+source = "git+https://github.com/sigp/lighthouse?rev=1a6863118#1a686311803c7a8123c4fa576f2ea7c0283005dc"
 dependencies = [
  "fnv",
 ]
@@ -4927,7 +4933,7 @@ dependencies = [
 [[package]]
 name = "merkle_proof"
 version = "0.2.0"
-source = "git+https://github.com/sigp/lighthouse?rev=4b3a9d3#4b3a9d3d10a6181a1a1588880de133457eb90816"
+source = "git+https://github.com/sigp/lighthouse?rev=1a6863118#1a686311803c7a8123c4fa576f2ea7c0283005dc"
 dependencies = [
  "alloy-primitives 1.5.7",
  "ethereum_hashing 0.8.0",
@@ -5025,7 +5031,7 @@ dependencies = [
 [[package]]
 name = "metrics"
 version = "0.2.0"
-source = "git+https://github.com/sigp/lighthouse?rev=4b3a9d3#4b3a9d3d10a6181a1a1588880de133457eb90816"
+source = "git+https://github.com/sigp/lighthouse?rev=1a6863118#1a686311803c7a8123c4fa576f2ea7c0283005dc"
 dependencies = [
  "prometheus",
 ]
@@ -5267,7 +5273,7 @@ dependencies = [
 [[package]]
 name = "network_utils"
 version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?rev=4b3a9d3#4b3a9d3d10a6181a1a1588880de133457eb90816"
+source = "git+https://github.com/sigp/lighthouse?rev=1a6863118#1a686311803c7a8123c4fa576f2ea7c0283005dc"
 dependencies = [
  "discv5",
  "libp2p-identity",
@@ -5330,7 +5336,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5832,7 +5838,7 @@ dependencies = [
 [[package]]
 name = "pretty_reqwest_error"
 version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?rev=4b3a9d3#4b3a9d3d10a6181a1a1588880de133457eb90816"
+source = "git+https://github.com/sigp/lighthouse?rev=1a6863118#1a686311803c7a8123c4fa576f2ea7c0283005dc"
 dependencies = [
  "reqwest",
  "sensitive_url",
@@ -5993,16 +5999,18 @@ dependencies = [
 [[package]]
 name = "proto_array"
 version = "0.2.0"
-source = "git+https://github.com/sigp/lighthouse?rev=4b3a9d3#4b3a9d3d10a6181a1a1588880de133457eb90816"
+source = "git+https://github.com/sigp/lighthouse?rev=1a6863118#1a686311803c7a8123c4fa576f2ea7c0283005dc"
 dependencies = [
  "ethereum_ssz",
  "ethereum_ssz_derive",
  "fixed_bytes",
  "safe_arith",
  "serde",
- "serde_yaml",
+ "smallvec",
  "superstruct",
+ "typenum",
  "types",
+ "yaml_serde",
 ]
 
 [[package]]
@@ -6724,7 +6732,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7241,7 +7249,7 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 [[package]]
 name = "slashing_protection"
 version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?rev=4b3a9d3#4b3a9d3d10a6181a1a1588880de133457eb90816"
+source = "git+https://github.com/sigp/lighthouse?rev=1a6863118#1a686311803c7a8123c4fa576f2ea7c0283005dc"
 dependencies = [
  "bls",
  "eip_3076",
@@ -7261,7 +7269,7 @@ dependencies = [
 [[package]]
 name = "slot_clock"
 version = "0.2.0"
-source = "git+https://github.com/sigp/lighthouse?rev=4b3a9d3#4b3a9d3d10a6181a1a1588880de133457eb90816"
+source = "git+https://github.com/sigp/lighthouse?rev=1a6863118#1a686311803c7a8123c4fa576f2ea7c0283005dc"
 dependencies = [
  "metrics",
  "parking_lot",
@@ -7311,7 +7319,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7407,9 +7415,9 @@ dependencies = [
 
 [[package]]
 name = "ssz_types"
-version = "0.14.0"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fc20a89bab2dabeee65e9c9eb96892dc222c23254b401e1319b85efd852fa31"
+checksum = "d625e4de8e0057eefe7e0b1510ba1dd7adf10cd375fad6cc7fcceac7c39623c9"
 dependencies = [
  "context_deserialize",
  "educe",
@@ -7508,7 +7516,7 @@ dependencies = [
 [[package]]
 name = "swap_or_not_shuffle"
 version = "0.2.0"
-source = "git+https://github.com/sigp/lighthouse?rev=4b3a9d3#4b3a9d3d10a6181a1a1588880de133457eb90816"
+source = "git+https://github.com/sigp/lighthouse?rev=1a6863118#1a686311803c7a8123c4fa576f2ea7c0283005dc"
 dependencies = [
  "alloy-primitives 1.5.7",
  "ethereum_hashing 0.8.0",
@@ -7611,7 +7619,7 @@ checksum = "c63f48baada5c52e65a29eef93ab4f8982681b67f9e8d29c7b05abcfec2b9ffe"
 [[package]]
 name = "task_executor"
 version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?rev=4b3a9d3#4b3a9d3d10a6181a1a1588880de133457eb90816"
+source = "git+https://github.com/sigp/lighthouse?rev=1a6863118#1a686311803c7a8123c4fa576f2ea7c0283005dc"
 dependencies = [
  "async-channel 1.9.0",
  "futures",
@@ -7632,7 +7640,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7650,15 +7658,6 @@ name = "termtree"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
-
-[[package]]
-name = "test_random_derive"
-version = "0.2.0"
-source = "git+https://github.com/sigp/lighthouse?rev=4b3a9d3#4b3a9d3d10a6181a1a1588880de133457eb90816"
-dependencies = [
- "quote",
- "syn 2.0.117",
-]
 
 [[package]]
 name = "thiserror"
@@ -8154,7 +8153,7 @@ checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 [[package]]
 name = "types"
 version = "0.2.1"
-source = "git+https://github.com/sigp/lighthouse?rev=4b3a9d3#4b3a9d3d10a6181a1a1588880de133457eb90816"
+source = "git+https://github.com/sigp/lighthouse?rev=1a6863118#1a686311803c7a8123c4fa576f2ea7c0283005dc"
 dependencies = [
  "alloy-primitives 1.5.7",
  "alloy-rlp",
@@ -8186,17 +8185,16 @@ dependencies = [
  "safe_arith",
  "serde",
  "serde_json",
- "serde_yaml",
  "smallvec",
  "ssz_types",
  "superstruct",
  "swap_or_not_shuffle",
  "tempfile",
- "test_random_derive",
  "tracing",
  "tree_hash",
  "tree_hash_derive",
  "typenum",
+ "yaml_serde",
 ]
 
 [[package]]
@@ -8343,7 +8341,7 @@ dependencies = [
 [[package]]
 name = "validator_metrics"
 version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?rev=4b3a9d3#4b3a9d3d10a6181a1a1588880de133457eb90816"
+source = "git+https://github.com/sigp/lighthouse?rev=1a6863118#1a686311803c7a8123c4fa576f2ea7c0283005dc"
 dependencies = [
  "metrics",
 ]
@@ -8351,7 +8349,7 @@ dependencies = [
 [[package]]
 name = "validator_services"
 version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?rev=4b3a9d3#4b3a9d3d10a6181a1a1588880de133457eb90816"
+source = "git+https://github.com/sigp/lighthouse?rev=1a6863118#1a686311803c7a8123c4fa576f2ea7c0283005dc"
 dependencies = [
  "beacon_node_fallback",
  "bls",
@@ -8376,7 +8374,7 @@ dependencies = [
 [[package]]
 name = "validator_store"
 version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?rev=4b3a9d3#4b3a9d3d10a6181a1a1588880de133457eb90816"
+source = "git+https://github.com/sigp/lighthouse?rev=1a6863118#1a686311803c7a8123c4fa576f2ea7c0283005dc"
 dependencies = [
  "bls",
  "eth2",
@@ -8662,7 +8660,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -9145,7 +9143,7 @@ dependencies = [
 [[package]]
 name = "workspace_members"
 version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?rev=4b3a9d3#4b3a9d3d10a6181a1a1588880de133457eb90816"
+source = "git+https://github.com/sigp/lighthouse?rev=1a6863118#1a686311803c7a8123c4fa576f2ea7c0283005dc"
 dependencies = [
  "cargo_metadata",
  "quote",
@@ -9227,6 +9225,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7d8a75eaf6557bb84a65ace8609883db44a29951042ada9b393151532e41fcb"
 dependencies = [
  "xml-rs",
+]
+
+[[package]]
+name = "yaml_serde"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c7c1b1a6a7c8a6b2741a6c21a4f8918e51899b111cfa08d1288202656e3975"
+dependencies = [
+ "indexmap 2.13.0",
+ "itoa",
+ "libyaml-rs",
+ "ryu",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,23 +71,23 @@ ssv_types = { path = "anchor/common/ssv_types" }
 subnet_service = { path = "anchor/subnet_service" }
 version = { path = "anchor/common/version" }
 
-# Lighthouse latest from unstable (4b3a9d3)
-beacon_node_fallback = { git = "https://github.com/sigp/lighthouse", rev = "4b3a9d3" }
-bls = { git = "https://github.com/sigp/lighthouse", rev = "4b3a9d3" }
-eth2 = { git = "https://github.com/sigp/lighthouse", rev = "4b3a9d3" }
-eth2_keystore = { git = "https://github.com/sigp/lighthouse", rev = "4b3a9d3" }
-eth2_network_config = { git = "https://github.com/sigp/lighthouse", rev = "4b3a9d3" }
-health_metrics = { git = "https://github.com/sigp/lighthouse", rev = "4b3a9d3" }
-metrics = { git = "https://github.com/sigp/lighthouse", rev = "4b3a9d3" }
-network_utils = { git = "https://github.com/sigp/lighthouse", rev = "4b3a9d3" }
-slashing_protection = { git = "https://github.com/sigp/lighthouse", rev = "4b3a9d3" }
-slot_clock = { git = "https://github.com/sigp/lighthouse", rev = "4b3a9d3" }
-task_executor = { git = "https://github.com/sigp/lighthouse", rev = "4b3a9d3" }
-types = { git = "https://github.com/sigp/lighthouse", rev = "4b3a9d3" }
-validator_metrics = { git = "https://github.com/sigp/lighthouse", rev = "4b3a9d3" }
-validator_services = { git = "https://github.com/sigp/lighthouse", rev = "4b3a9d3" }
-validator_store = { git = "https://github.com/sigp/lighthouse", rev = "4b3a9d3" }
-workspace_members = { git = "https://github.com/sigp/lighthouse", rev = "4b3a9d3" }
+# Lighthouse latest from unstable (1a6863118)
+beacon_node_fallback = { git = "https://github.com/sigp/lighthouse", rev = "1a6863118" }
+bls = { git = "https://github.com/sigp/lighthouse", rev = "1a6863118" }
+eth2 = { git = "https://github.com/sigp/lighthouse", rev = "1a6863118" }
+eth2_keystore = { git = "https://github.com/sigp/lighthouse", rev = "1a6863118" }
+eth2_network_config = { git = "https://github.com/sigp/lighthouse", rev = "1a6863118" }
+health_metrics = { git = "https://github.com/sigp/lighthouse", rev = "1a6863118" }
+metrics = { git = "https://github.com/sigp/lighthouse", rev = "1a6863118" }
+network_utils = { git = "https://github.com/sigp/lighthouse", rev = "1a6863118" }
+slashing_protection = { git = "https://github.com/sigp/lighthouse", rev = "1a6863118" }
+slot_clock = { git = "https://github.com/sigp/lighthouse", rev = "1a6863118" }
+task_executor = { git = "https://github.com/sigp/lighthouse", rev = "1a6863118" }
+types = { git = "https://github.com/sigp/lighthouse", rev = "1a6863118" }
+validator_metrics = { git = "https://github.com/sigp/lighthouse", rev = "1a6863118" }
+validator_services = { git = "https://github.com/sigp/lighthouse", rev = "1a6863118" }
+validator_store = { git = "https://github.com/sigp/lighthouse", rev = "1a6863118" }
+workspace_members = { git = "https://github.com/sigp/lighthouse", rev = "1a6863118" }
 
 alloy = { version = "1.2.1", features = [
     "sol-types",

--- a/anchor/client/src/lib.rs
+++ b/anchor/client/src/lib.rs
@@ -73,6 +73,8 @@ const HTTP_PROPOSAL_TIMEOUT_QUOTIENT: u32 = 2;
 const HTTP_PROPOSER_DUTIES_TIMEOUT_QUOTIENT: u32 = 4;
 const HTTP_SYNC_COMMITTEE_CONTRIBUTION_TIMEOUT_QUOTIENT: u32 = 4;
 const HTTP_SYNC_DUTIES_TIMEOUT_QUOTIENT: u32 = 4;
+const HTTP_PTC_DUTIES_TIMEOUT_QUOTIENT: u32 = 4;
+const HTTP_PAYLOAD_ATTESTATION_TIMEOUT_QUOTIENT: u32 = 4;
 const HTTP_GET_BEACON_BLOCK_SSZ_TIMEOUT_QUOTIENT: u32 = 4;
 const HTTP_GET_DEBUG_BEACON_STATE_QUOTIENT: u32 = 4;
 const HTTP_GET_DEPOSIT_SNAPSHOT_QUOTIENT: u32 = 4;
@@ -205,7 +207,7 @@ impl Client {
         let beacon_node_setup = |x: (usize, &SensitiveUrl)| {
             let i = x.0;
             let url = x.1;
-            let slot_duration = Duration::from_secs(spec.seconds_per_slot);
+            let slot_duration = spec.get_slot_duration();
 
             let mut beacon_node_http_client_builder = ClientBuilder::new();
 
@@ -239,6 +241,8 @@ impl Client {
                         / HTTP_SYNC_COMMITTEE_CONTRIBUTION_TIMEOUT_QUOTIENT,
                     sync_duties: slot_duration / HTTP_SYNC_DUTIES_TIMEOUT_QUOTIENT,
                     sync_aggregators: slot_duration / HTTP_SYNC_DUTIES_TIMEOUT_QUOTIENT,
+                    ptc_duties: slot_duration / HTTP_PTC_DUTIES_TIMEOUT_QUOTIENT,
+                    payload_attestation: slot_duration / HTTP_PAYLOAD_ATTESTATION_TIMEOUT_QUOTIENT,
                     get_beacon_blocks_ssz: slot_duration
                         / HTTP_GET_BEACON_BLOCK_SSZ_TIMEOUT_QUOTIENT,
                     get_debug_beacon_states: slot_duration / HTTP_GET_DEBUG_BEACON_STATE_QUOTIENT,
@@ -328,7 +332,7 @@ impl Client {
         let slot_clock = SystemTimeSlotClock::new(
             spec.genesis_slot,
             Duration::from_secs(genesis_time),
-            Duration::from_secs(spec.seconds_per_slot),
+            spec.get_slot_duration(),
         );
 
         beacon_nodes.set_slot_clock(slot_clock.clone());
@@ -369,7 +373,7 @@ impl Client {
             fork_schedule.clone(),
             slot_clock.clone(),
             E::slots_per_epoch(),
-            spec.seconds_per_slot,
+            spec.get_slot_duration().as_secs(),
             executor.clone(),
         )?;
 
@@ -441,7 +445,7 @@ impl Client {
                 operator_id.clone(),
                 startup_slot,
                 E::slots_per_epoch(),
-                Duration::from_secs(spec.seconds_per_slot),
+                spec.get_slot_duration(),
             )))
         } else {
             None

--- a/anchor/client/src/notifier.rs
+++ b/anchor/client/src/notifier.rs
@@ -5,10 +5,7 @@ use database::NetworkState;
 use operator_doppelganger::OperatorDoppelgangerService;
 use slot_clock::SlotClock;
 use task_executor::TaskExecutor;
-use tokio::{
-    sync::watch,
-    time::{Duration, sleep},
-};
+use tokio::{sync::watch, time::sleep};
 use tracing::{error, info};
 use types::{ChainSpec, EthSpec};
 
@@ -82,7 +79,7 @@ pub fn spawn_notifier<E: EthSpec, T: SlotClock + 'static>(
     executor: TaskExecutor,
     spec: &ChainSpec,
 ) {
-    let slot_duration = Duration::from_secs(spec.seconds_per_slot);
+    let slot_duration = spec.get_slot_duration();
 
     let interval_fut = async move {
         loop {

--- a/anchor/common/fork/src/monitor.rs
+++ b/anchor/common/fork/src/monitor.rs
@@ -302,7 +302,7 @@ mod tests {
 
     /// Get seconds per slot from minimal spec.
     fn seconds_per_slot() -> u64 {
-        ChainSpec::minimal().seconds_per_slot
+        ChainSpec::minimal().get_slot_duration().as_secs()
     }
 
     fn make_schedule_with_boole(boole_epoch: u64) -> Arc<ForkSchedule> {

--- a/anchor/database/src/tests/utils.rs
+++ b/anchor/database/src/tests/utils.rs
@@ -9,10 +9,7 @@ use ssv_types::{
     ValidatorIndex, ValidatorMetadata,
 };
 use tempfile::TempDir;
-use types::{
-    Address, Graffiti,
-    test_utils::{SeedableRng, XorShiftRng},
-};
+use types::{Address, Graffiti};
 
 use crate::{NetworkDatabase, PendingStateUpdates, multi_index::UniqueIndex};
 
@@ -20,7 +17,6 @@ use crate::{NetworkDatabase, PendingStateUpdates, multi_index::UniqueIndex};
 /// 4 operators allows for QBFT quorum (3) with 1 fault tolerance (f=1, n=3f+1=4)
 pub const DEFAULT_NUM_OPERATORS: u64 = 4;
 const RSA_KEY_SIZE: u32 = 2048;
-const DEFAULT_SEED: [u8; 16] = [42; 16];
 /// Test network name for database isolation
 pub const TEST_NETWORK: &str = "test";
 
@@ -302,8 +298,7 @@ pub mod generators {
     }
 
     pub mod pubkey {
-        use bls::PublicKeyBytes;
-        use types::test_utils::TestRandom;
+        use bls::{Keypair, PublicKeyBytes};
 
         use super::*;
 
@@ -316,10 +311,9 @@ pub mod generators {
                 .expect("Failed to process RSA key")
         }
 
-        // Generate a random public key for validators
+        // Generate a fresh public key for validators.
         pub fn random() -> PublicKeyBytes {
-            let rng = &mut XorShiftRng::from_seed(DEFAULT_SEED);
-            PublicKeyBytes::random_for_test(rng)
+            PublicKeyBytes::from(Keypair::random().pk)
         }
     }
 

--- a/anchor/network/src/behaviour.rs
+++ b/anchor/network/src/behaviour.rs
@@ -105,8 +105,7 @@ impl AnchorBehaviour {
         };
 
         let slots_per_epoch = E::slots_per_epoch();
-        let seconds_per_slot = spec.seconds_per_slot;
-        let duplicate_cache_time = Duration::from_secs(slots_per_epoch * seconds_per_slot); // 6.4 min TODO make this configurable
+        let duplicate_cache_time = spec.get_slot_duration() * slots_per_epoch as u32; // 6.4 min TODO make this configurable
 
         let gossipsub_config = gossipsub::ConfigBuilder::default()
             .duplicate_cache_time(duplicate_cache_time) // This is equivalent to seen_msg_ttl used in PeerScoreParams in go ssv
@@ -142,7 +141,7 @@ impl AnchorBehaviour {
         // Add peer scoring if not disabled
         if !network_config.disable_gossipsub_peer_scoring {
             let slots_per_epoch = E::slots_per_epoch();
-            let slot_duration = Duration::from_secs(spec.seconds_per_slot);
+            let slot_duration = spec.get_slot_duration();
             let one_epoch_duration = slot_duration * slots_per_epoch as u32;
             let score_params = peer_score_params(one_epoch_duration);
             let score_thresholds = peer_score_thresholds();
@@ -167,7 +166,7 @@ impl AnchorBehaviour {
 
         let peer_manager = {
             let slots_per_epoch = E::slots_per_epoch();
-            let slot_duration = Duration::from_secs(spec.seconds_per_slot);
+            let slot_duration = spec.get_slot_duration();
             let one_epoch_duration = slot_duration * slots_per_epoch as u32;
             PeerManager::new(network_config, one_epoch_duration, lifecycle_rx.clone())
         };

--- a/anchor/network/src/scoring/topic_score_config.rs
+++ b/anchor/network/src/scoring/topic_score_config.rs
@@ -113,7 +113,7 @@ impl TopicScoringOptions {
         message_rate: f64,
         chain_spec: &ChainSpec,
     ) -> Self {
-        let slot_duration = Duration::from_secs(chain_spec.seconds_per_slot);
+        let slot_duration = chain_spec.get_slot_duration();
         let one_epoch_duration = E::slots_per_epoch() as u32 * slot_duration;
 
         let network = NetworkConfig {

--- a/anchor/subnet_service/src/message_rate.rs
+++ b/anchor/subnet_service/src/message_rate.rs
@@ -172,7 +172,7 @@ pub fn calculate_message_rate_for_topic<E: EthSpec>(
     }
 
     let slots_per_epoch_f64 = E::slots_per_epoch() as f64;
-    let slot_duration_seconds = chain_spec.seconds_per_slot as f64;
+    let slot_duration_seconds = chain_spec.get_slot_duration().as_secs_f64();
     let sync_committee_size = E::sync_committee_size() as f64;
 
     let mut total_msg_rate = 0.0;

--- a/anchor/validator_store/src/lib.rs
+++ b/anchor/validator_store/src/lib.rs
@@ -65,9 +65,10 @@ use types::{
     AbstractExecPayload, Address, AggregateAndProof, AggregateAndProofBase,
     AggregateAndProofElectra, Attestation, AttestationBase, AttestationElectra, BeaconBlock,
     BeaconBlockRef, BlindedPayload, ChainSpec, ContributionAndProof, Domain, Epoch, EthSpec,
-    ExecutionPayloadEnvelope, ForkName, FullPayload, Graffiti, Hash256, SelectionProof,
-    SignedAggregateAndProof, SignedBeaconBlock, SignedBlindedBeaconBlock,
-    SignedContributionAndProof, SignedExecutionPayloadEnvelope, SignedRoot,
+    ExecutionPayloadEnvelope, ForkName, FullPayload, Graffiti, Hash256, PayloadAttestationData,
+    PayloadAttestationMessage, ProposerPreferences, SelectionProof, SignedAggregateAndProof,
+    SignedBeaconBlock, SignedBlindedBeaconBlock, SignedContributionAndProof,
+    SignedExecutionPayloadEnvelope, SignedProposerPreferences, SignedRoot,
     SignedValidatorRegistrationData, SignedVoluntaryExit, Slot, SlotData,
     SyncAggregatorSelectionData, SyncCommitteeContribution, SyncCommitteeMessage,
     SyncSelectionProof, SyncSubnetId, ValidatorRegistrationData, VoluntaryExit,
@@ -403,10 +404,8 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> AnchorValidator
 
         let timer = metrics::start_timer_vec(&metrics::CONSENSUS_TIMES, &[metric_label]);
         let timeout_mode = TimeoutMode::SlotTime {
-            instance_start_time: self.get_instant_in_slot(
-                slot,
-                Duration::from_secs(self.spec.seconds_per_slot) * 2 / 3,
-            )?,
+            instance_start_time: self
+                .get_instant_in_slot(slot, self.spec.get_slot_duration() * 2 / 3)?,
         };
 
         let completed = self
@@ -938,7 +937,7 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> AnchorValidator
             let timeout_mode = TimeoutMode::SlotTime {
                 instance_start_time: self.get_instant_in_slot(
                     message.aggregate().data().slot,
-                    Duration::from_secs(self.spec.seconds_per_slot) * 2 / 3,
+                    self.spec.get_slot_duration() * 2 / 3,
                 )?,
             };
 
@@ -1088,10 +1087,8 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> AnchorValidator
                 &[metrics::SYNC_CONTRIBUTION_AND_PROOF],
             );
             let timeout_mode = TimeoutMode::SlotTime {
-                instance_start_time: self.get_instant_in_slot(
-                    slot,
-                    Duration::from_secs(self.spec.seconds_per_slot) * 2 / 3,
-                )?,
+                instance_start_time: self
+                    .get_instant_in_slot(slot, self.spec.get_slot_duration() * 2 / 3)?,
             };
 
             let completed = self
@@ -1372,7 +1369,7 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> AnchorValidator
         let timer = metrics::start_timer_vec(&metrics::CONSENSUS_TIMES, &[metrics::BEACON_VOTE]);
         let timeout_mode = TimeoutMode::SlotTime {
             instance_start_time: self
-                .get_instant_in_slot(slot, Duration::from_secs(self.spec.seconds_per_slot) / 3)?,
+                .get_instant_in_slot(slot, self.spec.get_slot_duration() / 3)?,
         };
 
         let completed = self
@@ -1483,7 +1480,7 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> AnchorValidator
         let timer = metrics::start_timer_vec(&metrics::CONSENSUS_TIMES, &[metrics::BEACON_VOTE]);
         let timeout_mode = TimeoutMode::SlotTime {
             instance_start_time: self
-                .get_instant_in_slot(slot, Duration::from_secs(self.spec.seconds_per_slot) / 3)?,
+                .get_instant_in_slot(slot, self.spec.get_slot_duration() / 3)?,
         };
 
         let completed = self
@@ -2620,7 +2617,7 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> ValidatorStore
 
             // Stop at two thirds of the slot. If the selection proof is not ready by then, we
             // will not produce an aggregation anyway.
-            let delay = Duration::from_secs(self.spec.seconds_per_slot) * 2 / 3;
+            let delay = self.spec.get_slot_duration() * 2 / 3;
 
             let signature = if self.fork_schedule.active_fork(epoch) >= Fork::Boole {
                 let committee_id = cluster.committee_id();
@@ -2730,7 +2727,7 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> ValidatorStore
 
             // Stop at two thirds of the slot. If the selection proof is not ready by then, we
             // will not produce an aggregation anyway.
-            let delay = Duration::from_secs(self.spec.seconds_per_slot) * 2 / 3;
+            let delay = self.spec.get_slot_duration() * 2 / 3;
 
             let signature = if self.fork_schedule.active_fork(epoch) >= Fork::Boole {
                 // Under Boole, sync selection proofs use the same committee path as attestation
@@ -3043,6 +3040,24 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> ValidatorStore
         _envelope: ExecutionPayloadEnvelope<E>,
     ) -> Result<SignedExecutionPayloadEnvelope<E>, Error> {
         Err(Error::SpecificError(SpecificError::Unsupported))
+    }
+
+    async fn sign_payload_attestation(
+        &self,
+        _validator_pubkey: PublicKeyBytes,
+        _data: PayloadAttestationData,
+    ) -> Result<PayloadAttestationMessage, Error> {
+        // TODO(cstar)
+        todo!("sign_payload_attestation pending Gloas integration")
+    }
+
+    async fn sign_proposer_preferences(
+        &self,
+        _validator_pubkey: PublicKeyBytes,
+        _preferences: ProposerPreferences,
+    ) -> Result<SignedProposerPreferences, Error> {
+        // TODO(cstar)
+        todo!("sign_proposer_preferences pending Gloas integration")
     }
 }
 

--- a/anchor/validator_store/src/lib.rs
+++ b/anchor/validator_store/src/lib.rs
@@ -3039,6 +3039,7 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> ValidatorStore
         _validator_pubkey: PublicKeyBytes,
         _envelope: ExecutionPayloadEnvelope<E>,
     ) -> Result<SignedExecutionPayloadEnvelope<E>, Error> {
+        // TODO(cstar)
         Err(Error::SpecificError(SpecificError::Unsupported))
     }
 
@@ -3048,7 +3049,7 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> ValidatorStore
         _data: PayloadAttestationData,
     ) -> Result<PayloadAttestationMessage, Error> {
         // TODO(cstar)
-        todo!("sign_payload_attestation pending Gloas integration")
+        Err(Error::SpecificError(SpecificError::Unsupported))
     }
 
     async fn sign_proposer_preferences(
@@ -3057,7 +3058,7 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> ValidatorStore
         _preferences: ProposerPreferences,
     ) -> Result<SignedProposerPreferences, Error> {
         // TODO(cstar)
-        todo!("sign_proposer_preferences pending Gloas integration")
+        Err(Error::SpecificError(SpecificError::Unsupported))
     }
 }
 

--- a/anchor/validator_store/src/metadata_service.rs
+++ b/anchor/validator_store/src/metadata_service.rs
@@ -156,7 +156,7 @@ impl<E: EthSpec, T: SlotClock + 'static> MetadataService<E, T> {
     }
 
     pub fn start_update_service(self) -> Result<(), String> {
-        let slot_duration = Duration::from_secs(self.spec.seconds_per_slot);
+        let slot_duration = self.spec.get_slot_duration();
         let duration_to_next_slot = self
             .slot_clock
             .duration_to_next_slot()

--- a/anchor/validator_store/src/registration_service.rs
+++ b/anchor/validator_store/src/registration_service.rs
@@ -19,7 +19,7 @@ use bls::PublicKeyBytes;
 use futures::future::join_all;
 use slot_clock::SlotClock;
 use task_executor::TaskExecutor;
-use tokio::time::{Duration, sleep};
+use tokio::time::sleep;
 use tracing::{debug, error, info, warn};
 use types::{ChainSpec, EthSpec, SignedValidatorRegistrationData, Slot, ValidatorRegistrationData};
 use validator_store::{DoppelgangerStatus, ValidatorStore};
@@ -61,7 +61,7 @@ impl<S: ValidatorStore + 'static, T: SlotClock + 'static> RegistrationService<S,
         info!("Validator registration service started");
 
         let spec = spec.clone();
-        let slot_duration = Duration::from_secs(spec.seconds_per_slot);
+        let slot_duration = spec.get_slot_duration();
 
         let executor = self.inner.executor.clone();
 


### PR DESCRIPTION
## Problem, Evidence, and Context

The `epbs` branch needs a Lighthouse pin that includes the Gloas/ePBS validator-client surface. Anchor's current pin (`4b3a9d3`, 2026-03-12) predates that work. This PR bumps the pin so the rest of the ePBS integration can build on it.

## Change Overview

Bump every Lighthouse `rev` in workspace `Cargo.toml` from `4b3a9d3` to `1a6863118` (`unstable` HEAD, 2026-05-13). Two new `ValidatorStore` trait methods (`sign_payload_attestation`, `sign_proposer_preferences`) added as `TODO(cstar)` `Err(Error::SpecificError(SpecificError::Unsupported))` stubs on `AnchorValidatorStore`. Remaining changes are mechanical adaptations to upstream API drift: `ChainSpec.seconds_per_slot` is now private (switch to `get_slot_duration()`), `eth2::Timeouts` has two new fields, and `types::test_utils::TestRandom` was removed (one test helper rewritten).

No behavior change under `Fork::Alan` or `Fork::Boole`.

## Risks, Trade-offs, and Mitigations

The stubs panic if invoked, but the upstream services that would call them are not spawned by Anchor yet. Follow-up CStar PRs wire them in.

## Validation

`cargo check`, `make cargo-fmt-check`, `make lint`, `make test` (530 passed), `make audit` (exit 0): all clean.

## Rollback

Revert the single commit.
