### PR TITLE
fix(ci): claude-mentions fork PR checkout for action v1.0.127

### DIFF
--- a/.github/workflows/claude-mentions.yml
+++ b/.github/workflows/claude-mentions.yml
@@ -40,26 +40,12 @@ jobs:
                     exit 1
                   fi
 
-            - name: Get PR info for fork support
-              if: steps.check.outputs.is_member == 'true' && github.event.issue.pull_request
-              id: pr-info
-              run: |
-                  PR_DATA=$(gh api repos/${{ github.repository }}/pulls/${{ github.event.issue.number }})
-                  echo "pr_head_owner=$(echo "$PR_DATA" | jq -r '.head.repo.owner.login')" >> $GITHUB_OUTPUT
-                  echo "pr_head_repo=$(echo "$PR_DATA" | jq -r '.head.repo.name')" >> $GITHUB_OUTPUT
-                  echo "pr_head_ref=$(echo "$PR_DATA" | jq -r '.head.ref')" >> $GITHUB_OUTPUT
-                  echo "is_fork=$(echo "$PR_DATA" | jq -r '.head.repo.fork')" >> $GITHUB_OUTPUT
-              env:
-                  GH_TOKEN: ${{ github.token }}
-
-            - name: Checkout repository
-              if: steps.check.outputs.is_member == 'true'
-              uses: actions/checkout@v6
-              with:
-                  repository: ${{ github.event.issue.pull_request && steps.pr-info.outputs.is_fork == 'true' && format('{0}/{1}', steps.pr-info.outputs.pr_head_owner, steps.pr-info.outputs.pr_head_repo) || github.repository }}
-                  ref: ${{ github.event.issue.pull_request && steps.pr-info.outputs.pr_head_ref || github.ref }}
-                  fetch-depth: 0
-
+            # Generate the app token before checkout so it can be used for
+            # git operations. `claude-code-action` calls `setupBranch()` (which
+            # fetches PR refs via `git fetch origin pull/N/head:...`) before
+            # `configureGitAuth()`, so the token embedded in `origin` by
+            # `actions/checkout` must already have permission to fetch fork
+            # PR refs.
             - name: Generate GitHub App token
               if: steps.check.outputs.is_member == 'true'
               id: app-token
@@ -67,6 +53,12 @@ jobs:
               with:
                   app-id: ${{ vars.APP_ID }}
                   private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+            - name: Checkout repository
+              if: steps.check.outputs.is_member == 'true'
+              uses: actions/checkout@v6
+              with:
+                  token: ${{ steps.app-token.outputs.token }}
 
             - name: Configure AWS Credentials (OIDC)
               if: steps.check.outputs.is_member == 'true'


### PR DESCRIPTION
## Problem, Evidence, and Context (Required)

PR #1042 bumped `anthropics/claude-code-action` from `v1.0.52` to `v1.0.127`. v1.0.127 added fork-PR fetch logic that assumes `origin` is the base repo:

```ts
// claude-code-action v1.0.127, src/github/operations/branch.ts:175-184
if (prData.isCrossRepository) {
  execGit(["fetch", "origin", `--depth=${fetchDepth}`,
           `pull/${entityNumber}/head:${branchName}`]);
}
```

`claude-mentions.yml` predated this: when `is_fork == 'true'`, it pre-pointed `origin` at the **fork** via the `actions/checkout` `repository:` override. The fork doesn't have `refs/pull/N/head` (that namespace lives only on the base repo), so the action's fetch fails for every fork PR.

Live failure on PR #1053 (fork PR from `shane-moore/anchor`, [run 26296833180](https://github.com/sigp/anchor/actions/runs/26296833180/job/77411552034)):

```
PR #1053 is from a fork, fetching via refs/pull/1053/head...
fatal: couldn't find remote ref pull/1053/head
##[error]Action failed with error: Command failed:
  git fetch origin --depth=20 pull/1053/head:feat/ptc-voting-assignments
```

`claude-pr-review.yml` already runs the correct pattern (origin = base repo, app-token embedded before checkout; see its own `lines 63-68` comment block). This PR brings `claude-mentions.yml` in line with it.

Related: issue #1043 (separate stale-fork-base diff misattribution bug). Its proposed prompt fix is intentionally kept out of this PR to split by blast radius.

## Change Overview (Required)

One file: `.github/workflows/claude-mentions.yml`.

- Remove the `Get PR info for fork support` step. Its four outputs were consumed only by the now-removed `repository:` and `ref:` overrides; no other steps reference them.
- Move `Generate GitHub App token` to run **before** `Checkout repository` so the token is embedded in `origin` for the action's PR-ref fetch (matches the ordering and rationale documented in `claude-pr-review.yml:63-68`).
- Simplify `Checkout repository` to drop both `repository:` and `ref:` overrides. With defaults, `origin = sigp/anchor` and v1.0.127's `git fetch origin pull/N/head:branch` succeeds because that ref exists on the base repo.

End state structurally mirrors `claude-pr-review.yml:63-82`.

Intentionally unchanged:
- All other action version bumps from #1042.
- `claude-pr-review.yml` (already correct).
- `.github/prompts/review.md` (deferred; tied to #1043).
- Behavior for non-PR issue comments and for same-repo PRs.

## Risks, Trade-offs, and Mitigations (Required)

- **Blast radius**: workflow-only, gated by `@claude` mention plus org-membership check.
- **Same-repo PR path**: unchanged in effect. v1.0.127's non-fork branch (`isCrossRepository: false`) does `git fetch origin <branchName>` against `origin = sigp/anchor`, which works in both old and new flavors.
- **Non-PR issue comments**: `actions/checkout` defaults to the base repo at the default branch, and `setupBranch()` skips the PR-fetch path when `isPR == false`.
- **`pull_request_review_comment` events**: `GITHUB_REF` is `refs/pull/N/merge` (resolvable from `sigp/anchor`), then the action does its own `pull/N/head` fetch. Should work; only fully empirical post-merge.
- **App-token scope**: the same app-token + checkout ordering is already used by `claude-pr-review.yml` for fork PR ref fetches, so the GitHub App installation on `sigp/anchor` already has the required permissions.

## Validation (Required)

- **Source trace** (workflow YAML is not unit-testable):
  - `setupBranch()` runs before `configureGitAuth()` in `claude-code-action/src/modes/tag/index.ts:66, 83`.
  - `configureGitAuth()` rewrites `origin` to `context.repository.owner/repo` (base repo, derived from `GITHUB_REPOSITORY` env) in `src/github/operations/git-config.ts:82`.
  - Therefore the workflow's `actions/checkout` token must already be valid for fork PR ref reads on the base repo at the moment `setupBranch()` runs. This PR ensures that.
- `actionlint` passes on the changed file. The remaining SC2086 warnings are pre-existing in untouched shell blocks.
- **Post-merge live check** (mirrors #1043's acceptance pattern):
  1. Open a small fork PR (e.g. a comment-only README tweak from a personal fork).
  2. Mention `@claude` on it.
  3. Confirm the run succeeds (no `fatal: couldn't find remote ref pull/N/head`).

## Rollback

Revert this single commit. No data, config, or operational state involved. Restores the prior (broken) fork-PR behavior but is otherwise neutral.

## Blockers / Dependencies

None. Targets `stable`. `issue_comment` and `pull_request_review_comment` triggers load this workflow from the base repo's default branch, so the fix only takes effect once merged to `stable` (same rule that applied to PRs #830, #844, #845, #974, #997, #1042).