### PR TITLE
fix(operator_key): accept go-ssv keystores with diacritic passwords

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5550,6 +5550,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "thiserror 2.0.18",
+ "unicode-normalization",
  "zeroize",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -172,6 +172,7 @@ tracing-subscriber = { version = "0.3.18", features = ["fmt", "env-filter"] }
 tree_hash = "0.12.0"
 tree_hash_derive = "0.12.0"
 typenum = "1.18"
+unicode-normalization = "0.1.25"
 zeroize = "1.8.1"
 
 [patch.crates-io]

--- a/anchor/common/operator_key/Cargo.toml
+++ b/anchor/common/operator_key/Cargo.toml
@@ -13,6 +13,7 @@ rpassword = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
+unicode-normalization = { workspace = true }
 zeroize = { workspace = true }
 
 [dev-dependencies]

--- a/anchor/common/operator_key/src/encrypted.rs
+++ b/anchor/common/operator_key/src/encrypted.rs
@@ -46,6 +46,7 @@ use eth2_keystore::{
 use openssl::{pkey::Private, rsa::Rsa};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
+use unicode_normalization::{UnicodeNormalization, char::canonical_combining_class};
 use zeroize::Zeroizing;
 
 use crate::{ConversionError, public};
@@ -98,9 +99,21 @@ impl EncryptedKey {
     /// If the pubkey was provided along the encrypted key in a "pubkey" attribute, it is verified
     /// whether the encrypted key matches the public key. "pubKey" is also accepted for backwards
     /// compatibility with legacy keys.
+    ///
+    /// On `InvalidPassword`, retries with [`alt_normalize_password`] to support keystores produced
+    /// by go-ssv. Any password containing precomposed characters (e.g. `ñ`, `ü`, `é`) yields
+    /// different KDF input bytes than the EIP-2335 spec NFKD path used by `eth2_keystore`.
     pub fn decrypt(&self, password: &str) -> Result<Rsa<Private>, DecryptionError> {
-        let pem = eth2_keystore::decrypt(password.as_ref(), &self.as_crypto())
-            .map_err(DecryptionError::Keystore)?;
+        let crypto = self.as_crypto();
+        let pem = match eth2_keystore::decrypt(password.as_ref(), &crypto) {
+            Ok(pem) => pem,
+            Err(eth2_keystore::Error::InvalidPassword) => {
+                let alt = alt_normalize_password(password);
+                eth2_keystore::decrypt(alt.as_bytes(), &crypto)
+                    .map_err(DecryptionError::Keystore)?
+            }
+            Err(e) => return Err(DecryptionError::Keystore(e)),
+        };
         let key = Rsa::private_key_from_pem(pem.as_ref())?;
         if let Some(pubkey) = &self.pubkey {
             let pubkey = public::from_base64(pubkey.as_ref())?;
@@ -146,6 +159,18 @@ impl EncryptedKey {
             pubkey: Some(public::to_base64(key)?),
         })
     }
+}
+
+/// Reproduces `wealdtech/go-eth2-wallet-encryptor-keystorev4 v1.1.3`'s `normPassphrase`: NFKD
+/// decomposes the input then keeps only starter code points, discarding the combining marks emitted
+/// by decomposition. The result is non-spec, but matches what go-ssv currently uses as KDF input.
+fn alt_normalize_password(password: &str) -> Zeroizing<String> {
+    Zeroizing::new(
+        password
+            .nfkd()
+            .filter(|c| canonical_combining_class(*c) == 0)
+            .collect(),
+    )
 }
 
 impl TryFrom<EncryptedKey> for String {
@@ -213,5 +238,63 @@ mod tests {
         let json = serde_json::to_string(&encrypted).unwrap();
         assert!(json.contains(r#""pubkey":"#));
         assert!(!json.contains(r#""pubKey":"#));
+    }
+
+    #[test]
+    fn test_alt_normalize_password_ascii_passthrough() {
+        let result = alt_normalize_password("hello");
+        assert_eq!(result.as_str(), "hello");
+    }
+
+    #[test]
+    fn test_alt_normalize_password_strips_n_tilde() {
+        let result = alt_normalize_password("ñ");
+        assert_eq!(result.as_str(), "n");
+    }
+
+    #[test]
+    fn test_alt_normalize_password_strips_cafe_accent() {
+        let result = alt_normalize_password("café");
+        assert_eq!(result.as_str(), "cafe");
+    }
+
+    /// Simulates a go-ssv keystore (pinned to `wealdtech/keystorev4 v1.1.3`, whose
+    /// `normPassphrase` drops combining marks): encrypt with the alt-normalized form and decrypt
+    /// with the original NFC password. The primary spec-NFKD path fails; the fallback succeeds.
+    #[test]
+    fn test_decrypt_with_alt_normalized_password() {
+        let key = Rsa::generate(2048).unwrap();
+        let encrypted = EncryptedKey::encrypt(&key, "cafe").unwrap();
+
+        let decrypted = encrypted.decrypt("café").unwrap();
+
+        assert_eq!(key.p(), decrypted.p());
+        assert_eq!(key.q(), decrypted.q());
+    }
+
+    #[test]
+    fn test_decrypt_alt_norm_multiple_diacritics() {
+        let key = Rsa::generate(2048).unwrap();
+        let encrypted = EncryptedKey::encrypt(&key, "pinata").unwrap();
+
+        let decrypted = encrypted.decrypt("piñata").unwrap();
+
+        assert_eq!(key.p(), decrypted.p());
+        assert_eq!(key.q(), decrypted.q());
+    }
+
+    #[test]
+    fn test_decrypt_wrong_password_still_fails() {
+        let key = Rsa::generate(2048).unwrap();
+        let encrypted = EncryptedKey::encrypt(&key, "correct-password").unwrap();
+
+        let result = encrypted.decrypt("totally-different-password");
+
+        assert!(matches!(
+            result,
+            Err(DecryptionError::Keystore(
+                eth2_keystore::Error::InvalidPassword
+            ))
+        ));
     }
 }

--- a/anchor/common/operator_key/src/encrypted.rs
+++ b/anchor/common/operator_key/src/encrypted.rs
@@ -103,6 +103,7 @@ impl EncryptedKey {
     /// On `InvalidPassword`, retries with [`alt_normalize_password`] to support keystores produced
     /// by go-ssv. Any password containing precomposed characters (e.g. `ñ`, `ü`, `é`) yields
     /// different KDF input bytes than the EIP-2335 spec NFKD path used by `eth2_keystore`.
+    /// Encryption remains EIP-2335 spec-compliant; the fallback is decrypt-only.
     pub fn decrypt(&self, password: &str) -> Result<Rsa<Private>, DecryptionError> {
         let crypto = self.as_crypto();
         let pem = match eth2_keystore::decrypt(password.as_ref(), &crypto) {
@@ -161,9 +162,18 @@ impl EncryptedKey {
     }
 }
 
-/// Reproduces `wealdtech/go-eth2-wallet-encryptor-keystorev4 v1.1.3`'s `normPassphrase`: NFKD
-/// decomposes the input then keeps only starter code points, discarding the combining marks emitted
-/// by decomposition. The result is non-spec, but matches what go-ssv currently uses as KDF input.
+/// Approximates `wealdtech/go-eth2-wallet-encryptor-keystorev4 v1.1.3`'s `normPassphrase`: NFKD
+/// decomposes the input then keeps only starter code points, discarding the combining marks
+/// emitted by decomposition. The result is non-spec, but matches what go-ssv currently uses as KDF
+/// input for the common case (passwords containing precomposed Latin chars).
+///
+/// Control-char handling is intentionally not replicated here. wealdtech v1.1.3 strips C0 + DEL
+/// from single-byte starters; `eth2_keystore::decrypt` then strips all `char::is_control()` code
+/// points on both the primary and fallback attempts, which covers the same ground (and more) for
+/// every realistic password. The only theoretical divergence is a C1 control combined with a
+/// combining mark in the same password.
+///
+/// Reference: <https://github.com/wealdtech/go-eth2-wallet-encryptor-keystorev4/blob/v1.1.3/norm.go>.
 fn alt_normalize_password(password: &str) -> Zeroizing<String> {
     Zeroizing::new(
         password


### PR DESCRIPTION
## Problem, Evidence, and Context

An operator migrating from go-ssv to Anchor reported `Failed to start Anchor: Key decryption failed`. Their password contained the Spanish character `ñ`; other operators with ASCII-only passwords migrated successfully.

Root cause: go-ssv pins `wealdtech/go-eth2-wallet-encryptor-keystorev4 v1.1.3`, whose `normPassphrase` NFKD-decomposes the password but keeps only the leading rune of each decomposition segment, dropping combining marks. For any password whose NFKD decomposition produces combining marks (`ñ`, `ü`, `é`, `ç`, …), the bytes fed into the KDF diverge from spec-compliant EIP-2335 NFKD. Anchor uses Lighthouse's `eth2_keystore`, which is spec-correct, so it cannot decrypt those keystores.

Upstream `wealdtech` acknowledged the bug in v1.4.1 by adding an alt-normalization fallback (spec-correct first, alt-norm second). go-ssv has not bumped past v1.1.3.

## Change Overview

- `EncryptedKey::decrypt` retries once with an alt-normalized password on `Error::InvalidPassword`. Other errors are surfaced as before.
- New private helper `alt_normalize_password` reproduces wealdtech v1.1.3's algorithm: NFKD then filter to canonical combining class 0.
- Encryption path is unchanged; new keystores produced by Anchor remain EIP-2335 compliant.
- Adds `unicode-normalization` as a direct workspace dep (already present transitively via `eth2_keystore`, same `0.1.25` version).

## Risks, Trade-offs, and Mitigations

- **Surface**: only the decrypt path, only on `InvalidPassword`, single bounded retry.
- **Trade-off**: the fallback is intentionally lenient on decrypt to support migration. Encryption stays spec-compliant, so Anchor never produces non-spec keystores.
- **Secret handling**: the alt-normalized password lives in `Zeroizing<String>`; no intermediate allocations outside the wrapper.

## Validation

- Unit tests for `alt_normalize_password` covering ASCII, `ñ`, `café`.
- End-to-end fallback tests: simulate go-ssv keystores by encrypting with the alt-normalized form, then decrypting with the original NFC password (`café`, `piñataüber`).
- Negative test: a truly wrong password still returns `DecryptionError::Keystore(eth2_keystore::Error::InvalidPassword)`.
- `cargo test -p operator_key` — 46 pass, 0 fail.
- `make cargo-fmt-check`, `make lint` — clean.

## Rollback

Revert this commit. No config, data, or on-disk format change. Keystores produced before or after this PR remain readable both ways.