### PR TITLE
feat(qbft_manager): wire PTC committee-scoped QBFT instances and fork gate

### DIFF
--- a/anchor/qbft_manager/src/lib.rs
+++ b/anchor/qbft_manager/src/lib.rs
@@ -14,8 +14,8 @@ use slot_clock::SlotClock;
 use ssv_types::{
     CommitteeId, IndexSet, OperatorId,
     consensus::{
-        AggregatorCommitteeConsensusData, BeaconVote, ProposerConsensusData, QbftData,
-        QbftDataValidator,
+        AggregatorCommitteeConsensusData, BeaconVote, PayloadAttestationVote,
+        ProposerConsensusData, QbftData, QbftDataValidator,
     },
     domain_type::DomainType,
     message::SignedSSVMessage,
@@ -68,6 +68,13 @@ pub struct CommitteeInstanceId {
 // Unique Identifier for an aggregator committee QBFT instance
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
 pub struct AggregatorCommitteeInstanceId {
+    pub committee: CommitteeId,
+    pub instance_height: InstanceHeight,
+}
+
+// Unique Identifier for a PTC committee QBFT instance
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+pub struct PTCCommitteeInstanceId {
     pub committee: CommitteeId,
     pub instance_height: InstanceHeight,
 }
@@ -140,6 +147,8 @@ pub struct QbftManager<E: EthSpec, S: SlotClock> {
     // QBFT instances for AggregatorCommitteeConsensusData
     aggregator_committee_instances:
         Map<AggregatorCommitteeInstanceId, AggregatorCommitteeConsensusData<E>>,
+    // QBFT instances for PayloadAttestationVote
+    payload_attestation_vote_instances: Map<PTCCommitteeInstanceId, PayloadAttestationVote>,
     // Utility to sign and serialize network messages
     message_sender: Arc<dyn MessageSender>,
     // Number of slots per epoch
@@ -166,6 +175,7 @@ impl<E: EthSpec, S: SlotClock + Clone + 'static> QbftManager<E, S> {
             proposer_consensus_data_instances: DashMap::new(),
             beacon_vote_instances: DashMap::new(),
             aggregator_committee_instances: DashMap::new(),
+            payload_attestation_vote_instances: DashMap::new(),
             message_sender,
             slots_per_epoch,
             fork_schedule,
@@ -331,11 +341,27 @@ impl<E: EthSpec, S: SlotClock + Clone + 'static> QbftManager<E, S> {
                         )
                     }
                     Some(Role::PTCCommittee) => {
-                        // TODO(cstar): wire PTC instance routing and add pre-CStar
-                        // fork gate (mirror `AggregatorCommittee` arm above).
+                        // Route to PTC committee instances with fork gating
                         let slot = types::Slot::new(qbft_message.height);
-                        warn!(%slot, "Ignoring PTCCommittee message; routing not wired");
-                        Err(QbftError::RoleNotActive)
+                        let epoch = slot.epoch(E::slots_per_epoch());
+
+                        // Fork gating: Reject before CStar
+                        if self.fork_schedule.active_fork(epoch) < Fork::CStar {
+                            warn!(%slot, "Ignoring PTCCommittee message before CStar fork");
+                            return Err(QbftError::RoleNotActive);
+                        }
+
+                        let id = PTCCommitteeInstanceId {
+                            committee,
+                            instance_height,
+                        };
+                        self.pass_to_instance::<PayloadAttestationVote>(
+                            id,
+                            WrappedQbftMessage {
+                                signed_message: full_message,
+                                qbft_message,
+                            },
+                        )
                     }
                     // Validator roles should use DutyExecutor::Validator, not Committee
                     Some(Role::Aggregator | Role::Proposer | Role::SyncCommittee)
@@ -387,6 +413,8 @@ impl<E: EthSpec, S: SlotClock + Clone + 'static> QbftManager<E, S> {
             self.proposer_consensus_data_instances
                 .retain(|k, _| *k.instance_height >= cutoff.as_usize());
             self.aggregator_committee_instances
+                .retain(|k, _| *k.instance_height >= cutoff.as_usize());
+            self.payload_attestation_vote_instances
                 .retain(|k, _| *k.instance_height >= cutoff.as_usize());
         }
     }
@@ -507,6 +535,25 @@ impl<E: EthSpec> QbftDecidable<E> for AggregatorCommitteeConsensusData<E> {
         MessageId::new(
             domain,
             Role::AggregatorCommittee,
+            &DutyExecutor::Committee(id.committee),
+        )
+    }
+}
+
+impl<E: EthSpec> QbftDecidable<E> for PayloadAttestationVote {
+    type Id = PTCCommitteeInstanceId;
+    fn get_map<S: SlotClock>(manager: &QbftManager<E, S>) -> &Map<Self::Id, Self> {
+        &manager.payload_attestation_vote_instances
+    }
+
+    fn instance_height(&self, id: &Self::Id) -> InstanceHeight {
+        id.instance_height
+    }
+
+    fn message_id(domain: &DomainType, id: &Self::Id) -> MessageId {
+        MessageId::new(
+            domain,
+            Role::PTCCommittee,
             &DutyExecutor::Committee(id.committee),
         )
     }

--- a/anchor/qbft_manager/src/tests.rs
+++ b/anchor/qbft_manager/src/tests.rs
@@ -40,6 +40,7 @@ use super::{
 use crate::instance::qbft_instance;
 
 mod aggregator_tests;
+mod ptc_tests;
 mod setup;
 mod timeout_tests;
 

--- a/anchor/qbft_manager/src/tests.rs
+++ b/anchor/qbft_manager/src/tests.rs
@@ -34,8 +34,8 @@ use tracing::{debug, error};
 use types::{EthSpec, Hash256, Slot};
 
 use super::{
-    CommitteeInstanceId, Completed, QbftDecidable, QbftError, QbftInitialization, QbftManager,
-    QbftMessageKind, TimeoutMode, WrappedQbftMessage,
+    CommitteeInstanceId, Completed, PTCCommitteeInstanceId, QbftDecidable, QbftError,
+    QbftInitialization, QbftManager, QbftMessageKind, TimeoutMode, WrappedQbftMessage,
 };
 use crate::instance::qbft_instance;
 

--- a/anchor/qbft_manager/src/tests/ptc_tests.rs
+++ b/anchor/qbft_manager/src/tests/ptc_tests.rs
@@ -148,14 +148,27 @@ async fn test_ptc_committee_accepted_after_cstar() {
     )
     .expect("SignedSSVMessage creation should succeed");
 
-    // Call receive_data - should NOT return RoleNotActive
+    // Call receive_data - should pass the fork gate, spawn a PTC instance,
+    // and queue the message on the urgent_consensus processor.
     let result = manager.receive_data(signed_msg, qbft_message);
 
-    // It might return Ok or some other error (e.g., no instance running),
-    // but critically it should NOT be RoleNotActive
+    assert!(result.is_ok(), "Expected Ok after CStar, got: {:?}", result);
+
+    // Verify routing reached the PTC arm specifically: the new instance lives
+    // in payload_attestation_vote_instances at the expected committee+height.
+    let expected_id = PTCCommitteeInstanceId {
+        committee: CommitteeId([0; 32]),
+        instance_height: InstanceHeight::from(100usize),
+    };
     assert!(
-        !matches!(result, Err(QbftError::RoleNotActive)),
-        "Should not return RoleNotActive after CStar fork, got: {:?}",
-        result
+        manager
+            .payload_attestation_vote_instances
+            .contains_key(&expected_id),
+        "Expected payload_attestation_vote_instances to contain the routed entry",
+    );
+    assert_eq!(
+        manager.payload_attestation_vote_instances.len(),
+        1,
+        "Only the PTC arm should have spawned an instance",
     );
 }

--- a/anchor/qbft_manager/src/tests/ptc_tests.rs
+++ b/anchor/qbft_manager/src/tests/ptc_tests.rs
@@ -1,0 +1,161 @@
+use super::{setup::setup_test, *};
+
+/// Test that PTCCommittee messages are rejected before the CStar fork.
+/// Critical security test: the role must not be processed until CStar is active.
+#[tokio::test]
+async fn test_ptc_committee_rejected_before_cstar() {
+    use fork::ForkSchedule;
+    use message_sender::testing::MockMessageSender;
+    use ssv_types::{
+        RSA_SIGNATURE_SIZE,
+        consensus::{QbftMessage, QbftMessageType},
+        message::{MsgType, SSVMessage, SignedSSVMessage},
+    };
+    use ssz::Encode;
+
+    let setup = setup_test(1);
+
+    // Create QbftManager with fork schedule pinned at Boole (no CStar)
+    let config = processor::Config {
+        max_workers: 4,
+        queue_size: Default::default(),
+    };
+    let senders = processor::spawn(config, setup.executor);
+    let (network_tx, _network_rx) = mpsc::unbounded_channel();
+
+    let manager = QbftManager::<types::MainnetEthSpec, _>::new(
+        senders,
+        OperatorId(1).into(),
+        setup.clock,
+        Arc::new(MockMessageSender::new(network_tx, OperatorId(1))),
+        NonZeroU64::new(32).expect("slots_per_epoch is non-zero"),
+        Arc::new(ForkSchedule::new(
+            Fork::Boole,
+            DomainType::default(),
+            "test",
+        )), // No CStar fork
+    )
+    .expect("Manager creation should succeed");
+
+    // Create a PTCCommittee message
+    let msg_id = MessageId::new(
+        &DomainType([0; 4]),
+        Role::PTCCommittee,
+        &DutyExecutor::Committee(CommitteeId([0; 32])),
+    );
+
+    let qbft_message = QbftMessage {
+        qbft_message_type: QbftMessageType::Proposal,
+        height: 100, // Slot 100, well before any CStar epoch
+        round: 1,
+        identifier: (&msg_id).into(),
+        root: Hash256::from([0u8; 32]),
+        data_round: 1,
+        round_change_justification: ssv_types::VariableList::empty(),
+        prepare_justification: ssv_types::VariableList::empty(),
+    };
+
+    let ssv_msg = SSVMessage::new(
+        MsgType::SSVConsensusMsgType,
+        msg_id,
+        qbft_message.as_ssz_bytes(),
+    )
+    .expect("SSVMessage creation should succeed");
+
+    let signed_msg = SignedSSVMessage::new(
+        vec![[0xAA; RSA_SIGNATURE_SIZE]],
+        vec![OperatorId(1)],
+        ssv_msg,
+        vec![],
+    )
+    .expect("SignedSSVMessage creation should succeed");
+
+    // Call receive_data - should return RoleNotActive
+    let result = manager.receive_data(signed_msg, qbft_message);
+
+    assert!(
+        matches!(result, Err(QbftError::RoleNotActive)),
+        "Expected RoleNotActive error before CStar fork, got: {:?}",
+        result
+    );
+}
+
+/// Test that PTCCommittee messages are accepted after the CStar fork.
+/// Verifies the fork gating allows messages through when CStar is active.
+#[tokio::test]
+async fn test_ptc_committee_accepted_after_cstar() {
+    use fork::ForkSchedule;
+    use message_sender::testing::MockMessageSender;
+    use ssv_types::{
+        RSA_SIGNATURE_SIZE,
+        consensus::{QbftMessage, QbftMessageType},
+        message::{MsgType, SSVMessage, SignedSSVMessage},
+    };
+    use ssz::Encode;
+
+    let setup = setup_test(1);
+
+    // Create fork schedule with CStar active at epoch 0
+    let fork_schedule = ForkSchedule::new(Fork::CStar, DomainType::default(), "test");
+
+    let config = processor::Config {
+        max_workers: 4,
+        queue_size: Default::default(),
+    };
+    let senders = processor::spawn(config, setup.executor);
+    let (network_tx, _network_rx) = mpsc::unbounded_channel();
+
+    let manager = QbftManager::<types::MainnetEthSpec, _>::new(
+        senders,
+        OperatorId(1).into(),
+        setup.clock,
+        Arc::new(MockMessageSender::new(network_tx, OperatorId(1))),
+        NonZeroU64::new(32).expect("slots_per_epoch is non-zero"),
+        Arc::new(fork_schedule),
+    )
+    .expect("Manager creation should succeed");
+
+    // Create a PTCCommittee message
+    let msg_id = MessageId::new(
+        &DomainType([0; 4]),
+        Role::PTCCommittee,
+        &DutyExecutor::Committee(CommitteeId([0; 32])),
+    );
+
+    let qbft_message = QbftMessage {
+        qbft_message_type: QbftMessageType::Proposal,
+        height: 100, // Any slot, CStar is active from epoch 0
+        round: 1,
+        identifier: (&msg_id).into(),
+        root: Hash256::from([0u8; 32]),
+        data_round: 1,
+        round_change_justification: ssv_types::VariableList::empty(),
+        prepare_justification: ssv_types::VariableList::empty(),
+    };
+
+    let ssv_msg = SSVMessage::new(
+        MsgType::SSVConsensusMsgType,
+        msg_id,
+        qbft_message.as_ssz_bytes(),
+    )
+    .expect("SSVMessage creation should succeed");
+
+    let signed_msg = SignedSSVMessage::new(
+        vec![[0xAA; RSA_SIGNATURE_SIZE]],
+        vec![OperatorId(1)],
+        ssv_msg,
+        vec![],
+    )
+    .expect("SignedSSVMessage creation should succeed");
+
+    // Call receive_data - should NOT return RoleNotActive
+    let result = manager.receive_data(signed_msg, qbft_message);
+
+    // It might return Ok or some other error (e.g., no instance running),
+    // but critically it should NOT be RoleNotActive
+    assert!(
+        !matches!(result, Err(QbftError::RoleNotActive)),
+        "Should not return RoleNotActive after CStar fork, got: {:?}",
+        result
+    );
+}


### PR DESCRIPTION
## Problem, Evidence, and Context

Closes #1035. PR #1033 (issue #1032) added `Role::PTCCommittee` to `qbft_manager::receive_data` as a placeholder arm with a `//todo(cstar)` marker that rejected all PTC traffic. PR #1047 (issue #1034) added `PayloadAttestationVote` with `QbftData` + value checker in `ssv_types`. This PR completes the qbft_manager wire-up so the downstream issue #1037 (`sign_payload_attestation`) can compile against `consensus.decide_instance::<PayloadAttestationVote>(...)`.

Per [SIP-94](https://github.com/ssvlabs/SIPs/pull/94) §3, PTC runs one QBFT instance per cluster per slot over `PayloadAttestationVote`. The manager's existing four-role pattern (Committee, AggregatorCommittee, Proposer, plus a placeholder for PTCCommittee) gets the fourth role wired in here.

## Change Overview

Direct structural mirror of the `Role::AggregatorCommittee` precedent added in PR #1033, substituting `Fork::CStar` for `Fork::Boole` and `PayloadAttestationVote` for `AggregatorCommitteeConsensusData<E>`. Single-crate change (`qbft_manager/`), +215/-6 across 3 files.

**Reading order:** start at the replaced routing arm in `lib.rs` and compare against the `AggregatorCommittee` template it mirrors immediately above it. Then look at the four supporting edits (new `PTCCommitteeInstanceId` type, new map field on `QbftManager`, constructor init, cleaner `.retain` entry, `QbftDecidable for PayloadAttestationVote` impl alongside the other three impls). Finally `tests/ptc_tests.rs` for two fork-gating tests mirroring `tests/aggregator_tests.rs::test_aggregator_committee_rejected_before_boole` and `tests.rs::manager_tests::test_aggregator_committee_accepted_after_boole`.

**Intentionally unchanged:**
- Existing three routing arms and their cleaner entries.
- `message_validator/src/lib.rs` already rejects PTC before CStar; this PR's gate is defense-in-depth.
- No changes to `PayloadAttestationVote` or its validator (both shipped in #1047).

## Risks, Trade-offs, and Mitigations

**Defense-in-depth fork gate duplication.** The `< Fork::CStar` check duplicates the `message_validator` gate. Same intentional duplication exists for `< Fork::Boole` on `AggregatorCommittee`; not a new pattern.

**Test scope is tight.** Two new fork-gating tests cover the security boundary. No end-to-end consensus test for PTC, no cleaner eviction test. These are symmetric gaps across all four routing arms; scope-bounded here to avoid cross-cutting test refactoring. Test boilerplate is duplicated across the AggregatorCommittee precedent and the new PTC tests but is small and not separately tracked.

**Stub-removal completeness.** Two markers from #1033 are gone after this PR: the `//todo(cstar)` line comment and the placeholder `warn!(%slot, "Ignoring PTCCommittee message; routing not wired")`. Verified by grep.

## Validation

- `cargo build -p qbft_manager --tests` — clean.
- `make cargo-fmt && make cargo-fmt-check` — clean.
- `make lint` (clippy) — clean.
- `cargo test -p qbft_manager` — 18/18 pass (16 prior + 2 new PTC tests: `test_ptc_committee_rejected_before_cstar` and `test_ptc_committee_accepted_after_cstar`).
- Stub-removal greps return zero hits in `anchor/qbft_manager/`.

## Rollback

Pure additive change behind `Fork::CStar`. Pre-CStar behavior is bit-for-bit unchanged (the new arm returns `Err(QbftError::RoleNotActive)` before any state mutation; the new map stays empty until the fork activates). Downstream consumer #1037 has not landed, so revert pre-CStar is a no-op.

## Blockers / Dependencies

None for merge. Downstream:
- **#1037** `feat(validator_store): implement sign_payload_attestation` — first consumer of `PTCCommitteeInstanceId` + the `QbftDecidable for PayloadAttestationVote` impl shipped here.
- **#1038** `feat(client): spawn LH PayloadAttestationService` — downstream of #1037, not blocked by this PR.

## Additional Info / Next Steps

N/A
