### PR TITLE
chore: normalizes value_name CLI reference definition fields to UPPER_SNAKE_CASE

### DIFF
--- a/anchor/cli/src/cli.rs
+++ b/anchor/cli/src/cli.rs
@@ -78,7 +78,7 @@ pub struct ExternalApis {
 
     #[clap(
         long,
-        value_name = "CERTIFICATE-FILES",
+        value_name = "CERTIFICATE_FILES",
         value_delimiter = ',',
         help = "Comma-separated paths to custom TLS certificates to use when connecting \
                 to a beacon node (and/or proposer node). These certificates must be in PEM format and are used \
@@ -90,7 +90,7 @@ pub struct ExternalApis {
 
     #[clap(
         long,
-        value_name = "CERTIFICATE-FILES",
+        value_name = "CERTIFICATE_FILES",
         value_delimiter = ',',
         help = "Comma-separated paths to custom TLS certificates to use when connecting \
                 to an execution node. These certificates must be in PEM format and are used \

--- a/anchor/keysplit/src/cli.rs
+++ b/anchor/keysplit/src/cli.rs
@@ -87,7 +87,7 @@ pub struct SharedKeygenOptions {
     )]
     pub owner: Address,
 
-    #[clap(long, help = "Path for output", value_name = "OUTPUT PATH")]
+    #[clap(long, help = "Path for output", value_name = "OUTPUT_PATH")]
     pub output_path: String,
 
     #[clap(long, help = "Operators to split key among", value_name = "IDS")]

--- a/docs/docs/generated/cli-keysplit-options.mdx
+++ b/docs/docs/generated/cli-keysplit-options.mdx
@@ -1,37 +1,149 @@
-| Option | Description | Default |
-| --- | --- | ---|
-| `--keystore-path <PATH>` | Path to validator keystore file | Required |
-| `--password-file <PATH>` | Path to a file containing the password for the validator keystore (if omitted, password will be prompted) | None |
-| `--owner <ADDRESS>` | EOA address that owns the validator | Required |
-| `--output-path <OUTPUT PATH>` | Path for output file | Required |
-| `--operators <IDS>` | Comma-separated list of operator IDs | Required|
-| `-d, --data-dir <DIR>` | Data directory for node files | `~/.anchor/{network}` |
-| `--network <NETWORK>` | Network to use (mainnet, holesky, hoodi) | `hoodi` |
-| `-t, --testnet-dir <DIR>` | Directory containing testnet specs | None |
-| `--debug-level <DEBUG_LEVEL>` | Verbosity level for terminal logs | `INFO` |
-| `-h, --help` | Display help information | |
+```text
+SSV Keysplitting Tool
 
-### Manual Keysplit Subcommand
+Usage: anchor keysplit [OPTIONS] <COMMAND>
 
-```bash
-anchor keysplit manual [OPTIONS]
+Commands:
+    onchain  Utilize onchain data to split the key
+    manual   Split the key by manually providing data
+    help     Print this message or the help of the given subcommand(s)
+
+Options:
+    -d, --data-dir <DIR>
+               Used to specify a custom root data directory for the Anchor key
+               and database. Defaults to $HOME/.anchor/{network} where network
+               is the value of the `network` flag Note: Users should specify
+               separate custom datadirs for different networks.
+
+         --network <NETWORK>
+               Name of the chain Anchor will validate.
+               
+               [default: mainnet]
+               [possible values: mainnet, holesky, hoodi]
+
+    -t, --testnet-dir <DIR>
+               Path to directory containing eth2_testnet specs.
+
+         --debug-level <DEBUG_LEVEL>
+               Specifies the verbosity level used when emitting logs to the
+               terminal
+               
+               [default: INFO]
+
+    -h, --help
+               Print help
+
+onchain:
+
+Utilize onchain data to split the key
+
+Usage: anchor keysplit onchain [OPTIONS] --owner <ADDRESS> --output-path <OUTPUT_PATH> --operators <IDS> --rpc <ENDPOINT>
+
+Options:
+    -d, --data-dir <DIR>
+               Used to specify a custom root data directory for the Anchor key
+               and database. Defaults to $HOME/.anchor/{network} where network
+               is the value of the `network` flag Note: Users should specify
+               separate custom datadirs for different networks.
+
+         --keystore-paths <PATH>...
+               Path(s) to the validator keystore file
+
+         --network <NETWORK>
+               Name of the chain Anchor will validate.
+               
+               [default: mainnet]
+               [possible values: mainnet, holesky, hoodi]
+
+    -t, --testnet-dir <DIR>
+               Path to directory containing eth2_testnet specs.
+
+         --password-file <PATH>
+               Path to a file containing the password for the validator
+               keystore. If omitted, the password will be prompted for.
+
+         --owner <ADDRESS>
+               EOA address that owns the validator
+
+         --debug-level <DEBUG_LEVEL>
+               Specifies the verbosity level used when emitting logs to the
+               terminal
+               
+               [default: INFO]
+
+         --output-path <OUTPUT_PATH>
+               Path for output
+
+         --operators <IDS>
+               Operators to split key among
+
+         --rpc <ENDPOINT>
+               RPC endpoint to access L1 data
+
+    -h, --help
+               Print help
+
+manual:
+
+Split the key by manually providing data
+
+Usage: anchor keysplit manual [OPTIONS] --owner <ADDRESS> --output-path <OUTPUT_PATH> --operators <IDS> --nonce <NONCE> --public-keys <KEYS>...
+
+Options:
+    -d, --data-dir <DIR>
+               Used to specify a custom root data directory for the Anchor key
+               and database. Defaults to $HOME/.anchor/{network} where network
+               is the value of the `network` flag Note: Users should specify
+               separate custom datadirs for different networks.
+
+         --keystore-paths <PATH>...
+               Path(s) to the validator keystore file
+
+         --network <NETWORK>
+               Name of the chain Anchor will validate.
+               
+               [default: mainnet]
+               [possible values: mainnet, holesky, hoodi]
+
+    -t, --testnet-dir <DIR>
+               Path to directory containing eth2_testnet specs.
+
+         --password-file <PATH>
+               Path to a file containing the password for the validator
+               keystore. If omitted, the password will be prompted for.
+
+         --owner <ADDRESS>
+               EOA address that owns the validator
+
+         --debug-level <DEBUG_LEVEL>
+               Specifies the verbosity level used when emitting logs to the
+               terminal
+               
+               [default: INFO]
+
+         --output-path <OUTPUT_PATH>
+               Path for output
+
+         --operators <IDS>
+               Operators to split key among
+
+         --nonce <NONCE>
+               Nonce for the owner address
+
+         --public-keys <KEYS>...
+               RSA public keys for the operators
+
+    -h, --help
+               Print help
+
+help:
+
+Print this message or the help of the given subcommand(s)
+
+Usage: anchor keysplit help [COMMAND]
+
+Commands:
+    onchain  Utilize onchain data to split the key
+    manual   Split the key by manually providing data
+    help     Print this message or the help of the given subcommand(s)
 ```
-
-Additional Options:
-
-| Option | Description | Default |
-| --- | --- | ---|
-| `--nonce <NONCE>` | Nonce for the owner address | Required |
-| `--public-keys <KEYS>...` | RSA public keys for the operators | Required|
-
-### Onchain Keysplit Subcommand
-
-```bash
-anchor keysplit onchain [OPTIONS]
-```
-
-Additional Options:
-
-| Option | Description | Default |
-| --- | --- | ---|
-| `--rpc <ENDPOINT>` | RPC endpoint to access L1 data | Required|

--- a/docs/docs/generated/cli-node-options.mdx
+++ b/docs/docs/generated/cli-node-options.mdx
@@ -62,7 +62,7 @@ External APIs:
                
                [default: 8,8,48]
 
-         --beacon-nodes-tls-certs <CERTIFICATE-FILES>
+         --beacon-nodes-tls-certs <CERTIFICATE_FILES>
                Comma-separated paths to custom TLS certificates to use when
                connecting to a beacon node (and/or proposer node). These
                certificates must be in PEM format and are used in addition to
@@ -77,7 +77,7 @@ External APIs:
                [possible values: none, attestations, blocks, subscriptions,
                sync-committee]
 
-         --execution-nodes-tls-certs <CERTIFICATE-FILES>
+         --execution-nodes-tls-certs <CERTIFICATE_FILES>
                Comma-separated paths to custom TLS certificates to use when
                connecting to an execution node. These certificates must be in
                PEM format and are used in addition to the OS trust store.


### PR DESCRIPTION
## Problem, Evidence, and Context (Required)

Issues #1023 and #1031 (in retrospect) identified a problem detected while updating the Anchor CLI reference to machine generated documentation in #1019. The `value_name` values in Anchor's CLI are consistently expressed in `UPPER_SNAKE_CASE` if they contain multiple words.

This change fixes this issue by simply aligning `output_path` `value_name` fields that currently violate with this convention. This is worth doing now as we are currently working through corrections and alignments to the project's documentation.

## Change Overview (Required)

- `value_name` of `output_path` attribute in `SharedKeygenOptions` (`anchor/keysplit/src/cli.rs:90`) was changed from `OUTPUT PATH` to `OUTPUT_PATH`. The documentation page `docs/docs/generated/cli-keysplit-options.mdx` was subsequently updated to reflect this.
- `ExternalApis` `beacon_nodes_tls_certs` and `execution_nodes_tls_certs` attributes `value_name = "CERTIFICATE-FILES"` fields updated to `value_name = "CERTIFICATE_FILES"` in `anchor/cli/src/cli.rs`. 

## Risks, Trade-offs, and Mitigations (Required)

No risks, simply a change to a `clap` struct attribute's string value.

## Validation (Required)

This is a formatting change to align this value's case to the rest of the Anchor project's convention.

- `make cli-reference-check` shows consistency between CLI and documentation.

## Rollback (Required for behavior or runtime changes; optional otherwise)

This commit can be safely reverted.