### PR TITLE
chore: add Fork::CStar variant

### DIFF
--- a/anchor/common/fork/src/fork.rs
+++ b/anchor/common/fork/src/fork.rs
@@ -33,12 +33,19 @@ pub enum Fork {
     /// - Subnet topology: `min(SHA256(operator_id)) % 128`
     /// - Topic format: `/ssv/<network>/boole/<subnet>`
     Boole,
+
+    /// The CStar fork, the SSV-side rollout of Ethereum's Gloas (ePBS) features.
+    ///
+    /// Characteristics:
+    /// - Subnet topology: inherits Boole behavior (no subnet change at this fork).
+    /// - Topic format: `/ssv/<network>/cstar/<subnet>`
+    CStar,
 }
 
 impl Fork {
     /// Returns all known forks in chronological order.
     pub const fn all() -> &'static [Fork] {
-        &[Fork::Alan, Fork::Boole]
+        &[Fork::Alan, Fork::Boole, Fork::CStar]
     }
 
     /// Returns the name of this fork as a string.
@@ -46,6 +53,7 @@ impl Fork {
         match self {
             Fork::Alan => "alan",
             Fork::Boole => "boole",
+            Fork::CStar => "cstar",
         }
     }
 
@@ -74,6 +82,7 @@ impl std::str::FromStr for Fork {
         match s.to_lowercase().as_str() {
             "alan" => Ok(Fork::Alan),
             "boole" => Ok(Fork::Boole),
+            "cstar" => Ok(Fork::CStar),
             _ => Err(format!("Unknown fork: {s}")),
         }
     }
@@ -86,18 +95,21 @@ mod tests {
     #[test]
     fn test_fork_ordering() {
         assert!(Fork::Alan < Fork::Boole);
+        assert!(Fork::Boole < Fork::CStar);
     }
 
     #[test]
     fn test_fork_names() {
         assert_eq!(Fork::Alan.name(), "alan");
         assert_eq!(Fork::Boole.name(), "boole");
+        assert_eq!(Fork::CStar.name(), "cstar");
     }
 
     #[test]
     fn test_fork_display() {
         assert_eq!(format!("{}", Fork::Alan), "alan");
         assert_eq!(format!("{}", Fork::Boole), "boole");
+        assert_eq!(format!("{}", Fork::CStar), "cstar");
     }
 
     #[test]
@@ -105,14 +117,26 @@ mod tests {
         assert_eq!("alan".parse::<Fork>().unwrap(), Fork::Alan);
         assert_eq!("Boole".parse::<Fork>().unwrap(), Fork::Boole);
         assert_eq!("ALAN".parse::<Fork>().unwrap(), Fork::Alan);
+        assert_eq!("cstar".parse::<Fork>().unwrap(), Fork::CStar);
+        assert_eq!("CSTAR".parse::<Fork>().unwrap(), Fork::CStar);
         assert!("unknown".parse::<Fork>().is_err());
     }
 
     #[test]
     fn test_all_forks() {
         let all = Fork::all();
-        assert_eq!(all.len(), 2);
+        assert_eq!(all.len(), 3);
         assert_eq!(all[0], Fork::Alan);
         assert_eq!(all[1], Fork::Boole);
+        assert_eq!(all[2], Fork::CStar);
+    }
+
+    #[test]
+    fn test_cstar_topic_prefix() {
+        let prefix = Fork::CStar.topic_prefix("mainnet");
+        assert_eq!(prefix, "/ssv/mainnet/cstar/");
+
+        let prefix_holesky = Fork::CStar.topic_prefix("holesky");
+        assert_eq!(prefix_holesky, "/ssv/holesky/cstar/");
     }
 }

--- a/anchor/common/fork/src/lib.rs
+++ b/anchor/common/fork/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //! This crate provides types and utilities for managing SSV protocol forks:
 //!
-//! - [`Fork`]: Enum representing SSV protocol versions (Alan, Boole)
+//! - [`Fork`]: Enum representing SSV protocol versions (Alan, Boole, CStar)
 //! - [`ForkSchedule`]: Manages fork activation epochs and transition timing
 //! - [`ForkConfig`]: Complete configuration for a fork including topic prefix
 //! - [`ForkLifecycle`]: Fork lifecycle state distributed via `tokio::sync::watch`

--- a/anchor/common/fork/src/schedule.rs
+++ b/anchor/common/fork/src/schedule.rs
@@ -228,6 +228,7 @@ mod tests {
     const TEST_NETWORK: &str = "mainnet";
     const BASELINE_DOMAIN: DomainType = DomainType([0, 0, 0, 1]);
     const BOOLE_DOMAIN: DomainType = DomainType([0, 0, 0, 2]);
+    const CSTAR_DOMAIN: DomainType = DomainType([0, 0, 0, 3]);
 
     fn schedule_with_boole(epoch: u64) -> ForkSchedule {
         let mut configs = BTreeMap::new();
@@ -316,6 +317,23 @@ mod tests {
         assert_eq!(schedule.fork_epoch(Fork::Boole), Some(Epoch::new(100)));
         assert_eq!(schedule.domain_type(Fork::Alan), Some(BASELINE_DOMAIN));
         assert_eq!(schedule.domain_type(Fork::Boole), Some(BOOLE_DOMAIN));
+    }
+
+    #[test]
+    fn test_with_three_forks() {
+        let mut configs = BTreeMap::new();
+        configs.insert(Fork::Alan, (Epoch::new(0), BASELINE_DOMAIN));
+        configs.insert(Fork::Boole, (Epoch::new(100), BOOLE_DOMAIN));
+        configs.insert(Fork::CStar, (Epoch::new(200), CSTAR_DOMAIN));
+
+        let schedule = ForkSchedule::from_fork_configs(configs, TEST_NETWORK).unwrap();
+
+        assert_eq!(schedule.active_fork(Epoch::new(199)), Fork::Boole);
+        assert_eq!(schedule.active_fork(Epoch::new(200)), Fork::CStar);
+        assert_eq!(schedule.active_fork(Epoch::new(1000)), Fork::CStar);
+
+        assert_eq!(schedule.fork_epoch(Fork::CStar), Some(Epoch::new(200)));
+        assert_eq!(schedule.domain_type(Fork::CStar), Some(CSTAR_DOMAIN));
     }
 
     #[test]

--- a/anchor/common/ssv_network_config/src/lib.rs
+++ b/anchor/common/ssv_network_config/src/lib.rs
@@ -221,24 +221,29 @@ mod tests {
     const TEST_DOMAIN_TYPE_STR: &str = "00000001";
     const TEST_DOMAIN_TYPE: DomainType = DomainType([0, 0, 0, 1]);
     const BOOLE_DOMAIN_TYPE: DomainType = DomainType([0, 0, 0, 2]);
+    const CSTAR_DOMAIN_TYPE: DomainType = DomainType([0, 0, 0, 3]);
 
-    // Epoch constants for fork schedule tests
-    const ALAN_EPOCH: u64 = 0;
-    const BEFORE_BOOLE_EPOCH: u64 = 99;
+    // Fork activation epochs for tests. Scenario epochs (just before / just after
+    // activation) are derived inline at the use site.
+    const ALAN_FORK_EPOCH: u64 = 0;
     const BOOLE_FORK_EPOCH: u64 = 100;
-    const AFTER_BOOLE_EPOCH: u64 = 1000;
-    const LARGE_BOOLE_EPOCH: u64 = 12500;
+    const CSTAR_FORK_EPOCH: u64 = 200;
 
     /// Construct expected Boole topic prefix for a network.
     fn expected_boole_prefix(network: &str) -> String {
         format!("/ssv/{}/boole/", network)
     }
 
+    /// Construct expected CStar topic prefix for a network.
+    fn expected_cstar_prefix(network: &str) -> String {
+        format!("/ssv/{}/cstar/", network)
+    }
+
     /// Asserts that a config has a valid fork schedule with Alan at epoch 0.
     fn assert_valid_fork_schedule(config: &SsvNetworkConfig) {
         assert_eq!(
             config.fork_schedule.fork_epoch(Fork::Alan),
-            Some(Epoch::new(ALAN_EPOCH)),
+            Some(Epoch::new(ALAN_FORK_EPOCH)),
             "Alan must always be at epoch 0"
         );
     }
@@ -326,22 +331,29 @@ mod tests {
 boole:
   epoch: {}
   domain_type: "00000002"
+cstar:
+  epoch: {}
+  domain_type: "00000003"
 "#,
-            LARGE_BOOLE_EPOCH
+            BOOLE_FORK_EPOCH, CSTAR_FORK_EPOCH
         );
         let dir = create_test_config_dir(Some(&yaml));
 
         // Act
         let config = SsvNetworkConfig::load(dir.path().to_path_buf()).unwrap();
 
-        // Assert - fork schedule contains both epochs and domain types
+        // Assert - fork schedule contains every fork's epoch and domain type
         assert_eq!(
             config.fork_schedule.fork_epoch(Fork::Alan),
-            Some(Epoch::new(ALAN_EPOCH))
+            Some(Epoch::new(ALAN_FORK_EPOCH))
         );
         assert_eq!(
             config.fork_schedule.fork_epoch(Fork::Boole),
-            Some(Epoch::new(LARGE_BOOLE_EPOCH))
+            Some(Epoch::new(BOOLE_FORK_EPOCH))
+        );
+        assert_eq!(
+            config.fork_schedule.fork_epoch(Fork::CStar),
+            Some(Epoch::new(CSTAR_FORK_EPOCH))
         );
         assert_eq!(
             config.fork_schedule.domain_type(Fork::Alan),
@@ -350,6 +362,10 @@ boole:
         assert_eq!(
             config.fork_schedule.domain_type(Fork::Boole),
             Some(BOOLE_DOMAIN_TYPE)
+        );
+        assert_eq!(
+            config.fork_schedule.domain_type(Fork::CStar),
+            Some(CSTAR_DOMAIN_TYPE)
         );
     }
 
@@ -364,7 +380,7 @@ boole:
         // Assert
         assert_eq!(
             config.fork_schedule.fork_epoch(Fork::Alan),
-            Some(Epoch::new(ALAN_EPOCH))
+            Some(Epoch::new(ALAN_FORK_EPOCH))
         );
         assert_eq!(config.fork_schedule.fork_epoch(Fork::Boole), None);
         assert_eq!(
@@ -384,7 +400,7 @@ boole:
         // Assert
         assert_eq!(
             config.fork_schedule.fork_epoch(Fork::Alan),
-            Some(Epoch::new(ALAN_EPOCH))
+            Some(Epoch::new(ALAN_FORK_EPOCH))
         );
         assert_eq!(config.fork_schedule.fork_epoch(Fork::Boole), None);
     }
@@ -483,23 +499,28 @@ boole:
 boole:
   epoch: {}
   domain_type: "00000002"
+cstar:
+  epoch: {}
+  domain_type: "00000003"
 "#,
-            BOOLE_FORK_EPOCH
+            BOOLE_FORK_EPOCH, CSTAR_FORK_EPOCH
         );
         let dir = create_test_config_dir(Some(&yaml));
         let config = SsvNetworkConfig::load(dir.path().to_path_buf()).unwrap();
         let network_name = config.network_name.as_str();
 
         // Act & Assert: Before Boole activation - should use Alan prefix
-        let active_fork = config.fork_schedule.active_fork(Epoch::new(ALAN_EPOCH));
+        let active_fork = config
+            .fork_schedule
+            .active_fork(Epoch::new(ALAN_FORK_EPOCH));
         assert_eq!(active_fork.topic_prefix(network_name), ALAN_TOPIC_PREFIX);
 
         let active_fork = config
             .fork_schedule
-            .active_fork(Epoch::new(BEFORE_BOOLE_EPOCH));
+            .active_fork(Epoch::new(BOOLE_FORK_EPOCH - 1));
         assert_eq!(active_fork.topic_prefix(network_name), ALAN_TOPIC_PREFIX);
 
-        // Act & Assert: At and after Boole activation - should use Boole prefix
+        // Act & Assert: Between Boole and CStar activation - should use Boole prefix
         let active_fork = config
             .fork_schedule
             .active_fork(Epoch::new(BOOLE_FORK_EPOCH));
@@ -510,10 +531,27 @@ boole:
 
         let active_fork = config
             .fork_schedule
-            .active_fork(Epoch::new(AFTER_BOOLE_EPOCH));
+            .active_fork(Epoch::new(CSTAR_FORK_EPOCH - 1));
         assert_eq!(
             active_fork.topic_prefix(network_name),
             expected_boole_prefix(TEST_NETWORK_NAME)
+        );
+
+        // Act & Assert: At and after CStar activation - should use CStar prefix
+        let active_fork = config
+            .fork_schedule
+            .active_fork(Epoch::new(CSTAR_FORK_EPOCH));
+        assert_eq!(
+            active_fork.topic_prefix(network_name),
+            expected_cstar_prefix(TEST_NETWORK_NAME)
+        );
+
+        let active_fork = config
+            .fork_schedule
+            .active_fork(Epoch::new(CSTAR_FORK_EPOCH + 1));
+        assert_eq!(
+            active_fork.topic_prefix(network_name),
+            expected_cstar_prefix(TEST_NETWORK_NAME)
         );
     }
 

--- a/anchor/subnet_service/src/service.rs
+++ b/anchor/subnet_service/src/service.rs
@@ -102,8 +102,10 @@ impl<S: SlotClock> SubnetService<S> {
 
         match fork {
             Fork::Alan => Ok(SubnetId::from_committee_alan(committee_id, SUBNET_COUNT)),
-            Fork::Boole => SubnetId::from_operators(operator_ids, crate::SUBNET_COUNT_NZ)
-                .map_err(SubnetServiceError::SubnetCalculation),
+            Fork::Boole | Fork::CStar => {
+                SubnetId::from_operators(operator_ids, crate::SUBNET_COUNT_NZ)
+                    .map_err(SubnetServiceError::SubnetCalculation)
+            }
         }
     }
 

--- a/anchor/subnet_service/src/subnet.rs
+++ b/anchor/subnet_service/src/subnet.rs
@@ -118,7 +118,9 @@ impl SubnetId {
                 committee_id,
                 crate::SUBNET_COUNT,
             )),
-            Fork::Boole => SubnetId::from_operators(operator_ids, crate::SUBNET_COUNT_NZ),
+            Fork::Boole | Fork::CStar => {
+                SubnetId::from_operators(operator_ids, crate::SUBNET_COUNT_NZ)
+            }
         }
     }
 }


### PR DESCRIPTION
## Problem, Evidence, and Context

The `epbs` branch needs a CStar SSV fork variant so subsequent CStar-gated work (slot timing, fork transition handling, message validation tweaks) has a fork name, topic prefix, and exhaustive-match anchor point to attach to.

CStar is the SSV-side rollout of Ethereum's Gloas (ePBS) fork. At this fork the network topology does not change; only the topic string changes (`/ssv/<network>/boole/` becomes `/ssv/<network>/cstar/`). All Gloas-specific signing and validation logic lands in follow-up PRs.

## Change Overview

Adds `Fork::CStar` as a third variant alongside `Alan` and `Boole`, with name `"cstar"`, topic prefix `/ssv/<network>/cstar/`, and ordering `Alan < Boole < CStar`. Extends `Fork::all()`, `Fork::name()`, `FromStr`, and the parser path in `ssv_network_config`. Adds `Fork::CStar` to the two exhaustive match arms in `subnet_service` (grouped with `Boole` since subnet topology is unchanged).

Test surface: existing 2-fork tests extended to 3 forks where they exercise enum coverage or schedule resolution; one new test in `schedule.rs` for 3-fork schedule construction; the boundary test in `ssv_network_config` now walks Alan → Boole → CStar transitions.

**Reading order:** `anchor/common/fork/src/fork.rs` (enum + name/parse/ordering), then `anchor/subnet_service/src/{service,subnet}.rs` (match arms), then tests in `schedule.rs` and `ssv_network_config/src/lib.rs`.

**What did NOT change:** no behavior under `Fork::Alan` or `Fork::Boole`. No `ValidatorStore` changes. No production YAML schedule entries (`built_in_network_configs/*/ssv_fork_schedule.yaml`); those land in M0.2.

## Risks, Trade-offs, and Mitigations

Additive enum variant with behavioral parity to Boole at this fork. Risk is minimal: the only runtime effect is that `Fork::CStar` is now parseable, orderable, and produces its own topic prefix string. No code path yet activates CStar in any schedule.

## Validation

- `cargo check --workspace`: clean.
- `make cargo-fmt-check`: clean.
- `make lint`: clean.
- `cargo test -p fork -p ssv_network_config -p subnet_service`: 103 tests pass (35 + 14 + 54).

## Rollback

Revert the single commit. No config, schema, or operational impact.

## Blockers / Dependencies

Builds on #1013 (LH bump, already merged to `epbs`). Blocks downstream CStar-gated work (slot timing migration, M0.2 production schedule entries, M1-M5 fork-aware behavior changes).