### PR TITLE
feat(validator_store): drive Phase 2 from beacon head events

### DIFF
--- a/anchor/cli/src/cli.rs
+++ b/anchor/cli/src/cli.rs
@@ -547,6 +547,17 @@ pub struct Node {
 
     #[clap(
         long,
+        help = "Disable the beacon head monitor which tries to attest as soon as any of the \
+                configured beacon nodes sends a head event. Leaving the service enabled is \
+                recommended, but disabling it can lead to reduced bandwidth and more predictable \
+                usage of the primary beacon node (rather than the fastest BN).",
+        display_order = 0,
+        help_heading = FLAG_HEADER
+    )]
+    pub disable_beacon_head_monitor: bool,
+
+    #[clap(
+        long,
         help = "Disable slashing protection for all validator clients. DO NOT ENABLE THIS UNLESS YOU HAVE A MORE THAN SUFFICIENT REASON TO",
         hide = true,
         display_order = 0

--- a/anchor/cli/src/cli.rs
+++ b/anchor/cli/src/cli.rs
@@ -619,7 +619,10 @@ pub struct Node {
         help = "Enable parallel querying and scoring of attestation data across multiple beacon \
                 nodes. When enabled, Anchor queries all configured beacon nodes simultaneously \
                 and selects the attestation data with the highest score based on checkpoint \
-                epochs and head block proximity. Only useful with multiple beacon nodes.",
+                epochs and head block proximity. Only useful with multiple beacon nodes. \
+                Note: WAD is bypassed when the beacon head monitor (enabled by default, see \
+                --disable-beacon-head-monitor) wins the eager-attest race for a slot; the \
+                firing BN is queried directly. WAD still runs on the fallback path.",
         display_order = 0
     )]
     pub with_weighted_attestation_data: bool,

--- a/anchor/cli/src/cli.rs
+++ b/anchor/cli/src/cli.rs
@@ -540,9 +540,7 @@ pub struct Node {
         help = "Disable the beacon head monitor which tries to attest as soon as any of the \
                 configured beacon nodes sends a head event. Leaving the service enabled is \
                 recommended, but disabling it can lead to reduced bandwidth and more predictable \
-                usage of the primary beacon node (rather than the fastest BN).",
-        display_order = 0,
-        help_heading = FLAG_HEADER
+                usage of the primary beacon node (rather than the fastest BN)."
     )]
     pub disable_beacon_head_monitor: bool,
 

--- a/anchor/client/src/config.rs
+++ b/anchor/client/src/config.rs
@@ -71,6 +71,8 @@ pub struct Config {
     pub prefer_builder_proposals: bool,
     /// Controls whether the latency measurement service is enabled
     pub disable_latency_measurement_service: bool,
+    /// Enables the beacon head monitor that reacts to head updates from connected beacon nodes.
+    pub enable_beacon_head_monitor: bool,
     /// Enable operator doppelgänger protection (blocks messages and monitors for twins)
     pub operator_dg: bool,
     /// Number of epochs to monitor for twins after grace period
@@ -124,6 +126,7 @@ impl Config {
             prefer_builder_proposals: false,
             gas_limit: 36_000_000,
             disable_latency_measurement_service: false,
+            enable_beacon_head_monitor: true,
             operator_dg: false,
             operator_dg_wait_epochs: 2,
             strict_mfp: false,
@@ -281,6 +284,7 @@ pub fn from_cli(mut cli_args: Node, global_config: GlobalConfig) -> Result<Confi
 
     config.impostor = cli_args.impostor.map(OperatorId);
     config.disable_latency_measurement_service = cli_args.disable_latency_measurement_service;
+    config.enable_beacon_head_monitor = !cli_args.disable_beacon_head_monitor;
 
     // Operator doppelgänger protection
     config.operator_dg = cli_args.operator_dg;

--- a/anchor/client/src/lib.rs
+++ b/anchor/client/src/lib.rs
@@ -341,14 +341,51 @@ impl Client {
 
         // Only the beacon_nodes are used for attestation duties, so proposer_nodes do not need a
         // head_send ref.
-        let head_monitor_rx = if config.enable_beacon_head_monitor {
-            let (head_monitor_tx, head_monitor_rx) =
-                mpsc::channel::<HeadEvent>(MAX_HEAD_EVENT_QUEUE_LEN);
-            beacon_nodes.set_head_send(Arc::new(head_monitor_tx));
-            Some(Mutex::new(head_monitor_rx))
-        } else {
-            None
-        };
+        let (attestation_head_monitor_rx, metadata_head_monitor_rx) =
+            if config.enable_beacon_head_monitor {
+                let (head_event_tx, mut head_event_rx) =
+                    mpsc::channel::<HeadEvent>(MAX_HEAD_EVENT_QUEUE_LEN);
+                let (attestation_service_tx, attestation_service_rx) =
+                    mpsc::channel::<HeadEvent>(MAX_HEAD_EVENT_QUEUE_LEN);
+                let (metadata_service_tx, metadata_service_rx) =
+                    mpsc::channel::<HeadEvent>(MAX_HEAD_EVENT_QUEUE_LEN);
+                beacon_nodes.set_head_send(Arc::new(head_event_tx));
+
+                executor.spawn(
+                    async move {
+                        while let Some(head_event) = head_event_rx.recv().await {
+                            let HeadEvent {
+                                beacon_node_index,
+                                slot,
+                                beacon_block_root,
+                            } = head_event;
+                            let to_attest = HeadEvent {
+                                beacon_node_index,
+                                slot,
+                                beacon_block_root,
+                            };
+                            let to_meta = HeadEvent {
+                                beacon_node_index,
+                                slot,
+                                beacon_block_root,
+                            };
+                            if attestation_service_tx.send(to_attest).await.is_err()
+                                || metadata_service_tx.send(to_meta).await.is_err()
+                            {
+                                warn!("head event fan-out: downstream closed, exiting relay");
+                                return;
+                            }
+                        }
+                    },
+                    "head_event_fanout",
+                );
+                (
+                    Some(Mutex::new(attestation_service_rx)),
+                    Some(Arc::new(Mutex::new(metadata_service_rx))),
+                )
+            } else {
+                (None, None)
+            };
 
         let beacon_nodes = Arc::new(beacon_nodes);
         start_fallback_updater_service::<_, E>(executor.clone(), beacon_nodes.clone())?;
@@ -674,7 +711,7 @@ impl Client {
             .beacon_nodes(beacon_nodes.clone())
             .executor(executor.clone())
             .chain_spec(spec.clone())
-            .head_monitor_rx(head_monitor_rx)
+            .head_monitor_rx(attestation_head_monitor_rx)
             .build()?;
 
         let preparation_service = PreparationServiceBuilder::new()
@@ -717,6 +754,7 @@ impl Client {
             spec.clone(),
             fork_schedule.clone(),
             config.with_weighted_attestation_data,
+            metadata_head_monitor_rx,
         );
 
         // We use `SLOTS_PER_EPOCH` as the capacity of the block notification channel, because

--- a/anchor/client/src/lib.rs
+++ b/anchor/client/src/lib.rs
@@ -18,7 +18,8 @@ use anchor_validator_store::{
     registration_service::RegistrationService,
 };
 use beacon_node_fallback::{
-    BeaconNodeFallback, CandidateBeaconNode, start_fallback_updater_service,
+    BeaconNodeFallback, CandidateBeaconNode, beacon_head_monitor::HeadEvent,
+    start_fallback_updater_service,
 };
 use config::Config;
 use database::{NetworkDatabase, OwnOperatorId};
@@ -45,7 +46,10 @@ use task_executor::TaskExecutor;
 use tokio::{
     net::TcpListener,
     select,
-    sync::{mpsc, mpsc::unbounded_channel},
+    sync::{
+        Mutex,
+        mpsc::{self, unbounded_channel},
+    },
     time::{Instant, interval, sleep},
 };
 use tracing::{debug, error, info, warn};
@@ -78,6 +82,7 @@ const HTTP_GET_DEBUG_BEACON_STATE_QUOTIENT: u32 = 4;
 const HTTP_GET_DEPOSIT_SNAPSHOT_QUOTIENT: u32 = 4;
 const HTTP_GET_VALIDATOR_BLOCK_TIMEOUT_QUOTIENT: u32 = 4;
 const HTTP_DEFAULT_TIMEOUT_QUOTIENT: u32 = 4;
+const MAX_HEAD_EVENT_QUEUE_LEN: usize = 1_024;
 
 pub struct Client {}
 
@@ -333,6 +338,17 @@ impl Client {
 
         beacon_nodes.set_slot_clock(slot_clock.clone());
         proposer_nodes.set_slot_clock(slot_clock.clone());
+
+        // Only the beacon_nodes are used for attestation duties, so proposer_nodes do not need a
+        // head_send ref.
+        let head_monitor_rx = if config.enable_beacon_head_monitor {
+            let (head_monitor_tx, head_monitor_rx) =
+                mpsc::channel::<HeadEvent>(MAX_HEAD_EVENT_QUEUE_LEN);
+            beacon_nodes.set_head_send(Arc::new(head_monitor_tx));
+            Some(Mutex::new(head_monitor_rx))
+        } else {
+            None
+        };
 
         let beacon_nodes = Arc::new(beacon_nodes);
         start_fallback_updater_service::<_, E>(executor.clone(), beacon_nodes.clone())?;
@@ -658,6 +674,7 @@ impl Client {
             .beacon_nodes(beacon_nodes.clone())
             .executor(executor.clone())
             .chain_spec(spec.clone())
+            .head_monitor_rx(head_monitor_rx)
             .build()?;
 
         let preparation_service = PreparationServiceBuilder::new()

--- a/anchor/client/src/lib.rs
+++ b/anchor/client/src/lib.rs
@@ -48,7 +48,7 @@ use tokio::{
     select,
     sync::{
         Mutex,
-        mpsc::{self, unbounded_channel},
+        mpsc::{self, error::TrySendError, unbounded_channel},
     },
     time::{Instant, interval, sleep},
 };
@@ -354,6 +354,8 @@ impl Client {
                 executor.spawn(
                     async move {
                         while let Some(head_event) = head_event_rx.recv().await {
+                            // LH's `HeadEvent` doesn't derive Clone, so rebuild for each
+                            // downstream. All fields are Copy so this is essentially free.
                             let HeadEvent {
                                 beacon_node_index,
                                 slot,
@@ -369,11 +371,29 @@ impl Client {
                                 slot,
                                 beacon_block_root,
                             };
-                            if attestation_service_tx.send(to_attest).await.is_err()
-                                || metadata_service_tx.send(to_meta).await.is_err()
-                            {
-                                warn!("head event fan-out: downstream closed, exiting relay");
-                                return;
+                            // try_send avoids back-pressuring LH's SSE poll task during
+                            // cold-start when consumers aren't draining yet.
+                            match attestation_service_tx.try_send(to_attest) {
+                                Ok(()) => {}
+                                Err(TrySendError::Full(_)) => metrics::inc_counter_vec(
+                                    &metrics::HEAD_EVENT_FANOUT_DROPS,
+                                    &["attestation_service"],
+                                ),
+                                Err(TrySendError::Closed(_)) => {
+                                    warn!("head event fan-out: attestation downstream closed");
+                                    return;
+                                }
+                            }
+                            match metadata_service_tx.try_send(to_meta) {
+                                Ok(()) => {}
+                                Err(TrySendError::Full(_)) => metrics::inc_counter_vec(
+                                    &metrics::HEAD_EVENT_FANOUT_DROPS,
+                                    &["metadata_service"],
+                                ),
+                                Err(TrySendError::Closed(_)) => {
+                                    warn!("head event fan-out: metadata downstream closed");
+                                    return;
+                                }
                             }
                         }
                     },
@@ -381,7 +401,7 @@ impl Client {
                 );
                 (
                     Some(Mutex::new(attestation_service_rx)),
-                    Some(Arc::new(Mutex::new(metadata_service_rx))),
+                    Some(metadata_service_rx),
                 )
             } else {
                 (None, None)
@@ -754,7 +774,6 @@ impl Client {
             spec.clone(),
             fork_schedule.clone(),
             config.with_weighted_attestation_data,
-            metadata_head_monitor_rx,
         );
 
         // We use `SLOTS_PER_EPOCH` as the capacity of the block notification channel, because
@@ -778,7 +797,7 @@ impl Client {
             .map_err(|e| format!("Unable to start sync committee service: {e}"))?;
 
         metadata_service
-            .start_update_service()
+            .start_update_service(metadata_head_monitor_rx)
             .map_err(|e| format!("Unable to start metadata service: {e}"))?;
 
         preparation_service

--- a/anchor/client/src/metrics.rs
+++ b/anchor/client/src/metrics.rs
@@ -3,7 +3,7 @@ use std::{
     time::{SystemTime, UNIX_EPOCH},
 };
 
-use metrics::*;
+pub use metrics::*;
 use tracing::error;
 use version::VERSION;
 
@@ -19,6 +19,16 @@ pub static ANCHOR_VERSION: LazyLock<Result<IntGaugeVec>> = LazyLock::new(|| {
         "anchor_info",
         "The build of Anchor running on the server",
         &["version"],
+    )
+});
+
+/// Count of head events dropped by the fan-out relay because a downstream
+/// channel was full, labelled by which downstream filled up.
+pub static HEAD_EVENT_FANOUT_DROPS: LazyLock<Result<IntCounterVec>> = LazyLock::new(|| {
+    try_create_int_counter_vec(
+        "anchor_head_event_fanout_drops_total",
+        "Head events dropped by the fan-out relay due to a full downstream channel",
+        &["downstream"],
     )
 });
 

--- a/anchor/validator_store/src/metadata_service.rs
+++ b/anchor/validator_store/src/metadata_service.rs
@@ -4,7 +4,7 @@ use std::{
     time::Duration,
 };
 
-use beacon_node_fallback::BeaconNodeFallback;
+use beacon_node_fallback::{BeaconNodeFallback, beacon_head_monitor::HeadEvent};
 use bls::PublicKeyBytes;
 use eth2::{
     BeaconNodeHttpClient,
@@ -19,7 +19,10 @@ use ssv_types::{
 };
 use ssz::Encode;
 use task_executor::TaskExecutor;
-use tokio::time::{Instant, sleep, sleep_until};
+use tokio::{
+    sync::{Mutex, mpsc},
+    time::{Instant, sleep, sleep_until},
+};
 use tracing::{Instrument, debug, error, info, info_span, trace, warn};
 use tree_hash::TreeHash;
 use types::{
@@ -129,6 +132,7 @@ pub struct MetadataService<E: EthSpec, T: SlotClock + 'static> {
     spec: Arc<ChainSpec>,
     fork_schedule: Arc<ForkSchedule>,
     weighted_attestation_data: bool,
+    head_monitor_rx: Option<Arc<Mutex<mpsc::Receiver<HeadEvent>>>>,
 }
 
 impl<E: EthSpec, T: SlotClock + 'static> MetadataService<E, T> {
@@ -142,6 +146,7 @@ impl<E: EthSpec, T: SlotClock + 'static> MetadataService<E, T> {
         spec: Arc<ChainSpec>,
         fork_schedule: Arc<ForkSchedule>,
         weighted_attestation_data: bool,
+        head_monitor_rx: Option<Arc<Mutex<mpsc::Receiver<HeadEvent>>>>,
     ) -> Self {
         Self {
             duties_service,
@@ -152,6 +157,7 @@ impl<E: EthSpec, T: SlotClock + 'static> MetadataService<E, T> {
             spec,
             fork_schedule,
             weighted_attestation_data,
+            head_monitor_rx,
         }
     }
 

--- a/anchor/validator_store/src/metadata_service.rs
+++ b/anchor/validator_store/src/metadata_service.rs
@@ -2322,61 +2322,33 @@ mod tests {
         assert!((result_distance_2.score - 201.333333).abs() < 0.001);
     }
 
-    // ═══════════════════════════════════════════════════════════════════════════════════
-    // Phase 2 head-event race tests
-    //
-    // These cover `wait_for_head_event` and the timer-vs-event race it participates in.
-    // They use the free-function form of `wait_for_head_event` (extracted from the
-    // method body) so they can exercise the logic without constructing a full
-    // `MetadataService`, which would require a duties service, validator store,
-    // beacon node fallback, and task executor.
-    // ═══════════════════════════════════════════════════════════════════════════════════
-
     use slot_clock::ManualSlotClock;
     use tokio::time::{Duration as TokioDuration, timeout};
 
-    /// Slot used as the "current" slot in head-event race tests.
-    const HEAD_EVENT_TEST_SLOT: u64 = 100;
-    /// Slot duration used by the test slot clock. Value is arbitrary; tests
-    /// rely only on relative ordering produced by `set_slot`.
-    const HEAD_EVENT_SLOT_DURATION_SECS: u64 = 12;
-    /// Capacity for the head-event mpsc channel. The receiver-side logic does
-    /// not depend on capacity; a small bound is sufficient and matches the
-    /// production channel's bounded nature.
-    const HEAD_EVENT_CHANNEL_CAPACITY: usize = 8;
-    /// Upper bound for `tokio::time::timeout` calls that assert
-    /// `wait_for_head_event` resolves "quickly". With `start_paused = true`
-    /// virtual time advances only when the runtime is idle, so a generous
-    /// value is fine — the test still completes in real-time milliseconds.
+    const TEST_SLOT: u64 = 100;
+    const SLOT_DURATION_SECS: u64 = 12;
+    const CHANNEL_CAPACITY: usize = 8;
     const FAST_RESOLVE_TIMEOUT: TokioDuration = TokioDuration::from_secs(1);
-    /// Short virtual-time sleep used to model the 1/3-slot fallback timer in
-    /// the race-against-timer test.
     const TIMER_ARM_DURATION: TokioDuration = TokioDuration::from_millis(50);
 
-    /// Build a `ManualSlotClock` whose `now()` returns `HEAD_EVENT_TEST_SLOT`.
     fn make_test_slot_clock() -> ManualSlotClock {
         let clock = ManualSlotClock::new(
             Slot::new(0),
             std::time::Duration::from_secs(0),
-            std::time::Duration::from_secs(HEAD_EVENT_SLOT_DURATION_SECS),
+            std::time::Duration::from_secs(SLOT_DURATION_SECS),
         );
-        clock.set_slot(HEAD_EVENT_TEST_SLOT);
+        clock.set_slot(TEST_SLOT);
         clock
     }
 
-    /// Build a fresh `(sender, receiver)` pair wrapped to match the
-    /// `MetadataService::head_monitor_rx` shape.
     fn make_head_event_channel() -> (
         mpsc::Sender<HeadEvent>,
         Arc<Mutex<mpsc::Receiver<HeadEvent>>>,
     ) {
-        let (tx, rx) = mpsc::channel(HEAD_EVENT_CHANNEL_CAPACITY);
+        let (tx, rx) = mpsc::channel(CHANNEL_CAPACITY);
         (tx, Arc::new(Mutex::new(rx)))
     }
 
-    /// Construct a `HeadEvent` for a given slot. `beacon_node_index` and
-    /// `beacon_block_root` are not inspected by `wait_for_head_event`, so
-    /// fixed dummy values are used.
     fn make_head_event(slot: u64) -> HeadEvent {
         HeadEvent {
             beacon_node_index: 0,
@@ -2385,84 +2357,50 @@ mod tests {
         }
     }
 
-    /// A head event matching `slot_clock.now()` resolves `wait_for_head_event`
-    /// immediately with `Some(event)`. This is the happy path that lets Phase 2
-    /// short-circuit the 1/3-slot fallback timer.
+    // A head event for the current slot should resolve the wait immediately.
     #[tokio::test(start_paused = true)]
     async fn wait_for_head_event_returns_matching_slot_event() {
-        // Arrange
         let slot_clock = make_test_slot_clock();
         let (tx, rx) = make_head_event_channel();
-        tx.send(make_head_event(HEAD_EVENT_TEST_SLOT))
-            .await
-            .expect("channel should accept event");
+        tx.send(make_head_event(TEST_SLOT)).await.unwrap();
 
-        // Act
         let result = timeout(
             FAST_RESOLVE_TIMEOUT,
             wait_for_head_event(Some(&rx), &slot_clock),
         )
         .await
-        .expect("wait_for_head_event must resolve quickly for current-slot event");
+        .unwrap();
 
-        // Assert
-        let event = result.expect("matching-slot event must be returned");
-        assert_eq!(
-            event.slot,
-            Slot::new(HEAD_EVENT_TEST_SLOT),
-            "returned event slot must equal current slot",
-        );
+        let event = result.unwrap();
+        assert_eq!(event.slot, Slot::new(TEST_SLOT));
     }
 
-    /// Stale head events (slot < current slot) are dropped and not returned.
-    /// We then race `wait_for_head_event` against a short timer in a
-    /// `tokio::select!` and assert the timer arm wins — mirroring the Phase 2
-    /// fallback path when no in-slot event ever arrives.
+    // A stale event (past slot) gets dropped, so the timer arm wins the race.
     #[tokio::test(start_paused = true)]
     async fn wait_for_head_event_drops_stale_events() {
-        // Arrange
         let slot_clock = make_test_slot_clock();
         let (tx, rx) = make_head_event_channel();
-        // Send a stale event for the previous slot. It must be consumed
-        // without resolving `wait_for_head_event`.
-        tx.send(make_head_event(HEAD_EVENT_TEST_SLOT - 1))
-            .await
-            .expect("channel should accept stale event");
+        tx.send(make_head_event(TEST_SLOT - 1)).await.unwrap();
 
-        // Act: race the helper against the same kind of fallback timer used in
-        // Phase 2's `tokio::select!`. With only a stale event in the channel,
-        // the timer arm must win.
         let from_head_event = tokio::select! {
             biased;
             _ = tokio::time::sleep(TIMER_ARM_DURATION) => false,
             _ = wait_for_head_event(Some(&rx), &slot_clock) => true,
         };
 
-        // Assert
-        assert!(
-            !from_head_event,
-            "stale head event must not resolve wait_for_head_event; timer arm must win",
-        );
+        assert!(!from_head_event);
     }
 
-    /// When `head_monitor_rx` is `None`, `wait_for_head_event` short-circuits
-    /// via `?` on `as_ref()` and returns `None` without blocking. This is the
-    /// existing behaviour the Phase 2 loop relies on when head monitoring is
-    /// disabled (it then falls through to the bare-sleep branch).
+    // When the head monitor is disabled, the wait returns None right away
+    // instead of blocking, so Phase 2 falls back to the bare timer.
     #[tokio::test(start_paused = true)]
     async fn wait_for_head_event_returns_none_when_disabled() {
-        // Arrange
         let slot_clock = make_test_slot_clock();
 
-        // Act
         let result = timeout(FAST_RESOLVE_TIMEOUT, wait_for_head_event(None, &slot_clock))
             .await
-            .expect("wait_for_head_event must resolve immediately when receiver is None");
+            .unwrap();
 
-        // Assert
-        assert!(
-            result.is_none(),
-            "wait_for_head_event must return None when head monitor is disabled",
-        );
+        assert!(result.is_none());
     }
 }

--- a/anchor/validator_store/src/metadata_service.rs
+++ b/anchor/validator_store/src/metadata_service.rs
@@ -263,16 +263,18 @@ impl<E: EthSpec, T: SlotClock + 'static> MetadataService<E, T> {
                     };
 
                     // Race the 1/3-slot fallback timer against an in-slot head event.
-                    let from_head_event = if self_clone_phase2.head_monitor_rx.is_some() {
-                        tokio::select! {
-                            _ = sleep(slot_duration / 3) => false,
-                            _ = self_clone_phase2.wait_for_head_event() => true,
-                        }
-                    } else {
-                        sleep(slot_duration / 3).await;
-                        false
-                    };
+                    let head_event: Option<HeadEvent> =
+                        if self_clone_phase2.head_monitor_rx.is_some() {
+                            tokio::select! {
+                                _ = sleep(slot_duration / 3) => None,
+                                event = self_clone_phase2.wait_for_head_event() => event,
+                            }
+                        } else {
+                            sleep(slot_duration / 3).await;
+                            None
+                        };
 
+                    let from_head_event = head_event.is_some();
                     let trigger = if from_head_event {
                         metrics::TRIGGER_HEAD_EVENT
                     } else {
@@ -293,7 +295,9 @@ impl<E: EthSpec, T: SlotClock + 'static> MetadataService<E, T> {
                         );
                     }
 
-                    if let Err(err) = self_clone_phase2.update_voting_context().await {
+                    if let Err(err) =
+                        self_clone_phase2.update_voting_context(head_event).await
+                    {
                         error!(err, "Failed to update voting context")
                     } else {
                         trace!(%intended_slot, from_head_event, "Updated voting context");
@@ -422,8 +426,13 @@ impl<E: EthSpec, T: SlotClock + 'static> MetadataService<E, T> {
     }
 
     /// Phase 2: Build and publish `VotingContext`, triggered by a head event or
-    /// the 1/3-slot fallback timer.
-    async fn update_voting_context(&self) -> Result<(), String> {
+    /// the 1/3-slot fallback timer. When `head_event` is `Some`, the firing BN
+    /// is queried directly (bypassing WAD); any failure or block-root mismatch
+    /// falls back to the WAD/first_success path.
+    async fn update_voting_context(
+        &self,
+        head_event: Option<HeadEvent>,
+    ) -> Result<(), String> {
         let slot = self.slot_clock.now().ok_or("Failed to read slot clock")?;
 
         let voting_assignments = self
@@ -432,24 +441,12 @@ impl<E: EthSpec, T: SlotClock + 'static> MetadataService<E, T> {
             .await
             .map_err(|e| format!("Failed to get cached voting assignments: {:?}", e))?;
 
-        // Fetch beacon_vote - use WAD if enabled, otherwise fallback to first_success
-        let attestation_data = if self.weighted_attestation_data {
-            self.weighted_calculation(slot).await?
-        } else {
-            self.beacon_nodes
-                .first_success(|beacon_node| async move {
-                    let _timer = validator_metrics::start_timer_vec(
-                        &validator_metrics::ATTESTATION_SERVICE_TIMES,
-                        &[validator_metrics::ATTESTATIONS_HTTP_GET],
-                    );
-                    beacon_node
-                        .get_validator_attestation_data(slot, 0)
-                        .await
-                        .map_err(|e| format!("Failed to produce attestation data: {e:?}"))
-                        .map(|result| result.data)
-                })
-                .await
-                .map_err(|e| e.to_string())?
+        let attestation_data = match head_event {
+            Some(event) => match self.fetch_attestation_data_from_event(slot, &event).await {
+                Some(data) => data,
+                None => self.fetch_attestation_data(slot).await?,
+            },
+            None => self.fetch_attestation_data(slot).await?,
         };
 
         let beacon_vote = BeaconVote {
@@ -465,8 +462,63 @@ impl<E: EthSpec, T: SlotClock + 'static> MetadataService<E, T> {
 
         self.validator_store.update_voting_context(voting_context);
 
-        trace!(%slot, "Published VotingContext at 1/3 slot");
+        trace!(%slot, "Published VotingContext");
         Ok(())
+    }
+
+    /// Eager-attest path: query the BN that fired the head event. Verifies the
+    /// returned block_root matches the event's. Returns `None` on any failure
+    /// or mismatch so the caller can fall back.
+    async fn fetch_attestation_data_from_event(
+        &self,
+        slot: Slot,
+        event: &HeadEvent,
+    ) -> Option<AttestationData> {
+        match self
+            .beacon_nodes
+            .run_on_candidate_index(event.beacon_node_index, |beacon_node| async move {
+                beacon_node.get_validator_attestation_data(slot, 0).await
+            })
+            .await
+        {
+            Ok(response) if response.data.beacon_block_root == event.beacon_block_root => {
+                Some(response.data)
+            }
+            Ok(response) => {
+                warn!(
+                    expected = ?event.beacon_block_root,
+                    got = ?response.data.beacon_block_root,
+                    "Head-event BN returned mismatched block root, falling back",
+                );
+                None
+            }
+            Err(e) => {
+                warn!(error = ?e, "Failed to fetch attestation data from head-event BN, falling back");
+                None
+            }
+        }
+    }
+
+    /// Fallback path: WAD if enabled, otherwise first_success across all BNs.
+    async fn fetch_attestation_data(&self, slot: Slot) -> Result<AttestationData, String> {
+        if self.weighted_attestation_data {
+            self.weighted_calculation(slot).await
+        } else {
+            self.beacon_nodes
+                .first_success(|beacon_node| async move {
+                    let _timer = validator_metrics::start_timer_vec(
+                        &validator_metrics::ATTESTATION_SERVICE_TIMES,
+                        &[validator_metrics::ATTESTATIONS_HTTP_GET],
+                    );
+                    beacon_node
+                        .get_validator_attestation_data(slot, 0)
+                        .await
+                        .map_err(|e| format!("Failed to produce attestation data: {e:?}"))
+                        .map(|result| result.data)
+                })
+                .await
+                .map_err(|e| e.to_string())
+        }
     }
 
     /// Phase 3: Build and publish `AggregationAssignments` at 2/3 slot.

--- a/anchor/validator_store/src/metadata_service.rs
+++ b/anchor/validator_store/src/metadata_service.rs
@@ -205,27 +205,64 @@ impl<E: EthSpec, T: SlotClock + 'static> MetadataService<E, T> {
         );
 
         // ═══════════════════════════════════════════════════════════════════════
-        // PHASE 2: VotingContext (1/3 slot)
+        // PHASE 2: VotingContext (head event or 1/3 slot, whichever fires first)
         // Gets cached voting assignments, fetches beacon_vote, builds VotingContext.
         // ═══════════════════════════════════════════════════════════════════════
         let self_clone_phase2 = self.clone();
         executor.spawn(
             async move {
                 loop {
-                    if let Some(duration_to_next_slot) =
+                    let Some(duration_to_next_slot) =
                         self_clone_phase2.slot_clock.duration_to_next_slot()
-                    {
-                        // Sleep until 1/3 into slot
-                        sleep(duration_to_next_slot + slot_duration / 3).await;
-
-                        if let Err(err) = self_clone_phase2.update_voting_context().await {
-                            error!(err, "Failed to update voting context")
-                        } else {
-                            trace!("Updated voting context");
-                        }
-                    } else {
+                    else {
                         error!("Failed to read slot clock");
                         sleep(slot_duration).await;
+                        continue;
+                    };
+
+                    // Cross the slot boundary first so we race head events only within
+                    // the slot we're about to attest in.
+                    sleep(duration_to_next_slot).await;
+
+                    let Some(intended_slot) = self_clone_phase2.slot_clock.now() else {
+                        error!("Failed to read slot clock");
+                        continue;
+                    };
+
+                    // Race the 1/3-slot fallback timer against an in-slot head event.
+                    let from_head_event = if self_clone_phase2.head_monitor_rx.is_some() {
+                        tokio::select! {
+                            _ = sleep(slot_duration / 3) => false,
+                            _ = self_clone_phase2.wait_for_head_event() => true,
+                        }
+                    } else {
+                        sleep(slot_duration / 3).await;
+                        false
+                    };
+
+                    let trigger = if from_head_event {
+                        metrics::TRIGGER_HEAD_EVENT
+                    } else {
+                        metrics::TRIGGER_TIMER
+                    };
+                    metrics::inc_counter_vec(
+                        &metrics::METADATA_SERVICE_VOTING_CONTEXT_TRIGGERS_TOTAL,
+                        &[trigger],
+                    );
+                    if let Some(offset) =
+                        self_clone_phase2.slot_clock.millis_from_current_slot_start()
+                    {
+                        metrics::observe_timer_vec(
+                            &metrics::METADATA_SERVICE_VOTING_CONTEXT_OFFSET_SECONDS,
+                            &[trigger],
+                            offset,
+                        );
+                    }
+
+                    if let Err(err) = self_clone_phase2.update_voting_context().await {
+                        error!(err, "Failed to update voting context")
+                    } else {
+                        trace!(%intended_slot, from_head_event, "Updated voting context");
                     }
                 }
             },
@@ -343,7 +380,33 @@ impl<E: EthSpec, T: SlotClock + 'static> MetadataService<E, T> {
         Ok(())
     }
 
-    /// Phase 2: Build and publish `VotingContext` at 1/3 slot.
+    /// Wait for a head event matching the current slot. Stale events for past
+    /// slots are dropped. Resolves to `None` if the channel is closed or no
+    /// head monitor is configured.
+    async fn wait_for_head_event(&self) -> Option<HeadEvent> {
+        let receiver = self.head_monitor_rx.as_ref()?;
+        let mut receiver = receiver.lock().await;
+        loop {
+            match receiver.recv().await {
+                Some(head_event) => {
+                    // Only return head events for the current slot - this ensures the
+                    // block for this slot has been produced before triggering attestation.
+                    let current_slot = self.slot_clock.now()?;
+                    if head_event.slot == current_slot {
+                        return Some(head_event);
+                    }
+                    // Head event is for a previous slot, keep waiting
+                }
+                None => {
+                    warn!("Head monitor channel closed unexpectedly");
+                    return None;
+                }
+            }
+        }
+    }
+
+    /// Phase 2: Build and publish `VotingContext`, triggered by a head event or
+    /// the 1/3-slot fallback timer.
     async fn update_voting_context(&self) -> Result<(), String> {
         let slot = self.slot_clock.now().ok_or("Failed to read slot clock")?;
 

--- a/anchor/validator_store/src/metadata_service.rs
+++ b/anchor/validator_store/src/metadata_service.rs
@@ -135,6 +135,39 @@ pub struct MetadataService<E: EthSpec, T: SlotClock + 'static> {
     head_monitor_rx: Option<Arc<Mutex<mpsc::Receiver<HeadEvent>>>>,
 }
 
+/// Wait for a head event matching the current slot reported by `slot_clock`.
+///
+/// Drops events for past slots and keeps waiting. Resolves to `None` if
+/// `receiver` is `None`, the channel is closed, or `slot_clock.now()` fails.
+///
+/// Extracted as a free function so it can be unit-tested without constructing
+/// a full `MetadataService` (which requires a beacon node, duties service,
+/// validator store, etc.).
+async fn wait_for_head_event<T: SlotClock>(
+    receiver: Option<&Arc<Mutex<mpsc::Receiver<HeadEvent>>>>,
+    slot_clock: &T,
+) -> Option<HeadEvent> {
+    let receiver = receiver?;
+    let mut receiver = receiver.lock().await;
+    loop {
+        match receiver.recv().await {
+            Some(head_event) => {
+                // Only return head events for the current slot - this ensures the
+                // block for this slot has been produced before triggering attestation.
+                let current_slot = slot_clock.now()?;
+                if head_event.slot == current_slot {
+                    return Some(head_event);
+                }
+                // Head event is for a previous slot, keep waiting
+            }
+            None => {
+                warn!("Head monitor channel closed unexpectedly");
+                return None;
+            }
+        }
+    }
+}
+
 impl<E: EthSpec, T: SlotClock + 'static> MetadataService<E, T> {
     #[expect(clippy::too_many_arguments)]
     pub fn new(
@@ -249,8 +282,9 @@ impl<E: EthSpec, T: SlotClock + 'static> MetadataService<E, T> {
                         &metrics::METADATA_SERVICE_VOTING_CONTEXT_TRIGGERS_TOTAL,
                         &[trigger],
                     );
-                    if let Some(offset) =
-                        self_clone_phase2.slot_clock.millis_from_current_slot_start()
+                    if let Some(offset) = self_clone_phase2
+                        .slot_clock
+                        .millis_from_current_slot_start()
                     {
                         metrics::observe_timer_vec(
                             &metrics::METADATA_SERVICE_VOTING_CONTEXT_OFFSET_SECONDS,
@@ -384,25 +418,7 @@ impl<E: EthSpec, T: SlotClock + 'static> MetadataService<E, T> {
     /// slots are dropped. Resolves to `None` if the channel is closed or no
     /// head monitor is configured.
     async fn wait_for_head_event(&self) -> Option<HeadEvent> {
-        let receiver = self.head_monitor_rx.as_ref()?;
-        let mut receiver = receiver.lock().await;
-        loop {
-            match receiver.recv().await {
-                Some(head_event) => {
-                    // Only return head events for the current slot - this ensures the
-                    // block for this slot has been produced before triggering attestation.
-                    let current_slot = self.slot_clock.now()?;
-                    if head_event.slot == current_slot {
-                        return Some(head_event);
-                    }
-                    // Head event is for a previous slot, keep waiting
-                }
-                None => {
-                    warn!("Head monitor channel closed unexpectedly");
-                    return None;
-                }
-            }
-        }
+        wait_for_head_event(self.head_monitor_rx.as_ref(), &self.slot_clock).await
     }
 
     /// Phase 2: Build and publish `VotingContext`, triggered by a head event or
@@ -2304,5 +2320,149 @@ mod tests {
 
         let result_distance_2 = calculate_attestation_score(&data, Some(Slot::new(3230)));
         assert!((result_distance_2.score - 201.333333).abs() < 0.001);
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════════════════
+    // Phase 2 head-event race tests
+    //
+    // These cover `wait_for_head_event` and the timer-vs-event race it participates in.
+    // They use the free-function form of `wait_for_head_event` (extracted from the
+    // method body) so they can exercise the logic without constructing a full
+    // `MetadataService`, which would require a duties service, validator store,
+    // beacon node fallback, and task executor.
+    // ═══════════════════════════════════════════════════════════════════════════════════
+
+    use slot_clock::ManualSlotClock;
+    use tokio::time::{Duration as TokioDuration, timeout};
+
+    /// Slot used as the "current" slot in head-event race tests.
+    const HEAD_EVENT_TEST_SLOT: u64 = 100;
+    /// Slot duration used by the test slot clock. Value is arbitrary; tests
+    /// rely only on relative ordering produced by `set_slot`.
+    const HEAD_EVENT_SLOT_DURATION_SECS: u64 = 12;
+    /// Capacity for the head-event mpsc channel. The receiver-side logic does
+    /// not depend on capacity; a small bound is sufficient and matches the
+    /// production channel's bounded nature.
+    const HEAD_EVENT_CHANNEL_CAPACITY: usize = 8;
+    /// Upper bound for `tokio::time::timeout` calls that assert
+    /// `wait_for_head_event` resolves "quickly". With `start_paused = true`
+    /// virtual time advances only when the runtime is idle, so a generous
+    /// value is fine — the test still completes in real-time milliseconds.
+    const FAST_RESOLVE_TIMEOUT: TokioDuration = TokioDuration::from_secs(1);
+    /// Short virtual-time sleep used to model the 1/3-slot fallback timer in
+    /// the race-against-timer test.
+    const TIMER_ARM_DURATION: TokioDuration = TokioDuration::from_millis(50);
+
+    /// Build a `ManualSlotClock` whose `now()` returns `HEAD_EVENT_TEST_SLOT`.
+    fn make_test_slot_clock() -> ManualSlotClock {
+        let clock = ManualSlotClock::new(
+            Slot::new(0),
+            std::time::Duration::from_secs(0),
+            std::time::Duration::from_secs(HEAD_EVENT_SLOT_DURATION_SECS),
+        );
+        clock.set_slot(HEAD_EVENT_TEST_SLOT);
+        clock
+    }
+
+    /// Build a fresh `(sender, receiver)` pair wrapped to match the
+    /// `MetadataService::head_monitor_rx` shape.
+    fn make_head_event_channel() -> (
+        mpsc::Sender<HeadEvent>,
+        Arc<Mutex<mpsc::Receiver<HeadEvent>>>,
+    ) {
+        let (tx, rx) = mpsc::channel(HEAD_EVENT_CHANNEL_CAPACITY);
+        (tx, Arc::new(Mutex::new(rx)))
+    }
+
+    /// Construct a `HeadEvent` for a given slot. `beacon_node_index` and
+    /// `beacon_block_root` are not inspected by `wait_for_head_event`, so
+    /// fixed dummy values are used.
+    fn make_head_event(slot: u64) -> HeadEvent {
+        HeadEvent {
+            beacon_node_index: 0,
+            slot: Slot::new(slot),
+            beacon_block_root: Hash256::zero(),
+        }
+    }
+
+    /// A head event matching `slot_clock.now()` resolves `wait_for_head_event`
+    /// immediately with `Some(event)`. This is the happy path that lets Phase 2
+    /// short-circuit the 1/3-slot fallback timer.
+    #[tokio::test(start_paused = true)]
+    async fn wait_for_head_event_returns_matching_slot_event() {
+        // Arrange
+        let slot_clock = make_test_slot_clock();
+        let (tx, rx) = make_head_event_channel();
+        tx.send(make_head_event(HEAD_EVENT_TEST_SLOT))
+            .await
+            .expect("channel should accept event");
+
+        // Act
+        let result = timeout(
+            FAST_RESOLVE_TIMEOUT,
+            wait_for_head_event(Some(&rx), &slot_clock),
+        )
+        .await
+        .expect("wait_for_head_event must resolve quickly for current-slot event");
+
+        // Assert
+        let event = result.expect("matching-slot event must be returned");
+        assert_eq!(
+            event.slot,
+            Slot::new(HEAD_EVENT_TEST_SLOT),
+            "returned event slot must equal current slot",
+        );
+    }
+
+    /// Stale head events (slot < current slot) are dropped and not returned.
+    /// We then race `wait_for_head_event` against a short timer in a
+    /// `tokio::select!` and assert the timer arm wins — mirroring the Phase 2
+    /// fallback path when no in-slot event ever arrives.
+    #[tokio::test(start_paused = true)]
+    async fn wait_for_head_event_drops_stale_events() {
+        // Arrange
+        let slot_clock = make_test_slot_clock();
+        let (tx, rx) = make_head_event_channel();
+        // Send a stale event for the previous slot. It must be consumed
+        // without resolving `wait_for_head_event`.
+        tx.send(make_head_event(HEAD_EVENT_TEST_SLOT - 1))
+            .await
+            .expect("channel should accept stale event");
+
+        // Act: race the helper against the same kind of fallback timer used in
+        // Phase 2's `tokio::select!`. With only a stale event in the channel,
+        // the timer arm must win.
+        let from_head_event = tokio::select! {
+            biased;
+            _ = tokio::time::sleep(TIMER_ARM_DURATION) => false,
+            _ = wait_for_head_event(Some(&rx), &slot_clock) => true,
+        };
+
+        // Assert
+        assert!(
+            !from_head_event,
+            "stale head event must not resolve wait_for_head_event; timer arm must win",
+        );
+    }
+
+    /// When `head_monitor_rx` is `None`, `wait_for_head_event` short-circuits
+    /// via `?` on `as_ref()` and returns `None` without blocking. This is the
+    /// existing behaviour the Phase 2 loop relies on when head monitoring is
+    /// disabled (it then falls through to the bare-sleep branch).
+    #[tokio::test(start_paused = true)]
+    async fn wait_for_head_event_returns_none_when_disabled() {
+        // Arrange
+        let slot_clock = make_test_slot_clock();
+
+        // Act
+        let result = timeout(FAST_RESOLVE_TIMEOUT, wait_for_head_event(None, &slot_clock))
+            .await
+            .expect("wait_for_head_event must resolve immediately when receiver is None");
+
+        // Assert
+        assert!(
+            result.is_none(),
+            "wait_for_head_event must return None when head monitor is disabled",
+        );
     }
 }

--- a/anchor/validator_store/src/metadata_service.rs
+++ b/anchor/validator_store/src/metadata_service.rs
@@ -266,11 +266,11 @@ impl<E: EthSpec, T: SlotClock + 'static> MetadataService<E, T> {
                     let head_event: Option<HeadEvent> =
                         if self_clone_phase2.head_monitor_rx.is_some() {
                             tokio::select! {
-                                _ = sleep(slot_duration / 3) => None,
+                                _ = sleep(self_clone_phase2.spec.get_unaggregated_attestation_due()) => None,
                                 event = self_clone_phase2.wait_for_head_event() => event,
                             }
                         } else {
-                            sleep(slot_duration / 3).await;
+                            sleep(self_clone_phase2.spec.get_unaggregated_attestation_due()).await;
                             None
                         };
 
@@ -295,9 +295,7 @@ impl<E: EthSpec, T: SlotClock + 'static> MetadataService<E, T> {
                         );
                     }
 
-                    if let Err(err) =
-                        self_clone_phase2.update_voting_context(head_event).await
-                    {
+                    if let Err(err) = self_clone_phase2.update_voting_context(head_event).await {
                         error!(err, "Failed to update voting context")
                     } else {
                         trace!(%intended_slot, from_head_event, "Updated voting context");
@@ -429,10 +427,7 @@ impl<E: EthSpec, T: SlotClock + 'static> MetadataService<E, T> {
     /// the 1/3-slot fallback timer. When `head_event` is `Some`, the firing BN
     /// is queried directly (bypassing WAD); any failure or block-root mismatch
     /// falls back to the WAD/first_success path.
-    async fn update_voting_context(
-        &self,
-        head_event: Option<HeadEvent>,
-    ) -> Result<(), String> {
+    async fn update_voting_context(&self, head_event: Option<HeadEvent>) -> Result<(), String> {
         let slot = self.slot_clock.now().ok_or("Failed to read slot clock")?;
 
         let voting_assignments = self

--- a/anchor/validator_store/src/metadata_service.rs
+++ b/anchor/validator_store/src/metadata_service.rs
@@ -20,7 +20,7 @@ use ssv_types::{
 use ssz::Encode;
 use task_executor::TaskExecutor;
 use tokio::{
-    sync::{Mutex, mpsc},
+    sync::mpsc,
     time::{Instant, sleep, sleep_until},
 };
 use tracing::{Instrument, debug, error, info, info_span, trace, warn};
@@ -132,33 +132,24 @@ pub struct MetadataService<E: EthSpec, T: SlotClock + 'static> {
     spec: Arc<ChainSpec>,
     fork_schedule: Arc<ForkSchedule>,
     weighted_attestation_data: bool,
-    head_monitor_rx: Option<Arc<Mutex<mpsc::Receiver<HeadEvent>>>>,
 }
 
 /// Wait for a head event matching the current slot reported by `slot_clock`.
 ///
-/// Drops events for past slots and keeps waiting. Resolves to `None` if
-/// `receiver` is `None`, the channel is closed, or `slot_clock.now()` fails.
-///
-/// Extracted as a free function so it can be unit-tested without constructing
-/// a full `MetadataService` (which requires a beacon node, duties service,
-/// validator store, etc.).
+/// Drops events whose slot doesn't match the current slot and keeps waiting.
+/// Resolves to `None` if the channel is closed or `slot_clock.now()` fails.
 async fn wait_for_head_event<T: SlotClock>(
-    receiver: Option<&Arc<Mutex<mpsc::Receiver<HeadEvent>>>>,
+    receiver: &mut mpsc::Receiver<HeadEvent>,
     slot_clock: &T,
 ) -> Option<HeadEvent> {
-    let receiver = receiver?;
-    let mut receiver = receiver.lock().await;
     loop {
         match receiver.recv().await {
             Some(head_event) => {
-                // Only return head events for the current slot - this ensures the
-                // block for this slot has been produced before triggering attestation.
                 let current_slot = slot_clock.now()?;
                 if head_event.slot == current_slot {
                     return Some(head_event);
                 }
-                // Head event is for a previous slot, keep waiting
+                // Head event slot doesn't match current; drop and keep waiting.
             }
             None => {
                 warn!("Head monitor channel closed unexpectedly");
@@ -179,7 +170,6 @@ impl<E: EthSpec, T: SlotClock + 'static> MetadataService<E, T> {
         spec: Arc<ChainSpec>,
         fork_schedule: Arc<ForkSchedule>,
         weighted_attestation_data: bool,
-        head_monitor_rx: Option<Arc<Mutex<mpsc::Receiver<HeadEvent>>>>,
     ) -> Self {
         Self {
             duties_service,
@@ -190,11 +180,13 @@ impl<E: EthSpec, T: SlotClock + 'static> MetadataService<E, T> {
             spec,
             fork_schedule,
             weighted_attestation_data,
-            head_monitor_rx,
         }
     }
 
-    pub fn start_update_service(self) -> Result<(), String> {
+    pub fn start_update_service(
+        self,
+        mut head_monitor_rx: Option<mpsc::Receiver<HeadEvent>>,
+    ) -> Result<(), String> {
         let slot_duration = Duration::from_secs(self.spec.seconds_per_slot);
         let duration_to_next_slot = self
             .slot_clock
@@ -238,7 +230,7 @@ impl<E: EthSpec, T: SlotClock + 'static> MetadataService<E, T> {
         );
 
         // ═══════════════════════════════════════════════════════════════════════
-        // PHASE 2: VotingContext (head event or 1/3 slot, whichever fires first)
+        // PHASE 2: VotingContext (head event or spec-derived fallback, first to fire)
         // Gets cached voting assignments, fetches beacon_vote, builds VotingContext.
         // ═══════════════════════════════════════════════════════════════════════
         let self_clone_phase2 = self.clone();
@@ -257,25 +249,19 @@ impl<E: EthSpec, T: SlotClock + 'static> MetadataService<E, T> {
                     // the slot we're about to attest in.
                     sleep(duration_to_next_slot).await;
 
-                    let Some(intended_slot) = self_clone_phase2.slot_clock.now() else {
-                        error!("Failed to read slot clock");
-                        continue;
+                    let fallback = self_clone_phase2.spec.get_unaggregated_attestation_due();
+                    let head_event = match head_monitor_rx.as_mut() {
+                        Some(rx) => tokio::select! {
+                            _ = sleep(fallback) => None,
+                            event = wait_for_head_event(rx, &self_clone_phase2.slot_clock) => event,
+                        },
+                        None => {
+                            sleep(fallback).await;
+                            None
+                        }
                     };
 
-                    // Race the 1/3-slot fallback timer against an in-slot head event.
-                    let head_event: Option<HeadEvent> =
-                        if self_clone_phase2.head_monitor_rx.is_some() {
-                            tokio::select! {
-                                _ = sleep(self_clone_phase2.spec.get_unaggregated_attestation_due()) => None,
-                                event = self_clone_phase2.wait_for_head_event() => event,
-                            }
-                        } else {
-                            sleep(self_clone_phase2.spec.get_unaggregated_attestation_due()).await;
-                            None
-                        };
-
-                    let from_head_event = head_event.is_some();
-                    let trigger = if from_head_event {
+                    let trigger = if head_event.is_some() {
                         metrics::TRIGGER_HEAD_EVENT
                     } else {
                         metrics::TRIGGER_TIMER
@@ -297,8 +283,6 @@ impl<E: EthSpec, T: SlotClock + 'static> MetadataService<E, T> {
 
                     if let Err(err) = self_clone_phase2.update_voting_context(head_event).await {
                         error!(err, "Failed to update voting context")
-                    } else {
-                        trace!(%intended_slot, from_head_event, "Updated voting context");
                     }
                 }
             },
@@ -416,17 +400,10 @@ impl<E: EthSpec, T: SlotClock + 'static> MetadataService<E, T> {
         Ok(())
     }
 
-    /// Wait for a head event matching the current slot. Stale events for past
-    /// slots are dropped. Resolves to `None` if the channel is closed or no
-    /// head monitor is configured.
-    async fn wait_for_head_event(&self) -> Option<HeadEvent> {
-        wait_for_head_event(self.head_monitor_rx.as_ref(), &self.slot_clock).await
-    }
-
     /// Phase 2: Build and publish `VotingContext`, triggered by a head event or
-    /// the 1/3-slot fallback timer. When `head_event` is `Some`, the firing BN
-    /// is queried directly (bypassing WAD); any failure or block-root mismatch
-    /// falls back to the WAD/first_success path.
+    /// the spec-derived fallback timer. When `head_event` is `Some`, the firing
+    /// BN is queried directly (bypassing WAD); any failure or block-root
+    /// mismatch falls back to the WAD/first_success path.
     async fn update_voting_context(&self, head_event: Option<HeadEvent>) -> Result<(), String> {
         let slot = self.slot_clock.now().ok_or("Failed to read slot clock")?;
 
@@ -2388,12 +2365,8 @@ mod tests {
         clock
     }
 
-    fn make_head_event_channel() -> (
-        mpsc::Sender<HeadEvent>,
-        Arc<Mutex<mpsc::Receiver<HeadEvent>>>,
-    ) {
-        let (tx, rx) = mpsc::channel(CHANNEL_CAPACITY);
-        (tx, Arc::new(Mutex::new(rx)))
+    fn make_head_event_channel() -> (mpsc::Sender<HeadEvent>, mpsc::Receiver<HeadEvent>) {
+        mpsc::channel(CHANNEL_CAPACITY)
     }
 
     fn make_head_event(slot: u64) -> HeadEvent {
@@ -2408,12 +2381,12 @@ mod tests {
     #[tokio::test(start_paused = true)]
     async fn wait_for_head_event_returns_matching_slot_event() {
         let slot_clock = make_test_slot_clock();
-        let (tx, rx) = make_head_event_channel();
+        let (tx, mut rx) = make_head_event_channel();
         tx.send(make_head_event(TEST_SLOT)).await.unwrap();
 
         let result = timeout(
             FAST_RESOLVE_TIMEOUT,
-            wait_for_head_event(Some(&rx), &slot_clock),
+            wait_for_head_event(&mut rx, &slot_clock),
         )
         .await
         .unwrap();
@@ -2426,28 +2399,15 @@ mod tests {
     #[tokio::test(start_paused = true)]
     async fn wait_for_head_event_drops_stale_events() {
         let slot_clock = make_test_slot_clock();
-        let (tx, rx) = make_head_event_channel();
+        let (tx, mut rx) = make_head_event_channel();
         tx.send(make_head_event(TEST_SLOT - 1)).await.unwrap();
 
         let from_head_event = tokio::select! {
             biased;
             _ = tokio::time::sleep(TIMER_ARM_DURATION) => false,
-            _ = wait_for_head_event(Some(&rx), &slot_clock) => true,
+            _ = wait_for_head_event(&mut rx, &slot_clock) => true,
         };
 
         assert!(!from_head_event);
-    }
-
-    // When the head monitor is disabled, the wait returns None right away
-    // instead of blocking, so Phase 2 falls back to the bare timer.
-    #[tokio::test(start_paused = true)]
-    async fn wait_for_head_event_returns_none_when_disabled() {
-        let slot_clock = make_test_slot_clock();
-
-        let result = timeout(FAST_RESOLVE_TIMEOUT, wait_for_head_event(None, &slot_clock))
-            .await
-            .unwrap();
-
-        assert!(result.is_none());
     }
 }

--- a/anchor/validator_store/src/metrics.rs
+++ b/anchor/validator_store/src/metrics.rs
@@ -55,6 +55,31 @@ pub static METADATA_SERVICE_EMPTY_ASSIGNMENTS_TOTAL: LazyLock<Result<IntCounter>
         )
     });
 
+pub const TRIGGER_HEAD_EVENT: &str = "head_event";
+pub const TRIGGER_TIMER: &str = "timer";
+
+/// Count of Phase 2 firings, labelled by trigger source.
+pub static METADATA_SERVICE_VOTING_CONTEXT_TRIGGERS_TOTAL: LazyLock<Result<IntCounterVec>> =
+    LazyLock::new(|| {
+        try_create_int_counter_vec(
+            "anchor_metadata_service_voting_context_triggers_total",
+            "Number of voting context updates by trigger source (head_event or timer)",
+            &["trigger"],
+        )
+    });
+
+/// Offset within the slot at which Phase 2 fired, in seconds.
+/// Buckets target the 0–4s window before the 1/3-slot fallback timer.
+pub static METADATA_SERVICE_VOTING_CONTEXT_OFFSET_SECONDS: LazyLock<Result<HistogramVec>> =
+    LazyLock::new(|| {
+        try_create_histogram_vec_with_buckets(
+            "anchor_metadata_service_voting_context_offset_seconds",
+            "Time into slot (seconds) when voting context was triggered, by source",
+            Ok(vec![0.05, 0.1, 0.25, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0]),
+            &["trigger"],
+        )
+    });
+
 // ═══════════════════════════════════════════════════════════════════════════════
 // AggregatorCommittee metrics
 // ═══════════════════════════════════════════════════════════════════════════════

--- a/anchor/validator_store/src/metrics.rs
+++ b/anchor/validator_store/src/metrics.rs
@@ -8,6 +8,8 @@ pub const BEACON_VOTE: &str = "beacon_vote";
 pub const SYNC_CONTRIBUTION_AND_PROOF: &str = "sync_contribution_and_proof";
 pub const TIMEOUT: &str = "timeout";
 pub const OTHER_ERROR: &str = "other_error";
+pub const TRIGGER_HEAD_EVENT: &str = "head_event";
+pub const TRIGGER_TIMER: &str = "timer";
 
 pub static CONSENSUS_TIMES: LazyLock<Result<HistogramVec>> = LazyLock::new(|| {
     try_create_histogram_vec(
@@ -55,9 +57,6 @@ pub static METADATA_SERVICE_EMPTY_ASSIGNMENTS_TOTAL: LazyLock<Result<IntCounter>
         )
     });
 
-pub const TRIGGER_HEAD_EVENT: &str = "head_event";
-pub const TRIGGER_TIMER: &str = "timer";
-
 /// Count of Phase 2 firings, labelled by trigger source.
 pub static METADATA_SERVICE_VOTING_CONTEXT_TRIGGERS_TOTAL: LazyLock<Result<IntCounterVec>> =
     LazyLock::new(|| {
@@ -69,7 +68,7 @@ pub static METADATA_SERVICE_VOTING_CONTEXT_TRIGGERS_TOTAL: LazyLock<Result<IntCo
     });
 
 /// Offset within the slot at which Phase 2 fired, in seconds.
-/// Buckets target the 0–4s window before the 1/3-slot fallback timer.
+/// Buckets target the 0–4s window before the spec-derived fallback timer.
 pub static METADATA_SERVICE_VOTING_CONTEXT_OFFSET_SECONDS: LazyLock<Result<HistogramVec>> =
     LazyLock::new(|| {
         try_create_histogram_vec_with_buckets(

--- a/docs/docs/generated/cli-node-options.mdx
+++ b/docs/docs/generated/cli-node-options.mdx
@@ -315,7 +315,10 @@ Payload Building Options:
                configured beacon nodes simultaneously and selects the
                attestation data with the highest score based on checkpoint
                epochs and head block proximity. Only useful with multiple
-               beacon nodes.
+               beacon nodes. Note: WAD is bypassed when the beacon head monitor
+               (enabled by default, see --disable-beacon-head-monitor) wins the
+               eager-attest race for a slot; the firing BN is queried directly.
+               WAD still runs on the fallback path.
 
          --disable-beacon-head-monitor
                Disable the beacon head monitor which tries to attest as soon as

--- a/docs/docs/generated/cli-node-options.mdx
+++ b/docs/docs/generated/cli-node-options.mdx
@@ -317,6 +317,13 @@ Payload Building Options:
                epochs and head block proximity. Only useful with multiple
                beacon nodes.
 
+         --disable-beacon-head-monitor
+               Disable the beacon head monitor which tries to attest as soon as
+               any of the configured beacon nodes sends a head event. Leaving
+               the service enabled is recommended, but disabling it can lead to
+               reduced bandwidth and more predictable usage of the primary
+               beacon node (rather than the fastest BN).
+
 Logging Options:
          --logfile-debug-level <LOGFILE_DEBUG_LEVEL>
                Specifies the verbosity level used when emitting logs to the log


### PR DESCRIPTION
Second PR for #986. Depends on #1011 (LH head-monitor wiring). The diff will be clean once #1011 merges.

## Problem, Evidence, and Context

#1011 wires the LH 8.1.0 head monitor but the eager-attest path is inert end to end: `sign_committee_attestations` blocks on `get_voting_context(slot)`, which is only populated by MetadataService Phase 2 on a fixed timer. Even with the LH side firing early, attestation publishing still waits.

## Change Overview

* `Client::run` fans out the single LH head-event mpsc into two consumer channels via a relay task, one for LH `AttestationService` and one for a new `MetadataService` receiver. No LH changes.
* `MetadataService` Phase 2 waits out the current slot, then races `wait_for_head_event` against the fallback timer in a `tokio::select!`. First to fire triggers the voting-context update.
* When the head event wins, `update_voting_context` calls `run_on_candidate_index(event.beacon_node_index, ...)` directly, bypassing WAD. The returned block_root is verified against the event; on mismatch or RPC error we fall back to the WAD/first_success path.
* Two metrics: `anchor_metadata_service_voting_context_triggers_total{trigger}` and `anchor_metadata_service_voting_context_offset_seconds{trigger}` for hit rate and time-into-slot.

A couple of intentional choices worth flagging:

* The Phase 2 fallback timer uses `spec.get_unaggregated_attestation_due()` rather than `slot_duration / 3`, for parity with LH and so the value tracks any future fork that retunes it.
* The fan-out task's `send().await` is blocking. At expected head-event rates (one per BN per slot) the 1024 buffer is heavy overkill, so blocking is unreachable in practice. A single `warn!` fires if a downstream closes.

## Risks, Trade-offs, and Mitigations

* `MetadataService` is `#[derive(Clone)]`, so the receiver field is `Option<Arc<Mutex<mpsc::Receiver<HeadEvent>>>>` rather than LH's bare `Option<Mutex<...>>`. The `Arc` keeps clones cheap.
* Block-root mismatch handling (head event says root X, BN returns root Y) treats the BN response as untrusted and falls back. Avoids publishing a `BeaconVote` that diverges from the head event the cluster may also be receiving.

## Validation

* `cargo test -p anchor_validator_store --lib metadata_service::tests` clean (21 passed).
* Three unit tests cover `wait_for_head_event`: matching-slot returns the event, stale-slot events are dropped, disabled monitor returns `None` immediately.
* End-to-end "did this move attestation publishing earlier" is a hypothesis until run on a real network. The two new metrics are what's needed to confirm.

## Rollback

Revert the commit set, or pass `--disable-beacon-head-monitor` from #1011 to short-circuit the whole path.