### PR TITLE
feat(ssv_types): add PayloadAttestationVote with QbftData and value checker

### DIFF
--- a/anchor/common/ssv_types/src/consensus.rs
+++ b/anchor/common/ssv_types/src/consensus.rs
@@ -906,6 +906,27 @@ impl QbftData for BeaconVote {
     }
 }
 
+#[derive(Clone, Debug, TreeHash, PartialEq, Eq, Encode, Decode)]
+#[cfg_attr(feature = "arbitrary-fuzz", derive(arbitrary::Arbitrary))]
+pub struct PayloadAttestationVote {
+    pub beacon_block_root: Hash256,
+    pub payload_present: bool,
+    pub blob_data_available: bool,
+}
+
+impl QbftData for PayloadAttestationVote {
+    type Hash = Hash256;
+
+    fn hash(&self) -> Self::Hash {
+        let bytes = self.as_ssz_bytes();
+
+        let mut hasher = Sha256::new();
+        hasher.update(bytes);
+        let hash: [u8; 32] = hasher.finalize().into();
+        Hash256::from(hash)
+    }
+}
+
 /// Identifies a batch of pre-consensus selection proofs for a committee.
 /// All operators compute the same hash for a given `(slot, committee_id)` pair, ensuring
 /// consistent batching across the network.
@@ -1179,6 +1200,48 @@ pub enum BeaconVoteValidationError {
     EpochMismatch(Box<EpochMismatch>),
     #[error("Attestation would be slashable: {0}")]
     SlashableAttestation(NotSafe),
+}
+
+#[derive(Error, Debug)]
+pub enum PayloadAttestationVoteValidationError {
+    #[error("Beacon block root is zero")]
+    ZeroBeaconBlockRoot,
+}
+
+/// Validator for `PayloadAttestationVote` during QBFT consensus.
+///
+/// Per SIP-94 SC-2, `payload_present` and `blob_data_available` are trusted
+/// from the QBFT leader and intentionally not compared against any local view.
+/// The only required check is that `beacon_block_root` is non-zero.
+#[derive(Debug, Default)]
+pub struct PayloadAttestationVoteValidator;
+
+impl QbftDataValidator<PayloadAttestationVote> for PayloadAttestationVoteValidator {
+    fn validate(
+        &self,
+        value: &PayloadAttestationVote,
+        _our_value: &PayloadAttestationVote,
+    ) -> bool {
+        match self.do_validation(value) {
+            Ok(_) => true,
+            Err(err) => {
+                warn!(%err, "Operator proposed invalid payload attestation vote");
+                false
+            }
+        }
+    }
+}
+
+impl PayloadAttestationVoteValidator {
+    pub fn do_validation(
+        &self,
+        value: &PayloadAttestationVote,
+    ) -> Result<(), PayloadAttestationVoteValidationError> {
+        if value.beacon_block_root.is_zero() {
+            return Err(PayloadAttestationVoteValidationError::ZeroBeaconBlockRoot);
+        }
+        Ok(())
+    }
 }
 
 #[cfg(test)]
@@ -2045,5 +2108,124 @@ mod tests {
             // All operators should get the same hash
             assert_eq!(batch_id.hash(), expected_hash);
         }
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════════════
+    // PayloadAttestationVote Tests
+    // ═══════════════════════════════════════════════════════════════════════════════
+
+    fn create_payload_attestation_vote(
+        root: Hash256,
+        payload_present: bool,
+        blob_data_available: bool,
+    ) -> PayloadAttestationVote {
+        PayloadAttestationVote {
+            beacon_block_root: root,
+            payload_present,
+            blob_data_available,
+        }
+    }
+
+    #[test]
+    fn test_payload_attestation_vote_ssz_roundtrip() {
+        for (payload_present, blob_data_available) in
+            [(false, false), (false, true), (true, false), (true, true)]
+        {
+            let vote = create_payload_attestation_vote(
+                Hash256::from_low_u64_be(0xabcd),
+                payload_present,
+                blob_data_available,
+            );
+
+            let encoded = vote.as_ssz_bytes();
+            let decoded = PayloadAttestationVote::from_ssz_bytes(&encoded).unwrap();
+
+            assert_eq!(vote, decoded);
+        }
+    }
+
+    #[test]
+    fn test_payload_attestation_vote_ssz_byte_layout() {
+        // Fixed-length container: 32-byte root + 1-byte bool + 1-byte bool = 34 bytes.
+        let root_bytes = [0xAA; 32];
+        let vote = create_payload_attestation_vote(Hash256::from(root_bytes), true, false);
+
+        let encoded = vote.as_ssz_bytes();
+
+        assert_eq!(
+            encoded.len(),
+            34,
+            "PayloadAttestationVote should encode to 34 bytes"
+        );
+        assert_eq!(&encoded[0..32], &root_bytes);
+        assert_eq!(encoded[32], 1, "payload_present byte");
+        assert_eq!(encoded[33], 0, "blob_data_available byte");
+    }
+
+    #[test]
+    fn test_payload_attestation_vote_hash_deterministic() {
+        let root = Hash256::from_low_u64_be(0x1234);
+        let vote = create_payload_attestation_vote(root, true, false);
+
+        // Hashing two independently-constructed values with the same inputs
+        // must produce the same hash (catches identity- or address-dependent hashing).
+        let same = create_payload_attestation_vote(root, true, false);
+        assert_eq!(vote.hash(), same.hash());
+
+        let different_root =
+            create_payload_attestation_vote(Hash256::from_low_u64_be(0x5678), true, false);
+        assert_ne!(vote.hash(), different_root.hash());
+
+        let flipped_payload = create_payload_attestation_vote(root, false, false);
+        assert_ne!(vote.hash(), flipped_payload.hash());
+
+        let flipped_blob = create_payload_attestation_vote(root, true, true);
+        assert_ne!(vote.hash(), flipped_blob.hash());
+    }
+
+    #[test]
+    fn test_payload_attestation_vote_validator_rejects_zero_root() {
+        let validator = PayloadAttestationVoteValidator;
+        let zero_vote = create_payload_attestation_vote(Hash256::zero(), true, true);
+
+        let result = validator.do_validation(&zero_vote);
+        assert!(matches!(
+            result,
+            Err(PayloadAttestationVoteValidationError::ZeroBeaconBlockRoot)
+        ));
+    }
+
+    #[test]
+    fn test_payload_attestation_vote_validator_accepts_nonzero_root() {
+        let validator = PayloadAttestationVoteValidator;
+        let root = Hash256::from_low_u64_be(0xdead);
+
+        for (payload_present, blob_data_available) in
+            [(false, false), (false, true), (true, false), (true, true)]
+        {
+            let vote = create_payload_attestation_vote(root, payload_present, blob_data_available);
+            assert!(
+                validator.do_validation(&vote).is_ok(),
+                "validator should accept non-zero root regardless of payload-status flags \
+                 (payload_present={payload_present}, blob_data_available={blob_data_available})"
+            );
+        }
+    }
+
+    #[test]
+    fn test_payload_attestation_vote_validator_ignores_start_value() {
+        // SIP-94 SC-2: payload-status fields are trusted from the QBFT leader;
+        // the validator must NOT compare the proposed value against the local
+        // operator's view (start_value). Verified at the trait-surface level by
+        // calling `validate(value, our_value)` with divergent values and asserting
+        // acceptance; structurally also guaranteed by `do_validation` only taking
+        // `value`.
+        let validator = PayloadAttestationVoteValidator;
+        let proposed =
+            create_payload_attestation_vote(Hash256::from_low_u64_be(0x1111), true, true);
+        let local_view =
+            create_payload_attestation_vote(Hash256::from_low_u64_be(0x2222), false, false);
+
+        assert!(validator.validate(&proposed, &local_view));
     }
 }

--- a/anchor/common/ssv_types/src/consensus.rs
+++ b/anchor/common/ssv_types/src/consensus.rs
@@ -906,11 +906,21 @@ impl QbftData for BeaconVote {
     }
 }
 
+/// QBFT consensus value for PTC (Payload Timeliness Committee) duties at Gloas.
+///
+/// PTC operators run one QBFT instance per slot over this stripped shape; the
+/// slot is pinned by the QBFT instance and reconstructed from the duty when
+/// signing the full `PayloadAttestationData` under `DOMAIN_PTC_ATTESTER` after
+/// consensus decides.
 #[derive(Clone, Debug, TreeHash, PartialEq, Eq, Encode, Decode)]
 #[cfg_attr(feature = "arbitrary-fuzz", derive(arbitrary::Arbitrary))]
 pub struct PayloadAttestationVote {
+    /// Root of the beacon block whose payload-timeliness this vote describes.
     pub beacon_block_root: Hash256,
+    /// Whether the operator observed the execution payload envelope by the
+    /// PTC cutoff.
     pub payload_present: bool,
+    /// Whether the operator observed blob data availability by the PTC cutoff.
     pub blob_data_available: bool,
 }
 
@@ -1202,17 +1212,28 @@ pub enum BeaconVoteValidationError {
     SlashableAttestation(NotSafe),
 }
 
+/// Validation errors for `PayloadAttestationVote`.
 #[derive(Error, Debug)]
 pub enum PayloadAttestationVoteValidationError {
+    /// The proposed `beacon_block_root` is the zero hash, which can never be a
+    /// real block root and signals an empty or corrupt leader proposal.
     #[error("Beacon block root is zero")]
     ZeroBeaconBlockRoot,
 }
 
 /// Validator for `PayloadAttestationVote` during QBFT consensus.
 ///
-/// Per SIP-94 SC-2, `payload_present` and `blob_data_available` are trusted
-/// from the QBFT leader and intentionally not compared against any local view.
-/// The only required check is that `beacon_block_root` is non-zero.
+/// Reflects [SIP-94 §3][sip-94]: the cluster contributes one shared PTC
+/// observation per slot, sourced from the QBFT leader. `payload_present` and
+/// `blob_data_available` are intentionally not compared against the local
+/// operator's view (SC-2: trust-leader for payload-status fields). The only
+/// required check here is that `beacon_block_root` is non-zero.
+///
+/// If SIP-94 is later amended to require local-view equality on the
+/// payload-status booleans, extend `do_validation` with the additional rule;
+/// the `do_validation -> Result` shape is the extension point.
+///
+/// [sip-94]: https://github.com/ssvlabs/SIPs/blob/7e8b5bd6d4007682d8bd75b06a2f2ac7b617e9e5/sips/epbs_support.md#3-new-duty-payload-timeliness-committee-ptc-attestation
 #[derive(Debug, Default)]
 pub struct PayloadAttestationVoteValidator;
 
@@ -2213,18 +2234,18 @@ mod tests {
     }
 
     #[test]
-    fn test_payload_attestation_vote_validator_ignores_start_value() {
-        // SIP-94 SC-2: payload-status fields are trusted from the QBFT leader;
-        // the validator must NOT compare the proposed value against the local
-        // operator's view (start_value). Verified at the trait-surface level by
-        // calling `validate(value, our_value)` with divergent values and asserting
-        // acceptance; structurally also guaranteed by `do_validation` only taking
-        // `value`.
+    fn test_payload_attestation_vote_validator_accepts_status_flag_disagreement() {
+        // SIP-94 SC-2: `payload_present` and `blob_data_available` are trusted
+        // from the QBFT leader and must NOT be compared against the local
+        // operator's observation. Tested by holding `beacon_block_root` constant
+        // between proposed and local values and flipping only the payload-status
+        // flags, asserting acceptance. Root-mismatch behavior is intentionally
+        // not pinned here; the trait surface (`do_validation` taking only `value`)
+        // and the zero-root rejection test cover the root contract.
         let validator = PayloadAttestationVoteValidator;
-        let proposed =
-            create_payload_attestation_vote(Hash256::from_low_u64_be(0x1111), true, true);
-        let local_view =
-            create_payload_attestation_vote(Hash256::from_low_u64_be(0x2222), false, false);
+        let root = Hash256::from_low_u64_be(0x1111);
+        let proposed = create_payload_attestation_vote(root, true, true);
+        let local_view = create_payload_attestation_vote(root, false, false);
 
         assert!(validator.validate(&proposed, &local_view));
     }


### PR DESCRIPTION
## Problem, Evidence, and Context

Closes #1034. Next ePBS milestone item after PR #1033 (`Role::PTCCommittee` + message-validator handling).

Per [SIP-94](https://github.com/ssvlabs/SIPs/pull/94) §3 and the [Gloas validator spec](https://github.com/ethereum/consensus-specs/blob/dev/specs/gloas/validator.md#payload-attester-duties), PTC committees run QBFT each slot over a stripped `PayloadAttestationVote { beacon_block_root, payload_present, blob_data_available }` (slot omitted, pinned by the QBFT instance). After consensus, each PTC-assigned validator signs the full `PayloadAttestationData` (slot reconstructed from the duty) under `DOMAIN_PTC_ATTESTER`. This PR adds the SSZ container and value checker that the QBFT instance will use; downstream issues #1035 and #1037 wire the consumers.

## Change Overview

`anchor/common/ssv_types/src/consensus.rs` (single file, additive):

- **`PayloadAttestationVote`** — SSZ struct placed next to `BeaconVote`. `QbftData` impl with `sha256(self.as_ssz_bytes())` hash for cross-operator determinism. Mirrors `BeaconVote::hash` shape.
- **`PayloadAttestationVoteValidator`** + **`PayloadAttestationVoteValidationError`** — placed next to `BeaconVoteValidationError`. One rule: reject zero `beacon_block_root`. Uses the same `do_validation -> Result -> match Ok/Err -> warn -> bool` shape as `BeaconVoteValidator` and `AggregatorCommitteeDataValidator` for consistency.
- **6 unit tests** in the existing `mod tests` block under a new `═══ PayloadAttestationVote Tests ═══` section.

**Reading order:** start at the new `PayloadAttestationVote` struct (~L909); skim down to the validator (~L1205); the test block at end of `mod tests` mirrors the `AssignedAggregator` / `AggregatorCommittee` test patterns.

**Intentionally unchanged:**
- No production consumers wired (`qbft_manager` routing lands in #1035; `sign_payload_attestation` lands in #1037).
- No `QbftDecidable` impl — that lives in `qbft_manager` (#1035).
- The existing four `sha256(ssz_bytes)` hash impls (`ProposerConsensusData`, `AggregatorCommitteeConsensusData`, `BeaconVote`) — deferred standalone refactor; not mixed into this feature PR.

## Risks, Trade-offs, and Mitigations

**Validator is structurally weaker than `BeaconVoteValidator`.** No slashing-protection call, no comparison of `payload_present` / `blob_data_available` against local BN view. This is intentional per SIP-94 SC-2: at the 75% slot deadline, operator BNs may legitimately disagree on envelope arrival, and a "match local view" gate would amplify normal BN drift into cluster-level QBFT deadlocks even with an honest leader. PTC is non-slashable, so the worst case from leader malice is a wasted cluster signature, bounded.

**Mitigation:** the value check matches the SIP as-written. An [open thread on SIP-94 line 138](https://github.com/ssvlabs/SIPs/pull/94#discussion_r3265815226) between Diego and Shane discusses whether to strengthen this; if the SIP eventually demands strict equality, a follow-up PR adds the second rule (the `do_validation -> Result` shape this PR uses is exactly the extension point).

**Validator boilerplate.** The single-rule check could be inlined in `validate` directly. The `do_validation` wrapper is preserved deliberately to match the sibling-validator precedent and keep tests calling the same shape (`do_validation` + `matches!`) used elsewhere in the file.

## Validation

- `cargo test -p ssv_types` — 86 unit + 2 doctests pass (6 new + 80 existing); no regressions.
- `make cargo-fmt && make cargo-fmt-check` — clean.
- `make lint` — clean (workspace-wide clippy).
- `cargo check --workspace` — clean.

Test coverage for the new code:
- SSZ roundtrip across all 4 `(payload_present, blob_data_available)` combinations.
- Wire-byte layout: fixed 34 bytes (32-byte root + 2 bools); position-by-position assertions.
- Hash determinism: same inputs → same hash (two independently constructed values, mirroring `SelectionProofBatchId` precedent); different root or flipped boolean → different hash.
- Validator zero-root rejection: `do_validation` returns `Err(ZeroBeaconBlockRoot)`.
- Validator non-zero acceptance: 4-combo loop documents that payload-status flags are not validated.
- Validator ignores `start_value`: trait-surface guard for the SC-2 trust-leader contract.

## Rollback

Single-file additive change. Revert removes the type, validator, error enum, and tests. No production consumers yet, so revert has zero behavior impact.

## Blockers / Dependencies

None for merge. Downstream consumers (under milestone #4):
- **#1035** `feat(qbft_manager): wire PTC committee-scoped QBFT instances and fork gate` — consumes `PayloadAttestationVote` + `PayloadAttestationVoteValidator`.
- **#1037** `feat(validator_store): implement sign_payload_attestation` — signs the decided value.

## Additional Info / Next Steps
N/A