### PR TITLE
feat: fork-aware attestation deadline at Gloas

### DIFF
--- a/anchor/validator_store/src/lib.rs
+++ b/anchor/validator_store/src/lib.rs
@@ -1480,7 +1480,7 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> AnchorValidator
         let timer = metrics::start_timer_vec(&metrics::CONSENSUS_TIMES, &[metrics::BEACON_VOTE]);
         let timeout_mode = TimeoutMode::SlotTime {
             instance_start_time: self
-                .get_instant_in_slot(slot, self.spec.get_slot_duration() / 3)?,
+                .get_instant_in_slot(slot, self.spec.get_attestation_due::<E>(slot))?,
         };
 
         let completed = self
@@ -3392,5 +3392,26 @@ mod tests {
         } else {
             panic!("Should have voting assignments cached");
         }
+    }
+
+    /// Anchors that `get_attestation_due` flips from `unaggregated_attestation_due`
+    /// to `unaggregated_attestation_due_gloas` at the Gloas activation boundary.
+    /// A LH bump that changes the fork-gating logic will surface here.
+    #[test]
+    fn attestation_due_switches_at_gloas_boundary() {
+        use types::MainnetEthSpec;
+
+        let mut spec = ChainSpec::mainnet();
+        let gloas_activation_epoch = Epoch::new(100);
+        spec.gloas_fork_epoch = Some(gloas_activation_epoch);
+        let first_gloas_slot = gloas_activation_epoch.start_slot(MainnetEthSpec::slots_per_epoch());
+        let last_pre_gloas_slot = first_gloas_slot - 1;
+
+        let pre = spec.get_attestation_due::<MainnetEthSpec>(last_pre_gloas_slot);
+        let post = spec.get_attestation_due::<MainnetEthSpec>(first_gloas_slot);
+
+        assert_ne!(pre, post);
+        assert_eq!(pre, spec.unaggregated_attestation_due);
+        assert_eq!(post, spec.unaggregated_attestation_due_gloas);
     }
 }

--- a/anchor/validator_store/src/metadata_service.rs
+++ b/anchor/validator_store/src/metadata_service.rs
@@ -206,11 +206,16 @@ impl<E: EthSpec, T: SlotClock + 'static> MetadataService<E, T> {
         executor.spawn(
             async move {
                 loop {
+                    // We sleep into the next slot, so look up the deadline for that slot, not
+                    // the current one. Otherwise the tighter Gloas deadline would apply one
+                    // slot late at the fork boundary.
                     if let Some(duration_to_next_slot) =
                         self_clone_phase2.slot_clock.duration_to_next_slot()
+                        && let Some(next_slot) = self_clone_phase2.slot_clock.now().map(|s| s + 1)
                     {
-                        // Sleep until 1/3 into slot
-                        sleep(duration_to_next_slot + slot_duration / 3).await;
+                        let attestation_due =
+                            self_clone_phase2.spec.get_attestation_due::<E>(next_slot);
+                        sleep(duration_to_next_slot + attestation_due).await;
 
                         if let Err(err) = self_clone_phase2.update_voting_context().await {
                             error!(err, "Failed to update voting context")


### PR DESCRIPTION
## Problem, Evidence, and Context

Under Gloas, the unaggregated attestation deadline tightens from 1/3 slot (4000ms mainnet) to 25% slot (3000ms mainnet). Anchor's two QBFT/voting-context deadlines currently hardcode `slot_duration / 3`, so post-Gloas they would consume the full pre-Gloas window and miss the on-time threshold every slot.

## Change Overview

Two call sites switched to LH's fork-aware `ChainSpec::get_attestation_due::<E>(slot)`:

- `lib.rs:1483` (QBFT instance start in `sign_committee_attestations`): slot is given, direct call.
- `metadata_service.rs:219` (Phase 2 `VotingContext` wakeup): looks up the deadline for the *next* slot (`current_slot + 1`) so the tighter Gloas deadline applies from the first CStar slot rather than one slot late.

Unchanged: aggregate, sync-message, and contribution deadlines. LH has no `_gloas` variant for those

## Risks, Trade-offs, and Mitigations
- Boundary precision via `current_slot + 1` in metadata_service. Without the `+ 1`, the first Gloas slot would see Phase 2 wake 999ms late (pre-Gloas deadline used while sleeping into a Gloas slot). Comment at the call site explains.

## Validation

- `cargo test -p anchor_validator_store --lib`: 33 tests pass, including the new boundary-anchoring test `attestation_due_switches_at_gloas_boundary`.
- `make cargo-fmt-check` clean.
- `make lint` clean.
- The boundary test acts as a tripwire: any future LH bump that changes the gating logic or default field values fails this test rather than silently shipping.

## Rollback

Revert the commit. Two files, no schema or state changes, no operational impact.

## Blockers / Dependencies
N/A
