### PR TITLE
feat: add Role::PTCCommittee with message-validator fork-gate

### DIFF
--- a/anchor/common/ssv_types/src/msgid.rs
+++ b/anchor/common/ssv_types/src/msgid.rs
@@ -78,11 +78,11 @@ impl Role {
         match self {
             Role::Committee | Role::Aggregator | Role::AggregatorCommittee => Some(12),
             Role::Proposer | Role::SyncCommittee => Some(6),
-            // PTC duty starts at 75% slot with ~3s remaining; QUICK_TIMEOUT = 2s
-            // gives one useful round within the slot (round 1 expires at +2s).
-            // Rounds 2-4 (cumulative +4/+6/+8s) recover from operator start delay
-            // or round-1 message loss; rounds 5+ exceed any realistic inclusion
-            // window and are dead weight.
+            // PTC is expected near 75% of a 12s slot, leaving about 3s.
+            // With 2s quick round timeouts, only round 1 is likely to finish
+            // before slot end. Allow up to 4 rounds as a small local grace
+            // window for delayed starts or message loss; this is not a
+            // consensus-spec requirement.
             Role::PTCCommittee => Some(4),
             // These roles don't use QBFT consensus
             Role::ValidatorRegistration | Role::VoluntaryExit => None,

--- a/anchor/common/ssv_types/src/msgid.rs
+++ b/anchor/common/ssv_types/src/msgid.rs
@@ -21,6 +21,7 @@ pub enum Role {
     ValidatorRegistration,
     VoluntaryExit,
     AggregatorCommittee,
+    PTCCommittee,
 }
 
 impl From<Role> for [u8; 4] {
@@ -33,6 +34,7 @@ impl From<Role> for [u8; 4] {
             Role::ValidatorRegistration => [4, 0, 0, 0],
             Role::VoluntaryExit => [5, 0, 0, 0],
             Role::AggregatorCommittee => [6, 0, 0, 0],
+            Role::PTCCommittee => [7, 0, 0, 0],
         }
     }
 }
@@ -49,13 +51,15 @@ impl TryFrom<&[u8]> for Role {
             [4, 0, 0, 0] => Ok(Role::ValidatorRegistration),
             [5, 0, 0, 0] => Ok(Role::VoluntaryExit),
             [6, 0, 0, 0] => Ok(Role::AggregatorCommittee),
+            [7, 0, 0, 0] => Ok(Role::PTCCommittee),
             _ => Err(DecodeError::NoMatchingVariant),
         }
     }
 }
 
 impl Role {
-    /// Returns true if this role is a committee-based role (Committee or AggregatorCommittee).
+    /// Returns true if this role is a committee-based role (Committee, AggregatorCommittee, or
+    /// PTCCommittee).
     ///
     /// Committee roles handle multiple validators in batched operations and have relaxed
     /// validation rules compared to per-validator roles:
@@ -63,7 +67,10 @@ impl Role {
     /// - Skip slot advancement checks (allow processing "older" slots within 34-slot window)
     /// - Have different message count limits and validator index occurrence limits
     pub fn is_committee_role(self) -> bool {
-        matches!(self, Role::Committee | Role::AggregatorCommittee)
+        matches!(
+            self,
+            Role::Committee | Role::AggregatorCommittee | Role::PTCCommittee
+        )
     }
 
     pub fn max_round(self) -> Option<u64> {
@@ -71,6 +78,10 @@ impl Role {
         match self {
             Role::Committee | Role::Aggregator | Role::AggregatorCommittee => Some(12),
             Role::Proposer | Role::SyncCommittee => Some(6),
+            // PTC duty starts at 75% slot with ~3s remaining; `QUICK_TIMEOUT` = 2s
+            // gives one useful round before the slot-end deadline. Rounds 2-4
+            // cover clock skew between operators; rounds 5+ are dead weight.
+            Role::PTCCommittee => Some(4),
             // These roles don't use QBFT consensus
             Role::ValidatorRegistration | Role::VoluntaryExit => None,
         }
@@ -143,7 +154,7 @@ impl MessageId {
     pub fn duty_executor(&self) -> Option<DutyExecutor> {
         // which kind of executor we need to get depends on the role
         match self.role()? {
-            Role::Committee | Role::AggregatorCommittee => {
+            Role::Committee | Role::AggregatorCommittee | Role::PTCCommittee => {
                 self.0[24..].try_into().ok().map(DutyExecutor::Committee)
             }
             Role::Aggregator
@@ -306,5 +317,41 @@ mod tests {
             }
             None => panic!("Failed to extract duty executor"),
         }
+    }
+
+    #[test]
+    fn ptc_uses_committee_duty_executor() {
+        // PTCCommittee must use Committee-style duty executor (CommitteeId),
+        // not Validator-style (PublicKeyBytes)
+        let domain = DomainType([0, 0, 0, 0]);
+        let committee_id = CommitteeId::from(vec![OperatorId(100), OperatorId(200)]);
+        let duty_executor = DutyExecutor::Committee(committee_id);
+
+        let msg_id = MessageId::new(&domain, Role::PTCCommittee, &duty_executor);
+
+        assert_eq!(msg_id.role(), Some(Role::PTCCommittee));
+
+        match msg_id.duty_executor() {
+            Some(DutyExecutor::Committee(id)) => assert_eq!(id, committee_id),
+            Some(DutyExecutor::Validator(_)) => {
+                panic!("PTCCommittee should use Committee duty executor, not Validator")
+            }
+            None => panic!("Failed to extract duty executor"),
+        }
+    }
+
+    #[test]
+    fn ptc_max_round_is_four() {
+        // PTC duty starts at 75% slot; Some(4) is the deliberate cap distinct
+        // from Committee's Some(12). Regressions copying the Committee value
+        // would compile silently — this guards against that.
+        assert_eq!(Role::PTCCommittee.max_round(), Some(4));
+    }
+
+    #[test]
+    fn ptc_is_committee_role() {
+        // is_committee_role drives the validator-index-mismatch skip and
+        // slot-advancement skip in message_validator. PTC must qualify.
+        assert!(Role::PTCCommittee.is_committee_role());
     }
 }

--- a/anchor/common/ssv_types/src/msgid.rs
+++ b/anchor/common/ssv_types/src/msgid.rs
@@ -78,9 +78,11 @@ impl Role {
         match self {
             Role::Committee | Role::Aggregator | Role::AggregatorCommittee => Some(12),
             Role::Proposer | Role::SyncCommittee => Some(6),
-            // PTC duty starts at 75% slot with ~3s remaining; `QUICK_TIMEOUT` = 2s
-            // gives one useful round before the slot-end deadline. Rounds 2-4
-            // cover clock skew between operators; rounds 5+ are dead weight.
+            // PTC duty starts at 75% slot with ~3s remaining; QUICK_TIMEOUT = 2s
+            // gives one useful round within the slot (round 1 expires at +2s).
+            // Rounds 2-4 (cumulative +4/+6/+8s) recover from operator start delay
+            // or round-1 message loss; rounds 5+ exceed any realistic inclusion
+            // window and are dead weight.
             Role::PTCCommittee => Some(4),
             // These roles don't use QBFT consensus
             Role::ValidatorRegistration | Role::VoluntaryExit => None,

--- a/anchor/message_validator/src/consensus_message.rs
+++ b/anchor/message_validator/src/consensus_message.rs
@@ -486,7 +486,7 @@ mod tests {
     use bls::{Hash256, PublicKeyBytes};
     use openssl::hash::MessageDigest;
     use ssv_types::{
-        OperatorId, RSA_SIGNATURE_SIZE, VariableList,
+        CommitteeId, OperatorId, RSA_SIGNATURE_SIZE, ValidatorIndex, VariableList,
         consensus::{QbftMessage, QbftMessageType},
         domain_type::DomainType,
         message::{MsgType, SSVMessage, SignedSSVMessage},
@@ -1715,6 +1715,72 @@ mod tests {
         let result = duty_limit(&validation_context, slot, &[], mock_duties_provider);
 
         assert_eq!(result, Ok(Some(expected_duty_count)));
+    }
+
+    #[test]
+    fn test_duty_limit_ptc_committee() {
+        let now = SystemTime::now();
+        let slot_clock = ManualSlotClock::new(
+            Slot::new(100),
+            now.duration_since(UNIX_EPOCH).unwrap(),
+            Duration::from_secs(1),
+        );
+
+        let msg_id = MessageId::new(
+            &DomainType([0, 0, 0, 1]),
+            Role::PTCCommittee,
+            &DutyExecutor::Committee(CommitteeId([0u8; 32])),
+        );
+        let ssv_msg = SSVMessage::new(MsgType::SSVConsensusMsgType, msg_id, vec![1, 2, 3])
+            .expect("SSVMessage should be created");
+        let signed_msg = SignedSSVMessage::new(
+            vec![[0xAA; RSA_SIGNATURE_SIZE]],
+            vec![OperatorId(1)],
+            ssv_msg,
+            vec![],
+        )
+        .expect("SignedSSVMessage should be created");
+
+        let committee_info = create_committee_info(SINGLE_NODE_COMMITTEE);
+        let mock_duties_provider = Arc::new(MockDutiesProvider {
+            voluntary_exit_duty_count: 0,
+        });
+        let map = create_operator_pub_keys(committee_info.committee_members.clone(), vec![]);
+
+        let validation_context = ValidationContext {
+            signed_ssv_message: &signed_msg,
+            committee_info: &committee_info,
+            role: Role::PTCCommittee,
+            received_at: now,
+            slots_per_epoch: 32,
+            epochs_per_sync_committee_period: 256,
+            sync_committee_size: 512,
+            slot_clock: slot_clock.clone(),
+            operator_pub_keys: &map,
+            fork_schedule: generate_fork_schedule(),
+        };
+
+        let slot = slot_clock.now().unwrap();
+
+        // V < slots_per_epoch: V is the binding constraint.
+        let small_cluster = vec![ValidatorIndex(0); 4];
+        let result = duty_limit(
+            &validation_context,
+            slot,
+            &small_cluster,
+            mock_duties_provider.clone(),
+        );
+        assert_eq!(result, Ok(Some(4)));
+
+        // V > slots_per_epoch: slot count is the binding constraint.
+        let large_cluster = vec![ValidatorIndex(0); 100];
+        let result = duty_limit(
+            &validation_context,
+            slot,
+            &large_cluster,
+            mock_duties_provider,
+        );
+        assert_eq!(result, Ok(Some(32)));
     }
 
     /// Helper function for testing role validation against fork schedules.

--- a/anchor/message_validator/src/lib.rs
+++ b/anchor/message_validator/src/lib.rs
@@ -450,7 +450,7 @@ impl<S: SlotClock + 'static, D: DutiesProvider> Validator<S, D> {
         // Get committee info based on role and duty executor
         let network_state = self.network_state_rx.borrow();
         let committee_info = match role {
-            Role::Committee | Role::AggregatorCommittee => {
+            Role::Committee | Role::AggregatorCommittee | Role::PTCCommittee => {
                 let committee_id = committee_id.ok_or(ValidationFailure::NonExistentCommitteeID)?;
                 network_state
                     .get_committee_info_by_committee_id(&committee_id)
@@ -859,6 +859,15 @@ pub(crate) fn validate_role_for_fork(
         });
     }
 
+    // Reject PTCCommittee before CStar fork (safety net)
+    if role == Role::PTCCommittee && active_fork < Fork::CStar {
+        return Err(ValidationFailure::RoleNotActiveBeforeFork {
+            role,
+            current_fork: active_fork,
+            minimum_fork: Fork::CStar,
+        });
+    }
+
     Ok(())
 }
 
@@ -925,7 +934,8 @@ fn message_lateness(
         | Role::Aggregator
         | Role::ValidatorRegistration
         | Role::VoluntaryExit
-        | Role::AggregatorCommittee => validation_context.slots_per_epoch + LATE_SLOT_ALLOWANCE,
+        | Role::AggregatorCommittee
+        | Role::PTCCommittee => validation_context.slots_per_epoch + LATE_SLOT_ALLOWANCE,
     };
 
     let deadline = slot_start_time(slot + ttl, validation_context.slot_clock.clone())
@@ -1033,6 +1043,16 @@ fn duty_limit(
         }
         // Proposer and SyncCommittee have no duty limit
         Role::Proposer | Role::SyncCommittee => Ok(None),
+        // PTC: each validator is eligible for the PTC only in the one slot of the
+        // epoch where it has its attestation duty (PTC pool = union of beacon
+        // committees for that slot; see `compute_ptc` at
+        // https://github.com/ethereum/consensus-specs/blob/4a4937bea332d72a55a76aaebcb97fbcdc189f69/specs/gloas/beacon-chain.md#new-compute_ptc).
+        // So per-epoch max duties = min(slots_per_epoch, V) where V is the
+        // cluster's local validator count.
+        Role::PTCCommittee => Ok(Some(std::cmp::min(
+            validation_context.slots_per_epoch,
+            validator_indices.len() as u64,
+        ))),
     }
 }
 
@@ -1278,7 +1298,7 @@ mod tests {
     pub(crate) fn create_message_id_for_test(role: Role) -> MessageId {
         let domain = DomainType([0, 0, 0, 1]);
         let duty_executor = match role {
-            Role::Committee | Role::AggregatorCommittee => {
+            Role::Committee | Role::AggregatorCommittee | Role::PTCCommittee => {
                 DutyExecutor::Committee(CommitteeId([0u8; 32]))
             }
             Role::Aggregator

--- a/anchor/message_validator/src/partial_signature.rs
+++ b/anchor/message_validator/src/partial_signature.rs
@@ -144,7 +144,7 @@ fn validate_partial_signature_message_semantics(
 
 fn partial_signature_type_matches_role(kind: PartialSignatureKind, role: Role) -> bool {
     match role {
-        Role::Committee => kind == PartialSignatureKind::PostConsensus,
+        Role::Committee | Role::PTCCommittee => kind == PartialSignatureKind::PostConsensus,
         Role::Aggregator => {
             kind == PartialSignatureKind::PostConsensus
                 || kind == PartialSignatureKind::SelectionProofPartialSig
@@ -310,6 +310,31 @@ fn validate_partial_sig_messages_by_duty_logic(
                         validator_index: message.validator_index,
                         got: *count,
                         limit: 5,
+                    });
+                }
+            }
+        }
+        Role::PTCCommittee => {
+            // PTC produces exactly one partial signature per locally-assigned
+            // validator per slot.
+            if message_count > validator_count {
+                return Err(ValidationFailure::TooManyPartialSignatureMessages {
+                    got: message_count,
+                    limit: validator_count,
+                });
+            }
+
+            let mut validator_index_count = HashMap::new();
+            for message in &partial_signature_messages.messages {
+                let count = validator_index_count
+                    .entry(message.validator_index)
+                    .or_insert(0);
+                *count += 1;
+                if *count > 1 {
+                    return Err(ValidationFailure::TooManyValidatorIndexOccurrences {
+                        validator_index: message.validator_index,
+                        got: *count,
+                        limit: 1,
                     });
                 }
             }
@@ -1629,6 +1654,386 @@ mod tests {
                 )
             },
             "TooManyValidatorIndexOccurrences (limit exceeded for AggregatorCommittee)",
+        );
+    }
+
+    #[test]
+    fn test_ptc_committee_validator_index_occurrence_limit() {
+        // PTC allows exactly 1 occurrence per validator index per partial-sig packet.
+        let committee_info = create_committee_info(FOUR_NODE_COMMITTEE);
+        let (private_key, public_key) = generate_test_key_pair();
+
+        // 1 occurrence: should pass.
+        let messages = vec![PartialSignatureMessage {
+            partial_signature: Signature::empty(),
+            signing_root: Hash256::from([0u8; 32]),
+            signer: OperatorId(1),
+            validator_index: ValidatorIndex(100),
+        }];
+
+        let partial_sig_messages = PartialSignatureMessages {
+            kind: PartialSignatureKind::PostConsensus,
+            slot: Slot::new(1),
+            messages: VariableList::new(messages).unwrap(),
+        };
+
+        let msg_id = create_message_id_for_test(Role::PTCCommittee);
+        let ssv_msg = SSVMessage::new(
+            MsgType::SSVPartialSignatureMsgType,
+            msg_id,
+            partial_sig_messages.as_ssz_bytes(),
+        )
+        .unwrap();
+
+        let p_key = PKey::from_rsa(private_key.clone()).unwrap();
+        let mut signer = Signer::new(MessageDigest::sha256(), &p_key).unwrap();
+        signer.update(&ssv_msg.as_ssz_bytes()).unwrap();
+        let signature = signer.sign_to_vec().unwrap().try_into().unwrap();
+
+        let signed_msg =
+            SignedSSVMessage::new(vec![signature], vec![OperatorId(1)], ssv_msg, vec![]).unwrap();
+
+        let map = create_operator_pub_keys(
+            committee_info.committee_members.clone(),
+            vec![public_key.clone()],
+        );
+
+        let now = SystemTime::now();
+        let slot_clock = ManualSlotClock::new(
+            Slot::new(1),
+            now.duration_since(UNIX_EPOCH).unwrap(),
+            Duration::from_secs(12),
+        );
+
+        let fork_schedule = generate_fork_schedule(Fork::CStar);
+
+        let validation_context = ValidationContext {
+            signed_ssv_message: &signed_msg,
+            committee_info: &committee_info,
+            role: Role::PTCCommittee,
+            received_at: now,
+            slots_per_epoch: 32,
+            epochs_per_sync_committee_period: 256,
+            sync_committee_size: 512,
+            slot_clock,
+            operator_pub_keys: &map,
+            fork_schedule: fork_schedule.clone(),
+        };
+
+        let result = validate_partial_signature_message(
+            validation_context,
+            &mut DutyState::new(2),
+            Arc::new(MockDutiesProvider {
+                voluntary_exit_duty_count: 0,
+            }),
+        );
+
+        assert!(
+            result.is_ok(),
+            "Expected 1 occurrence to be valid for PTCCommittee, but got: {:?}",
+            result
+        );
+
+        // 2 occurrences: should fail.
+        let messages: Vec<_> = (0..2)
+            .map(|_| PartialSignatureMessage {
+                partial_signature: Signature::empty(),
+                signing_root: Hash256::from([0u8; 32]),
+                signer: OperatorId(1),
+                validator_index: ValidatorIndex(100),
+            })
+            .collect();
+
+        let partial_sig_messages = PartialSignatureMessages {
+            kind: PartialSignatureKind::PostConsensus,
+            slot: Slot::new(1),
+            messages: VariableList::new(messages).unwrap(),
+        };
+
+        let msg_id = create_message_id_for_test(Role::PTCCommittee);
+        let ssv_msg = SSVMessage::new(
+            MsgType::SSVPartialSignatureMsgType,
+            msg_id,
+            partial_sig_messages.as_ssz_bytes(),
+        )
+        .unwrap();
+
+        let p_key = PKey::from_rsa(private_key).unwrap();
+        let mut signer = Signer::new(MessageDigest::sha256(), &p_key).unwrap();
+        signer.update(&ssv_msg.as_ssz_bytes()).unwrap();
+        let signature = signer.sign_to_vec().unwrap().try_into().unwrap();
+
+        let signed_msg =
+            SignedSSVMessage::new(vec![signature], vec![OperatorId(1)], ssv_msg, vec![]).unwrap();
+
+        let slot_clock2 = ManualSlotClock::new(
+            Slot::new(1),
+            now.duration_since(UNIX_EPOCH).unwrap(),
+            Duration::from_secs(12),
+        );
+
+        let validation_context = ValidationContext {
+            signed_ssv_message: &signed_msg,
+            committee_info: &committee_info,
+            role: Role::PTCCommittee,
+            received_at: now,
+            slots_per_epoch: 32,
+            epochs_per_sync_committee_period: 256,
+            sync_committee_size: 512,
+            slot_clock: slot_clock2,
+            operator_pub_keys: &map,
+            fork_schedule,
+        };
+
+        let result = validate_partial_signature_message(
+            validation_context,
+            &mut DutyState::new(2),
+            Arc::new(MockDutiesProvider {
+                voluntary_exit_duty_count: 0,
+            }),
+        );
+
+        assert_validation_error(
+            result,
+            |failure| {
+                matches!(
+                    failure,
+                    ValidationFailure::TooManyValidatorIndexOccurrences { limit: 1, .. }
+                )
+            },
+            "TooManyValidatorIndexOccurrences (limit exceeded for PTCCommittee)",
+        );
+    }
+
+    #[test]
+    fn test_ptc_committee_message_count_exceeds_validator_count() {
+        // V+1 distinct validator indices: must trip the message_count > V
+        // check before the per-validator-index occurrence check fires.
+        let committee_info = create_committee_info(FOUR_NODE_COMMITTEE);
+        let validator_count = committee_info.validator_indices.len();
+        let (private_key, public_key) = generate_test_key_pair();
+
+        let messages: Vec<_> = (0..=validator_count)
+            .map(|i| PartialSignatureMessage {
+                partial_signature: Signature::empty(),
+                signing_root: Hash256::from([0u8; 32]),
+                signer: OperatorId(1),
+                validator_index: ValidatorIndex(i),
+            })
+            .collect();
+
+        let partial_sig_messages = PartialSignatureMessages {
+            kind: PartialSignatureKind::PostConsensus,
+            slot: Slot::new(1),
+            messages: VariableList::new(messages).unwrap(),
+        };
+
+        let msg_id = create_message_id_for_test(Role::PTCCommittee);
+        let ssv_msg = SSVMessage::new(
+            MsgType::SSVPartialSignatureMsgType,
+            msg_id,
+            partial_sig_messages.as_ssz_bytes(),
+        )
+        .unwrap();
+
+        let p_key = PKey::from_rsa(private_key).unwrap();
+        let mut signer = Signer::new(MessageDigest::sha256(), &p_key).unwrap();
+        signer.update(&ssv_msg.as_ssz_bytes()).unwrap();
+        let signature = signer.sign_to_vec().unwrap().try_into().unwrap();
+
+        let signed_msg =
+            SignedSSVMessage::new(vec![signature], vec![OperatorId(1)], ssv_msg, vec![]).unwrap();
+
+        let map =
+            create_operator_pub_keys(committee_info.committee_members.clone(), vec![public_key]);
+
+        let now = SystemTime::now();
+        let slot_clock = ManualSlotClock::new(
+            Slot::new(1),
+            now.duration_since(UNIX_EPOCH).unwrap(),
+            Duration::from_secs(12),
+        );
+
+        let validation_context = ValidationContext {
+            signed_ssv_message: &signed_msg,
+            committee_info: &committee_info,
+            role: Role::PTCCommittee,
+            received_at: now,
+            slots_per_epoch: 32,
+            epochs_per_sync_committee_period: 256,
+            sync_committee_size: 512,
+            slot_clock,
+            operator_pub_keys: &map,
+            fork_schedule: generate_fork_schedule(Fork::CStar),
+        };
+
+        let result = validate_partial_signature_message(
+            validation_context,
+            &mut DutyState::new(2),
+            Arc::new(MockDutiesProvider {
+                voluntary_exit_duty_count: 0,
+            }),
+        );
+
+        assert_validation_error(
+            result,
+            |failure| {
+                matches!(
+                    failure,
+                    ValidationFailure::TooManyPartialSignatureMessages { limit, .. } if *limit == validator_count
+                )
+            },
+            "TooManyPartialSignatureMessages (PTCCommittee message_count > V)",
+        );
+    }
+
+    #[test]
+    fn test_ptc_committee_rejected_before_cstar() {
+        use crate::validate_role_for_fork;
+
+        let committee_info = create_committee_info(FOUR_NODE_COMMITTEE);
+        let (private_key, public_key) = generate_test_key_pair();
+        let map =
+            create_operator_pub_keys(committee_info.committee_members.clone(), vec![public_key]);
+        let signed_msg = create_signed_partial_sig_message(
+            Role::PTCCommittee,
+            PartialSignatureKind::PostConsensus,
+            OperatorId(1),
+            &private_key,
+        );
+
+        let fork_schedule = generate_fork_schedule(Fork::Boole);
+        let validation_context = create_test_validation_context_with_fork(
+            &signed_msg,
+            &committee_info,
+            Role::PTCCommittee,
+            &map,
+            Some(fork_schedule),
+        );
+
+        let result = validate_role_for_fork(Slot::new(0), &validation_context);
+        assert_validation_error(
+            result,
+            |failure| {
+                matches!(
+                    failure,
+                    ValidationFailure::RoleNotActiveBeforeFork {
+                        minimum_fork: Fork::CStar,
+                        ..
+                    }
+                )
+            },
+            "RoleNotActiveBeforeFork (PTCCommittee pre-CStar)",
+        );
+    }
+
+    #[test]
+    fn test_ptc_committee_within_ttl_accepted() {
+        let committee_info = create_committee_info(FOUR_NODE_COMMITTEE);
+        let (private_key, public_key) = generate_test_key_pair();
+        let map =
+            create_operator_pub_keys(committee_info.committee_members.clone(), vec![public_key]);
+        let signed_msg = create_signed_partial_sig_message(
+            Role::PTCCommittee,
+            PartialSignatureKind::PostConsensus,
+            OperatorId(1),
+            &private_key,
+        );
+
+        let validation_context = create_ttl_validation_context(
+            &signed_msg,
+            &committee_info,
+            Role::PTCCommittee,
+            &map,
+            TTL_SLOTS,
+            generate_fork_schedule(Fork::CStar),
+        );
+
+        let result = validate_partial_signature_message(
+            validation_context,
+            &mut DutyState::new(64),
+            Arc::new(MockDutiesProvider {
+                voluntary_exit_duty_count: 0,
+            }),
+        );
+
+        assert!(result.is_ok(), "Expected ok but got: {result:?}");
+    }
+
+    #[test]
+    fn test_ptc_committee_beyond_ttl_rejected() {
+        let committee_info = create_committee_info(FOUR_NODE_COMMITTEE);
+        let (private_key, public_key) = generate_test_key_pair();
+        let map =
+            create_operator_pub_keys(committee_info.committee_members.clone(), vec![public_key]);
+        let signed_msg = create_signed_partial_sig_message(
+            Role::PTCCommittee,
+            PartialSignatureKind::PostConsensus,
+            OperatorId(1),
+            &private_key,
+        );
+
+        let validation_context = create_ttl_validation_context(
+            &signed_msg,
+            &committee_info,
+            Role::PTCCommittee,
+            &map,
+            BEYOND_TTL_SLOTS,
+            generate_fork_schedule(Fork::CStar),
+        );
+
+        let result = validate_partial_signature_message(
+            validation_context,
+            &mut DutyState::new(64),
+            Arc::new(MockDutiesProvider {
+                voluntary_exit_duty_count: 0,
+            }),
+        );
+
+        assert_validation_error(
+            result,
+            |failure| matches!(failure, ValidationFailure::LateSlotMessage { .. }),
+            "LateSlotMessage",
+        );
+    }
+
+    #[test]
+    fn test_ptc_committee_invalid_partial_sig_kind_rejected() {
+        // PTC binds to PartialSignatureKind::PostConsensus. Any other kind
+        // must trip PartialSignatureTypeRoleMismatch.
+        let committee_info = create_committee_info(FOUR_NODE_COMMITTEE);
+
+        let (_, signed_msg) = create_test_partial_signature(
+            Role::PTCCommittee,
+            PartialSignatureKind::RandaoPartialSig,
+            OperatorId(1),
+            PartialSigTestOptions::default(),
+            None,
+        );
+
+        let binding = generate_random_rsa_public_keys(signed_msg.operator_ids().len());
+        let map = create_operator_pub_keys(committee_info.committee_members.clone(), binding);
+
+        let validation_context = create_test_validation_context(
+            &signed_msg,
+            &committee_info,
+            Role::PTCCommittee,
+            &map,
+            generate_fork_schedule(Fork::CStar),
+        );
+
+        let result = validate_partial_signature_message(
+            validation_context,
+            &mut DutyState::new(2),
+            Arc::new(MockDutiesProvider {
+                voluntary_exit_duty_count: 0,
+            }),
+        );
+
+        assert_validation_error(
+            result,
+            |failure| matches!(failure, ValidationFailure::PartialSignatureTypeRoleMismatch),
+            "PartialSignatureTypeRoleMismatch",
         );
     }
 

--- a/anchor/message_validator/src/partial_signature.rs
+++ b/anchor/message_validator/src/partial_signature.rs
@@ -1807,8 +1807,7 @@ mod tests {
 
     #[test]
     fn test_ptc_committee_message_count_exceeds_validator_count() {
-        // V+1 distinct validator indices: must trip the message_count > V
-        // check before the per-validator-index occurrence check fires.
+        // V+1 distinct validator indices: verifies the structural message-count cap (V).
         let committee_info = create_committee_info(FOUR_NODE_COMMITTEE);
         let validator_count = committee_info.validator_indices.len();
         let (private_key, public_key) = generate_test_key_pair();

--- a/anchor/message_validator/src/partial_signature.rs
+++ b/anchor/message_validator/src/partial_signature.rs
@@ -5,7 +5,10 @@ use slot_clock::SlotClock;
 use ssv_types::{
     OperatorId,
     msgid::Role,
-    partial_sig::{PartialSignatureKind, PartialSignatureMessages, PartialSignatureMessagesError},
+    partial_sig::{
+        PartialSignatureKind, PartialSignatureMessage, PartialSignatureMessages,
+        PartialSignatureMessagesError,
+    },
 };
 use ssz::Decode;
 use types::consts::altair::SYNC_COMMITTEE_SUBNET_COUNT;
@@ -317,27 +320,8 @@ fn validate_partial_sig_messages_by_duty_logic(
         Role::PTCCommittee => {
             // PTC produces exactly one partial signature per locally-assigned
             // validator per slot.
-            if message_count > validator_count {
-                return Err(ValidationFailure::TooManyPartialSignatureMessages {
-                    got: message_count,
-                    limit: validator_count,
-                });
-            }
-
-            let mut validator_index_count = HashMap::new();
-            for message in &partial_signature_messages.messages {
-                let count = validator_index_count
-                    .entry(message.validator_index)
-                    .or_insert(0);
-                *count += 1;
-                if *count > 1 {
-                    return Err(ValidationFailure::TooManyValidatorIndexOccurrences {
-                        validator_index: message.validator_index,
-                        got: *count,
-                        limit: 1,
-                    });
-                }
-            }
+            validate_ptc_committee_message_count(message_count, validator_count)?;
+            validate_validator_index_occurrence_limit(&partial_signature_messages.messages, 1)?;
         }
         // Per-validator roles only allow one signature
         Role::Aggregator | Role::Proposer | Role::ValidatorRegistration | Role::VoluntaryExit => {
@@ -350,6 +334,40 @@ fn validate_partial_sig_messages_by_duty_logic(
         }
     }
 
+    Ok(())
+}
+
+fn validate_validator_index_occurrence_limit(
+    messages: &[PartialSignatureMessage],
+    limit: usize,
+) -> Result<(), ValidationFailure> {
+    let mut validator_index_count = HashMap::new();
+    for message in messages {
+        let count = validator_index_count
+            .entry(message.validator_index)
+            .or_insert(0usize);
+        *count += 1;
+        if *count > limit {
+            return Err(ValidationFailure::TooManyValidatorIndexOccurrences {
+                validator_index: message.validator_index,
+                got: *count,
+                limit,
+            });
+        }
+    }
+    Ok(())
+}
+
+fn validate_ptc_committee_message_count(
+    message_count: usize,
+    validator_count: usize,
+) -> Result<(), ValidationFailure> {
+    if message_count > validator_count {
+        return Err(ValidationFailure::TooManyPartialSignatureMessages {
+            got: message_count,
+            limit: validator_count,
+        });
+    }
     Ok(())
 }
 
@@ -1228,6 +1246,10 @@ mod tests {
     const LATE_SLOT_ALLOWANCE_TEST: u64 = 2;
     const TTL_SLOTS: u64 = SLOTS_PER_EPOCH_TEST + LATE_SLOT_ALLOWANCE_TEST; // 34 slots
     const BEYOND_TTL_SLOTS: u64 = 40;
+    // Past the proposer/sync TTL (1 + LATE_SLOT_ALLOWANCE_TEST = 3 slots), well
+    // within the committee TTL (TTL_SLOTS = 34). Lets a test prove a role is in
+    // the committee TTL bucket rather than just inside the long-TTL boundary.
+    const COMMITTEE_TTL_BUCKET_SLOTS: u64 = 20;
 
     // Helper to create validation context for TTL tests
     fn create_ttl_validation_context<'a>(
@@ -1657,232 +1679,51 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_ptc_committee_validator_index_occurrence_limit() {
-        // PTC allows exactly 1 occurrence per validator index per partial-sig packet.
-        let committee_info = create_committee_info(FOUR_NODE_COMMITTEE);
-        let (private_key, public_key) = generate_test_key_pair();
-
-        // 1 occurrence: should pass.
-        let messages = vec![PartialSignatureMessage {
+    fn create_partial_sig_message(validator_index: ValidatorIndex) -> PartialSignatureMessage {
+        PartialSignatureMessage {
             partial_signature: Signature::empty(),
             signing_root: Hash256::from([0u8; 32]),
             signer: OperatorId(1),
-            validator_index: ValidatorIndex(100),
-        }];
+            validator_index,
+        }
+    }
 
-        let partial_sig_messages = PartialSignatureMessages {
-            kind: PartialSignatureKind::PostConsensus,
-            slot: Slot::new(1),
-            messages: VariableList::new(messages).unwrap(),
-        };
+    #[test]
+    fn test_ptc_committee_validator_index_occurrence_limit() {
+        // PTC allows exactly 1 occurrence per validator index per partial-sig packet.
+        let one = vec![create_partial_sig_message(ValidatorIndex(100))];
+        assert!(validate_validator_index_occurrence_limit(&one, 1).is_ok());
 
-        let msg_id = create_message_id_for_test(Role::PTCCommittee);
-        let ssv_msg = SSVMessage::new(
-            MsgType::SSVPartialSignatureMsgType,
-            msg_id,
-            partial_sig_messages.as_ssz_bytes(),
-        )
-        .unwrap();
-
-        let p_key = PKey::from_rsa(private_key.clone()).unwrap();
-        let mut signer = Signer::new(MessageDigest::sha256(), &p_key).unwrap();
-        signer.update(&ssv_msg.as_ssz_bytes()).unwrap();
-        let signature = signer.sign_to_vec().unwrap().try_into().unwrap();
-
-        let signed_msg =
-            SignedSSVMessage::new(vec![signature], vec![OperatorId(1)], ssv_msg, vec![]).unwrap();
-
-        let map = create_operator_pub_keys(
-            committee_info.committee_members.clone(),
-            vec![public_key.clone()],
-        );
-
-        let now = SystemTime::now();
-        let slot_clock = ManualSlotClock::new(
-            Slot::new(1),
-            now.duration_since(UNIX_EPOCH).unwrap(),
-            Duration::from_secs(12),
-        );
-
-        let fork_schedule = generate_fork_schedule(Fork::CStar);
-
-        let validation_context = ValidationContext {
-            signed_ssv_message: &signed_msg,
-            committee_info: &committee_info,
-            role: Role::PTCCommittee,
-            received_at: now,
-            slots_per_epoch: 32,
-            epochs_per_sync_committee_period: 256,
-            sync_committee_size: 512,
-            slot_clock,
-            operator_pub_keys: &map,
-            fork_schedule: fork_schedule.clone(),
-        };
-
-        let result = validate_partial_signature_message(
-            validation_context,
-            &mut DutyState::new(2),
-            Arc::new(MockDutiesProvider {
-                voluntary_exit_duty_count: 0,
-            }),
-        );
-
-        assert!(
-            result.is_ok(),
-            "Expected 1 occurrence to be valid for PTCCommittee, but got: {:?}",
-            result
-        );
-
-        // 2 occurrences: should fail.
-        let messages: Vec<_> = (0..2)
-            .map(|_| PartialSignatureMessage {
-                partial_signature: Signature::empty(),
-                signing_root: Hash256::from([0u8; 32]),
-                signer: OperatorId(1),
-                validator_index: ValidatorIndex(100),
-            })
-            .collect();
-
-        let partial_sig_messages = PartialSignatureMessages {
-            kind: PartialSignatureKind::PostConsensus,
-            slot: Slot::new(1),
-            messages: VariableList::new(messages).unwrap(),
-        };
-
-        let msg_id = create_message_id_for_test(Role::PTCCommittee);
-        let ssv_msg = SSVMessage::new(
-            MsgType::SSVPartialSignatureMsgType,
-            msg_id,
-            partial_sig_messages.as_ssz_bytes(),
-        )
-        .unwrap();
-
-        let p_key = PKey::from_rsa(private_key).unwrap();
-        let mut signer = Signer::new(MessageDigest::sha256(), &p_key).unwrap();
-        signer.update(&ssv_msg.as_ssz_bytes()).unwrap();
-        let signature = signer.sign_to_vec().unwrap().try_into().unwrap();
-
-        let signed_msg =
-            SignedSSVMessage::new(vec![signature], vec![OperatorId(1)], ssv_msg, vec![]).unwrap();
-
-        let slot_clock2 = ManualSlotClock::new(
-            Slot::new(1),
-            now.duration_since(UNIX_EPOCH).unwrap(),
-            Duration::from_secs(12),
-        );
-
-        let validation_context = ValidationContext {
-            signed_ssv_message: &signed_msg,
-            committee_info: &committee_info,
-            role: Role::PTCCommittee,
-            received_at: now,
-            slots_per_epoch: 32,
-            epochs_per_sync_committee_period: 256,
-            sync_committee_size: 512,
-            slot_clock: slot_clock2,
-            operator_pub_keys: &map,
-            fork_schedule,
-        };
-
-        let result = validate_partial_signature_message(
-            validation_context,
-            &mut DutyState::new(2),
-            Arc::new(MockDutiesProvider {
-                voluntary_exit_duty_count: 0,
-            }),
-        );
-
+        let two = vec![
+            create_partial_sig_message(ValidatorIndex(100)),
+            create_partial_sig_message(ValidatorIndex(100)),
+        ];
         assert_validation_error(
-            result,
-            |failure| {
+            validate_validator_index_occurrence_limit(&two, 1),
+            |f| {
                 matches!(
-                    failure,
+                    f,
                     ValidationFailure::TooManyValidatorIndexOccurrences { limit: 1, .. }
                 )
             },
-            "TooManyValidatorIndexOccurrences (limit exceeded for PTCCommittee)",
+            "TooManyValidatorIndexOccurrences (PTC limit)",
         );
     }
 
     #[test]
     fn test_ptc_committee_message_count_exceeds_validator_count() {
-        // V+1 distinct validator indices: verifies the structural message-count cap (V).
-        let committee_info = create_committee_info(FOUR_NODE_COMMITTEE);
-        let validator_count = committee_info.validator_indices.len();
-        let (private_key, public_key) = generate_test_key_pair();
-
-        let messages: Vec<_> = (0..=validator_count)
-            .map(|i| PartialSignatureMessage {
-                partial_signature: Signature::empty(),
-                signing_root: Hash256::from([0u8; 32]),
-                signer: OperatorId(1),
-                validator_index: ValidatorIndex(i),
-            })
-            .collect();
-
-        let partial_sig_messages = PartialSignatureMessages {
-            kind: PartialSignatureKind::PostConsensus,
-            slot: Slot::new(1),
-            messages: VariableList::new(messages).unwrap(),
-        };
-
-        let msg_id = create_message_id_for_test(Role::PTCCommittee);
-        let ssv_msg = SSVMessage::new(
-            MsgType::SSVPartialSignatureMsgType,
-            msg_id,
-            partial_sig_messages.as_ssz_bytes(),
-        )
-        .unwrap();
-
-        let p_key = PKey::from_rsa(private_key).unwrap();
-        let mut signer = Signer::new(MessageDigest::sha256(), &p_key).unwrap();
-        signer.update(&ssv_msg.as_ssz_bytes()).unwrap();
-        let signature = signer.sign_to_vec().unwrap().try_into().unwrap();
-
-        let signed_msg =
-            SignedSSVMessage::new(vec![signature], vec![OperatorId(1)], ssv_msg, vec![]).unwrap();
-
-        let map =
-            create_operator_pub_keys(committee_info.committee_members.clone(), vec![public_key]);
-
-        let now = SystemTime::now();
-        let slot_clock = ManualSlotClock::new(
-            Slot::new(1),
-            now.duration_since(UNIX_EPOCH).unwrap(),
-            Duration::from_secs(12),
-        );
-
-        let validation_context = ValidationContext {
-            signed_ssv_message: &signed_msg,
-            committee_info: &committee_info,
-            role: Role::PTCCommittee,
-            received_at: now,
-            slots_per_epoch: 32,
-            epochs_per_sync_committee_period: 256,
-            sync_committee_size: 512,
-            slot_clock,
-            operator_pub_keys: &map,
-            fork_schedule: generate_fork_schedule(Fork::CStar),
-        };
-
-        let result = validate_partial_signature_message(
-            validation_context,
-            &mut DutyState::new(2),
-            Arc::new(MockDutiesProvider {
-                voluntary_exit_duty_count: 0,
-            }),
-        );
-
+        // V+1 messages trip the structural message-count cap (V).
+        let v = FOUR_NODE_COMMITTEE;
+        assert!(validate_ptc_committee_message_count(v, v).is_ok());
         assert_validation_error(
-            result,
-            |failure| {
+            validate_ptc_committee_message_count(v + 1, v),
+            |f| {
                 matches!(
-                    failure,
-                    ValidationFailure::TooManyPartialSignatureMessages { limit, .. } if *limit == validator_count
+                    f,
+                    ValidationFailure::TooManyPartialSignatureMessages { limit, .. } if *limit == v
                 )
             },
-            "TooManyPartialSignatureMessages (PTCCommittee message_count > V)",
+            "TooManyPartialSignatureMessages (PTC count > V)",
         );
     }
 
@@ -1939,12 +1780,15 @@ mod tests {
             &private_key,
         );
 
+        // COMMITTEE_TTL_BUCKET_SLOTS = 20 is past the proposer/sync TTL (3) but
+        // well inside the committee TTL (34). Accepting here proves PTC is
+        // bucketed as committee, not just inside a long TTL.
         let validation_context = create_ttl_validation_context(
             &signed_msg,
             &committee_info,
             Role::PTCCommittee,
             &map,
-            TTL_SLOTS,
+            COMMITTEE_TTL_BUCKET_SLOTS,
             generate_fork_schedule(Fork::CStar),
         );
 
@@ -1960,80 +1804,18 @@ mod tests {
     }
 
     #[test]
-    fn test_ptc_committee_beyond_ttl_rejected() {
-        let committee_info = create_committee_info(FOUR_NODE_COMMITTEE);
-        let (private_key, public_key) = generate_test_key_pair();
-        let map =
-            create_operator_pub_keys(committee_info.committee_members.clone(), vec![public_key]);
-        let signed_msg = create_signed_partial_sig_message(
-            Role::PTCCommittee,
+    fn test_ptc_committee_binds_post_consensus_only() {
+        // PTC binds to PartialSignatureKind::PostConsensus.
+        // Mapping to ValidationFailure::PartialSignatureTypeRoleMismatch is covered
+        // end-to-end by test_partial_signature_message_with_invalid_type_for_role.
+        assert!(partial_signature_type_matches_role(
             PartialSignatureKind::PostConsensus,
-            OperatorId(1),
-            &private_key,
-        );
-
-        let validation_context = create_ttl_validation_context(
-            &signed_msg,
-            &committee_info,
             Role::PTCCommittee,
-            &map,
-            BEYOND_TTL_SLOTS,
-            generate_fork_schedule(Fork::CStar),
-        );
-
-        let result = validate_partial_signature_message(
-            validation_context,
-            &mut DutyState::new(64),
-            Arc::new(MockDutiesProvider {
-                voluntary_exit_duty_count: 0,
-            }),
-        );
-
-        assert_validation_error(
-            result,
-            |failure| matches!(failure, ValidationFailure::LateSlotMessage { .. }),
-            "LateSlotMessage",
-        );
-    }
-
-    #[test]
-    fn test_ptc_committee_invalid_partial_sig_kind_rejected() {
-        // PTC binds to PartialSignatureKind::PostConsensus. Any other kind
-        // must trip PartialSignatureTypeRoleMismatch.
-        let committee_info = create_committee_info(FOUR_NODE_COMMITTEE);
-
-        let (_, signed_msg) = create_test_partial_signature(
-            Role::PTCCommittee,
+        ));
+        assert!(!partial_signature_type_matches_role(
             PartialSignatureKind::RandaoPartialSig,
-            OperatorId(1),
-            PartialSigTestOptions::default(),
-            None,
-        );
-
-        let binding = generate_random_rsa_public_keys(signed_msg.operator_ids().len());
-        let map = create_operator_pub_keys(committee_info.committee_members.clone(), binding);
-
-        let validation_context = create_test_validation_context(
-            &signed_msg,
-            &committee_info,
             Role::PTCCommittee,
-            &map,
-            generate_fork_schedule(Fork::CStar),
-        );
-
-        let result = validate_partial_signature_message(
-            validation_context,
-            &mut DutyState::new(2),
-            Arc::new(MockDutiesProvider {
-                voluntary_exit_duty_count: 0,
-            }),
-        );
-
-        assert_validation_error(
-            result,
-            |failure| matches!(failure, ValidationFailure::PartialSignatureTypeRoleMismatch),
-            "PartialSignatureTypeRoleMismatch",
-        );
+        ));
     }
 
     #[test]

--- a/anchor/qbft_manager/src/lib.rs
+++ b/anchor/qbft_manager/src/lib.rs
@@ -331,7 +331,8 @@ impl<E: EthSpec, S: SlotClock + Clone + 'static> QbftManager<E, S> {
                         )
                     }
                     Some(Role::PTCCommittee) => {
-                        //todo(cstar): wire PTC instance routing
+                        // TODO(cstar): wire PTC instance routing and add pre-CStar
+                        // fork gate (mirror `AggregatorCommittee` arm above).
                         let slot = types::Slot::new(qbft_message.height);
                         warn!(%slot, "Ignoring PTCCommittee message; routing not wired");
                         Err(QbftError::RoleNotActive)

--- a/anchor/qbft_manager/src/lib.rs
+++ b/anchor/qbft_manager/src/lib.rs
@@ -270,7 +270,7 @@ impl<E: EthSpec, S: SlotClock + Clone + 'static> QbftManager<E, S> {
                     Some(Role::Aggregator) => ValidatorDutyKind::Aggregator,
                     Some(Role::SyncCommittee) => ValidatorDutyKind::SyncCommitteeAggregator,
                     // Committee roles use DutyExecutor::Committee, not Validator
-                    Some(Role::Committee | Role::AggregatorCommittee)
+                    Some(Role::Committee | Role::AggregatorCommittee | Role::PTCCommittee)
                     // These roles don't use QBFT consensus
                     | Some(Role::ValidatorRegistration | Role::VoluntaryExit)
                     | None => {
@@ -329,6 +329,12 @@ impl<E: EthSpec, S: SlotClock + Clone + 'static> QbftManager<E, S> {
                                 qbft_message,
                             },
                         )
+                    }
+                    Some(Role::PTCCommittee) => {
+                        //todo(cstar): wire PTC instance routing
+                        let slot = types::Slot::new(qbft_message.height);
+                        warn!(%slot, "Ignoring PTCCommittee message; routing not wired");
+                        Err(QbftError::RoleNotActive)
                     }
                     // Validator roles should use DutyExecutor::Validator, not Committee
                     Some(Role::Aggregator | Role::Proposer | Role::SyncCommittee)


### PR DESCRIPTION
## Problem, Evidence, and Context

- SIP-94 §3 ([ssvlabs/SIPs#94](https://github.com/ssvlabs/SIPs/pull/94)) adds the Payload Timeliness Committee duty at the Gloas / EIP-7732 / ePBS fork. Anchor needs a new `Role::PTCCommittee` wire surface before any other PTC work can land.
- Adding the variant breaks five exhaustive `match` sites in `message_validator` and `qbft_manager`; those edits ship together so the workspace stays green between PRs. The `qbft_manager` change is a one-line stub that the PTC instance routing PR replaces.
- The role is wire-incompatible with pre-CStar operators (pre-CStar nodes decode the byte as `Err(NoMatchingVariant)`). The message-validator fork-gate is defense-in-depth for CStar-capable nodes that might receive a PTC message before their local `active_fork >= Fork::CStar`.
- Issue: sigp/anchor#1032
- Milestone: [ePBS: Payload Timeliness Committee (PTC) Attestation](https://github.com/sigp/anchor/milestone/4)
- Spec: [consensus-specs Gloas `compute_ptc`](https://github.com/ethereum/consensus-specs/blob/4a4937bea332d72a55a76aaebcb97fbcdc189f69/specs/gloas/beacon-chain.md#L666)

## Change Overview

Diff shape: **+553 / -9 across 5 files. ~69 lines of production code, ~484 lines of tests (≈7:1).** Most of the test volume is `ValidationContext` construction boilerplate (matches the existing house style for full-pipeline integration tests in `partial_signature.rs`).

`ssv_types` — wire surface:
- `Role::PTCCommittee` variant: byte `[7, 0, 0, 0]` (matches SIP-94 `BNRolePTCAttester = 7`), `is_committee_role = true`, `duty_executor = Committee`, `max_round = Some(4)`.
- **No new `PartialSignatureKind` variant.** PTC is structurally a post-consensus signature (signed after QBFT decides `PayloadAttestationData`, same shape as `Role::Committee`'s post-consensus path). Reusing `PostConsensus` eliminates a wire-discriminant slot and ~30 LOC of test boilerplate. The role-to-kind binding lives in `partial_signature_type_matches_role`.

`message_validator` — fork-gate + bounds:
- `validate_role_for_fork`: pre-CStar reject mirroring the AggregatorCommittee/pre-Boole safety net.
- `message_lateness`: PTC bucketed in the long-TTL arm (committee-scoped messages need cross-cluster propagation time, even with mid-slot deadlines).
- `duty_limit`: `Some(min(slots_per_epoch, V))` where `V` = local validator count. PTC pool for slot S = union of beacon committees for slot S, so each validator is PTC-eligible in at most one slot per epoch. Distinct from Committee/AggregatorCommittee's `min(slots_per_epoch, 2*V)` — PTC has no sync-committee component and no attest+sync multiplier.
- `partial_signature_type_matches_role`: binds PTC to `PostConsensus` (folded into the existing Committee arm).
- Per-role bounds: new `Role::PTCCommittee` arm with `message_count <= V` and validator-index occurrence cap `1`. Structural maximum — PTC produces exactly one partial-sig per locally-assigned validator per slot. Distinct from Committee's caps (2V, 2) and AggregatorCommittee's (5V, 5).

`qbft_manager` — transient stub:
- Adds `Role::PTCCommittee` to the `Some(DutyExecutor::Validator(_))` invalid-combination group.
- New committee-role arm returns `Err(QbftError::RoleNotActive)` with a warn-log, marked `//todo(cstar)`. The PTC instance routing PR replaces both.

Tests delivered (10): 3 in `ssv_types`, 7 in `message_validator`. Each maps one-to-one to a design decision documented in the local milestone plan.

**Intentionally not changed.** `partial_sig.rs` and `message_counts.rs` (no new `PartialSignatureKind` variant). Slot-advancement-skip and validator-index-mismatch-skip behavior is inherited via `is_committee_role() == true` and structurally covered by existing AggregatorCommittee skip tests; adding PTC-specific copies would duplicate ~150 LOC with no new signal. The `ptc_is_committee_role` unit test asserts the boolean that drives both skips.

## Risks, Trade-offs, and Mitigations

- **Wire-byte collision audit.** Anchor's `Role::AggregatorCommittee = [6, 0, 0, 0]` is Anchor-internal; PTC = 7 is upstream SIP-94. Manual audit for upstream go-ssv role conflict is required before merge. Byte 7 matches the SIP-assigned value and Anchor's byte 6 sits below the SIP allocation.
- **`qbft_manager` stub is transient.** PTC messages reaching `receive_data` are rejected with `RoleNotActive` + warn-log. Not a safety issue (no PTC QBFT instance exists yet — rejection is the correct response). The `//todo(cstar)` marker and warn-log must not survive the PTC instance routing PR.
- **`max_round = Some(4)` is timing-derived, not measured.** Follows from the 75% slot start and `QUICK_TIMEOUT = 2s`: round 1 finishes within slot, rounds 2-4 cover operator clock skew, rounds 5+ are dead weight. Retune only if Lighthouse moves the PTC service start time off 75% slot.

## Validation

- `cargo test -p ssv_types -p message_validator` — 64 + 83 tests pass (10 new PTC tests; 0 regressions).
- `make cargo-fmt-check`, `make lint` — green.
- Each of the 10 new tests targets a specific design decision (PostConsensus binding, fork gate, TTL bucketing, `duty_limit` formula, per-role bounds, committee-role semantics, `max_round` value, committee-style duty-executor).
- Production code comments at three non-obvious sites document the WHY for reviewers reading the diff cold: `lib.rs::message_lateness` (long-TTL rationale), `lib.rs::duty_limit` (PTC selection mechanics + consensus-specs permalink to `compute_ptc`), `partial_signature.rs::partial_signature_type_matches_role` (`PostConsensus` reuse).

## Rollback

- Single-commit revert. The variant is wire-incompatible with pre-CStar operators by design; pre-CStar peers reject the byte already. No data, config, or operational impact. Until CStar activates on a live SSV network, the new role is unreachable from any production code path.

## Blockers / Dependencies

- None for this PR.
- Follow-up issues (same milestone): PTC instance routing in `qbft_manager` (replaces `//todo(cstar)` stub), `PayloadAttestationVote` SSZ container + value checker, `metadata_service` PTC voting-context phase, `sign_payload_attestation` impl, Lighthouse `PayloadAttestationService` spawn.

## Additional Info

Base: `epbs`. The milestone bundles original M3.1 (ssv_types) + M3.7 (message-validator) because the exhaustive-match cascade made splitting them produce double-touched files. The follow-up issues land independently against this base.