### PR TITLE
feat(ssv_types): add GloasBeaconVote with QbftData for Gloas slots

### DIFF
--- a/anchor/common/ssv_types/src/consensus.rs
+++ b/anchor/common/ssv_types/src/consensus.rs
@@ -906,6 +906,38 @@ impl QbftData for BeaconVote {
     }
 }
 
+/// QBFT consensus value for committee attestation duties at Gloas-and-later forks.
+///
+/// Mirrors `BeaconVote` plus `attestation_data_index`, the BN-supplied
+/// `AttestationData.index` field. Under Gloas this field encodes the attester's
+/// fork-choice view of payload status (`0` = `EMPTY`, `1` = `FULL` for non-same-slot
+/// attestations), is part of the signed attestation root, and therefore must
+/// travel through QBFT rather than being reconstructed locally.
+///
+/// `GloasBeaconVote` and `BeaconVote` are kept as separate types so their SSZ
+/// wire bytes mutually reject on length mismatch across the fork boundary.
+#[derive(Clone, Debug, TreeHash, PartialEq, Eq, Encode, Decode)]
+#[cfg_attr(feature = "arbitrary-fuzz", derive(arbitrary::Arbitrary))]
+pub struct GloasBeaconVote {
+    pub block_root: Hash256,
+    pub source: Checkpoint,
+    pub target: Checkpoint,
+    pub attestation_data_index: u64,
+}
+
+impl QbftData for GloasBeaconVote {
+    type Hash = Hash256;
+
+    fn hash(&self) -> Self::Hash {
+        let bytes = self.as_ssz_bytes();
+
+        let mut hasher = Sha256::new();
+        hasher.update(bytes);
+        let hash: [u8; 32] = hasher.finalize().into();
+        Hash256::from(hash)
+    }
+}
+
 /// QBFT consensus value for PTC (Payload Timeliness Committee) duties at Gloas.
 ///
 /// PTC operators run one QBFT instance per slot over this stripped shape; the
@@ -2248,5 +2280,142 @@ mod tests {
         let local_view = create_payload_attestation_vote(root, false, false);
 
         assert!(validator.validate(&proposed, &local_view));
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════════════
+    // GloasBeaconVote Tests
+    // ═══════════════════════════════════════════════════════════════════════════════
+
+    fn create_gloas_beacon_vote(
+        block_root: Hash256,
+        source_epoch: u64,
+        source_root: Hash256,
+        target_epoch: u64,
+        target_root: Hash256,
+        attestation_data_index: u64,
+    ) -> GloasBeaconVote {
+        GloasBeaconVote {
+            block_root,
+            source: Checkpoint {
+                epoch: Epoch::new(source_epoch),
+                root: source_root,
+            },
+            target: Checkpoint {
+                epoch: Epoch::new(target_epoch),
+                root: target_root,
+            },
+            attestation_data_index,
+        }
+    }
+
+    #[test]
+    fn test_gloas_beacon_vote_ssz_roundtrip() {
+        // Arrange: cover the `attestation_data_index` range boundaries (SSZ must round-trip any
+        // u64).
+        let block_root = Hash256::from_low_u64_be(0xabcd);
+        let source_root = Hash256::from_low_u64_be(0x1111);
+        let target_root = Hash256::from_low_u64_be(0x2222);
+
+        for attestation_data_index in [0u64, 1, u64::MAX] {
+            let vote = create_gloas_beacon_vote(
+                block_root,
+                3,
+                source_root,
+                4,
+                target_root,
+                attestation_data_index,
+            );
+
+            // Act
+            let encoded = vote.as_ssz_bytes();
+            let decoded = GloasBeaconVote::from_ssz_bytes(&encoded)
+                .expect("SSZ-encoded `GloasBeaconVote` must decode");
+
+            // Assert
+            assert_eq!(vote, decoded);
+        }
+    }
+
+    #[test]
+    fn test_gloas_beacon_vote_hash_deterministic() {
+        // Arrange: two independently-constructed votes with the same field values.
+        let block_root = Hash256::from_low_u64_be(0x1234);
+        let source_root = Hash256::from_low_u64_be(0x5555);
+        let target_root = Hash256::from_low_u64_be(0x7777);
+        let vote = create_gloas_beacon_vote(block_root, 3, source_root, 4, target_root, 0);
+        let same = create_gloas_beacon_vote(block_root, 3, source_root, 4, target_root, 0);
+
+        // Act + Assert: identical field values must hash identically (catches
+        // identity- or address-dependent hashing).
+        assert_eq!(vote.hash(), same.hash());
+
+        // hash() must literally be SHA-256 over the SSZ bytes — this is the
+        // cross-operator agreement contract: every operator independently
+        // SSZ-encodes their `GloasBeaconVote` and hashes the bytes.
+        let expected = {
+            let mut hasher = Sha256::new();
+            hasher.update(vote.as_ssz_bytes());
+            Hash256::from(<[u8; 32]>::from(hasher.finalize()))
+        };
+        assert_eq!(
+            vote.hash(),
+            expected,
+            "hash() must be SHA-256 over SSZ bytes"
+        );
+
+        // Flip block_root.
+        let flipped_block_root = create_gloas_beacon_vote(
+            Hash256::from_low_u64_be(0x9999),
+            3,
+            source_root,
+            4,
+            target_root,
+            0,
+        );
+        assert_ne!(vote.hash(), flipped_block_root.hash());
+
+        // Flip source.epoch.
+        let flipped_source_epoch =
+            create_gloas_beacon_vote(block_root, 99, source_root, 4, target_root, 0);
+        assert_ne!(vote.hash(), flipped_source_epoch.hash());
+
+        // Flip target.epoch.
+        let flipped_target_epoch =
+            create_gloas_beacon_vote(block_root, 3, source_root, 99, target_root, 0);
+        assert_ne!(vote.hash(), flipped_target_epoch.hash());
+
+        // Flip attestation_data_index: index=0 vs index=1 MUST differ — this is the
+        // cross-index equivocation protection #1025 unlocks.
+        let index_one = create_gloas_beacon_vote(block_root, 3, source_root, 4, target_root, 1);
+        assert_ne!(
+            vote.hash(),
+            index_one.hash(),
+            "index=0 and index=1 must produce distinct hashes (cross-index equivocation guard)"
+        );
+    }
+
+    #[test]
+    fn test_beacon_vote_rejects_gloas_bytes() {
+        // Arrange: encode a `GloasBeaconVote` (120 bytes).
+        let gloas_vote = create_gloas_beacon_vote(
+            Hash256::from_low_u64_be(0xdead),
+            1,
+            Hash256::from_low_u64_be(0xbeef),
+            2,
+            Hash256::from_low_u64_be(0xcafe),
+            7,
+        );
+        let bytes = gloas_vote.as_ssz_bytes();
+        assert_eq!(bytes.len(), 120);
+
+        // Act: try to decode those bytes as the pre-Gloas `BeaconVote`.
+        let result = BeaconVote::from_ssz_bytes(&bytes);
+
+        // Assert: SIP §2 length-mismatch mutual rejection — pre-Gloas binaries
+        // must not silently accept Gloas-shaped wire bytes.
+        assert!(
+            result.is_err(),
+            "BeaconVote (112-byte fixed) must reject 120-byte GloasBeaconVote encoding"
+        );
     }
 }

--- a/anchor/common/ssv_types/src/consensus.rs
+++ b/anchor/common/ssv_types/src/consensus.rs
@@ -919,9 +919,17 @@ impl QbftData for BeaconVote {
 #[derive(Clone, Debug, TreeHash, PartialEq, Eq, Encode, Decode)]
 #[cfg_attr(feature = "arbitrary-fuzz", derive(arbitrary::Arbitrary))]
 pub struct GloasBeaconVote {
+    /// LMD-GHOST vote: root of the beacon block being attested to.
     pub block_root: Hash256,
+    /// FFG source checkpoint, copied from the BN-supplied `AttestationData`.
     pub source: Checkpoint,
+    /// FFG target checkpoint, copied from the BN-supplied `AttestationData`.
     pub target: Checkpoint,
+    /// BN-supplied `AttestationData.index`. Under Gloas this encodes the
+    /// attester's fork-choice view of payload status (`0` = `EMPTY`,
+    /// `1` = `FULL` for non-same-slot attestations) and participates in the
+    /// signed attestation root, so it must travel through QBFT rather than
+    /// being reconstructed locally.
     pub attestation_data_index: u64,
 }
 

--- a/anchor/qbft_manager/src/lib.rs
+++ b/anchor/qbft_manager/src/lib.rs
@@ -14,8 +14,8 @@ use slot_clock::SlotClock;
 use ssv_types::{
     CommitteeId, IndexSet, OperatorId,
     consensus::{
-        AggregatorCommitteeConsensusData, BeaconVote, ProposerConsensusData, QbftData,
-        QbftDataValidator,
+        AggregatorCommitteeConsensusData, BeaconVote, GloasBeaconVote, ProposerConsensusData,
+        QbftData, QbftDataValidator,
     },
     domain_type::DomainType,
     message::SignedSSVMessage,
@@ -137,6 +137,9 @@ pub struct QbftManager<E: EthSpec, S: SlotClock> {
     proposer_consensus_data_instances: Map<ProposerInstanceId, ProposerConsensusData>,
     // All of the QBFT instances that are voting on beacon data
     beacon_vote_instances: Map<CommitteeInstanceId, BeaconVote>,
+    // All of the QBFT instances that are voting on Gloas-era beacon data
+    // (carries the BN-supplied `attestation_data_index`).
+    gloas_beacon_vote_instances: Map<CommitteeInstanceId, GloasBeaconVote>,
     // QBFT instances for AggregatorCommitteeConsensusData
     aggregator_committee_instances:
         Map<AggregatorCommitteeInstanceId, AggregatorCommitteeConsensusData<E>>,
@@ -165,6 +168,7 @@ impl<E: EthSpec, S: SlotClock + Clone + 'static> QbftManager<E, S> {
             operator_id,
             proposer_consensus_data_instances: DashMap::new(),
             beacon_vote_instances: DashMap::new(),
+            gloas_beacon_vote_instances: DashMap::new(),
             aggregator_committee_instances: DashMap::new(),
             message_sender,
             slots_per_epoch,
@@ -294,18 +298,22 @@ impl<E: EthSpec, S: SlotClock + Clone + 'static> QbftManager<E, S> {
             Some(DutyExecutor::Committee(committee)) => {
                 match msg_id.role() {
                     Some(Role::Committee) => {
-                        // Existing BeaconVote routing
+                        let slot = types::Slot::new(qbft_message.height);
+                        let epoch = slot.epoch(E::slots_per_epoch());
                         let id = CommitteeInstanceId {
                             committee,
                             instance_height,
                         };
-                        self.pass_to_instance::<BeaconVote>(
-                            id,
-                            WrappedQbftMessage {
-                                signed_message: full_message,
-                                qbft_message,
-                            },
-                        )
+                        let wrapped = WrappedQbftMessage {
+                            signed_message: full_message,
+                            qbft_message,
+                        };
+
+                        if self.fork_schedule.active_fork(epoch) >= Fork::CStar {
+                            self.pass_to_instance::<GloasBeaconVote>(id, wrapped)
+                        } else {
+                            self.pass_to_instance::<BeaconVote>(id, wrapped)
+                        }
                     }
                     Some(Role::AggregatorCommittee) => {
                         // Route to aggregator committee instances with fork gating
@@ -383,6 +391,8 @@ impl<E: EthSpec, S: SlotClock + Clone + 'static> QbftManager<E, S> {
             };
             let cutoff = slot.saturating_sub(QBFT_RETAIN_SLOTS);
             self.beacon_vote_instances
+                .retain(|k, _| *k.instance_height >= cutoff.as_usize());
+            self.gloas_beacon_vote_instances
                 .retain(|k, _| *k.instance_height >= cutoff.as_usize());
             self.proposer_consensus_data_instances
                 .retain(|k, _| *k.instance_height >= cutoff.as_usize());
@@ -478,6 +488,26 @@ impl<E: EthSpec> QbftDecidable<E> for BeaconVote {
     type Id = CommitteeInstanceId;
     fn get_map<S: SlotClock>(manager: &QbftManager<E, S>) -> &Map<Self::Id, Self> {
         &manager.beacon_vote_instances
+    }
+
+    fn instance_height(&self, id: &Self::Id) -> InstanceHeight {
+        id.instance_height
+    }
+
+    fn message_id(domain: &DomainType, id: &Self::Id) -> MessageId {
+        MessageId::new(
+            domain,
+            Role::Committee,
+            &DutyExecutor::Committee(id.committee),
+        )
+    }
+}
+
+impl<E: EthSpec> QbftDecidable<E> for GloasBeaconVote {
+    type Id = CommitteeInstanceId;
+
+    fn get_map<S: SlotClock>(manager: &QbftManager<E, S>) -> &Map<Self::Id, Self> {
+        &manager.gloas_beacon_vote_instances
     }
 
     fn instance_height(&self, id: &Self::Id) -> InstanceHeight {

--- a/anchor/qbft_manager/src/tests.rs
+++ b/anchor/qbft_manager/src/tests.rs
@@ -40,6 +40,7 @@ use super::{
 use crate::instance::qbft_instance;
 
 mod aggregator_tests;
+mod gloas_dispatch_tests;
 mod setup;
 mod timeout_tests;
 

--- a/anchor/qbft_manager/src/tests/gloas_dispatch_tests.rs
+++ b/anchor/qbft_manager/src/tests/gloas_dispatch_tests.rs
@@ -154,3 +154,43 @@ async fn test_committee_message_routes_to_beacon_pre_cstar() {
         "Committee message pre-CStar must NOT spawn a GloasBeaconVote instance"
     );
 }
+
+/// Pin the slot-to-epoch + `active_fork(epoch)` + `>= Fork::CStar` composition
+/// at the activation boundary. Off-by-one in any of the three would flip
+/// exactly one of the assertions below.
+#[tokio::test]
+async fn test_committee_message_routes_at_cstar_activation_boundary() {
+    use std::collections::BTreeMap;
+
+    use types::Epoch;
+
+    const CSTAR_ACTIVATION_EPOCH: u64 = 5;
+    const SLOTS_PER_EPOCH: u64 = 32;
+
+    let setup = setup_test(1);
+
+    let mut configs = BTreeMap::new();
+    configs.insert(Fork::Alan, (Epoch::new(0), DomainType::default()));
+    configs.insert(
+        Fork::CStar,
+        (Epoch::new(CSTAR_ACTIVATION_EPOCH), DomainType::default()),
+    );
+    let schedule = ForkSchedule::from_fork_configs(configs, "test")
+        .expect("Alan@0 + CStar@5 is a valid schedule");
+    let manager = build_manager(&setup, schedule);
+
+    let last_pre_cstar = CSTAR_ACTIVATION_EPOCH * SLOTS_PER_EPOCH - 1;
+    let (signed, qbft) = build_committee_message(last_pre_cstar);
+    manager
+        .receive_data(signed, qbft)
+        .expect("pre-CStar dispatch");
+    assert_eq!(manager.beacon_vote_instances.len(), 1);
+    assert_eq!(manager.gloas_beacon_vote_instances.len(), 0);
+
+    let first_cstar = CSTAR_ACTIVATION_EPOCH * SLOTS_PER_EPOCH;
+    let (signed, qbft) = build_committee_message(first_cstar);
+    manager.receive_data(signed, qbft).expect("CStar dispatch");
+    assert_eq!(manager.gloas_beacon_vote_instances.len(), 1);
+    // BeaconVote map still holds the pre-CStar instance.
+    assert_eq!(manager.beacon_vote_instances.len(), 1);
+}

--- a/anchor/qbft_manager/src/tests/gloas_dispatch_tests.rs
+++ b/anchor/qbft_manager/src/tests/gloas_dispatch_tests.rs
@@ -1,0 +1,156 @@
+//! `Role::Committee` dispatch tests for the CStar (Gloas) fork.
+//!
+//! These exercise the fork-gated routing added in #1025 inside
+//! `QbftManager::receive_data`: at or after CStar a committee message must spawn
+//! a `GloasBeaconVote` instance, before CStar a `BeaconVote` instance. The
+//! `DashMap` entry is inserted synchronously inside `get_or_spawn_instance`
+//! before the processor task is even dispatched, so map sizes are deterministic
+//! immediately after `receive_data` returns.
+
+use fork::ForkSchedule;
+use message_sender::testing::MockMessageSender;
+use ssv_types::{
+    RSA_SIGNATURE_SIZE,
+    consensus::{QbftMessage, QbftMessageType},
+    message::{MsgType, SSVMessage, SignedSSVMessage},
+};
+use ssz::Encode;
+
+use super::{setup::setup_test, *};
+
+// Slot picked well past any baseline-epoch boundary so the chosen fork schedule
+// dominates routing rather than any genesis edge case (`slot 100` mirrors the
+// existing aggregator dispatch test).
+const TEST_SLOT_HEIGHT: u64 = 100;
+
+/// Build a single-operator `QbftManager` with the supplied `ForkSchedule`,
+/// mirroring the canonical setup from
+/// `aggregator_tests::test_aggregator_committee_rejected_before_boole`.
+fn build_manager(
+    setup: &super::setup::Setup,
+    fork_schedule: ForkSchedule,
+) -> Arc<QbftManager<types::MainnetEthSpec, ManualSlotClock>> {
+    let config = processor::Config {
+        max_workers: 4,
+        queue_size: Default::default(),
+    };
+    let senders = processor::spawn(config, setup.executor.clone());
+    let (network_tx, _network_rx) = mpsc::unbounded_channel();
+
+    QbftManager::<types::MainnetEthSpec, _>::new(
+        senders,
+        OperatorId(1).into(),
+        setup.clock.clone(),
+        Arc::new(MockMessageSender::new(network_tx, OperatorId(1))),
+        NonZeroU64::new(32).expect("slots_per_epoch is non-zero"),
+        Arc::new(fork_schedule),
+    )
+    .expect("Manager creation should succeed")
+}
+
+/// Build a `Role::Committee` (`SignedSSVMessage`, `QbftMessage`) pair at the
+/// given slot height. The shape mirrors the aggregator dispatch test so the
+/// two tests stay aligned.
+fn build_committee_message(slot_height: u64) -> (SignedSSVMessage, QbftMessage) {
+    let msg_id = MessageId::new(
+        &DomainType([0; 4]),
+        Role::Committee,
+        &DutyExecutor::Committee(CommitteeId([0; 32])),
+    );
+
+    let qbft_message = QbftMessage {
+        qbft_message_type: QbftMessageType::Proposal,
+        height: slot_height,
+        round: 1,
+        identifier: (&msg_id).into(),
+        root: Hash256::from([0u8; 32]),
+        data_round: 1,
+        round_change_justification: ssv_types::VariableList::empty(),
+        prepare_justification: ssv_types::VariableList::empty(),
+    };
+
+    let ssv_msg = SSVMessage::new(
+        MsgType::SSVConsensusMsgType,
+        msg_id,
+        qbft_message.as_ssz_bytes(),
+    )
+    .expect("SSVMessage creation should succeed");
+
+    let signed_msg = SignedSSVMessage::new(
+        vec![[0xAA; RSA_SIGNATURE_SIZE]],
+        vec![OperatorId(1)],
+        ssv_msg,
+        vec![],
+    )
+    .expect("SignedSSVMessage creation should succeed");
+
+    (signed_msg, qbft_message)
+}
+
+/// With `Fork::CStar` active from genesis, a `Role::Committee` message must
+/// spawn a `GloasBeaconVote` instance and leave the legacy `BeaconVote` map
+/// untouched.
+#[tokio::test]
+async fn test_committee_message_routes_to_gloas_at_cstar() {
+    // Arrange
+    let setup = setup_test(1);
+    let manager = build_manager(
+        &setup,
+        ForkSchedule::new(Fork::CStar, DomainType::default(), "test"),
+    );
+    let (signed_msg, qbft_message) = build_committee_message(TEST_SLOT_HEIGHT);
+
+    // Act
+    let result = manager.receive_data(signed_msg, qbft_message);
+
+    // Assert
+    assert!(
+        result.is_ok(),
+        "receive_data should succeed at CStar, got: {:?}",
+        result
+    );
+    assert_eq!(
+        manager.gloas_beacon_vote_instances.len(),
+        1,
+        "Committee message at CStar must spawn a GloasBeaconVote instance"
+    );
+    assert_eq!(
+        manager.beacon_vote_instances.len(),
+        0,
+        "Committee message at CStar must NOT spawn a legacy BeaconVote instance"
+    );
+}
+
+/// Before CStar (here: `Fork::Alan` active from genesis), the existing
+/// `BeaconVote` routing must remain in force and the new `GloasBeaconVote` map
+/// must stay empty. This is the "BeaconVote unaffected" acceptance criterion.
+#[tokio::test]
+async fn test_committee_message_routes_to_beacon_pre_cstar() {
+    // Arrange
+    let setup = setup_test(1);
+    let manager = build_manager(
+        &setup,
+        ForkSchedule::new(Fork::Alan, DomainType::default(), "test"),
+    );
+    let (signed_msg, qbft_message) = build_committee_message(TEST_SLOT_HEIGHT);
+
+    // Act
+    let result = manager.receive_data(signed_msg, qbft_message);
+
+    // Assert
+    assert!(
+        result.is_ok(),
+        "receive_data should succeed pre-CStar, got: {:?}",
+        result
+    );
+    assert_eq!(
+        manager.beacon_vote_instances.len(),
+        1,
+        "Committee message pre-CStar must spawn a BeaconVote instance"
+    );
+    assert_eq!(
+        manager.gloas_beacon_vote_instances.len(),
+        0,
+        "Committee message pre-CStar must NOT spawn a GloasBeaconVote instance"
+    );
+}

--- a/anchor/validator_store/src/lib.rs
+++ b/anchor/validator_store/src/lib.rs
@@ -46,8 +46,8 @@ use ssv_types::{
         AggregatorCommitteeConsensusData, AggregatorCommitteeDataValidator, BEACON_ROLE_AGGREGATOR,
         BEACON_ROLE_PROPOSER, BEACON_ROLE_SYNC_COMMITTEE_CONTRIBUTION, BeaconVote,
         BeaconVoteValidator, Contribution, ContributionWrapper, Contributions, DataVersion,
-        ProposerConsensusData, ProposerConsensusDataValidator, QbftData, SelectionProofBatchId,
-        ValidatorDuty,
+        GloasBeaconVote, ProposerConsensusData, ProposerConsensusDataValidator, QbftData,
+        QbftDataValidator, SelectionProofBatchId, ValidatorDuty,
     },
     msgid::Role,
     partial_sig::PartialSignatureKind,
@@ -885,6 +885,17 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> AnchorValidator
         ))
     }
 
+    /// Constructs the QBFT data validator for Gloas-era committee attestation duties.
+    /// Body lands in #1026 (`GloasBeaconVoteValidator`); the helper is wired into the
+    /// fork branch of `sign_committee_attestations` now so #1026 is a body-only change.
+    fn create_gloas_beacon_vote_validator(
+        &self,
+        _slot: Slot,
+        _validator_attestation_committees: HashMap<PublicKeyBytes, u64>,
+    ) -> Box<dyn QbftDataValidator<GloasBeaconVote>> {
+        todo!("#1026: implement GloasBeaconVoteValidator")
+    }
+
     fn get_attesting_validators_in_committee(
         &self,
         metadata: &VotingContext,
@@ -1483,33 +1494,78 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> AnchorValidator
                 .get_instant_in_slot(slot, self.spec.get_attestation_due::<E>(slot))?,
         };
 
-        let completed = self
-            .consensus
-            .decide_instance(
-                CommitteeInstanceId {
-                    committee: committee_id,
-                    instance_height: slot.as_usize().into(),
-                },
-                BeaconVote {
-                    block_root: first_att_data.beacon_block_root,
-                    source: first_att_data.source,
-                    target: first_att_data.target,
-                },
-                self.create_beacon_vote_validator(slot, validator_attestation_committees),
-                timeout_mode,
-                &cluster.cluster_members,
-            )
-            .await
-            .map_err(SpecificError::from)?;
-        drop(timer);
+        let instance_id = CommitteeInstanceId {
+            committee: committee_id,
+            instance_height: slot.as_usize().into(),
+        };
 
-        let data = match completed {
-            Completed::TimedOut => return Err(Error::SpecificError(SpecificError::Timeout)),
-            Completed::Success(data) => data,
+        let (block_root, source, target, decided_hash) = if self
+            .fork_schedule
+            .active_fork(slot.epoch(E::slots_per_epoch()))
+            >= Fork::CStar
+        {
+            let completed = self
+                .consensus
+                .decide_instance(
+                    instance_id,
+                    GloasBeaconVote {
+                        block_root: first_att_data.beacon_block_root,
+                        source: first_att_data.source,
+                        target: first_att_data.target,
+                        attestation_data_index: first_att_data.index,
+                    },
+                    self.create_gloas_beacon_vote_validator(slot, validator_attestation_committees),
+                    timeout_mode,
+                    &cluster.cluster_members,
+                )
+                .await
+                .map_err(SpecificError::from)?;
+            drop(timer);
+            match completed {
+                Completed::TimedOut => {
+                    return Err(Error::SpecificError(SpecificError::Timeout));
+                }
+                // TODO(#1027): apply `decided.attestation_data_index` to each validator's
+                // `attestation.data.index` before signing.
+                Completed::Success(decided) => (
+                    decided.block_root,
+                    decided.source,
+                    decided.target,
+                    decided.hash(),
+                ),
+            }
+        } else {
+            let completed = self
+                .consensus
+                .decide_instance(
+                    instance_id,
+                    BeaconVote {
+                        block_root: first_att_data.beacon_block_root,
+                        source: first_att_data.source,
+                        target: first_att_data.target,
+                    },
+                    self.create_beacon_vote_validator(slot, validator_attestation_committees),
+                    timeout_mode,
+                    &cluster.cluster_members,
+                )
+                .await
+                .map_err(SpecificError::from)?;
+            drop(timer);
+            match completed {
+                Completed::TimedOut => {
+                    return Err(Error::SpecificError(SpecificError::Timeout));
+                }
+                Completed::Success(decided) => (
+                    decided.block_root,
+                    decided.source,
+                    decided.target,
+                    decided.hash(),
+                ),
+            }
         };
 
         // Shared values for all validators in this committee
-        let domain_hash = self.get_domain(data.target.epoch, Domain::BeaconAttester);
+        let domain_hash = self.get_domain(target.epoch, Domain::BeaconAttester);
 
         // Prepare all validators and apply consensus results upfront
         // (metadata already resolved by `group_by_committee`)
@@ -1517,9 +1573,9 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> AnchorValidator
             .into_iter()
             .map(|(validator, mut att)| {
                 // Apply consensus result to this attestation
-                att.attestation.data_mut().beacon_block_root = data.block_root;
-                att.attestation.data_mut().source = data.source;
-                att.attestation.data_mut().target = data.target;
+                att.attestation.data_mut().beacon_block_root = block_root;
+                att.attestation.data_mut().source = source;
+                att.attestation.data_mut().target = target;
 
                 let signing_root = att.attestation.data().signing_root(domain_hash);
                 SigningRequest {
@@ -1542,7 +1598,7 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> AnchorValidator
                 slot,
                 &cluster,
                 validator_partial_signature_batch_size,
-                data.hash(),
+                decided_hash,
                 &prepared,
             )
             .await?;


### PR DESCRIPTION
## Problem, Evidence, and Context

Under Gloas (`Fork::CStar`), `AttestationData.index` is BN-supplied and part of the signed attestation root. SSV's current `BeaconVote` drops `index` and lets each operator reconstruct it locally at signing time, which was safe pre-Gloas (deterministically `0` post-Electra, duty-derived earlier) but is unsafe post-Gloas: operators can agree on `block_root`/`source`/`target` and still produce different signing roots, and an operator can be led to sign both `index=0` and `index=1` for the same `(source, target, slot)` without local slashing protection tripping.

Resolves #1025. Spec source: SIP-94 §2.

## Change Overview

This PR adds only the type and dispatch surface; value-checking (#1026) and end-to-end plumbing (#1027) ride on top.

- New `GloasBeaconVote { block_root, source, target, attestation_data_index }` next to `BeaconVote`. Kept as a separate type so the two SSZ wire formats mutually reject on length mismatch across the fork boundary (112 vs 120 fixed bytes). `QbftData` impl mirrors `BeaconVote::hash()` (SHA-256 over SSZ bytes).
- `QbftManager`: new `gloas_beacon_vote_instances` map, `QbftDecidable<E>` impl, retention in the cleaner, and fork-gated routing in the `Role::Committee` arm of `receive_data`.
- `validator_store::sign_committee_attestations`: fork-branched `decide_instance` call. The Gloas branch references `create_gloas_beacon_vote_validator()`, a stub returning `todo!()` whose body lands in #1026 — wiring it now makes #1026 a body-only change. A `TODO(#1027)` marker flags where the decided `attestation_data_index` is currently discarded; #1027 plumbs it into each validator's `attestation.data.index` before signing.
- Pre-Gloas paths are byte-for-byte unchanged.

## Risks, Trade-offs, and Mitigations

- **Runtime panic on Gloas slots until #1026 lands.** `create_gloas_beacon_vote_validator()` is `todo!()`; any committee-attestation slot at `active_fork(epoch) >= Fork::CStar` will panic. The panic is intentional and obvious, and #1026 is the immediate follow-up. Pre-Gloas operation is unaffected.
- **Wire mutual rejection across the fork epoch.** Pre-Gloas operators decoding Gloas wire bytes hard-reject by design (covered by the rejection test). Rollout is coordinated via the existing `FORK_PREPARATION_EPOCHS` dual-subscription window.
- **Two-type duplication.** Both types coexist during the Gloas activation window. A future SIP retires `BeaconVote` and renames the Gloas type back once Gloas has activated on all networks.

## Validation

- `cargo test -p ssv_types --lib` — 92 passed (3 new: SSZ round-trip, hash determinism with explicit `Sha256(SSZ-bytes)` assertion plus cross-index guard, length-mismatch rejection).
- `cargo test -p qbft_manager --lib` — 18 passed (2 new: dispatch routes committee messages to the Gloas map at `Fork::CStar`, to the legacy map pre-CStar).
- `cargo test -p anchor_validator_store --lib` — 33 passed, unchanged.
- `make cargo-fmt-check` and `make lint` clean.
- All five #1025 acceptance criteria are covered by the new tests; the "BeaconVote tests unaffected" criterion is verified by the existing tests continuing to pass.

## Rollback

Pure-additive at the type layer; the fork-gate in `receive_data` and the fork-branch in `sign_committee_attestations` collapse cleanly to the pre-PR shape if reverted. No config, data, or operational impact pre-Gloas.

## Blockers / Dependencies

- #1026 (`GloasBeaconVoteValidator`) is the immediate follow-up — required before Gloas activation to replace the `todo!()` stub.
- #1027 plumbs the decided `attestation_data_index` through the signing path.