### PR TITLE
ci: bump Node20-deprecated actions in remaining workflows (Phase 2 of #1040)

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -30,7 +30,7 @@ jobs:
       contents: read
       id-token: write
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         submodules: 'recursive'
     - name: Get latest version of stable Rust
@@ -42,7 +42,7 @@ jobs:
     - name: Generate coverage report
       run: make coverage
     - name: Upload lcov report artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: lcov-report
         path: lcov.info

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -47,19 +47,19 @@ jobs:
             VERSION_SUFFIX: ${{ needs.extract-version.outputs.VERSION_SUFFIX }}
         steps:
             - name: Checkout sources
-              uses: actions/checkout@v4
+              uses: actions/checkout@v6
 
             - name: Dockerhub login
               run: |
                   echo "${DOCKER_PASSWORD}" | docker login --username ${DOCKER_USERNAME} --password-stdin
 
             - name: Setup QEMU
-              uses: docker/setup-qemu-action@v3
+              uses: docker/setup-qemu-action@v4
             - name: Setup Docker Buildx
-              uses: docker/setup-buildx-action@v3
+              uses: docker/setup-buildx-action@v4
 
             - name: Build and push
-              uses: docker/build-push-action@v6
+              uses: docker/build-push-action@v7
               with:
                 context: .
                 platforms: linux/${{ matrix.target.docker-arch }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,12 +14,12 @@ jobs:
     if: github.repository_owner == 'sigp'
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
           cache-dependency-path: docs/package-lock.json
 

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -21,12 +21,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
           cache-dependency-path: docs/package-lock.json
 

--- a/.github/workflows/local-testnet.yml
+++ b/.github/workflows/local-testnet.yml
@@ -13,7 +13,7 @@ jobs:
   build-docker-image:
     runs-on: warp-ubuntu-latest-x64-16x
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Build Docker Image
         # has to be Dockerfile.devnet as spec-minimal is necessary
@@ -22,7 +22,7 @@ jobs:
           docker save node/anchor:latest -o anchor-docker.tar
 
       - name: Upload Docker Image Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: anchor-docker
           path: anchor-docker.tar
@@ -32,13 +32,13 @@ jobs:
     runs-on: warp-ubuntu-latest-x64-16x
     needs: build-docker-image
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           repository: ssvlabs/ssv-mini
           ref: ae910a2da2aec8c3151bec0a7e5ea3be4c479a30
           path: ssv-mini
 
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           path: anchor
 
@@ -53,7 +53,7 @@ jobs:
           kurtosis analytics disable
 
       - name: Download Docker Image Artifact
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v7
         with:
           name: anchor-docker
           path: .
@@ -105,7 +105,7 @@ jobs:
 
       - name: Upload Logs Artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: anchor-localnet-test-logs
           path: anchor-localnet-test-logs/

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -60,7 +60,7 @@ jobs:
     # Use self-hosted runners only on the sigp repo.
     runs-on: ubuntu-22.04 #${{ github.repository == 'sigp/anchor' && fromJson('["self-hosted", "linux", "CI", "large"]') || 'ubuntu-22.04'  }}
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         submodules: 'recursive'
     - name: Get latest version of stable Rust
@@ -86,7 +86,7 @@ jobs:
     env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         submodules: 'recursive'
     - name: Get latest version of stable Rust
@@ -105,7 +105,7 @@ jobs:
     name: check-fmt
     runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Get latest version of nightly Rust
       uses: moonrepo/setup-rust@v1
       with:
@@ -119,7 +119,7 @@ jobs:
     env:
       CARGO_INCREMENTAL: 1
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Get latest version of stable Rust
       uses: moonrepo/setup-rust@v1
       with:
@@ -142,7 +142,7 @@ jobs:
     name: check-msrv
     runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Install Rust at Minimum Supported Rust Version (MSRV)
       run: |
         metadata=$(cargo metadata --no-deps --format-version 1)
@@ -156,7 +156,7 @@ jobs:
     if: needs.check-labels.outputs.skip_ci != 'true'
     runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Get latest version of nightly Rust
       uses: moonrepo/setup-rust@v1
       with:
@@ -178,7 +178,7 @@ jobs:
     name: spellcheck
     runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       # Uses the canonical version so that the version is up to date:
       # https://github.com/rojopolis/spellcheck-github-actions?tab=readme-ov-file#using-a-canonical-version
     - uses: rojopolis/spellcheck-github-actions@0.46.0
@@ -191,7 +191,7 @@ jobs:
     if: needs.check-labels.outputs.skip_ci != 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Get latest version of stable Rust
         uses: moonrepo/setup-rust@v1
         with:
@@ -208,7 +208,7 @@ jobs:
       image: sigmaprime/lockbud:latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
       - name: Install dependencies
         run: apt update && apt install -y cmake libclang-dev
       - name: Check for deadlocks
@@ -233,6 +233,6 @@ jobs:
       'lockbud',
     ]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Check that success job is dependent on all others
         run: ./.github/scripts/check_success_job.sh ./.github/workflows/test-suite.yml test-suite-success


### PR DESCRIPTION
## Problem, Evidence, and Context

GitHub Actions force-migrates Node20 actions to Node24 on **2026-06-02** and removes the Node20 runtime entirely on **2026-09-16** ([announcement](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)). Phase 2 of #1040.

Phase 1 (#1042, targeting `stable`) covers the three workflows whose YAML is loaded from the default branch (`claude-mentions.yml`, `claude-pr-review.yml`, `pr-checks.yml`). This PR bumps the Node20 (and one Node16) action references across the remaining `pull_request`/`push`-triggered workflows. `release.yml` is intentionally **not** included here and will follow as a separate PR validated via personal-fork tag-push, per [#1040's self-validation comment](https://github.com/sigp/anchor/issues/1040#issuecomment-4501565553).

This PR also opportunistically bumps the **Node toolchain** used by `docs.yml` and `linkcheck.yml` from Node 20 to Node 22 LTS. Node 20 reached end-of-life on **2026-04-30** ([Node release schedule](https://github.com/nodejs/release)) — i.e. it's already EOL as of today. The toolchain change is a 2-line `node-version: '20'` → `'22'` and was folded in here because it's the same two files.

## Change Overview

6 files. 13 GitHub Actions version bumps + 2 Node toolchain bumps. All actions target each one's latest stable major:

- `actions/checkout` v3/v4/v5 → v6 (mass; `v3` is the long-overdue `lockbud` Node16 bump in `test-suite.yml`)
- `actions/upload-artifact` v4 → v6 (v5 is still Node20)
- `actions/download-artifact` v5 → v7 (v6 is still Node20)
- `actions/setup-node` v4 → v5
- `docker/setup-qemu-action` v3 → v4
- `docker/setup-buildx-action` v3 → v4
- `docker/build-push-action` v6 → v7
- **Node toolchain `node-version: '20'` → `'22'`** in `docs.yml` and `linkcheck.yml` (used to run vocs build, playwright, linkcheck)

## Risks, Trade-offs, and Mitigations

- **Action bumps**: each new major's release notes were checked against our actual inputs (`platforms`, `build-args`, `tags`, `cache: 'npm'`, `cache-dependency-path`, no-input "download all", etc.) — no breaking changes for our usage.
- **Node toolchain bump**: Node 22 is current LTS; vocs and playwright both support it. Risk is a transitive npm dep declaring an `engines` upper bound that excludes Node 22; mitigated by post-merge validation (docs.yml fires on next unstable push).
- `actionlint`: identical warning counts pre/post bump on all 6 files (no new lint regressions).
- All bumped majors require Actions Runner `>= 2.327.1`; GitHub-hosted runners auto-update, no self-hosted runner work needed. The `local-testnet.yml` job uses Warp Build runners (`warp-ubuntu-latest-x64-16x`); Warp publishes no runner version SLA, so first post-merge run is a soft validation point.

## Validation

Per-workflow validation event:

| Workflow | When validated |
| --- | --- |
| `coverage.yml` | this PR (fires on every PR open) |
| `local-testnet.yml` | this PR (fires on every PR open) |
| `test-suite.yml` | this PR (fires on every PR open) |
| `docker.yml` | post-merge push to `unstable` (empirically fires within ~3s of every unstable merge — verified across last 7 unstable merges, all `conclusion: success`) |
| `docs.yml` | post-merge push to `unstable` (also validates Node 22 toolchain) |
| `linkcheck.yml` | post-merge push to `unstable` (PR trigger is path-filtered to `docs/**`; this PR doesn't touch docs/, so won't trigger on PR) |

## Rollback

Simple revert of the single commit; workflows are isolated from product code. Between 2026-06-02 and 2026-09-16, any remaining Node20 action can also be force-run via `ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true` as a temporary safety net.

## Additional Info / Next Steps

- `release.yml` will land in a separate PR, validated via a personal-fork `v*` tag-push so the full cross-compile + artifact round-trip + GitHub Release publication exercises the bumped actions end-to-end without touching `sigp/anchor`.
- The `app-id` → `client-id` migration on `actions/create-github-app-token@v3` (introduced in Phase 1 #1042) is tracked as a follow-up at #1044.
- `rojopolis/spellcheck-github-actions@0.46.0` in `test-suite.yml` is a Docker action (unaffected by Node deprecation) and intentionally not bumped here.
