### PR TITLE
chore(metrics): add Eager Attesting dashboard row

### DIFF
--- a/metrics/dashboards/anchor-dash.json
+++ b/metrics/dashboards/anchor-dash.json
@@ -3635,16 +3635,29 @@
     "list": [
       {
         "current": {
-          "text": [],
-          "value": []
+          "text": "All",
+          "value": "$__all"
         },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROMETHEUS}"
+        },
+        "definition": "label_values(libp2p_peers, instance)",
         "includeAll": true,
         "label": "Instances",
         "multi": true,
         "name": "anchor_instances",
         "options": [],
-        "query": "",
-        "type": "custom"
+        "query": {
+          "qryType": 1,
+          "query": "label_values(libp2p_peers, instance)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
       }
     ]
   },
@@ -3656,6 +3669,6 @@
   "timezone": "browser",
   "title": "Anchor Dashboard",
   "uid": "0b1c33ef-7c9a-48ca-9321-51265035d023",
-  "version": 30,
+  "version": 31,
   "weekStart": ""
 }

--- a/metrics/dashboards/anchor-dash.json
+++ b/metrics/dashboards/anchor-dash.json
@@ -3170,7 +3170,7 @@
       },
       "id": 100,
       "panels": [],
-      "title": "Eager Attesting (PR #1041)",
+      "title": "Beacon Head Events",
       "type": "row"
     },
     {
@@ -3444,7 +3444,7 @@
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
       },
-      "description": "Distribution of offsets (seconds into slot) at which Phase 2 fell back to the spec-derived timer. This is the baseline behaviour from before PR #1041; mass concentrated here means head events aren't arriving in time and the optimisation isn't kicking in.",
+      "description": "Distribution of offsets (seconds into slot) at which Phase 2 fell back to the spec-derived timer. Mass concentrated here means head events aren't arriving in time and the eager path isn't kicking in.",
       "fieldConfig": {
         "defaults": {
           "custom": {

--- a/metrics/dashboards/anchor-dash.json
+++ b/metrics/dashboards/anchor-dash.json
@@ -3159,6 +3159,474 @@
       ],
       "transparent": true,
       "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 118
+      },
+      "id": 100,
+      "panels": [],
+      "title": "Eager Attesting (PR #1041)",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Rate of MetadataService Phase 2 firings, split by which source won the race: head_event (LH beacon head SSE) vs timer (spec-derived fallback at unaggregated-attestation-due offset).",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 119
+      },
+      "id": 101,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "mean"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.1.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(anchor_metadata_service_voting_context_triggers_total{instance=~\"$anchor_instances\"}[$__rate_interval])) by (instance, trigger)",
+          "instant": false,
+          "legendFormat": "{{instance}} - {{trigger}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Phase 2 Trigger Source Rate",
+      "transparent": true,
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Share of Phase 2 firings driven by a beacon head event rather than the fallback timer, over a 5-minute window. Higher is better: it means the BN is delivering the head before the 1/3-slot deadline. Expect 100% on a healthy chain; drops indicate missed slots or a slow/disconnected BN.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "max": 100,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": 0
+              },
+              {
+                "color": "orange",
+                "value": 50
+              },
+              {
+                "color": "yellow",
+                "value": 80
+              },
+              {
+                "color": "green",
+                "value": 95
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 119
+      },
+      "id": 102,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.1.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "100 * sum by (instance) (rate(anchor_metadata_service_voting_context_triggers_total{instance=~\"$anchor_instances\", trigger=\"head_event\"}[5m])) / clamp_min(sum by (instance) (rate(anchor_metadata_service_voting_context_triggers_total{instance=~\"$anchor_instances\"}[5m])), 1e-9)",
+          "instant": false,
+          "legendFormat": "{{instance}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Head-Event Win Share (5m)",
+      "transparent": true,
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Distribution of offsets (seconds into slot) at which Phase 2 fired via the head_event path. Lower is better; the closer to 0, the earlier the voting context is populated and attestations can be signed. Compare against the timer-fallback panel to see the latency saved.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "scaleDistribution": {
+              "type": "linear"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 127
+      },
+      "id": 103,
+      "maxDataPoints": 50,
+      "options": {
+        "calculate": false,
+        "cellGap": 1,
+        "color": {
+          "exponent": 0.5,
+          "fill": "dark-green",
+          "mode": "scheme",
+          "reverse": false,
+          "scale": "exponential",
+          "scheme": "Greens",
+          "steps": 64
+        },
+        "exemplars": {
+          "color": "rgba(255,0,255,0.7)"
+        },
+        "filterValues": {
+          "le": 1e-9
+        },
+        "legend": {
+          "show": true
+        },
+        "rowsFrame": {
+          "layout": "auto"
+        },
+        "tooltip": {
+          "mode": "single",
+          "showColorScale": false,
+          "yHistogram": false
+        },
+        "yAxis": {
+          "axisPlacement": "left",
+          "reverse": false,
+          "unit": "s"
+        }
+      },
+      "pluginVersion": "12.1.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "sum(increase(anchor_metadata_service_voting_context_offset_seconds_bucket{instance=~\"$anchor_instances\", trigger=\"head_event\"}[$__rate_interval])) by (le)",
+          "format": "heatmap",
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Voting Context Offset — Head Event",
+      "transparent": true,
+      "type": "heatmap"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Distribution of offsets (seconds into slot) at which Phase 2 fell back to the spec-derived timer. This is the baseline behaviour from before PR #1041; mass concentrated here means head events aren't arriving in time and the optimisation isn't kicking in.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "scaleDistribution": {
+              "type": "linear"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 127
+      },
+      "id": 104,
+      "maxDataPoints": 50,
+      "options": {
+        "calculate": false,
+        "cellGap": 1,
+        "color": {
+          "exponent": 0.5,
+          "fill": "dark-orange",
+          "mode": "scheme",
+          "reverse": false,
+          "scale": "exponential",
+          "scheme": "Oranges",
+          "steps": 64
+        },
+        "exemplars": {
+          "color": "rgba(255,0,255,0.7)"
+        },
+        "filterValues": {
+          "le": 1e-9
+        },
+        "legend": {
+          "show": true
+        },
+        "rowsFrame": {
+          "layout": "auto"
+        },
+        "tooltip": {
+          "mode": "single",
+          "showColorScale": false,
+          "yHistogram": false
+        },
+        "yAxis": {
+          "axisPlacement": "left",
+          "reverse": false,
+          "unit": "s"
+        }
+      },
+      "pluginVersion": "12.1.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "sum(increase(anchor_metadata_service_voting_context_offset_seconds_bucket{instance=~\"$anchor_instances\", trigger=\"timer\"}[$__rate_interval])) by (le)",
+          "format": "heatmap",
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Voting Context Offset — Timer Fallback",
+      "transparent": true,
+      "type": "heatmap"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Head events dropped by the Client::run fan-out relay because a downstream channel (LH AttestationService or MetadataService) was full. Steady-state value should be 0; sustained non-zero values mean a downstream consumer is back-pressured and the fan-out is shedding load via try_send.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 135
+      },
+      "id": 105,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max",
+            "sum"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "12.1.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(anchor_head_event_fanout_drops_total{instance=~\"$anchor_instances\"}[$__rate_interval])) by (instance, downstream)",
+          "instant": false,
+          "legendFormat": "{{instance}} - {{downstream}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Head-Event Fan-out Drops",
+      "transparent": true,
+      "type": "timeseries"
     }
   ],
   "schemaVersion": 41,
@@ -3188,6 +3656,6 @@
   "timezone": "browser",
   "title": "Anchor Dashboard",
   "uid": "0b1c33ef-7c9a-48ca-9321-51265035d023",
-  "version": 29,
+  "version": 30,
   "weekStart": ""
 }

--- a/metrics/dashboards/anchor-dash.json
+++ b/metrics/dashboards/anchor-dash.json
@@ -3178,7 +3178,7 @@
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
       },
-      "description": "Rate of MetadataService Phase 2 firings, split by which source won the race: head_event (LH beacon head SSE) vs timer (spec-derived fallback at unaggregated-attestation-due offset).",
+      "description": "Rate of voting-context updates at the attestation deadline, split by which source won the race: head_event (LH beacon head SSE) vs timer (spec-derived fallback at the unaggregated attestation deadline, slot_duration / INTERVALS_PER_SLOT).",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -3269,7 +3269,7 @@
           "refId": "A"
         }
       ],
-      "title": "Phase 2 Trigger Source Rate",
+      "title": "Attestation Deadline Trigger Source Rate",
       "transparent": true,
       "type": "timeseries"
     },
@@ -3278,7 +3278,7 @@
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
       },
-      "description": "Share of Phase 2 firings driven by a beacon head event rather than the fallback timer, over a 5-minute window. Higher is better: it means the BN is delivering the head before the 1/3-slot deadline. Expect 100% on a healthy chain; drops indicate missed slots or a slow/disconnected BN.",
+      "description": "Share of attestation-deadline triggers driven by a beacon head event rather than the fallback timer, over a 5-minute window. Higher is better: it means the BN is delivering the head before the attestation deadline (slot_duration / INTERVALS_PER_SLOT). Expect 100% on a healthy chain; drops indicate missed slots or a slow/disconnected BN.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -3360,7 +3360,7 @@
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
       },
-      "description": "Distribution of offsets (seconds into slot) at which Phase 2 fired via the head_event path. Lower is better; the closer to 0, the earlier the voting context is populated and attestations can be signed. Compare against the timer-fallback panel to see the latency saved.",
+      "description": "Distribution of offsets (seconds into slot) at which the voting context was updated via the head_event path. Lower is better; the closer to 0, the earlier the voting context is populated and attestations can be signed. Compare against the timer-fallback panel to see the latency saved against the attestation deadline.",
       "fieldConfig": {
         "defaults": {
           "custom": {
@@ -3444,7 +3444,7 @@
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
       },
-      "description": "Distribution of offsets (seconds into slot) at which Phase 2 fell back to the spec-derived timer. Mass concentrated here means head events aren't arriving in time and the eager path isn't kicking in.",
+      "description": "Distribution of offsets (seconds into slot) at which the voting context fell back to the attestation-deadline timer (slot_duration / INTERVALS_PER_SLOT). Mass concentrated here means head events aren't arriving in time and the eager path isn't kicking in.",
       "fieldConfig": {
         "defaults": {
           "custom": {
@@ -3669,6 +3669,6 @@
   "timezone": "browser",
   "title": "Anchor Dashboard",
   "uid": "0b1c33ef-7c9a-48ca-9321-51265035d023",
-  "version": 31,
+  "version": 32,
   "weekStart": ""
 }


### PR DESCRIPTION
## Problem, Evidence, and Context

#1041 added three metrics for the head-event-driven Phase 2 path (`anchor_metadata_service_voting_context_triggers_total`, `anchor_metadata_service_voting_context_offset_seconds`, `anchor_head_event_fanout_drops_total`) but none of them are surfaced on the Grafana dashboard, so the optimisation's effect on attestation timing isn't observable from the operator UI. The PR description itself flagged that "end-to-end did this move attestation publishing earlier is a hypothesis until run on a real network. The two new metrics are what's needed to confirm." This PR makes them visible.

Relevant: #1041, #986.

## Change Overview

Adds a new collapsed-by-default "Eager Attesting (PR #1041)" row to `metrics/dashboards/anchor-dash.json` with five panels:

- **Phase 2 Trigger Source Rate** — stacked timeseries of trigger rate split by `trigger={head_event,timer}`, per instance.
- **Head-Event Win Share (5m)** — stat panel showing the percentage of Phase 2 firings driven by a head event over a 5-minute window, with red/orange/yellow/green thresholds at 0/50/80/95%. Quick health read.
- **Voting Context Offset — Head Event** — heatmap over the `_offset_seconds` histogram filtered to `trigger=head_event`. Greens scheme; lower-is-better is the whole point.
- **Voting Context Offset — Timer Fallback** — same heatmap for `trigger=timer`. Oranges scheme; this is the pre-#1041 baseline, so visual contrast against the head-event panel is the point.
- **Head-Event Fan-out Drops** — timeseries of `anchor_head_event_fanout_drops_total` rate per `downstream`, full-width. Should sit at 0; non-zero is a back-pressure alert.

Dashboard `version` bumped from 29 to 30. No other panels touched.

## Risks, Trade-offs, and Mitigations

- Dashboard-only JSON change; no runtime or code-path impact.
- Panel IDs 100-105 are new and don't collide with the existing 1-37 range, so re-import on an existing instance won't displace anything.
- Heatmap bucket resolution is bounded by the buckets defined in code (`0.05, 0.1, 0.25, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0`). Coarse below 50ms — fine for confirming the head-event path fires sub-second; not fine-grained enough for micro-tuning.
- The win-share stat uses `clamp_min(..., 1e-9)` in the denominator to avoid div-by-zero before any traffic.

## Validation

- `python3 -c "import json; json.load(open('metrics/dashboards/anchor-dash.json'))"` parses cleanly; panel count 35 -> 40.
- PromQL expressions reference the exact metric names and labels registered in `anchor/validator_store/src/metrics.rs` and `anchor/client/src/metrics.rs` from #1041.
- Live render against a Prometheus with #1041 deployed is still pending; behaviour under real traffic is the next verification step.

## Rollback

Revert the commit. The dashboard JSON is the only artifact; no migrations or stateful changes.