### PR TITLE
chore: add cstar example to built-in fork schedule configs

### DIFF
--- a/anchor/common/ssv_network_config/built_in_network_configs/holesky/ssv_fork_schedule.yaml
+++ b/anchor/common/ssv_network_config/built_in_network_configs/holesky/ssv_fork_schedule.yaml
@@ -6,3 +6,6 @@
 # boole:
 #   epoch: 12500
 #   domain_type: "00000002"
+# cstar:
+#   epoch: 13000
+#   domain_type: "00000003"

--- a/anchor/common/ssv_network_config/built_in_network_configs/hoodi/ssv_fork_schedule.yaml
+++ b/anchor/common/ssv_network_config/built_in_network_configs/hoodi/ssv_fork_schedule.yaml
@@ -6,3 +6,6 @@
 # boole:
 #   epoch: 12500
 #   domain_type: "00000002"
+# cstar:
+#   epoch: 13000
+#   domain_type: "00000003"

--- a/anchor/common/ssv_network_config/built_in_network_configs/mainnet/ssv_fork_schedule.yaml
+++ b/anchor/common/ssv_network_config/built_in_network_configs/mainnet/ssv_fork_schedule.yaml
@@ -6,3 +6,6 @@
 # boole:
 #   epoch: 12500
 #   domain_type: "00000002"
+# cstar:
+#   epoch: 13000
+#   domain_type: "00000003"


### PR DESCRIPTION
## Problem, Evidence, and Context

Built-in `ssv_fork_schedule.yaml` files already document a commented `boole:` example but no `cstar:` equivalent.

## Change Overview

Adds a commented `cstar:` block mirroring the existing `boole:` example in all three built-in network configs (mainnet, holesky, hoodi). Comments only; no operational behavior changes.

## Risks, Trade-offs, and Mitigations

N/A. YAML parser ignores comments; runtime behavior unchanged.

## Validation

- `cargo test -p ssv_network_config` (14 passed)
- `make cargo-fmt-check` and `make lint` clean

## Rollback

Revert the commit; no operational impact.