### PR TITLE
ci: scope claude review/mention bots to read-only git tools

### DIFF
--- a/.github/workflows/claude-mentions.yml
+++ b/.github/workflows/claude-mentions.yml
@@ -91,4 +91,6 @@ jobs:
                   claude_args: |
                       --max-turns 50
                       --model us.anthropic.claude-opus-4-7
+                      --allowedTools "Glob,Grep,LS,Read,mcp__github_comment__update_claude_comment,mcp__github_inline_comment__create_inline_comment,mcp__github_ci__get_ci_status,mcp__github_ci__get_workflow_run_details,mcp__github_ci__download_job_log,Bash(git status:*),Bash(git diff:*),Bash(git show:*),Bash(git log:*),Bash(git rev-parse:*),Bash(git merge-base:*),Bash(git grep:*)"
+                      --disallowedTools "Edit,MultiEdit,Write,NotebookEdit,Bash(git add:*),Bash(git commit:*),Bash(git rm:*)"
                       --append-system-prompt "${{ steps.review-prompt.outputs.content }}"

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -127,7 +127,7 @@ jobs:
                   claude_args: |
                       --max-turns 50
                       --model us.anthropic.claude-opus-4-7
-                      --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Read,Grep"
+                      --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Read,Grep,Bash(git status:*),Bash(git diff:*),Bash(git show:*),Bash(git log:*),Bash(git rev-parse:*),Bash(git merge-base:*),Bash(git grep:*)"
 
             - name: Remove claude-recheck label if present
               if: steps.check.outputs.is_member == 'true' && github.event.action == 'labeled' && github.event.label.name == 'claude-recheck'


### PR DESCRIPTION
## Problem, Evidence, and Context (Required)

- The `claude-mentions` workflow did not declare its own tool allowlist, and the action-generated allowlist did not include read-only git inspection commands. The PR-review bot also lacked those read-only git tools. The shared `review.md` prompt expects the bot to orient against the diff, so missing git access can cause denied tool calls and turn churn; a recent follow-up review job exhausted its budget and exited with `Reached maximum number of turns (50)`.
- Failed run: https://github.com/sigp/anchor/actions/runs/26618588227 (triggered from #1068).
- Worth doing now: the failure surfaced on an active review (#1068) and the same class can recur on non-trivial reviews.

## Change Overview (Required)

- `claude-pr-review`: extend the existing allowlist with read-only git (`status/diff/show/log/rev-parse/merge-base/grep`).
- `claude-mentions`: introduce an allowlist (`Glob/Grep/LS/Read`, the comment + inline-comment + CI MCP tools, read-only git) and an explicit `--disallowedTools` deny for file edits and commit-producing git operations (`Edit/MultiEdit/Write/NotebookEdit`, `git add/commit/rm`).
- The inline-comment tool is included so the bot can follow `review.md`'s "use inline comments" instruction instead of stalling on a denied tool.
- Intentionally unchanged: `--max-turns 50`, the model, and the prompt-loading step.

## Risks, Trade-offs, and Mitigations (Required)

- Blast radius is limited to the two Claude bot workflows; no product code.
- Trade-off: introducing an allowlist on `claude-mentions` also restricts it to the listed tools. Mitigated by including the inline + sticky comment tools so it retains a working output path.
- `claude-mentions` remains review-oriented: it can inspect code and comment, but cannot edit files or create commits. The action's version-pinned push wrapper is not explicitly denied to avoid a brittle path-specific entry; with edits and commits denied, there should be nothing new to push.

## Validation (Required)

- `pull_request_target`/mention workflows load from the default branch, so this can only be exercised once merged to `stable`. First real test is an `@claude` mention post-merge.

## Rollback (Required for behavior or runtime changes; optional otherwise)

- Revert the commit; no config, data, or runtime state involved.
