### PR TITLE
ci: bump Node20-deprecated actions in `stable`-loaded workflows (Phase 1 of #1040)

### DIFF
--- a/.github/workflows/claude-mentions.yml
+++ b/.github/workflows/claude-mentions.yml
@@ -54,7 +54,7 @@ jobs:
 
             - name: Checkout repository
               if: steps.check.outputs.is_member == 'true'
-              uses: actions/checkout@v4
+              uses: actions/checkout@v6
               with:
                   repository: ${{ github.event.issue.pull_request && steps.pr-info.outputs.is_fork == 'true' && format('{0}/{1}', steps.pr-info.outputs.pr_head_owner, steps.pr-info.outputs.pr_head_repo) || github.repository }}
                   ref: ${{ github.event.issue.pull_request && steps.pr-info.outputs.pr_head_ref || github.ref }}
@@ -63,14 +63,14 @@ jobs:
             - name: Generate GitHub App token
               if: steps.check.outputs.is_member == 'true'
               id: app-token
-              uses: actions/create-github-app-token@v2
+              uses: actions/create-github-app-token@v3
               with:
                   app-id: ${{ vars.APP_ID }}
                   private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
             - name: Configure AWS Credentials (OIDC)
               if: steps.check.outputs.is_member == 'true'
-              uses: aws-actions/configure-aws-credentials@v4
+              uses: aws-actions/configure-aws-credentials@v6
               with:
                   role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
                   aws-region: us-west-2
@@ -92,7 +92,7 @@ jobs:
             - name: Run Claude Code Action
               if: steps.check.outputs.is_member == 'true'
               timeout-minutes: 15
-              uses: anthropics/claude-code-action@v1.0.52
+              uses: anthropics/claude-code-action@v1.0.127
               with:
                   github_token: ${{ steps.app-token.outputs.token }}
                   use_bedrock: "true"

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -69,21 +69,21 @@ jobs:
             - name: Generate GitHub App token
               if: steps.check.outputs.is_member == 'true'
               id: app-token
-              uses: actions/create-github-app-token@v2
+              uses: actions/create-github-app-token@v3
               with:
                   app-id: ${{ vars.APP_ID }}
                   private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
             - name: Checkout repository
               if: steps.check.outputs.is_member == 'true'
-              uses: actions/checkout@v4
+              uses: actions/checkout@v6
               with:
                   token: ${{ steps.app-token.outputs.token }}
                   ref: ${{ github.event.pull_request.head.sha }}
 
             - name: Configure AWS Credentials (OIDC)
               if: steps.check.outputs.is_member == 'true'
-              uses: aws-actions/configure-aws-credentials@v4
+              uses: aws-actions/configure-aws-credentials@v6
               with:
                   role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
                   aws-region: us-west-2
@@ -107,7 +107,7 @@ jobs:
               timeout-minutes: 15
               env:
                   ACTIONS_STEP_DEBUG: true
-              uses: anthropics/claude-code-action@v1.0.52
+              uses: anthropics/claude-code-action@v1.0.127
               with:
                   github_token: ${{ steps.app-token.outputs.token }}
                   use_bedrock: "true"

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -38,7 +38,7 @@ jobs:
     steps:
       - name: Check title
         id: lint_pr_title
-        uses: amannn/action-semantic-pull-request@v5
+        uses: amannn/action-semantic-pull-request@v6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -55,7 +55,7 @@ jobs:
         continue-on-error: true
       - name: Add PR Comment for Invalid Title
         if: steps.lint_pr_title.outcome == 'failure'
-        uses: marocchino/sticky-pull-request-comment@v2
+        uses: marocchino/sticky-pull-request-comment@v3
         with:
           header: pr-title-lint-error
           message: |
@@ -89,7 +89,7 @@ jobs:
 
       - name: Remove Comment for Valid Title
         if: steps.lint_pr_title.outcome == 'success'
-        uses: marocchino/sticky-pull-request-comment@v2
+        uses: marocchino/sticky-pull-request-comment@v3
         with:
           header: pr-title-lint-error
           delete: true


### PR DESCRIPTION
## Problem, Evidence, and Context (Required)

GitHub is deprecating the Node.js 20 runtime on Actions runners:

- **2026-06-02** — Node20-declared actions get force-migrated to the Node24 runtime.
- **2026-09-16** — Node20 runtime is removed from runners entirely.

See [GitHub's announcement](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/) and the full audit in #1040.

The audit identified two operational groups of workflows that need action bumps. This PR handles **Phase 1**: the subset that *must* land on `stable` because their triggers (`pull_request_target` / `issue_comment` / `pull_request_review_comment`) load workflow YAML from the **default branch of the base repository**, not from the PR base ref. Per [GitHub's docs](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#pull_request_target):

> "This event runs in the context of the default branch of the base repository, rather than in the context of the merge commit, as the `pull_request` event does."

A change landed on `unstable` would therefore have zero effect on these workflows' runs until the next release-merge. Historical precedent for landing this class of fix on `stable`: #430, #705, #830, #844, #845, #974, #997.

Phase 2 (the remaining workflows — `coverage`, `docker`, `docs`, `linkcheck`, `local-testnet`, `release`, `test-suite`) will be a separate PR against `unstable`.

## Change Overview (Required)

Six action version bumps across three workflows:

| File | Action | From | To |
| --- | --- | --- | --- |
| `claude-mentions.yml` | `actions/checkout` | `@v4` | `@v6` |
| `claude-mentions.yml` | `actions/create-github-app-token` | `@v2` | `@v3` |
| `claude-mentions.yml` | `aws-actions/configure-aws-credentials` | `@v4` | `@v6` |
| `claude-mentions.yml` | `anthropics/claude-code-action` | `@v1.0.52` | `@v1.0.127` |
| `claude-pr-review.yml` | (same four bumps) | (same) | (same) |
| `pr-checks.yml` | `amannn/action-semantic-pull-request` | `@v5` | `@v6` |
| `pr-checks.yml` | `marocchino/sticky-pull-request-comment` | `@v2` | `@v3` (×2 occurrences) |

The `claude-code-action` bump transitively re-pins the embedded `oven-sh/setup-bun` from `v2.1.2` (Node20) to `v2.2.0` (Node24), addressing the fourth action named in the runner warning.

Total diff: ~22 lines across 3 files. No input names, no input values, no step ordering, no conditional logic touched.

## Risks, Trade-offs, and Mitigations (Required)

Each major-version bump researched against upstream release notes; none affect the input shape used in these workflows:

**`claude-mentions.yml` + `claude-pr-review.yml`:**

- **`actions/checkout` v4→v6** — v5 was a Node24 runtime bump only. v6 moves credentials from `.git/config` to `$RUNNER_TEMP` via `includeIf` (transparent to downstream `git` commands). No `container:` jobs in these workflows, so the v6 Docker container caveat does not apply.
- **`actions/create-github-app-token` v2→v3** — Only breaking change is removal of custom HTTP proxy support (unused here). `app-id` is deprecated in v3.1.0+ in favor of `client-id` but still functional (just emits a log warning); migration to `client-id` requires adding a new org variable and is left as a follow-up.
- **`configure-aws-credentials` v4→v6** — v5 added stricter boolean parsing (we pass no booleans). v6 was Node24 runtime bump. OIDC trust-policy flow, audience claim, and session defaults unchanged. **No IAM changes required.**
- **`claude-code-action` v1.0.52→v1.0.127** — Inputs (`github_token`, `use_bedrock`, `prompt`, `claude_args`) unchanged. Model `us.anthropic.claude-opus-4-7` still supported. Note: v1.0.65 flipped the `display_report` default from `true` to `false`; we do not set it explicitly, so post-bump there will be no step-summary report (we use PR comments as the user-facing surface, so this is fine).

**`pr-checks.yml`:**

- **`amannn/action-semantic-pull-request` v5→v6** — Pure Node24 runtime swap. v6 has no input changes; `types`, `requireScope`, `subjectPattern`, `GITHUB_TOKEN` env all unchanged. Our usage at lines 43-54 only touches `types`, so unaffected.
- **`marocchino/sticky-pull-request-comment` v2→v3** — Pure Node24 runtime swap. `header`, `message`, `delete`, `recreate`, `hide_and_recreate` all unchanged. Our two usages (lines 58 and 92) use only `header`, `message`, `delete: true`.

**Mitigation if anything regresses on 2026-06-02:** set `ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true` in the workflow env to opt back to Node20 (valid between 2026-06-02 and 2026-09-16). Permanent fix is the upgrade in this PR.

## Validation (Required)

- `actionlint` (1.7.12) clean on all three modified files. Confirmed warning count matches pristine `upstream/stable` (existing shellcheck warnings in `run:` blocks are pre-existing, none introduced by this diff).
- Each target tag verified to resolve at upstream (`v6`, `v3`, `v6`, `v1.0.127`, `v6`, `v3` all confirmed to point at real commits).
- Release notes / changelogs read end-to-end for each version range; no input/output/default changes affect the workflow YAML as written.
- Live end-to-end validation happens automatically when this PR opens: `claude-pr-review` runs on `pull_request_target` against `stable` and `claude-mentions` runs on `@claude` mentions, both using real `sigp` org secrets.

## Rollback (Required for behavior or runtime changes; optional otherwise)

Simple `git revert` of the merge commit. No data migration, no schema change, no operational state to clean up.

If revert is not immediately possible and Node24 surfaces an unexpected incompatibility on 2026-06-02, the `ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true` env var (set per-job or per-workflow) restores Node20 behavior through 2026-09-16.

## Blockers / Dependencies (Optional)

None. Phase 2 of #1040 (the remaining workflows) is independent and will be opened as a separate PR against `unstable`.

## Additional Info / Next Steps (Optional)

Follow-ups (not in this PR):

- `app-id` → `client-id` rename in `create-github-app-token` — requires fetching the GitHub App's Client ID and adding a new org variable. Currently just a deprecation log warning.
- Phase 2 of #1040 — `coverage`, `docker`, `docs`, `linkcheck`, `local-testnet`, `release`, `test-suite` (plus the overdue `lockbud` Node16 → Node24 bump in `test-suite.yml` and the consistency bump `actions/checkout@v5 → @v6` in `local-testnet.yml`). Target: `unstable`.
- Improvement to the Claude review bot's diff baseline tracked in #1043 (out of scope here).

Closes Phase 1 of #1040.
