### PR TITLE
ci: bump release.yml actions ahead of Node20 deprecation (Phase 3 of #1040)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
         needs: extract-version
         steps:
             - name: Checkout sources
-              uses: actions/checkout@v4
+              uses: actions/checkout@v6
             - name: Get latest version of stable Rust
               run: rustup update stable
 
@@ -93,14 +93,14 @@ jobs:
             # =======================================================================
 
             - name: Upload artifact
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@v6
               with:
                   name: anchor-${{ needs.extract-version.outputs.VERSION }}-${{ matrix.arch }}.tar.gz
                   path: anchor-${{ needs.extract-version.outputs.VERSION }}-${{ matrix.arch }}.tar.gz
                   compression-level: 0
 
             - name: Upload signature
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@v6
               with:
                   name: anchor-${{ needs.extract-version.outputs.VERSION }}-${{ matrix.arch }}.tar.gz.asc
                   path: anchor-${{ needs.extract-version.outputs.VERSION }}-${{ matrix.arch }}.tar.gz.asc
@@ -115,7 +115,7 @@ jobs:
         steps:
             # This is necessary for generating the changelog. It has to come before "Download Artifacts" or else it deletes the artifacts.
             - name: Checkout sources
-              uses: actions/checkout@v4
+              uses: actions/checkout@v6
               with:
                   fetch-depth: 0
 
@@ -124,7 +124,7 @@ jobs:
             # ==============================
 
             - name: Download artifacts
-              uses: actions/download-artifact@v4
+              uses: actions/download-artifact@v7
 
             # ==============================
             #       Create release draft


### PR DESCRIPTION
## Problem, Evidence, and Context

GitHub Actions force-migrates Node20 actions to Node24 on **2026-06-02** and removes the Node20 runtime entirely on **2026-09-16** ([announcement](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)). Phase 3 (final closure) of #1040.

Phase 1 (#1042, `stable`) covered the default-branch-loaded workflows. Phase 2 (#1045, `unstable`) covered the `pull_request`/`push`-triggered workflows. This PR bumps `release.yml`, which triggers only on `v*` tag-push and so couldn't be PR- or merge-validated — see [#1040's self-validation comment](https://github.com/sigp/anchor/issues/1040#issuecomment-4501565553) for the fork-tag-push recipe used here.

## Change Overview

5 line changes in `release.yml`:

- `actions/checkout@v4` → `@v6` (×2: `build` and `draft-release` jobs)
- `actions/upload-artifact@v4` → `@v6` (×2: tarball + signature uploads in the `build` job matrix)
- `actions/download-artifact@v4` → `@v7` (no-name "download all" in the `draft-release` job)

## Risks, Trade-offs, and Mitigations

- All five new majors' release notes were verified against actual inputs (`compression-level: 0`, `fetch-depth: 0`, no-name "download all") — no breaking changes for our usage.
- `actionlint`: identical warning counts pre/post bump (11 → 11, no new lint regressions).
- All bumped majors require Actions Runner `>= 2.327.1`; GitHub-hosted runners (which `release.yml` uses) auto-update.

## Validation

End-to-end validated via fork-tag-push on `shane-moore/anchor` before opening this PR. The recipe:

1. Pushed `ci/node24-phase3-release` to `shane-moore/anchor`.
2. Added throwaway GPG secrets to the fork (`GPG_SIGNING_KEY` + `GPG_PASSPHRASE`).
3. Tagged `v0.0.0-node24-test` on the bumped commit and pushed the tag to the fork only.
4. Watched the full workflow run end-to-end.
5. Cleaned up: deleted the draft release, throwaway GPG key, and fork secrets.

**Result** ([run #26194898745](https://github.com/shane-moore/anchor/actions/runs/26194898745)):

| Job | Duration | Status |
| --- | --- | --- |
| `extract-version` | 4s | ✓ |
| Build Release (aarch64-apple-darwin) | 9m 2s | ✓ |
| Build Release (x86_64-unknown-linux-gnu) | 10m 48s | ✓ |
| Build Release (aarch64-unknown-linux-gnu) | 10m 50s | ✓ |
| Draft Release | 14s | ✓ |

Every bumped action invocation succeeded end-to-end: `checkout@v6` (×2 jobs), `upload-artifact@v6` (×6 invocations across the 3-arch matrix), `download-artifact@v7` (in `draft-release`). The draft Release that landed in the fork had all 6 expected assets (3 tarballs + 3 GPG signatures, real anchor binaries signed by the throwaway key).

The next exercise after merge is the next real `v*` tag cut from `stable`; the bumps have already been proven by the fork run.

## Rollback

Simple revert of the single commit; `release.yml` is isolated from product code. Between 2026-06-02 and 2026-09-16, any remaining Node20 action can also be force-run via `ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true` as a temporary safety net.

## Additional Info / Next Steps

- Closes the action-runtime work for #1040 across all four PRs (#1042, #1045, this PR; with #1044 tracking the `app-id` → `client-id` follow-up).
- `rojopolis/spellcheck-github-actions@0.46.0` in `test-suite.yml` is a Docker action (unaffected by Node deprecation) and not bumped.
