### PR TITLE
feat(validator_store): publish PTC validator set on VotingAssignments

### DIFF
--- a/anchor/validator_store/src/lib.rs
+++ b/anchor/validator_store/src/lib.rs
@@ -2014,7 +2014,7 @@ impl VotingAssignments {
     {
         self.ptc_validators
             .iter()
-            .filter(|idx| is_in_committee(idx))
+            .filter(|&idx| is_in_committee(idx))
             .count()
     }
 }
@@ -3342,6 +3342,17 @@ mod tests {
         // Voting message: 2 attesting + 2 sync = 4
         let message_count = voting_assignments.voting_message_count_for_committee(all_in_committee);
         assert_eq!(message_count, 4);
+    }
+
+    #[test]
+    fn test_ptc_signature_count_with_filter() {
+        let mut voting_assignments = create_test_voting_assignments(vec![], vec![]);
+        voting_assignments.ptc_validators =
+            vec![ValidatorIndex(1), ValidatorIndex(2), ValidatorIndex(3)];
+
+        let in_committee = |idx: &ValidatorIndex| matches!(idx.0, 1 | 3);
+        let count = voting_assignments.ptc_signature_count_for_committee(in_committee);
+        assert_eq!(count, 2);
     }
 
     #[tokio::test]

--- a/anchor/validator_store/src/lib.rs
+++ b/anchor/validator_store/src/lib.rs
@@ -1927,8 +1927,7 @@ pub struct VotingAssignments {
     /// Sync committee validators mapped to their subnet IDs.
     /// A validator may participate in multiple subnets.
     pub sync_validators_by_subnet: HashMap<ValidatorIndex, HashSet<SyncSubnetId>>,
-    /// The indices of local validators with a PTC duty in this slot. Empty when the operator has
-    /// no local PTC duties in this slot.
+    /// The indices of local validators with a PTC duty in this slot.
     pub ptc_validators: Vec<ValidatorIndex>,
 }
 

--- a/anchor/validator_store/src/lib.rs
+++ b/anchor/validator_store/src/lib.rs
@@ -1927,6 +1927,9 @@ pub struct VotingAssignments {
     /// Sync committee validators mapped to their subnet IDs.
     /// A validator may participate in multiple subnets.
     pub sync_validators_by_subnet: HashMap<ValidatorIndex, HashSet<SyncSubnetId>>,
+    /// The indices of local validators with a PTC duty in this slot. Empty when the operator has
+    /// no local PTC duties in this slot.
+    pub ptc_validators: Vec<ValidatorIndex>,
 }
 
 impl VotingAssignments {
@@ -1998,6 +2001,21 @@ impl VotingAssignments {
         }
 
         count
+    }
+
+    /// Counts expected PTC partial signatures for a given cluster.
+    ///
+    /// PTC runs a separate QBFT instance from attestation/sync, so its batch
+    /// size is tallied independently rather than being folded into
+    /// `voting_message_count_for_committee`.
+    pub fn ptc_signature_count_for_committee<F>(&self, is_in_committee: F) -> usize
+    where
+        F: Fn(&ValidatorIndex) -> bool,
+    {
+        self.ptc_validators
+            .iter()
+            .filter(|idx| is_in_committee(idx))
+            .count()
     }
 }
 
@@ -3201,6 +3219,7 @@ mod tests {
                     )
                 })
                 .collect(),
+            ptc_validators: Vec::new(),
         }
     }
 
@@ -3355,6 +3374,7 @@ mod tests {
             attesting_validators: vec![ValidatorIndex(1)],
             attesting_committees: HashMap::new(),
             sync_validators_by_subnet: HashMap::new(),
+            ptc_validators: Vec::new(),
         };
         tx.send_replace(Some(Arc::new(voting_assignments)));
 
@@ -3377,6 +3397,7 @@ mod tests {
             attesting_validators: vec![],
             attesting_committees: HashMap::new(),
             sync_validators_by_subnet: HashMap::new(),
+            ptc_validators: Vec::new(),
         };
         tx.send_replace(Some(Arc::new(voting_assignments)));
 

--- a/anchor/validator_store/src/metadata_service.rs
+++ b/anchor/validator_store/src/metadata_service.rs
@@ -312,9 +312,7 @@ impl<E: EthSpec, T: SlotClock + 'static> MetadataService<E, T> {
             })
             .unwrap_or_default();
 
-        // Get PTC validators (CStar+ only). Duties are read from LH's epoch-cached
-        // `PtcMap`; the per-pubkey check is the same `get_validator_and_cluster`
-        // shape used by the Phase-2/3 consensus-data builder.
+        // Get PTC validators
         let epoch = slot.epoch(E::slots_per_epoch());
         let ptc_validators = if self.fork_schedule.active_fork(epoch) >= Fork::CStar {
             let duties = self.duties_service.get_ptc_duties_for_slot(slot);
@@ -1278,10 +1276,6 @@ pub fn filter_contributors_with_contributions<E: EthSpec>(
 }
 
 /// Build the local PTC validator-index list for one slot from LH-provided duties.
-///
-/// `is_local_active` returns true for pubkeys whose validator resolves to a
-/// non-liquidated SSV cluster on this operator (i.e.
-/// `get_validator_and_cluster(pubkey).is_ok()`).
 pub fn build_ptc_validators<F>(duties: &[PtcDuty], is_local_active: F) -> Vec<ValidatorIndex>
 where
     F: Fn(&PublicKeyBytes) -> bool,

--- a/anchor/validator_store/src/metadata_service.rs
+++ b/anchor/validator_store/src/metadata_service.rs
@@ -8,7 +8,7 @@ use beacon_node_fallback::BeaconNodeFallback;
 use bls::PublicKeyBytes;
 use eth2::{
     BeaconNodeHttpClient,
-    types::{BlockId, SyncContributionData},
+    types::{BlockId, PtcDuty, SyncContributionData},
 };
 use fork::{Fork, ForkSchedule};
 use futures::stream::{FuturesUnordered, StreamExt};
@@ -312,14 +312,31 @@ impl<E: EthSpec, T: SlotClock + 'static> MetadataService<E, T> {
             })
             .unwrap_or_default();
 
+        // Get PTC validators (CStar+ only). Duties are read from LH's epoch-cached
+        // `PtcMap`; the per-pubkey check is the same `get_validator_and_cluster`
+        // shape used by the Phase-2/3 consensus-data builder.
+        let epoch = slot.epoch(E::slots_per_epoch());
+        let ptc_validators = if self.fork_schedule.active_fork(epoch) >= Fork::CStar {
+            let duties = self.duties_service.get_ptc_duties_for_slot(slot);
+            build_ptc_validators(&duties, |pubkey| {
+                self.validator_store
+                    .get_validator_and_cluster(*pubkey)
+                    .is_ok()
+            })
+        } else {
+            Vec::new()
+        };
+
         let attester_count = attesting_validators.len();
         let sync_count = sync_validators_by_subnet.len();
+        let ptc_count = ptc_validators.len();
 
         let voting_assignments = VotingAssignments {
             slot,
             attesting_validators,
             attesting_committees,
             sync_validators_by_subnet,
+            ptc_validators,
         };
 
         self.validator_store
@@ -334,11 +351,12 @@ impl<E: EthSpec, T: SlotClock + 'static> MetadataService<E, T> {
             &metrics::METADATA_SERVICE_SYNC_VALIDATORS,
             sync_count as i64,
         );
-        if attester_count == 0 && sync_count == 0 {
+        metrics::set_gauge(&metrics::METADATA_SERVICE_PTC_VALIDATORS, ptc_count as i64);
+        if attester_count == 0 && sync_count == 0 && ptc_count == 0 {
             metrics::inc_counter(&metrics::METADATA_SERVICE_EMPTY_ASSIGNMENTS_TOTAL);
         }
 
-        trace!(%slot, attester_count, sync_count, "Published VotingAssignments at slot start");
+        trace!(%slot, attester_count, sync_count, ptc_count, "Published VotingAssignments at slot start");
         Ok(())
     }
 
@@ -1257,6 +1275,22 @@ pub fn filter_contributors_with_contributions<E: EthSpec>(
     contributors_with_roots.retain(|(_, contrib)| {
         sync_contributions.contains_key(&SyncSubnetId::new(contrib.committee_index))
     });
+}
+
+/// Build the local PTC validator-index list for one slot from LH-provided duties.
+///
+/// `is_local_active` returns true for pubkeys whose validator resolves to a
+/// non-liquidated SSV cluster on this operator (i.e.
+/// `get_validator_and_cluster(pubkey).is_ok()`).
+pub fn build_ptc_validators<F>(duties: &[PtcDuty], is_local_active: F) -> Vec<ValidatorIndex>
+where
+    F: Fn(&PublicKeyBytes) -> bool,
+{
+    duties
+        .iter()
+        .filter(|d| is_local_active(&d.pubkey))
+        .map(|d| ValidatorIndex(d.validator_index as usize))
+        .collect()
 }
 
 #[cfg(test)]
@@ -2240,5 +2274,60 @@ mod tests {
 
         let result_distance_2 = calculate_attestation_score(&data, Some(Slot::new(3230)));
         assert!((result_distance_2.score - 201.333333).abs() < 0.001);
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════════════════
+    // build_ptc_validators tests
+    // ═══════════════════════════════════════════════════════════════════════════════════
+
+    fn create_ptc_duty(pubkey_byte: u8, validator_index: u64) -> PtcDuty {
+        PtcDuty {
+            pubkey: PublicKeyBytes::deserialize(&[pubkey_byte; 48]).expect("valid length"),
+            validator_index,
+            slot: Slot::new(1000),
+        }
+    }
+
+    #[test]
+    fn test_build_ptc_validators_empty_input() {
+        let duties: Vec<PtcDuty> = vec![];
+        let out = build_ptc_validators(&duties, |_| true);
+        assert!(out.is_empty(), "Empty input must produce empty output");
+    }
+
+    #[test]
+    fn test_build_ptc_validators_all_local() {
+        let duties = vec![
+            create_ptc_duty(0x01, 100),
+            create_ptc_duty(0x02, 200),
+            create_ptc_duty(0x03, 300),
+        ];
+        let out = build_ptc_validators(&duties, |_| true);
+        assert_eq!(
+            out,
+            vec![
+                ValidatorIndex(100),
+                ValidatorIndex(200),
+                ValidatorIndex(300)
+            ],
+            "All-local predicate must keep every duty in order and convert u64 -> usize"
+        );
+    }
+
+    #[test]
+    fn test_build_ptc_validators_filters_liquidated() {
+        // Simulate ClusterLiquidated: predicate returns false for the second pubkey.
+        let liquidated = PublicKeyBytes::deserialize(&[0x02; 48]).expect("valid length");
+        let duties = vec![
+            create_ptc_duty(0x01, 100),
+            create_ptc_duty(0x02, 200),
+            create_ptc_duty(0x03, 300),
+        ];
+        let out = build_ptc_validators(&duties, |pubkey| *pubkey != liquidated);
+        assert_eq!(
+            out,
+            vec![ValidatorIndex(100), ValidatorIndex(300)],
+            "Liquidated-cluster duty must be excluded"
+        );
     }
 }

--- a/anchor/validator_store/src/metrics.rs
+++ b/anchor/validator_store/src/metrics.rs
@@ -46,6 +46,14 @@ pub static METADATA_SERVICE_SYNC_VALIDATORS: LazyLock<Result<IntGauge>> = LazyLo
     )
 });
 
+/// Current count of PTC validators in VotingAssignments (CStar+; 0 pre-fork)
+pub static METADATA_SERVICE_PTC_VALIDATORS: LazyLock<Result<IntGauge>> = LazyLock::new(|| {
+    try_create_int_gauge(
+        "anchor_metadata_service_ptc_validators",
+        "Count of validators with PTC duties this slot",
+    )
+});
+
 /// Count of slots where VotingAssignments was empty
 pub static METADATA_SERVICE_EMPTY_ASSIGNMENTS_TOTAL: LazyLock<Result<IntCounter>> =
     LazyLock::new(|| {

--- a/anchor/validator_store/src/testing/common.rs
+++ b/anchor/validator_store/src/testing/common.rs
@@ -312,6 +312,7 @@ impl ValidatorStoreTestHarness {
                 attesting_validators,
                 attesting_committees,
                 sync_validators_by_subnet: HashMap::new(),
+                ptc_validators: Vec::new(),
             }),
             beacon_vote: ssv_types::consensus::BeaconVote {
                 block_root: Hash256::zero(),


### PR DESCRIPTION
## Problem, Evidence, and Context

Closes #1036. Next ePBS milestone item after PR #1033 (`Role::PTCCommittee` + message-validator handling), alongside PR #1047 (`PayloadAttestationVote` SSZ container).

Per [SIP-94](https://github.com/ssvlabs/SIPs/pull/94) §3 and the [Gloas validator spec](https://github.com/ethereum/consensus-specs/blob/dev/specs/gloas/validator.md#payload-attester-duties), each PTC-assigned validator signs `PayloadAttestationData` under `DOMAIN_PTC_ATTESTER`. In SSV, a cluster runs one QBFT instance per slot and each locally-assigned PTC validator contributes a partial signature on the decided data. The downstream `sign_payload_attestation` path (#1037) needs the per-cluster partial-signature batch size at signing time, mirroring how `sign_committee_attestations` uses `voting_message_count_for_committee` at \`lib.rs:1534-1537\` for the attestation batch.

This PR publishes that count input on \`VotingAssignments\` so #1037 can size its batch with the same closure-based filter pattern.

## Change Overview

Additive change across four files, +122/-3. All work lives in \`anchor/validator_store\`.

- **\`VotingAssignments::ptc_validators: Vec<ValidatorIndex>\`** — new field populated at slot start during Phase 1, mirroring \`attesting_validators\` exactly.
- **\`ptc_signature_count_for_committee(F)\`** — count helper on \`VotingAssignments\`, closure-based filter matching sibling \`voting_message_count_for_committee\`. PTC stays in a separate helper because the QBFT instance is separate from attestation.
- **Fork-gated wire-up in \`update_voting_assignments\`** — first \`>= Fork::CStar\` site in the codebase; mirrors the existing \`>= Fork::Boole\` precedent at \`metadata_service.rs:501\`. Pre-CStar slots get an empty vec.
- **Pure helper \`build_ptc_validators\`** — intersects LH's epoch-cached \`PtcMap\` with the local validator set; filters liquidated clusters via \`.is_ok()\` on \`get_validator_and_cluster\` (same pattern as the existing Phase-2/3 builder at \`metadata_service.rs:421-428\`).
- **\`METADATA_SERVICE_PTC_VALIDATORS\` gauge** — sibling of existing attester/sync gauges.
- **Empty-assignments counter tightened** — now requires \`attester_count == 0 && sync_count == 0 && ptc_count == 0\` so a PTC-only slot post-CStar isn't miscounted as empty.

**Reading order:** start at \`validator_store/src/lib.rs\` (new field + count helper on \`VotingAssignments\`); then \`metadata_service.rs\` (fork-gated lookup + the pure helper in the helper bay); unit tests in the existing \`#[cfg(test)] mod tests\` block mirror \`test_aggregators_sorted_by_validator_index\`.

**Intentionally unchanged:**
- No new metadata-service phase, no new watch channel, no new spawned task, no BN fetch. Issue #1036 was rescoped after re-reading the attestation precedent at \`lib.rs:1461-1497\`: LH's \`sign_payload_attestation(pubkey, data)\` passes every field of \`PayloadAttestationVote\`, so #1037 can build the QBFT initial value directly without a metadata-level BN fetch. The honest-skip case is filtered by LH itself before the trait is invoked.
- Phase-1/2/3 loops untouched outside the single Phase-1 insert.
- \`voting_message_count_for_committee\` and the attestation count path unchanged.

## Risks, Trade-offs, and Mitigations

**Slot-start lookup cost.** Adds ~30 O(1) hashmap reads per slot for a typical operator (1-10 PTC duties, three \`database.state()\` reads each via \`get_validator_and_cluster\`). Cheaper than the per-validator \`SyncSubnetId::compute_subnets_for_sync_committee::<E>(...)\` already running in Phase 1. The alternative (separate 9s-fraction fetch phase) was rejected because PTC duties are epoch-stable and the source is an in-memory \`PtcMap\` read.

**Flat vec vs per-cluster grouping.** \`ptc_validators\` is flat across clusters, mirroring \`attesting_validators\`. The attestation precedent at \`lib.rs:1534-1537\` shows the flat-vec + closure-filter pattern is sufficient for per-cluster batch sizing; #1037 mirrors it. If a non-count consumer ever emerges, a refactor is one field-shape change with the call site as the regression test.

**Empty-assignments counter behavior.** Tightening to include \`ptc_count == 0\` makes the counter strictly more accurate — it fires only when no duties exist at the slot. Not noisier during early CStar rollout; the prior condition would have falsely counted PTC-only slots as empty post-fork.

## Validation

- \`cargo test -p anchor_validator_store\` — 36/36 pass (3 new PTC tests + 33 existing).
- \`make cargo-fmt && make cargo-fmt-check\` — clean.
- \`make lint\` — clean.
- \`cargo check --workspace\` — clean.

New test coverage (pure-helper tests, no tokio runtime, no \`MetadataService\` instance):
- \`test_build_ptc_validators_empty_input\` — empty input returns empty Vec.
- \`test_build_ptc_validators_all_local\` — all-\`true\` predicate retains every duty with correct \`u64 → usize\` conversion.
- \`test_build_ptc_validators_filters_liquidated\` — predicate returns false for one pubkey (simulating \`ClusterLiquidated\`); excluded duty is dropped.

## Rollback

Additive change on a metadata-only struct. Revert removes the field, helper method, fork-gated lookup, pure helper, gauge, and tests. Pre-CStar behavior is unchanged (empty vec until fork activation), so revert pre-CStar is a no-op. Post-CStar revert removes the input #1037 reads, but #1037 has not landed yet, so no downstream impact.

## Blockers / Dependencies

None for merge. Downstream consumer (milestone #4):
- **#1037** \`feat(validator_store): implement sign_payload_attestation\` — first consumer of \`ptc_validators\`. Will mirror \`sign_committee_attestations\`'s shape and use \`ptc_signature_count_for_committee\` to size the partial-sig batch per cluster.

## Additional Info / Next Steps

N/A