### PR TITLE
feat(qbft_manager): add instrumentation taxonomy and metrics surface

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6064,6 +6064,7 @@ dependencies = [
  "fork",
  "futures",
  "message_sender",
+ "metrics",
  "processor",
  "qbft",
  "slot_clock",

--- a/anchor/common/qbft/src/lib.rs
+++ b/anchor/common/qbft/src/lib.rs
@@ -7,8 +7,8 @@ use std::{
 pub use config::{Config, ConfigBuilder};
 pub use error::ConfigBuilderError;
 pub use qbft_types::{
-    Completed, ConsensusData, DefaultLeaderFunction, InstanceHeight, InstanceState, LeaderFunction,
-    UnsignedWrappedQbftMessage, WrappedQbftMessage,
+    Completed, ConsensusData, DefaultLeaderFunction, InstanceHeight, InstanceState,
+    InstanceStateKind, LeaderFunction, UnsignedWrappedQbftMessage, WrappedQbftMessage,
 };
 use ssv_types::{
     OperatorId, Round, VariableList,
@@ -236,9 +236,12 @@ where
         self.instance_height
     }
 
-    /// Get the current instance state
-    pub fn state(&self) -> InstanceState {
-        self.state
+    /// Get the kind of the current instance state.
+    ///
+    /// Returns a payload-free [`InstanceStateKind`] to provide callers with a clean object for state-machine
+    /// comparison.
+    pub fn state_kind(&self) -> InstanceStateKind {
+        self.state.kind()
     }
 
     // Shifts this instance into a new round>

--- a/anchor/common/qbft/src/lib.rs
+++ b/anchor/common/qbft/src/lib.rs
@@ -238,8 +238,8 @@ where
 
     /// Get the kind of the current instance state.
     ///
-    /// Returns a payload-free [`InstanceStateKind`] to provide callers with a clean object for state-machine
-    /// comparison.
+    /// Returns a payload-free `InstanceStateKind` to provide callers with a clean object for
+    /// state-machine comparison.
     pub fn state_kind(&self) -> InstanceStateKind {
         self.state.kind()
     }

--- a/anchor/common/qbft/src/lib.rs
+++ b/anchor/common/qbft/src/lib.rs
@@ -236,6 +236,11 @@ where
         self.instance_height
     }
 
+    /// Get the current instance state
+    pub fn state(&self) -> InstanceState {
+        self.state
+    }
+
     // Shifts this instance into a new round>
     fn set_round(&mut self, new_round: Round) {
         self.current_round.set(new_round);

--- a/anchor/common/qbft/src/qbft_types.rs
+++ b/anchor/common/qbft/src/qbft_types.rs
@@ -152,6 +152,41 @@ impl From<InstanceState> for u8 {
     }
 }
 
+/// A payload-free view of [`InstanceState`].
+///
+/// `InstanceState` carries a `proposal_root` payload on its `Prepare` and `Commit` variants.
+/// This kind identifies *which* state an instance is in without that instance-specific detail,
+/// supporting state-machine decision branching where only the variant matters.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum InstanceStateKind {
+    /// Awaiting a proposal from a leader.
+    AwaitingProposal,
+    /// Awaiting consensus on PREPARE messages.
+    Prepare,
+    /// Awaiting consensus on COMMIT messages.
+    Commit,
+    /// We have sent a round change message.
+    SentRoundChange,
+    /// The consensus instance is complete.
+    Complete,
+    /// We have reached consensus on a round change.
+    RoundChangeConsensus,
+}
+
+impl InstanceState {
+    /// Returns the payload-free [`InstanceStateKind`] of this state.
+    pub fn kind(&self) -> InstanceStateKind {
+        match self {
+            InstanceState::AwaitingProposal => InstanceStateKind::AwaitingProposal,
+            InstanceState::Prepare { .. } => InstanceStateKind::Prepare,
+            InstanceState::Commit { .. } => InstanceStateKind::Commit,
+            InstanceState::SentRoundChange => InstanceStateKind::SentRoundChange,
+            InstanceState::Complete => InstanceStateKind::Complete,
+            InstanceState::RoundChangeConsensus => InstanceStateKind::RoundChangeConsensus,
+        }
+    }
+}
+
 /// Type definitions for the allowable messages
 /// This holds the consensus data for a given round.
 #[derive(Debug, Clone)]

--- a/anchor/common/qbft/src/qbft_types.rs
+++ b/anchor/common/qbft/src/qbft_types.rs
@@ -174,7 +174,7 @@ pub enum InstanceStateKind {
 }
 
 impl InstanceState {
-    /// Returns the payload-free [`InstanceStateKind`] of this state.
+    /// Returns the payload-free `InstanceStateKind` of this state.
     pub fn kind(&self) -> InstanceStateKind {
         match self {
             InstanceState::AwaitingProposal => InstanceStateKind::AwaitingProposal,

--- a/anchor/qbft_manager/Cargo.toml
+++ b/anchor/qbft_manager/Cargo.toml
@@ -11,6 +11,7 @@ database = { workspace = true }
 ethereum_ssz = { workspace = true }
 fork = { workspace = true }
 message_sender = { workspace = true }
+metrics = { workspace = true }
 processor = { workspace = true }
 qbft = { workspace = true }
 slot_clock = { workspace = true }

--- a/anchor/qbft_manager/src/instrumentation.rs
+++ b/anchor/qbft_manager/src/instrumentation.rs
@@ -26,9 +26,6 @@ pub enum RoundAdvanceReason {
     /// The node observed f+1 round-change messages from peers at a higher
     /// round.
     FPlusOneRoundChange,
-    /// A full quorum of round-change messages was observed, achieving
-    /// round-change consensus.
-    RoundChangeQuorum,
     /// A justified proposal for a higher round arrived, pulling the instance
     /// forward to catch up with the leader's round (no round change occurred).
     FutureRoundProposal,
@@ -39,7 +36,6 @@ impl RoundAdvanceReason {
         match self {
             Self::Timeout => "timeout",
             Self::FPlusOneRoundChange => "f_plus_1_rc",
-            Self::RoundChangeQuorum => "rc_quorum",
             Self::FutureRoundProposal => "future_proposal",
         }
     }
@@ -57,16 +53,18 @@ pub enum RecvArmTag {
 /// Classify a round advance observed at the boundary layer.
 ///
 /// Consumes the payload-free `InstanceStateKind` of the after-state so the classifier depends
-/// only on the state variant without concern for state attributes.
+/// only on the state variant without concern for state attributes. Returns `None` if the round
+/// did not actually advance and `Some(reason)` when it did.
 ///
-/// `Message` match arm after-state kind captures how the round advanced:
+/// `Message`-arm after-states coincide with a
+/// round advance:
 /// - `SentRoundChange`: f+1 peers at a higher round pulled us forward.
-/// - `Prepare`: a justified future-round proposal arrived (we caught up to the leader, no round
-///   change occurred).
-/// - anything else (e.g. `AwaitingProposal`, `RoundChangeConsensus`): a full round-change quorum
-///   was reached.
+/// - `Prepare`: a justified future-round proposal arrived.
 ///
-/// Returns `None` if the round did not actually advance and `Some(reason)` when it did.
+/// `AwaitingProposal` and `RoundChangeConsensus` can appear on the `Message` arm when a
+/// round-change quorum completes, but the round has *already* advanced on the prior f+1
+/// message (`f+1 < 2f+1` for all canonical committees), so `after_round == before_round`.
+/// This variant is functionally unreachable.
 pub fn classify_round_advance(
     _before_state: InstanceStateKind,
     after_state: InstanceStateKind,
@@ -83,7 +81,10 @@ pub fn classify_round_advance(
         RecvArmTag::Message => match after_state {
             InstanceStateKind::SentRoundChange => RoundAdvanceReason::FPlusOneRoundChange,
             InstanceStateKind::Prepare => RoundAdvanceReason::FutureRoundProposal,
-            _ => RoundAdvanceReason::RoundChangeQuorum,
+            InstanceStateKind::AwaitingProposal
+            | InstanceStateKind::RoundChangeConsensus
+            | InstanceStateKind::Commit
+            | InstanceStateKind::Complete => return None,
         },
     };
 
@@ -92,7 +93,93 @@ pub fn classify_round_advance(
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use bls::FixedBytesExtended;
+    use qbft::{
+        ConfigBuilder, DefaultLeaderFunction, InstanceHeight, InstanceStateKind, Qbft,
+        WrappedQbftMessage,
+    };
+    use ssv_types::{
+        OperatorId, RSA_SIGNATURE_SIZE, Round, VariableList,
+        consensus::{BeaconVote, NoDataValidation, QbftData, QbftMessage, QbftMessageType},
+        message::{MsgType, SSVMessage, SignedSSVMessage},
+        msgid::MessageId,
+    };
+    use ssz::Encode;
+    use types::{Checkpoint, Hash256};
+
+    use super::{RecvArmTag, RoundAdvanceReason, classify_round_advance};
+
+    /// Constructs a fake signed QBFT network message that can be fed into `instance.receive`.
+    fn build_wrapped_msg(
+        msg_type: QbftMessageType,
+        round: u64,
+        root: Hash256,
+        data_round: u64,
+        signer: u64,
+        rc_justifications: Vec<
+            VariableList<u8, ssv_types::consensus::RoundChangeJustificationLength>,
+        >,
+        full_data: Vec<u8>,
+    ) -> WrappedQbftMessage {
+        let qbft_message = QbftMessage {
+            qbft_message_type: msg_type,
+            height: 0,
+            round,
+            identifier: VariableList::repeat_full(0),
+            root,
+            data_round,
+            round_change_justification: if rc_justifications.is_empty() {
+                VariableList::empty()
+            } else {
+                VariableList::new(rc_justifications).unwrap()
+            },
+            prepare_justification: VariableList::empty(),
+        };
+
+        let ssv_message = SSVMessage::new(
+            MsgType::SSVConsensusMsgType,
+            MessageId::from([0; 56]),
+            qbft_message.as_ssz_bytes(),
+        )
+        .expect("should create SSVMessage");
+
+        let signed_message = SignedSSVMessage::new(
+            vec![[0; RSA_SIGNATURE_SIZE]],
+            vec![OperatorId::from(signer)],
+            ssv_message,
+            full_data,
+        )
+        .expect("should create SignedSSVMessage");
+
+        WrappedQbftMessage {
+            signed_message,
+            qbft_message,
+        }
+    }
+
+    /// Creates a Qbft instance with default or no-op parameter values to use in tests.
+    fn fresh_instance()
+    -> Qbft<DefaultLeaderFunction, BeaconVote, impl FnMut(qbft::UnsignedWrappedQbftMessage)> {
+        let config = ConfigBuilder::<DefaultLeaderFunction>::new(
+            1.into(),
+            InstanceHeight::default(),
+            (1..=4).map(OperatorId::from).collect(),
+        )
+        .build()
+        .expect("valid config");
+
+        Qbft::new(
+            config,
+            BeaconVote {
+                block_root: Hash256::zero(),
+                source: Checkpoint::default(),
+                target: Checkpoint::default(),
+            },
+            Box::new(NoDataValidation),
+            MessageId::from([0; 56]),
+            |_| {},
+        )
+    }
 
     #[test]
     fn no_advance_when_round_unchanged() {
@@ -125,22 +212,6 @@ mod tests {
     }
 
     #[test]
-    fn timeout_on_round_end() {
-        let result = classify_round_advance(
-            InstanceStateKind::AwaitingProposal,
-            InstanceStateKind::AwaitingProposal,
-            RecvArmTag::RoundEnd,
-            Round::from(1u64),
-            Round::from(2u64),
-        );
-        assert_eq!(
-            result,
-            Some(RoundAdvanceReason::Timeout),
-            "RoundEnd arm should always classify as Timeout regardless of state"
-        );
-    }
-
-    #[test]
     fn f_plus_one_rc_when_after_state_is_sent_round_change() {
         let result = classify_round_advance(
             InstanceStateKind::AwaitingProposal,
@@ -157,7 +228,7 @@ mod tests {
     }
 
     #[test]
-    fn rc_quorum_when_after_state_is_awaiting_proposal() {
+    fn none_when_awaiting_proposal_on_message_arm() {
         let result = classify_round_advance(
             InstanceStateKind::SentRoundChange,
             InstanceStateKind::AwaitingProposal,
@@ -166,15 +237,13 @@ mod tests {
             Round::from(3u64),
         );
         assert_eq!(
-            result,
-            Some(RoundAdvanceReason::RoundChangeQuorum),
-            "Message arm landing in AwaitingProposal (neither SentRoundChange nor Prepare) means \
-             full quorum was reached"
+            result, None,
+            "AwaitingProposal on Message arm must return None."
         );
     }
 
     #[test]
-    fn rc_quorum_when_after_state_is_round_change_consensus() {
+    fn none_when_round_change_consensus_on_message_arm() {
         let result = classify_round_advance(
             InstanceStateKind::SentRoundChange,
             InstanceStateKind::RoundChangeConsensus,
@@ -183,9 +252,8 @@ mod tests {
             Round::from(3u64),
         );
         assert_eq!(
-            result,
-            Some(RoundAdvanceReason::RoundChangeQuorum),
-            "RoundChangeConsensus state also indicates full quorum was observed"
+            result, None,
+            "RoundChangeConsensus on Message arm must return None."
         );
     }
 
@@ -231,5 +299,218 @@ mod tests {
                 "RoundEnd arm must always produce Timeout, but failed for after_state {after_state:?}"
             );
         }
+    }
+
+    /// Calling `end_round()` on a real instance advances to `SentRoundChange` and classifies as
+    /// `Timeout`.
+    #[test]
+    fn end_round_timeout_advances_round_and_classifies_as_timeout() {
+        let mut inst = fresh_instance();
+        let before_kind = inst.state_kind();
+        let before_round = inst.get_round();
+
+        inst.end_round();
+
+        let after_kind = inst.state_kind();
+        let after_round = inst.get_round();
+        assert!(
+            after_round > before_round,
+            "end_round should advance the round"
+        );
+        assert_eq!(
+            classify_round_advance(
+                before_kind,
+                after_kind,
+                RecvArmTag::RoundEnd,
+                before_round,
+                after_round
+            ),
+            Some(RoundAdvanceReason::Timeout),
+            "end_round path should classify as Timeout"
+        );
+    }
+
+    /// Receiving f+1 round-change messages advances the round to `SentRoundChange` and classifies
+    /// as `FPlusOneRoundChange`.
+    #[test]
+    fn f_plus_one_round_changes_advance_round_and_classify_as_f_plus_one() {
+        let mut inst = fresh_instance();
+        let before_kind = inst.state_kind();
+        let before_round = inst.get_round();
+
+        for signer in [2u64, 3] {
+            let msg = build_wrapped_msg(
+                QbftMessageType::RoundChange,
+                2,
+                Hash256::zero(),
+                0,
+                signer,
+                vec![],
+                vec![],
+            );
+            inst.receive(msg).expect("rc msg should be accepted");
+        }
+
+        let after_kind = inst.state_kind();
+        let after_round = inst.get_round();
+        assert!(
+            after_round > before_round,
+            "f+1 round-change messages should advance the round"
+        );
+        assert_eq!(
+            classify_round_advance(
+                before_kind,
+                after_kind,
+                RecvArmTag::Message,
+                before_round,
+                after_round
+            ),
+            Some(RoundAdvanceReason::FPlusOneRoundChange),
+            "f+1 round-change path should classify as FPlusOneRoundChange"
+        );
+    }
+
+    /// The quorum-completing message lands in `AwaitingProposal` without advancing the round (f+1
+    /// already did).
+    #[test]
+    fn round_change_quorum_does_not_advance_round_beyond_f_plus_one() {
+        let mut inst = fresh_instance();
+
+        // Feed f+1 messages first, then capture state before the quorum-completing message.
+        for signer in [2u64, 3] {
+            let msg = build_wrapped_msg(
+                QbftMessageType::RoundChange,
+                2,
+                Hash256::zero(),
+                0,
+                signer,
+                vec![],
+                vec![],
+            );
+            inst.receive(msg).expect("rc msg should be accepted");
+        }
+
+        let before_kind = inst.state_kind();
+        let before_round = inst.get_round();
+
+        // Quorum-completing message
+        let msg = build_wrapped_msg(
+            QbftMessageType::RoundChange,
+            2,
+            Hash256::zero(),
+            0,
+            4,
+            vec![],
+            vec![],
+        );
+        inst.receive(msg).expect("quorum rc msg should be accepted");
+
+        let after_kind = inst.state_kind();
+        let after_round = inst.get_round();
+
+        // The quorum message resets state to AwaitingProposal but does not advance the round
+        assert_eq!(
+            after_kind,
+            InstanceStateKind::AwaitingProposal,
+            "after quorum, state should be AwaitingProposal (not RoundChangeConsensus)"
+        );
+        assert_eq!(
+            after_round, before_round,
+            "quorum message should not advance the round beyond what f+1 already did"
+        );
+        assert_eq!(
+            classify_round_advance(
+                before_kind,
+                after_kind,
+                RecvArmTag::Message,
+                before_round,
+                after_round
+            ),
+            None,
+            "quorum message should classify as None since the round did not advance"
+        );
+    }
+
+    /// A justified future-round proposal advances to `Prepare` and classifies as
+    /// `FutureRoundProposal`.
+    #[test]
+    fn future_round_proposal_advances_round_and_classifies_as_future_proposal() {
+        let mut inst = fresh_instance();
+        let before_kind = inst.state_kind();
+        let before_round = inst.get_round();
+
+        let start_data = BeaconVote {
+            block_root: Hash256::zero(),
+            source: Checkpoint::default(),
+            target: Checkpoint::default(),
+        };
+        let start_data_hash = start_data.hash();
+        let start_data_bytes = start_data.as_ssz_bytes();
+
+        let justifications: Vec<
+            VariableList<u8, ssv_types::consensus::RoundChangeJustificationLength>,
+        > = [2u64, 3, 4]
+            .iter()
+            .map(|&signer| {
+                let rc_qbft_msg = QbftMessage {
+                    qbft_message_type: QbftMessageType::RoundChange,
+                    height: 0,
+                    round: 2,
+                    identifier: VariableList::repeat_full(0),
+                    root: Hash256::zero(),
+                    data_round: 0,
+                    round_change_justification: VariableList::empty(),
+                    prepare_justification: VariableList::empty(),
+                };
+
+                let rc_ssv = SSVMessage::new(
+                    MsgType::SSVConsensusMsgType,
+                    MessageId::from([0; 56]),
+                    rc_qbft_msg.as_ssz_bytes(),
+                )
+                .expect("rc SSVMessage");
+
+                let signed_rc = SignedSSVMessage::new(
+                    vec![[0; RSA_SIGNATURE_SIZE]],
+                    vec![OperatorId::from(signer)],
+                    rc_ssv,
+                    vec![],
+                )
+                .expect("signed rc");
+
+                VariableList::new(signed_rc.as_ssz_bytes()).unwrap()
+            })
+            .collect();
+
+        let proposal = build_wrapped_msg(
+            QbftMessageType::Proposal,
+            2,
+            start_data_hash,
+            0,
+            2, // op 2 is leader for round 2.
+            justifications,
+            start_data_bytes,
+        );
+
+        inst.receive(proposal)
+            .expect("future proposal should be accepted");
+
+        let after_kind = inst.state_kind();
+        let after_round = inst.get_round();
+        assert!(
+            after_round > before_round,
+            "future-round proposal should advance the round"
+        );
+        assert_eq!(
+            classify_round_advance(
+                before_kind,
+                after_kind,
+                RecvArmTag::Message,
+                before_round,
+                after_round
+            ),
+            Some(RoundAdvanceReason::FutureRoundProposal),
+            "future-round proposal path should classify as FutureRoundProposal"
+        );
     }
 }

--- a/anchor/qbft_manager/src/instrumentation.rs
+++ b/anchor/qbft_manager/src/instrumentation.rs
@@ -1,0 +1,212 @@
+//! Instrumentation taxonomy for QBFT Manager.
+#![expect(
+    dead_code,
+    reason = "Expected to be implemented by proposer QBFT instrumentation"
+)]
+
+use std::mem::{Discriminant, discriminant};
+
+use qbft::InstanceState;
+use ssv_types::Round;
+
+pub mod checkpoints {
+    pub const QBFT_INSTANCE_STARTED: &str = "qbft_instance_started";
+    pub const QBFT_PROPOSAL_ACCEPTED: &str = "qbft_proposal_accepted";
+    pub const QBFT_PREPARE_QUORUM: &str = "qbft_prepare_quorum";
+    pub const QBFT_ROUND_ADVANCE: &str = "qbft_round_advance";
+    pub const QBFT_DECIDED: &str = "qbft_decided";
+    pub const QBFT_TIMED_OUT: &str = "qbft_timed_out";
+    pub const QBFT_CHANNEL_CLOSED: &str = "qbft_channel_closed";
+}
+
+/// Reason why a QBFT round advanced, determined by the boundary layer
+/// through before/after state observation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RoundAdvanceReason {
+    /// The local round timer expired without reaching consensus.
+    Timeout,
+    /// The node observed f+1 round-change messages from peers at a higher
+    /// round.
+    FPlusOneRoundChange,
+    /// A full quorum of round-change messages was observed, achieving
+    /// round-change consensus.
+    RoundChangeQuorum,
+}
+
+impl RoundAdvanceReason {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Timeout => "timeout",
+            Self::FPlusOneRoundChange => "f_plus_1_rc",
+            Self::RoundChangeQuorum => "rc_quorum",
+        }
+    }
+}
+
+/// Identifies which branch of the recv loop observed the round advance.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RecvArmTag {
+    /// A network message was received and processed.
+    Message,
+    /// The local round timer expired and `end_round` was called.
+    RoundEnd,
+}
+
+/// Classify a round advance observed at the boundary layer.
+///
+/// This function uses `std::mem::Discriminant<InstanceState>` to avoid comparing the
+/// `proposal_root` payload of certain states or modifying internal API components. Only the state
+/// variant is relevant here.
+///
+/// Returns `None` if the round did not actually advance and `Some(reason)` when it did.
+pub fn classify_round_advance(
+    _before_state: Discriminant<InstanceState>,
+    after_state: Discriminant<InstanceState>,
+    recv_arm: RecvArmTag,
+    before_round: Round,
+    after_round: Round,
+) -> Option<RoundAdvanceReason> {
+    if after_round <= before_round {
+        return None;
+    }
+
+    let reason = match recv_arm {
+        RecvArmTag::RoundEnd => RoundAdvanceReason::Timeout,
+        RecvArmTag::Message => {
+            if after_state == discriminant(&InstanceState::SentRoundChange) {
+                RoundAdvanceReason::FPlusOneRoundChange
+            } else {
+                RoundAdvanceReason::RoundChangeQuorum
+            }
+        }
+    };
+
+    Some(reason)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn disc(state: InstanceState) -> Discriminant<InstanceState> {
+        discriminant(&state)
+    }
+
+    #[test]
+    fn no_advance_when_round_unchanged() {
+        let result = classify_round_advance(
+            disc(InstanceState::AwaitingProposal),
+            disc(InstanceState::AwaitingProposal),
+            RecvArmTag::Message,
+            Round::from(1u64),
+            Round::from(1u64),
+        );
+        assert_eq!(
+            result, None,
+            "should return None when after_round == before_round (no advance occurred)"
+        );
+    }
+
+    #[test]
+    fn no_advance_when_round_decreased() {
+        let result = classify_round_advance(
+            disc(InstanceState::AwaitingProposal),
+            disc(InstanceState::AwaitingProposal),
+            RecvArmTag::Message,
+            Round::from(3u64),
+            Round::from(2u64),
+        );
+        assert_eq!(
+            result, None,
+            "should return None when after_round < before_round (defensive case)"
+        );
+    }
+
+    #[test]
+    fn timeout_on_round_end() {
+        let result = classify_round_advance(
+            disc(InstanceState::AwaitingProposal),
+            disc(InstanceState::AwaitingProposal),
+            RecvArmTag::RoundEnd,
+            Round::from(1u64),
+            Round::from(2u64),
+        );
+        assert_eq!(
+            result,
+            Some(RoundAdvanceReason::Timeout),
+            "RoundEnd arm should always classify as Timeout regardless of state"
+        );
+    }
+
+    #[test]
+    fn f_plus_one_rc_when_after_state_is_sent_round_change() {
+        let result = classify_round_advance(
+            disc(InstanceState::AwaitingProposal),
+            disc(InstanceState::SentRoundChange),
+            RecvArmTag::Message,
+            Round::from(1u64),
+            Round::from(3u64),
+        );
+        assert_eq!(
+            result,
+            Some(RoundAdvanceReason::FPlusOneRoundChange),
+            "Message arm with after_state == SentRoundChange means f+1 peers pulled us forward"
+        );
+    }
+
+    #[test]
+    fn rc_quorum_when_after_state_is_awaiting_proposal() {
+        let result = classify_round_advance(
+            disc(InstanceState::SentRoundChange),
+            disc(InstanceState::AwaitingProposal),
+            RecvArmTag::Message,
+            Round::from(2u64),
+            Round::from(3u64),
+        );
+        assert_eq!(
+            result,
+            Some(RoundAdvanceReason::RoundChangeQuorum),
+            "Message arm with after_state != SentRoundChange means full quorum was reached"
+        );
+    }
+
+    #[test]
+    fn rc_quorum_when_after_state_is_round_change_consensus() {
+        let result = classify_round_advance(
+            disc(InstanceState::SentRoundChange),
+            disc(InstanceState::RoundChangeConsensus),
+            RecvArmTag::Message,
+            Round::from(2u64),
+            Round::from(3u64),
+        );
+        assert_eq!(
+            result,
+            Some(RoundAdvanceReason::RoundChangeQuorum),
+            "RoundChangeConsensus state also indicates full quorum was observed"
+        );
+    }
+
+    #[test]
+    fn timeout_regardless_of_state() {
+        for state in [
+            InstanceState::AwaitingProposal,
+            InstanceState::SentRoundChange,
+            InstanceState::Complete,
+            InstanceState::RoundChangeConsensus,
+        ] {
+            let result = classify_round_advance(
+                disc(state),
+                disc(state),
+                RecvArmTag::RoundEnd,
+                Round::from(1u64),
+                Round::from(2u64),
+            );
+            assert_eq!(
+                result,
+                Some(RoundAdvanceReason::Timeout),
+                "RoundEnd arm must always produce Timeout, but failed for state {:?}",
+                state
+            );
+        }
+    }
+}

--- a/anchor/qbft_manager/src/instrumentation.rs
+++ b/anchor/qbft_manager/src/instrumentation.rs
@@ -4,9 +4,7 @@
     reason = "Expected to be implemented by proposer QBFT instrumentation"
 )]
 
-use std::mem::{Discriminant, discriminant};
-
-use qbft::InstanceState;
+use qbft::InstanceStateKind;
 use ssv_types::Round;
 
 pub mod checkpoints {
@@ -21,7 +19,7 @@ pub mod checkpoints {
 
 /// Reason why a QBFT round advanced, determined by the boundary layer
 /// through before/after state observation.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum RoundAdvanceReason {
     /// The local round timer expired without reaching consensus.
     Timeout,
@@ -31,6 +29,9 @@ pub enum RoundAdvanceReason {
     /// A full quorum of round-change messages was observed, achieving
     /// round-change consensus.
     RoundChangeQuorum,
+    /// A justified proposal for a higher round arrived, pulling the instance
+    /// forward to catch up with the leader's round (no round change occurred).
+    FutureRoundProposal,
 }
 
 impl RoundAdvanceReason {
@@ -39,6 +40,7 @@ impl RoundAdvanceReason {
             Self::Timeout => "timeout",
             Self::FPlusOneRoundChange => "f_plus_1_rc",
             Self::RoundChangeQuorum => "rc_quorum",
+            Self::FutureRoundProposal => "future_proposal",
         }
     }
 }
@@ -54,14 +56,20 @@ pub enum RecvArmTag {
 
 /// Classify a round advance observed at the boundary layer.
 ///
-/// This function uses `std::mem::Discriminant<InstanceState>` to avoid comparing the
-/// `proposal_root` payload of certain states or modifying internal API components. Only the state
-/// variant is relevant here.
+/// Consumes the payload-free [`InstanceStateKind`] of the after-state so the classifier depends
+/// only on the state variant without concern for state attributes.
+///
+/// `Message` match arm after-state kind captures how the round advanced:
+/// - `SentRoundChange`: f+1 peers at a higher round pulled us forward.
+/// - `Prepare`: a justified future-round proposal arrived (we caught up to the leader, no round
+///   change occurred).
+/// - anything else (e.g. `AwaitingProposal`, `RoundChangeConsensus`): a full round-change quorum
+///   was reached.
 ///
 /// Returns `None` if the round did not actually advance and `Some(reason)` when it did.
 pub fn classify_round_advance(
-    _before_state: Discriminant<InstanceState>,
-    after_state: Discriminant<InstanceState>,
+    _before_state: InstanceStateKind,
+    after_state: InstanceStateKind,
     recv_arm: RecvArmTag,
     before_round: Round,
     after_round: Round,
@@ -72,13 +80,11 @@ pub fn classify_round_advance(
 
     let reason = match recv_arm {
         RecvArmTag::RoundEnd => RoundAdvanceReason::Timeout,
-        RecvArmTag::Message => {
-            if after_state == discriminant(&InstanceState::SentRoundChange) {
-                RoundAdvanceReason::FPlusOneRoundChange
-            } else {
-                RoundAdvanceReason::RoundChangeQuorum
-            }
-        }
+        RecvArmTag::Message => match after_state {
+            InstanceStateKind::SentRoundChange => RoundAdvanceReason::FPlusOneRoundChange,
+            InstanceStateKind::Prepare => RoundAdvanceReason::FutureRoundProposal,
+            _ => RoundAdvanceReason::RoundChangeQuorum,
+        },
     };
 
     Some(reason)
@@ -88,15 +94,11 @@ pub fn classify_round_advance(
 mod tests {
     use super::*;
 
-    fn disc(state: InstanceState) -> Discriminant<InstanceState> {
-        discriminant(&state)
-    }
-
     #[test]
     fn no_advance_when_round_unchanged() {
         let result = classify_round_advance(
-            disc(InstanceState::AwaitingProposal),
-            disc(InstanceState::AwaitingProposal),
+            InstanceStateKind::AwaitingProposal,
+            InstanceStateKind::AwaitingProposal,
             RecvArmTag::Message,
             Round::from(1u64),
             Round::from(1u64),
@@ -110,8 +112,8 @@ mod tests {
     #[test]
     fn no_advance_when_round_decreased() {
         let result = classify_round_advance(
-            disc(InstanceState::AwaitingProposal),
-            disc(InstanceState::AwaitingProposal),
+            InstanceStateKind::AwaitingProposal,
+            InstanceStateKind::AwaitingProposal,
             RecvArmTag::Message,
             Round::from(3u64),
             Round::from(2u64),
@@ -125,8 +127,8 @@ mod tests {
     #[test]
     fn timeout_on_round_end() {
         let result = classify_round_advance(
-            disc(InstanceState::AwaitingProposal),
-            disc(InstanceState::AwaitingProposal),
+            InstanceStateKind::AwaitingProposal,
+            InstanceStateKind::AwaitingProposal,
             RecvArmTag::RoundEnd,
             Round::from(1u64),
             Round::from(2u64),
@@ -141,8 +143,8 @@ mod tests {
     #[test]
     fn f_plus_one_rc_when_after_state_is_sent_round_change() {
         let result = classify_round_advance(
-            disc(InstanceState::AwaitingProposal),
-            disc(InstanceState::SentRoundChange),
+            InstanceStateKind::AwaitingProposal,
+            InstanceStateKind::SentRoundChange,
             RecvArmTag::Message,
             Round::from(1u64),
             Round::from(3u64),
@@ -157,8 +159,8 @@ mod tests {
     #[test]
     fn rc_quorum_when_after_state_is_awaiting_proposal() {
         let result = classify_round_advance(
-            disc(InstanceState::SentRoundChange),
-            disc(InstanceState::AwaitingProposal),
+            InstanceStateKind::SentRoundChange,
+            InstanceStateKind::AwaitingProposal,
             RecvArmTag::Message,
             Round::from(2u64),
             Round::from(3u64),
@@ -166,15 +168,16 @@ mod tests {
         assert_eq!(
             result,
             Some(RoundAdvanceReason::RoundChangeQuorum),
-            "Message arm with after_state != SentRoundChange means full quorum was reached"
+            "Message arm landing in AwaitingProposal (neither SentRoundChange nor Prepare) means \
+             full quorum was reached"
         );
     }
 
     #[test]
     fn rc_quorum_when_after_state_is_round_change_consensus() {
         let result = classify_round_advance(
-            disc(InstanceState::SentRoundChange),
-            disc(InstanceState::RoundChangeConsensus),
+            InstanceStateKind::SentRoundChange,
+            InstanceStateKind::RoundChangeConsensus,
             RecvArmTag::Message,
             Round::from(2u64),
             Round::from(3u64),
@@ -187,16 +190,37 @@ mod tests {
     }
 
     #[test]
+    fn future_proposal_when_after_state_is_prepare() {
+        let result = classify_round_advance(
+            InstanceStateKind::AwaitingProposal,
+            InstanceStateKind::Prepare,
+            RecvArmTag::Message,
+            Round::from(1u64),
+            Round::from(3u64),
+        );
+        assert_eq!(
+            result,
+            Some(RoundAdvanceReason::FutureRoundProposal),
+            "Message arm landing in Prepare means a justified future-round proposal pulled the \
+             instance forward to catch up with the leader (no round change occurred), not a \
+             round-change quorum"
+        );
+    }
+
+    #[test]
     fn timeout_regardless_of_state() {
-        for state in [
-            InstanceState::AwaitingProposal,
-            InstanceState::SentRoundChange,
-            InstanceState::Complete,
-            InstanceState::RoundChangeConsensus,
-        ] {
+        let after_states = [
+            InstanceStateKind::AwaitingProposal,
+            InstanceStateKind::Prepare,
+            InstanceStateKind::SentRoundChange,
+            InstanceStateKind::Complete,
+            InstanceStateKind::RoundChangeConsensus,
+        ];
+
+        for after_state in after_states {
             let result = classify_round_advance(
-                disc(state),
-                disc(state),
+                InstanceStateKind::AwaitingProposal,
+                after_state,
                 RecvArmTag::RoundEnd,
                 Round::from(1u64),
                 Round::from(2u64),
@@ -204,8 +228,7 @@ mod tests {
             assert_eq!(
                 result,
                 Some(RoundAdvanceReason::Timeout),
-                "RoundEnd arm must always produce Timeout, but failed for state {:?}",
-                state
+                "RoundEnd arm must always produce Timeout, but failed for after_state {after_state:?}"
             );
         }
     }

--- a/anchor/qbft_manager/src/instrumentation.rs
+++ b/anchor/qbft_manager/src/instrumentation.rs
@@ -56,7 +56,7 @@ pub enum RecvArmTag {
 
 /// Classify a round advance observed at the boundary layer.
 ///
-/// Consumes the payload-free [`InstanceStateKind`] of the after-state so the classifier depends
+/// Consumes the payload-free `InstanceStateKind` of the after-state so the classifier depends
 /// only on the state variant without concern for state attributes.
 ///
 /// `Message` match arm after-state kind captures how the round advanced:

--- a/anchor/qbft_manager/src/instrumentation.rs
+++ b/anchor/qbft_manager/src/instrumentation.rs
@@ -29,6 +29,9 @@ pub enum RoundAdvanceReason {
     /// A justified proposal for a higher round arrived, pulling the instance
     /// forward to catch up with the leader's round (no round change occurred).
     FutureRoundProposal,
+    /// A full quorum of round-change messages was observed, achieving
+    /// round-change consensus.
+    RoundChangeQuorum,
 }
 
 impl RoundAdvanceReason {
@@ -37,6 +40,7 @@ impl RoundAdvanceReason {
             Self::Timeout => "timeout",
             Self::FPlusOneRoundChange => "f_plus_1_rc",
             Self::FutureRoundProposal => "future_proposal",
+            Self::RoundChangeQuorum => "rc_quorum",
         }
     }
 }
@@ -60,11 +64,7 @@ pub enum RecvArmTag {
 /// round advance:
 /// - `SentRoundChange`: f+1 peers at a higher round pulled us forward.
 /// - `Prepare`: a justified future-round proposal arrived.
-///
-/// `AwaitingProposal` and `RoundChangeConsensus` can appear on the `Message` arm when a
-/// round-change quorum completes, but the round has *already* advanced on the prior f+1
-/// message (`f+1 < 2f+1` for all canonical committees), so `after_round == before_round`.
-/// This variant is functionally unreachable.
+/// - `AwaitingProposal` or `RoundChangeConsensus`: a full round-change quorum was observed.
 pub fn classify_round_advance(
     _before_state: InstanceStateKind,
     after_state: InstanceStateKind,
@@ -81,10 +81,14 @@ pub fn classify_round_advance(
         RecvArmTag::Message => match after_state {
             InstanceStateKind::SentRoundChange => RoundAdvanceReason::FPlusOneRoundChange,
             InstanceStateKind::Prepare => RoundAdvanceReason::FutureRoundProposal,
-            InstanceStateKind::AwaitingProposal
-            | InstanceStateKind::RoundChangeConsensus
-            | InstanceStateKind::Commit
-            | InstanceStateKind::Complete => return None,
+            // A Message-arm round advance into AwaitingProposal is the round-change quorum path:
+            // received_round_change sets RoundChangeConsensus, then set_round() calls
+            // start_round(), which leaves both leader and non-leader instances in
+            // AwaitingProposal.
+            InstanceStateKind::AwaitingProposal | InstanceStateKind::RoundChangeConsensus => {
+                RoundAdvanceReason::RoundChangeQuorum
+            }
+            InstanceStateKind::Commit | InstanceStateKind::Complete => return None,
         },
     };
 
@@ -228,7 +232,7 @@ mod tests {
     }
 
     #[test]
-    fn none_when_awaiting_proposal_on_message_arm() {
+    fn round_change_quorum_when_awaiting_proposal_on_message_arm() {
         let result = classify_round_advance(
             InstanceStateKind::SentRoundChange,
             InstanceStateKind::AwaitingProposal,
@@ -237,13 +241,14 @@ mod tests {
             Round::from(3u64),
         );
         assert_eq!(
-            result, None,
-            "AwaitingProposal on Message arm must return None."
+            result,
+            Some(RoundAdvanceReason::RoundChangeQuorum),
+            "AwaitingProposal on Message arm must return RoundChangeQuorum."
         );
     }
 
     #[test]
-    fn none_when_round_change_consensus_on_message_arm() {
+    fn round_change_quorum_when_round_change_consensus_on_message_arm() {
         let result = classify_round_advance(
             InstanceStateKind::SentRoundChange,
             InstanceStateKind::RoundChangeConsensus,
@@ -252,8 +257,9 @@ mod tests {
             Round::from(3u64),
         );
         assert_eq!(
-            result, None,
-            "RoundChangeConsensus on Message arm must return None."
+            result,
+            Some(RoundAdvanceReason::RoundChangeQuorum),
+            "RoundChangeConsensus on Message arm must return RoundChangeQuorum."
         );
     }
 
@@ -428,6 +434,67 @@ mod tests {
             ),
             None,
             "quorum message should classify as None since the round did not advance"
+        );
+    }
+
+    /// A round-change quorum completing at a round above the f+1-set round advances
+    /// `current_round` via the quorum branch and classifies as `RoundChangeQuorum`.
+    #[test]
+    fn round_change_quorum_above_f_plus_one_round_advances_and_classifies_as_quorum() {
+        // Position instance so that the f+1-set round results in current_round at round 2 (the
+        // lowest future round). Round 3 does not yet hold quorum.
+        let mut inst = fresh_instance();
+
+        for (round, signer) in [(2u64, 2u64), (3, 2), (3, 3)] {
+            let msg = build_wrapped_msg(
+                QbftMessageType::RoundChange,
+                round,
+                Hash256::zero(),
+                0,
+                signer,
+                vec![],
+                vec![],
+            );
+            inst.receive(msg).expect("rc msg should be accepted");
+        }
+
+        let before_kind = inst.state_kind();
+        let before_round = inst.get_round();
+
+        // Sends quorum-completing message so round 3 holds.
+        let msg = build_wrapped_msg(
+            QbftMessageType::RoundChange,
+            3,
+            Hash256::zero(),
+            0,
+            4,
+            vec![],
+            vec![],
+        );
+        inst.receive(msg).expect("quorum rc msg should be accepted");
+
+        let after_kind = inst.state_kind();
+        let after_round = inst.get_round();
+
+        assert!(
+            after_round > before_round,
+            "quorum at a round above the f+1-set round advances current_round via set_round"
+        );
+        assert_eq!(
+            after_kind,
+            InstanceStateKind::AwaitingProposal,
+            "the quorum path lands in AwaitingProposal after set_round -> start_round"
+        );
+        assert_eq!(
+            classify_round_advance(
+                before_kind,
+                after_kind,
+                RecvArmTag::Message,
+                before_round,
+                after_round
+            ),
+            Some(RoundAdvanceReason::RoundChangeQuorum),
+            "a Message-arm round advance into AwaitingProposal is the round-change quorum path"
         );
     }
 

--- a/anchor/qbft_manager/src/lib.rs
+++ b/anchor/qbft_manager/src/lib.rs
@@ -36,6 +36,8 @@ use types::{Epoch, EthSpec, Hash256, Slot};
 use crate::instance::qbft_instance;
 
 mod instance;
+mod instrumentation;
+mod metrics;
 #[cfg(test)]
 mod tests;
 mod timeout;

--- a/anchor/qbft_manager/src/metrics.rs
+++ b/anchor/qbft_manager/src/metrics.rs
@@ -9,24 +9,29 @@ use std::sync::LazyLock;
 pub use metrics::*;
 
 pub static PROPOSER_QBFT_DECIDED_ROUND: LazyLock<Result<Histogram>> = LazyLock::new(|| {
-    try_create_histogram(
+    // 12 buckets created as headroom to avoid unintentional overflow.
+    try_create_histogram_with_buckets(
         "anchor_proposer_qbft_decided_round",
         "Round on which proposer QBFT decided or timed out",
+        linear_buckets(1.0, 1.0, 12),
     )
 });
 
 pub static PROPOSER_QBFT_DURATION_SECONDS: LazyLock<Result<Histogram>> = LazyLock::new(|| {
-    try_create_histogram(
+    try_create_histogram_with_buckets(
         "anchor_proposer_qbft_duration_seconds",
         "Total duration of a proposer QBFT instance",
+        Ok(vec![0.5, 1.0, 2.0, 4.0, 6.0, 8.0, 10.0, 15.0, 20.0, 30.0]),
     )
 });
 
 pub static PROPOSER_QBFT_HANDOFF_BUDGET_SECONDS: LazyLock<Result<Histogram>> =
     LazyLock::new(|| {
-        try_create_histogram(
+        // Budget is bounded by the slot duration (12s on mainnet).
+        try_create_histogram_with_buckets(
             "anchor_proposer_qbft_handoff_budget_seconds",
             "Slot budget remaining when QBFT instance starts (slot_duration - slot_elapsed)",
+            Ok(vec![0.5, 1.0, 2.0, 3.0, 4.0, 6.0, 8.0, 10.0, 12.0]),
         )
     });
 

--- a/anchor/qbft_manager/src/metrics.rs
+++ b/anchor/qbft_manager/src/metrics.rs
@@ -1,0 +1,47 @@
+//! Metrics for proposer QBFT.
+#![expect(
+    dead_code,
+    reason = "Expected to be implemented by proposer QBFT instrumentation"
+)]
+
+use std::sync::LazyLock;
+
+pub use metrics::*;
+
+pub static PROPOSER_QBFT_DECIDED_ROUND: LazyLock<Result<Histogram>> = LazyLock::new(|| {
+    try_create_histogram(
+        "anchor_proposer_qbft_decided_round",
+        "Round on which proposer QBFT decided or timed out",
+    )
+});
+
+pub static PROPOSER_QBFT_DURATION_SECONDS: LazyLock<Result<Histogram>> = LazyLock::new(|| {
+    try_create_histogram(
+        "anchor_proposer_qbft_duration_seconds",
+        "Total duration of a proposer QBFT instance",
+    )
+});
+
+pub static PROPOSER_QBFT_HANDOFF_BUDGET_SECONDS: LazyLock<Result<Histogram>> =
+    LazyLock::new(|| {
+        try_create_histogram(
+            "anchor_proposer_qbft_handoff_budget_seconds",
+            "Slot budget remaining when QBFT instance starts (slot_duration - slot_elapsed)",
+        )
+    });
+
+pub static PROPOSER_QBFT_OUTCOME_TOTAL: LazyLock<Result<IntCounterVec>> = LazyLock::new(|| {
+    try_create_int_counter_vec(
+        "anchor_proposer_qbft_outcome_total",
+        "Count of proposer QBFT instance outcomes",
+        &["outcome"],
+    )
+});
+
+pub static PROPOSER_ROUND_ADVANCE_TOTAL: LazyLock<Result<IntCounterVec>> = LazyLock::new(|| {
+    try_create_int_counter_vec(
+        "anchor_proposer_round_advance_total",
+        "Count of proposer QBFT round advances by reason",
+        &["reason"],
+    )
+});


### PR DESCRIPTION
## Problem, Evidence, and Context (Required)

- Anchor's proposer QBFT path lacks structured observability: when consensus stalls or rounds advance, operators and maintainers have no visibility of the cause. Debugging round-change cascades, understanding bottlenecks, and explaining timeouts are currently difficult.
- This is **PR 1 of 2** for the QBFT instrumentation work tracked in #1066. It introduces new components and API modifications without altering the control flow of `qbft_instance`. This includes taxonomy, metrics, and a specific bare-state getter on `Qbft`. A follow up change tracking #1067 will address concrete implementation.
- Splitting the work into 2 PRs introduces a pure-additive review (no behavior change to audit) that is isolated from higher-risk recv-loop changes.
- It is worth doing now because we have already added instrumentation to pre-QBFT flow in #924 and #920.

## Change Overview (Required)

- New `qbft_manager::instrumentation` module: checkpoint string constants, `RoundAdvanceReason` and `RecvArmTag` enums, and a pure `classify_round_advance` function. Classification uses new `InstanceStateKind` enum as a distinguisher between the four round-advance causes:
  - timeout (recv arm)
  - f+1 round-change
  - a justified future-round proposal
  - a round-change quorum
- New `qbft_manager::metrics` module: five Prometheus statics (decided round, total duration, handoff budget, outcome counter, round-advance counter) following the existing `eth/src/metrics.rs` `LazyLock<Result<...>>` pattern. This makes these metrics available to operators in addition to considering OTLP inclusions for us.
- Public read-only `Instance::state_kind()` getter on the QBFT instance. This is the only leakage of this change into `common/qbft`. Required so the boundary layer in the follow up change (#1067) can observe before/after state without changing internal consensus logic. We still keep the QBFT internal API untouched behaviourally with only a new type and this read-only method that allows `proposal_root` payloads to not be included in bare state machine comparison.
- **Intentionally not changed**: `qbft::Instance` recv loop, message handlers, state transitions, or any behavior. No call sites are added to the new symbols in this PR.

## Risks, Trade-offs, and Mitigations (Required)

- **Risk**: Main risks only arise from delayed implementation of #1067. If we follow this right away then that is largely mitigated and the surface introduced here will be used.
- **Trade-off**: `state_kind()` getter widens `Qbft`'s public surface by one read-only accessor and a new type. Chosen over passing `Discriminant<InstanceState>` through internal hooks because it's simpler and keeps the boundary layer purely observational.

## Validation (Required)

- 12 simple tests in `instrumentation::tests` cover new `classify_round_advance` function across all 4 reason branches, both recv arms, and the no-advance / decreased-round defensive cases.
  - Additionally, unit tests implemented that drive a `Qbft` instance through each round-advance path, and feed observed state into classifier function.
- `make cargo-fmt-check`
- `make lint`
- `cargo test -p qbft -p qbft_manager --release`

## Rollback (Required for behavior or runtime changes; optional otherwise)

- Pure-additive change with no runtime impact. Revert is simple with no overhead.

## Additional Info / Next Steps (Optional)

- File-scope `#![expect(dead_code, reason = ...)]` on both new modules to keep lint clean while symbols are unused.