### PR TITLE
docs: updates machine-generated docs with anchor-docgen format

### DIFF
--- a/docs/docs/generated/cli-global-options.mdx
+++ b/docs/docs/generated/cli-global-options.mdx
@@ -1,8 +1,39 @@
-| Option | Description | Default               |
-| --- | --- |-----------------------|
-| `-d, --data-dir <DIR>` | Data directory for node files | `~/.anchor/{network}` |
-| `-t, --testnet-dir <DIR>` | Directory containing testnet specs | None                  |
-| `--network <NETWORK>` | Network to use (mainnet, holesky, hoodi) | `mainnet`               |
-| `--debug-level <DEBUG_LEVEL>` | Verbosity level for terminal logs | `INFO` |
-| `-h, --help` | Display help information | Unset                 |
-| `-V, --version` | Print version information | Unset |
+```text
+SSV Validator client. Maintained by Sigma Prime.
+
+Usage: anchor [OPTIONS] <COMMAND>
+
+Commands:
+    node      Start Anchor node
+    keysplit  SSV Keysplitting Tool
+    keygen    RSA key generation tool. Outputs key to data directory.
+    help      Print this message or the help of the given subcommand(s)
+
+Options:
+    -d, --data-dir <DIR>
+               Used to specify a custom root data directory for the Anchor key
+               and database. Defaults to $HOME/.anchor/{network} where network
+               is the value of the `network` flag Note: Users should specify
+               separate custom datadirs for different networks.
+
+         --network <NETWORK>
+               Name of the chain Anchor will validate.
+               
+               [default: mainnet]
+               [possible values: mainnet, holesky, hoodi]
+
+    -t, --testnet-dir <DIR>
+               Path to directory containing eth2_testnet specs.
+
+         --debug-level <DEBUG_LEVEL>
+               Specifies the verbosity level used when emitting logs to the
+               terminal
+               
+               [default: INFO]
+
+    -h, --help
+               Print help
+
+    -V, --version
+               Print version
+```

--- a/docs/docs/generated/cli-keygen-options.mdx
+++ b/docs/docs/generated/cli-keygen-options.mdx
@@ -1,10 +1,51 @@
-| Option | Description | Default |
-| --- | --- | ---|
-| `-d, --data-dir <DIR>` | Directory to store generated keys | `~/.anchor/{network}` |
-| `--force` | Force overwrite of existing key files | Disabled |
-| `--encrypt` | Enable password encryption (password read from terminal or `--password-file`) | Disabled |
-| `--password-file <PATH>` | Path to a file containing the password to use | None |
-| `--network <NETWORK>` | Network to use (mainnet, holesky, hoodi) | `hoodi` |
-| `-t, --testnet-dir <DIR>` | Directory containing testnet specs | None |
-| `--debug-level <DEBUG_LEVEL>` | Verbosity level for terminal logs | `INFO` |
-| `-h, --help` | Display help information | |
+```text
+RSA key generation tool. Outputs key to data directory.
+
+Usage: anchor keygen [OPTIONS]
+
+Options:
+    -d, --data-dir <DIR>
+               Used to specify a custom root data directory for the Anchor key
+               and database. Defaults to $HOME/.anchor/{network} where network
+               is the value of the `network` flag Note: Users should specify
+               separate custom datadirs for different networks.
+
+         --force
+               Force file overwrite
+
+         --network <NETWORK>
+               Name of the chain Anchor will validate.
+               
+               [default: mainnet]
+               [possible values: mainnet, holesky, hoodi]
+
+    -t, --testnet-dir <DIR>
+               Path to directory containing eth2_testnet specs.
+
+         --encrypt
+               Enable password encryption. Password is read from terminal or
+               via --password-file
+
+         --password-file <PATH>
+               Path to a file containing the password to use for the new key
+               file
+
+         --debug-level <DEBUG_LEVEL>
+               Specifies the verbosity level used when emitting logs to the
+               terminal
+               
+               [default: INFO]
+
+         --use-existing <PATH>
+               Path to an existing key file to use instead of generating a new
+               one. If encrypted, the password is read from terminal or via
+               --password-file-for-existing. The existing file is NOT
+               automatically removed.
+
+         --password-file-for-existing <PATH>
+               Path to a file containing the password to use for the EXISTING
+               key file
+
+    -h, --help
+               Print help
+```

--- a/docs/docs/generated/cli-keysplit-options.mdx
+++ b/docs/docs/generated/cli-keysplit-options.mdx
@@ -1,37 +1,149 @@
-| Option | Description | Default |
-| --- | --- | ---|
-| `--keystore-path <PATH>` | Path to validator keystore file | Required |
-| `--password-file <PATH>` | Path to a file containing the password for the validator keystore (if omitted, password will be prompted) | None |
-| `--owner <ADDRESS>` | EOA address that owns the validator | Required |
-| `--output-path <OUTPUT PATH>` | Path for output file | Required |
-| `--operators <IDS>` | Comma-separated list of operator IDs | Required|
-| `-d, --data-dir <DIR>` | Data directory for node files | `~/.anchor/{network}` |
-| `--network <NETWORK>` | Network to use (mainnet, holesky, hoodi) | `hoodi` |
-| `-t, --testnet-dir <DIR>` | Directory containing testnet specs | None |
-| `--debug-level <DEBUG_LEVEL>` | Verbosity level for terminal logs | `INFO` |
-| `-h, --help` | Display help information | |
+```text
+SSV Keysplitting Tool
 
-### Manual Keysplit Subcommand
+Usage: anchor keysplit [OPTIONS] <COMMAND>
 
-```bash
-anchor keysplit manual [OPTIONS]
+Commands:
+    onchain  Utilize onchain data to split the key
+    manual   Split the key by manually providing data
+    help     Print this message or the help of the given subcommand(s)
+
+Options:
+    -d, --data-dir <DIR>
+               Used to specify a custom root data directory for the Anchor key
+               and database. Defaults to $HOME/.anchor/{network} where network
+               is the value of the `network` flag Note: Users should specify
+               separate custom datadirs for different networks.
+
+         --network <NETWORK>
+               Name of the chain Anchor will validate.
+               
+               [default: mainnet]
+               [possible values: mainnet, holesky, hoodi]
+
+    -t, --testnet-dir <DIR>
+               Path to directory containing eth2_testnet specs.
+
+         --debug-level <DEBUG_LEVEL>
+               Specifies the verbosity level used when emitting logs to the
+               terminal
+               
+               [default: INFO]
+
+    -h, --help
+               Print help
+
+onchain:
+
+Utilize onchain data to split the key
+
+Usage: anchor keysplit onchain [OPTIONS] --owner <ADDRESS> --output-path <OUTPUT PATH> --operators <IDS> --rpc <ENDPOINT>
+
+Options:
+    -d, --data-dir <DIR>
+               Used to specify a custom root data directory for the Anchor key
+               and database. Defaults to $HOME/.anchor/{network} where network
+               is the value of the `network` flag Note: Users should specify
+               separate custom datadirs for different networks.
+
+         --keystore-paths <PATH>...
+               Path(s) to the validator keystore file
+
+         --network <NETWORK>
+               Name of the chain Anchor will validate.
+               
+               [default: mainnet]
+               [possible values: mainnet, holesky, hoodi]
+
+    -t, --testnet-dir <DIR>
+               Path to directory containing eth2_testnet specs.
+
+         --password-file <PATH>
+               Path to a file containing the password for the validator
+               keystore. If omitted, the password will be prompted for.
+
+         --owner <ADDRESS>
+               EOA address that owns the validator
+
+         --debug-level <DEBUG_LEVEL>
+               Specifies the verbosity level used when emitting logs to the
+               terminal
+               
+               [default: INFO]
+
+         --output-path <OUTPUT PATH>
+               Path for output
+
+         --operators <IDS>
+               Operators to split key among
+
+         --rpc <ENDPOINT>
+               RPC endpoint to access L1 data
+
+    -h, --help
+               Print help
+
+manual:
+
+Split the key by manually providing data
+
+Usage: anchor keysplit manual [OPTIONS] --owner <ADDRESS> --output-path <OUTPUT PATH> --operators <IDS> --nonce <NONCE> --public-keys <KEYS>...
+
+Options:
+    -d, --data-dir <DIR>
+               Used to specify a custom root data directory for the Anchor key
+               and database. Defaults to $HOME/.anchor/{network} where network
+               is the value of the `network` flag Note: Users should specify
+               separate custom datadirs for different networks.
+
+         --keystore-paths <PATH>...
+               Path(s) to the validator keystore file
+
+         --network <NETWORK>
+               Name of the chain Anchor will validate.
+               
+               [default: mainnet]
+               [possible values: mainnet, holesky, hoodi]
+
+    -t, --testnet-dir <DIR>
+               Path to directory containing eth2_testnet specs.
+
+         --password-file <PATH>
+               Path to a file containing the password for the validator
+               keystore. If omitted, the password will be prompted for.
+
+         --owner <ADDRESS>
+               EOA address that owns the validator
+
+         --debug-level <DEBUG_LEVEL>
+               Specifies the verbosity level used when emitting logs to the
+               terminal
+               
+               [default: INFO]
+
+         --output-path <OUTPUT PATH>
+               Path for output
+
+         --operators <IDS>
+               Operators to split key among
+
+         --nonce <NONCE>
+               Nonce for the owner address
+
+         --public-keys <KEYS>...
+               RSA public keys for the operators
+
+    -h, --help
+               Print help
+
+help:
+
+Print this message or the help of the given subcommand(s)
+
+Usage: anchor keysplit help [COMMAND]
+
+Commands:
+    onchain  Utilize onchain data to split the key
+    manual   Split the key by manually providing data
+    help     Print this message or the help of the given subcommand(s)
 ```
-
-Additional Options:
-
-| Option | Description | Default |
-| --- | --- | ---|
-| `--nonce <NONCE>` | Nonce for the owner address | Required |
-| `--public-keys <KEYS>...` | RSA public keys for the operators | Required|
-
-### Onchain Keysplit Subcommand
-
-```bash
-anchor keysplit onchain [OPTIONS]
-```
-
-Additional Options:
-
-| Option | Description | Default |
-| --- | --- | ---|
-| `--rpc <ENDPOINT>` | RPC endpoint to access L1 data | Required|

--- a/docs/docs/generated/cli-node-options.mdx
+++ b/docs/docs/generated/cli-node-options.mdx
@@ -1,87 +1,361 @@
-#### External APIs
+```text
+Start Anchor node
 
-| Option | Description | Default |
-| --- | --- | ---|
-| `--beacon-nodes <NETWORK_ADDRESSES>` | Comma-separated beacon node HTTP URLs | `http://localhost:5052`|
-| `--execution-rpc <NETWORK_ADDRESSES>` | Comma-separated execution node RPC URLs | `http://localhost:8545` |
-| `--execution-ws <NETWORK_ADDRESSES>` | Execution node websocket URL | `ws://localhost:8546` |
-| `--beacon-nodes-tls-certs <CERTIFICATE-FILES>` | Comma-separated paths to custom TLS certificates for beacon nodes (PEM format) | None |
-| `--execution-nodes-tls-certs <CERTIFICATE-FILES>` | Comma-separated paths to custom TLS certificates for execution nodes (PEM format) | None |
+Usage: anchor node [OPTIONS]
 
-#### HTTP API
+Options:
+    -d, --data-dir <DIR>
+               Used to specify a custom root data directory for the Anchor key
+               and database. Defaults to $HOME/.anchor/{network} where network
+               is the value of the `network` flag Note: Users should specify
+               separate custom datadirs for different networks.
 
-| Option | Description | Default |
-| --- | --- | ---|
-| `--http` | Enable the HTTP API sever | Disabled |
-| `--http-address <ADDRESS>` | Listen address for HTTP API | None |
-| `--http-port <PORT>` | Listen port for HTTP API | `5062` if `--http` is set |
-| `--http-allow-origin <ORIGIN>` | Set CORS allowed origin | None |
-| `--unencrypted-http-transport` | Safety flag to acknowledge HTTP is unencrypted | Required if `--http-address` is set|
+         --network <NETWORK>
+               Name of the chain Anchor will validate.
+               
+               [default: mainnet]
+               [possible values: mainnet, holesky, hoodi]
 
-#### Metrics Options
+    -t, --testnet-dir <DIR>
+               Path to directory containing eth2_testnet specs.
 
-| Option | Description | Default |
-| --- | --- | ---|
-| `--metrics` | Enable metrics server | Disabled |
-| `--metrics-address <ADDRESS>` | Listen address for metrics server | `127.0.0.1` if `--metrics` is set |
-| `--metrics-port <PORT>` | Listen port for metrics server | `5164` if `--metrics` is set |
+         --debug-level <DEBUG_LEVEL>
+               Specifies the verbosity level used when emitting logs to the
+               terminal
+               
+               [default: INFO]
 
-#### Network Options
+    -h, --help
+               Print help
 
-| Option | Description | Default |
-| --- | --- | ---|
-| `--listen-addresses [<ADDRESS>...]` | Network addresses to listen for UDP & TCP connections (can be set multiple times for IPv4 and IPv6) | `0.0.0.0` |
-| `--port <PORT>` | TCP/UDP ports for IPv4 (discovery and TCP will use this value, QUIC will use this + 1) | `12001` (discovery), `13001` (TCP) |
-| `--port6 <PORT>` | TCP/UDP ports for IPv6 when listening over both IPv4 and IPv6 (QUIC will use this + 1) | Same as `--port` |
-| `--discovery-port <PORT>` | UDP port for discovery | Same as `--port` if specified, otherwise `12001` |
-| `--discovery-port6 <PORT>` | UDP port for IPv6 discovery | Same as `--discovery-port` |
-| `--quic-port <PORT>` | UDP port for QUIC protocol | `--port` + 1 |
-| `--quic-port6 <PORT>` | UDP port for IPv6 QUIC protocol | `--port6` + 1 |
-| `--boot-nodes <BOOT_NODES>` | Comma-separated ENRs or Multiaddrs to bootstrap the network | None|
-| `--enr-address <ADDRESS>` | IPv4 address to broadcast in the node's ENR | None |
-| `--enr-address6 <ADDRESS>` | IPv6 address to broadcast in the node's ENR | None |
-| `--enr-udp-port <PORT>` | UDP port to advertise in the node's ENR | None |
-| `--enr-tcp-port <PORT>` | TCP port to advertise in the node's ENR | None |
-| `--enr-quic-port <PORT>` | QUIC port to advertise in the node's ENR | None |
-| `--enr-udp6-port <PORT>` | IPv6 UDP port to advertise in the node's ENR | None |
-| `--enr-tcp6-port <PORT>` | IPv6 TCP port to advertise in the node's ENR | None |
-| `--enr-quic6-port <PORT>` | IPv6 QUIC port to advertise in the node's ENR | None |
-| `--disable-enr-auto-update` | Disable discovery from automatically updating the ENR with external addresses | Disabled |
-| `--subscribe-all-subnets` | Subscribe to all subnets regardless of committee membership | Disabled|
+Security Options:
+         --key-file <PATH>
+               Path to the operator key file. File name needs to end in `.txt`
+               for unencrypted keys, or `.json` for encrypted keys. If not
+               provided, Anchor will look for the key in the data dir. If
+               provided and the file does not exist, Anchor will exit.
 
-#### Security Options
+         --password-file <PATH>
+               Path to the password used to decrypt the operator private key.
+               If not provided but required, Anchor will request the password
+               interactively.
 
-| Option | Description | Default |
-| --- | --- | ---|
-| `--key-file <PATH>` | Path to the operator key file (`.txt` for unencrypted, `.json` for encrypted) | Detected in data dir |
-| `--password-file <PATH>` | Path to a file containing the key password for decryption | None |
+External APIs:
+         --beacon-nodes <NETWORK_ADDRESSES>
+               Comma-separated addresses to one or more beacon node HTTP APIs.
+               
+               [default: http://localhost:5052/]
 
-#### Payload Building Options
+         --beacon-nodes-sync-tolerances <SYNC_TOLERANCES>
+               A comma-separated list of 3 values which sets the size of each
+               sync distance range when determining the health of each
+               connected beacon node. The first value determines the `Synced`
+               range. If a connected beacon node is synced to within this
+               number of slots it is considered 'Synced'. The second value
+               determines the `Small` sync distance range. This range starts
+               immediately after the `Synced` range. The third value determines
+               the `Medium` sync distance range. This range starts immediately
+               after the `Small` range. Any sync distance larger than the
+               `Medium` range is considered `Large`. For example, a value of
+               '8,8,48' would mean: Synced: 0..=8, Small: 9..=16, Medium:
+               17..=64, Large: 65..
+               
+               [default: 8,8,48]
 
-| Option | Description | Default |
-| --- | --- | ---|
-| `--builder-boost-factor <UINT64>` | Percentage multiplier to apply to builder's payload value | None |
-| `--prefer-builder-proposals` | Always prefer builder blocks regardless of payload value | Disabled |
-| `--gas-limit <INTEGER>` | Gas limit for all builder proposals for all validators | `36000000` |
+         --beacon-nodes-tls-certs <CERTIFICATE-FILES>
+               Comma-separated paths to custom TLS certificates to use when
+               connecting to a beacon node (and/or proposer node). These
+               certificates must be in PEM format and are used in addition to
+               the OS trust store. Commas must only be used as a delimiter, and
+               must not be part of the certificate path.
 
-#### Logging Options
+         --broadcast <API_TOPICS>
+               Comma-separated list of beacon API topics to broadcast to all
+               beacon nodes. Default (when flag is omitted) is to broadcast
+               subscriptions only.
+               
+               [possible values: none, attestations, blocks, subscriptions,
+               sync-committee]
 
-| Option | Description | Default |
-| --- | --- | ---|
-| `--debug-level <DEBUG_LEVEL>` | Verbosity for terminal logs | `INFO` |
-| `--logfile-debug-level <LOGFILE_DEBUG_LEVEL>` | Verbosity for file logs | `DEBUG` |
-| `--logfile-max-size <SIZE>` | Maximum size of each log file in MB (set to 0 to disable) | `50` |
-| `--logfile-max-number <NUMBER>` | Maximum number of log files to keep (set to 0 to disable) | `10` |
-| `--logfile-dir <DIR>` | Directory to store log files | Same as `--data-dir` |
-| `--logfile-compression` | Compress old log files | Disabled |
-| `--logfile-color` | Enable colors in logfile | Disabled |
-| `--discv5-log-level <DISCV5_LOG_LEVEL>` | Verbosity level for discv5 dependency log file | `DEBUG` |
-| `--libp2p-log-level <LIBP2P_LOG_LEVEL>` | Verbosity level for libp2p dependency log file | `DEBUG` |
+         --execution-nodes-tls-certs <CERTIFICATE-FILES>
+               Comma-separated paths to custom TLS certificates to use when
+               connecting to an execution node. These certificates must be in
+               PEM format and are used in addition to the OS trust store.
+               Commas must only be used as a delimiter, and must not be part of
+               the certificate path
 
-#### Additional Network and Performance Options
+         --execution-rpc <NETWORK_ADDRESSES>
+               Comma-separated addresses to one or more execution node JSON-RPC
+               APIs.
+               
+               [default: http://localhost:8545/]
 
-| Option | Description | Default |
-| --- | --- | ---|
-| `--disable-gossipsub-peer-scoring` | Disable gossipsub peer scoring | Enabled |
-| `--disable-latency-measurement-service` | Disable the latency measurement service | Enabled |
-| `--enable-high-validator-count-metrics` | Enable per validator metrics for > 64 validators | Auto-enabled for ≤ 64 validators |
+         --execution-ws <NETWORK_ADDRESSES>
+               Address of execution node WS API.
+               
+               [default: ws://localhost:8546/]
+
+HTTP API Options:
+         --http
+               Enable the RESTful HTTP API server. Disabled by default.
+
+         --http-address <ADDRESS>
+               Set the address for the HTTP address. The HTTP server is not
+               encrypted and therefore it is unsafe to publish on a public
+               network. When this flag is used, it additionally requires the
+               explicit use of the `--unencrypted-http-transport` flag to
+               ensure the user is aware of the risks involved. For access via
+               the Internet, users should apply transport-layer security like a
+               HTTPS reverse-proxy or SSH tunneling.
+
+         --http-allow-origin <ORIGIN>
+               Set the value of the Access-Control-Allow-Origin response HTTP
+               header. Use * to allow any origin (not recommended in
+               production). If no value is supplied, the CORS allowed origin is
+               set to the listen address of this server (e.g.,
+               http://localhost:5062).
+
+         --http-port <PORT>
+               Set the listen TCP port for the RESTful HTTP API server.
+               Defaults to 5062 if --http is set.
+
+         --unencrypted-http-transport
+               This is a safety flag to ensure that the user is aware that the
+               http transport is unencrypted and using a custom HTTP address is
+               unsafe.
+
+Metrics Options:
+         --enable-high-validator-count-metrics
+               Enable per validator metrics for > 64 validators. Note: This
+               flag is automatically enabled for < 65 validators. Enabling this
+               metric for higher validator counts will lead to higher volume of
+               prometheus metrics being collected.
+
+         --metrics
+               Enable the Prometheus metrics HTTP server. Disabled by default.
+
+         --metrics-address <ADDRESS>
+               Set the listen address for the Prometheus metrics HTTP server.
+               Defaults to 127.0.0.1 if --metrics is set.
+
+         --metrics-allow-origin <ORIGIN>
+               Set the value of the Access-Control-Allow-Origin response HTTP
+               header for the metrics server. Use * to allow any origin (not
+               recommended in production). If no value is supplied, the CORS
+               allowed origin is set to the listen address of this server
+               (e.g., http://localhost:5164).
+
+         --metrics-port <PORT>
+               Set the listen TCP port for the Prometheus metrics HTTP server.
+               Defaults to 5164 if --metrics is set.
+
+Network Options:
+         --boot-nodes <BOOT_NODES>
+               One or more comma-delimited ENRs or Multiaddrs to bootstrap the
+               p2p network
+
+         --disable-enr-auto-update
+               Discovery can automatically discover external addresses if the
+               node has correctly set up port forwards. It will automatically
+               update this nodes ENR with values it finds. This can have
+               undesired effects for complicated networks. Setting this flag
+               will disable discovery from updating the ENR from CLI set
+               values.
+
+         --disable-gossipsub-peer-scoring
+               Disables gossipsub peer scoring.
+
+         --enr-address <ADDRESS>
+               The IPv4 address to broadcast to other peers on how to reach
+               this node. Set this only if you are sure other nodes can connect
+               to your local node on this address. This will update the `ip4`
+               ENR field accordingly.
+
+         --enr-address6 <ADDRESS>
+               The IPv6 address to broadcast to other peers on how to reach
+               this node. Set this only if you are sure other nodes can connect
+               to your local node on this address. This will update the `ip6`
+               ENR field accordingly.
+
+         --enr-quic-port <PORT>
+               The quic UDP4 port that will be set on the local ENR. Set this
+               only if you are sure other nodes can connect to your local node
+               on this port over IPv4.
+
+         --enr-quic6-port <PORT>
+               The quic UDP6 port that will be set on the local ENR. Set this
+               only if you are sure other nodes can connect to your local node
+               on this port over IPv6.
+
+         --enr-tcp-port <PORT>
+               The TCP4 port of the local ENR. Set this only if you are sure
+               other nodes can connect to your local node on this port over
+               IPv4. The --port flag is used if this is not set.
+
+         --enr-tcp6-port <PORT>
+               The TCP6 port of the local ENR. Set this only if you are sure
+               other nodes can connect to your local node on this port over
+               IPv6. The --port6 flag is used if this is not set.
+
+         --enr-udp-port <PORT>
+               The UDP4 port of the local ENR. Set this only if you are sure
+               other nodes can connect to your local node on this port over
+               IPv4.
+
+         --enr-udp6-port <PORT>
+               The UDP6 port of the local ENR. Set this only if you are sure
+               other nodes can connect to your local node on this port over
+               IPv6.
+
+         --subscribe-all-subnets
+               Subscribe to all subnets, regardless of committee membership.
+
+         --listen-addresses [<ADDRESS>...]
+               The address anchor will listen for UDP and TCP connections. To
+               listen over IpV4 and IpV6 set this flag twice with the different
+               values.
+               Examples:
+               - --listen-addresses '0.0.0.0' will listen over IPv4.
+               - --listen-addresses '::' will listen over IPv6.
+               - --listen-addresses '0.0.0.0' --listen-addresses '::' will
+               listen over both IPv4 and IPv6. The order of the given addresses
+               is not relevant. However, multiple IPv4, or multiple IPv6
+               addresses will not be accepted.
+               
+               [default: 0.0.0.0]
+
+         --port <PORT>
+               The TCP/UDP ports to listen on. There are two UDP ports. The
+               discovery UDP and TCP port will be set to this value. The Quic
+               UDP port will be set to this value + 1. The discovery port can
+               be modified by the --discovery-port flag and the quic port can
+               be modified by the --quic-port flag. If listening over both IPv4
+               and IPv6 the --port flag will apply to the IPv4 address and
+               --port6 to the IPv6 address. If this flag is not set, the
+               default values will be 12001 for discovery and 13001 for TCP.
+
+         --port6 <PORT>
+               The TCP/UDP ports to listen on over IPv6 when listening over
+               both IPv4 and IPv6. The Quic UDP port will be set to this value
+               + 1.
+
+         --discovery-port <PORT>
+               The UDP port that discovery will listen on. Defaults to --port
+               if --port is explicitly specified, and `12001` otherwise.
+
+         --discovery-port6 <PORT>
+               The UDP port that discovery will listen on over IPv6 if
+               listening over both IPv4 and IPv6. Defaults to `discovery_port`
+
+         --quic-port <PORT>
+               The UDP port that quic will listen on. Defaults to `port` + 1
+
+         --quic-port6 <PORT>
+               The UDP port that quic will listen on over IPv6 if listening
+               over both IPv4 and IPv6. Defaults to `port6` + 1
+
+         --disable-upnp
+               Disables UPnP support. Setting this will prevent Anchor from
+               attempting to automatically establish external port mappings.
+
+         --target-peers <TARGET_PEERS>
+               Specify the target number of connected peers. If omitted, the
+               target is calculated dynamically based on active subnets (60
+               base + 3 per subnet, capped at 150)
+
+Payload Building Options:
+         --builder-boost-factor <UINT64>
+               Defines the boost factor, a percentage multiplier to apply to
+               the builder's payload value when choosing between a builder
+               payload header and payload from the local execution node.
+
+         --disable-latency-measurement-service
+               Disable the latency measurement service.
+
+         --gas-limit <INTEGER>
+               The gas limit to be used in all builder proposals for all
+               validators managed. Note this will not necessarily be used if
+               the gas limit set here moves too far from the previous block's
+               gas limit.
+               
+               [default: 36000000]
+
+         --operator-dg <OPERATOR_DG>
+               Enable operator doppelgänger protection. When enabled, the node
+               blocks all outgoing messages and monitors the network for
+               messages signed with its operator ID that reference slots after
+               startup. Shuts down if a twin operator is detected to prevent
+               QBFT protocol violations.
+               
+               [default: false]
+               [possible values: true, false]
+
+         --operator-dg-wait-epochs <EPOCHS>
+               Number of epochs to monitor for twin operators using slot-based
+               detection. During monitoring, outgoing messages remain blocked
+               and the node checks incoming messages for slots after startup to
+               detect duplicate operator instances.
+               
+               [default: 2]
+
+         --prefer-builder-proposals
+               If this flag is set, Anchor will always prefer blocks
+               constructed by builders, regardless of payload value.
+
+         --strict-mfp
+               Enable strict majority fork protection. When enabled, the node
+               will not participate in attestation production if the checkpoint
+               roots mismatch. Using this flag might reduce validator
+               performance if cluster operators have struggling nodes, but can
+               help to avoid finalization of a faulty majority fork.
+
+         --with-weighted-attestation-data
+               Enable parallel querying and scoring of attestation data across
+               multiple beacon nodes. When enabled, Anchor queries all
+               configured beacon nodes simultaneously and selects the
+               attestation data with the highest score based on checkpoint
+               epochs and head block proximity. Only useful with multiple
+               beacon nodes.
+
+Logging Options:
+         --logfile-debug-level <LOGFILE_DEBUG_LEVEL>
+               Specifies the verbosity level used when emitting logs to the log
+               file
+               
+               [default: DEBUG]
+
+         --logfile-max-size <SIZE>
+               Maximum size of each log file in MB. Set to 0 to disable file
+               logging.
+               
+               [default: 50]
+
+         --logfile-max-number <NUMBER>
+               Maximum number of log files to keep. Set to 0 to disable file
+               logging.
+               
+               [default: 10]
+
+         --logfile-dir <DIR>
+               Directory path where the log file will be stored
+
+         --logfile-compression
+               If present, compress old log files. This can help reduce the
+               space needed to store old logs.
+
+         --logfile-color
+               Enables colors in logfile.
+
+         --discv5-log-level <DISCV5_LOG_LEVEL>
+               Specifies the verbosity level used for the discv5 dependency log
+               file
+               
+               [default: DEBUG]
+
+         --libp2p-log-level <LIBP2P_LOG_LEVEL>
+               Specifies the verbosity level used for the libp2p dependency log
+               file. Certain score penalty information is logged regardless of
+               this setting.
+               
+               [default: DEBUG]
+```


### PR DESCRIPTION
## Problem, Evidence, and Context (Required)

This change updates the existing manually maintained Anchor CLI Reference documentation in `docs/docs/generated` to the machine generated outputs finalised in #939.

Updating the documentation was the logical next step after creating the `docgen` crate to align the documentation with the current CLI tree prior to implementing a CI/CD check (specified in #856) to ensure that documentation matches the application code going forward.

Follows on logically from PRs #901, #910, #939.

## Change Overview (Required)

Machine-generated CLI reference snippets in `docs/docs/generate` were all updated:

**Overview:**
<img width="833" height="1221" alt="image" src="https://github.com/user-attachments/assets/314f4072-1881-4ae7-ba02-134295afbebc" />

**Node:**
<img width="816" height="1127" alt="image" src="https://github.com/user-attachments/assets/3deeafa7-f227-45c3-9030-7ebc458beb5d" />

**Keysplit:**
<img width="846" height="1248" alt="image" src="https://github.com/user-attachments/assets/b6dbf75f-ede5-4112-998c-6461568a606c" />

**Keygen:**
<img width="846" height="1214" alt="image" src="https://github.com/user-attachments/assets/164d348e-3a1a-425a-a93a-39fff1569228" />

**What Didn't Change?**

Automatic updates occur to
- `docs/docs/pages/index.mdx`
- `docs/docs/pages/installation.mdx`
- `docs/vocs.config`

when the documentation server is rendered on my local machine and from past accidental leakage into HEAD by multiple authors previously, this occurs consistently when docs are rendered. These changes represent application versioning and release binaries. Updating this detail is outside the scope of this change and will be deferred to a future decision. As a result, nothing in `docs/docs/pages` or other files in `docs/` were changed.

## Risks, Trade-offs, and Mitigations (Required)

There are no risks here other than the inability of the Anchor documentation to correctly render. A case of 'it works for me' could be a factor in whether the documentation renders error-free at deploy-time.

My local development flow to render the documentation:
```
# Set npm at version 22 for compatibility with vocs.
$ nvm use 22;

# Run the documentation server.
$ cd docs && npm run dev;
```

I've been able to render the documentation in multiple browsers
- Chrome Version 147.0.7727.137 (Official Build) (64-bit)
- Brave 1.89.145 (Official Build) (64-bit) w/ Chromium: 147.0.7727.137

The primary trade-off was aesthetics vs maintainability. Anchor's maintainer team decided to reduce the visual appeal of the CLI reference code snippets by rendering a text-fenced copy of the clap `render_long_help()` call 

## Validation (Required)

Not required as no code change. See above for web server rendering steps.

## Rollback (Required for behavior or runtime changes; optional otherwise)

Revert this commit.

## Additional Info / Next Steps (Optional)

- Final step is to create a GitHub Actions workflow to run `make cli-reference-check` to ensure docs align with CLI tree.
