### PR TITLE
feat(ssv_types): Gloas decode branch on ProposerConsensusData

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7405,6 +7405,7 @@ dependencies = [
  "slashing_protection",
  "ssz_types",
  "strum",
+ "tempfile",
  "thiserror 2.0.18",
  "tracing",
  "tree_hash",

--- a/anchor/common/ssv_types/Cargo.toml
+++ b/anchor/common/ssv_types/Cargo.toml
@@ -35,3 +35,4 @@ types = { workspace = true }
 
 [dev-dependencies]
 strum = { workspace = true }
+tempfile = { workspace = true }

--- a/anchor/common/ssv_types/src/consensus.rs
+++ b/anchor/common/ssv_types/src/consensus.rs
@@ -24,8 +24,8 @@ use typenum::{
 };
 use types::{
     AggregateAndProofBase, AggregateAndProofElectra, AttestationBase, AttestationData,
-    AttestationElectra, BlindedBeaconBlock, ChainSpec, Checkpoint, CommitteeIndex, Domain, EthSpec,
-    ForkName, Hash256, Slot, SyncCommitteeContribution,
+    AttestationElectra, BeaconBlock, BlindedBeaconBlock, ChainSpec, Checkpoint, CommitteeIndex,
+    Domain, EthSpec, ForkName, Hash256, Slot, SyncCommitteeContribution,
 };
 
 use crate::{CommitteeId, ValidatorIndex, message::*, partial_sig::PartialSignatureKind};
@@ -259,6 +259,11 @@ impl ProposerConsensusData {
         let fork = ForkName::from(self.version);
         FullBlockContents::from_ssz_bytes_for_fork(&self.data_ssz, fork)
     }
+
+    /// Decode the block data as a Gloas beacon block (block-only, no envelope/blobs/KZG).
+    pub fn decode_gloas_block<E: EthSpec>(&self) -> Result<BeaconBlock<E>, DecodeError> {
+        BeaconBlock::from_ssz_bytes_for_fork(&self.data_ssz, ForkName::Gloas)
+    }
 }
 
 impl QbftData for ProposerConsensusData {
@@ -379,17 +384,30 @@ impl<E: EthSpec> ProposerConsensusDataValidator<E> {
         &self,
         value: &ProposerConsensusData,
     ) -> Result<(), DataValidationError> {
-        // Always do this check, even if we're not validating slashing. This is to ensure that we
-        // have a decodable value.
-        let header = value
-            .decode_blinded_block::<E>()
-            .map(|block| block.block_header())
-            .or_else(|_| {
-                value
-                    .decode_block_contents::<E>()
-                    .map(|block| block.block().block_header())
-            })
-            .map_err(DataValidationError::DecodeError)?;
+        // Decode the block header to ensure the value is decodable (even when slashing
+        // protection is disabled). Under Gloas (EIP-7732), DataSSZ is decoded directly as a plain
+        // BeaconBlock. This behaviour is not behaviourally load-bearing as the execution
+        // payload is decoupled from the block body. The outcome of `decode_blinded_block`
+        // and `decode_gloas_block` are identical for this variant. The Pre-Gloas branch
+        // preserves the existing try-blinded-then-full fallback.
+        let fork = ForkName::from(value.version);
+
+        let header = if fork >= ForkName::Gloas {
+            value
+                .decode_gloas_block::<E>()
+                .map(|block| block.block_header())
+                .map_err(DataValidationError::DecodeError)?
+        } else {
+            value
+                .decode_blinded_block::<E>()
+                .map(|block| block.block_header())
+                .or_else(|_| {
+                    value
+                        .decode_block_contents::<E>()
+                        .map(|block| block.block().block_header())
+                })
+                .map_err(DataValidationError::DecodeError)?
+        };
 
         if !self.disable_slashing_protection {
             let epoch = header.slot.epoch(E::slots_per_epoch());
@@ -1270,8 +1288,12 @@ mod tests {
     use std::collections::HashMap;
 
     use bls::{AggregateSignature, FixedBytesExtended};
+    use eth2::types::FullBlockContents;
     use ssz_types::{BitList, BitVector};
-    use types::{Checkpoint, Epoch, MainnetEthSpec, SyncCommitteeContribution};
+    use types::{
+        BeaconBlockDeneb, BeaconBlockGloas, Checkpoint, EmptyBlock, Epoch, MainnetEthSpec,
+        SyncCommitteeContribution,
+    };
 
     use super::*;
 
@@ -2248,5 +2270,190 @@ mod tests {
         let local_view = create_payload_attestation_vote(root, false, false);
 
         assert!(validator.validate(&proposed, &local_view));
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════════════
+    // ProposerConsensusData Gloas (EIP-7732) Tests
+    // ═══════════════════════════════════════════════════════════════════════════════
+
+    /// Creates a minimal proposer `ValidatorDuty` at slot 0 for Gloas block tests.
+    fn test_proposer_duty() -> ValidatorDuty {
+        ValidatorDuty {
+            r#type: BEACON_ROLE_PROPOSER,
+            pub_key: PublicKeyBytes::empty(),
+            slot: Slot::new(0),
+            validator_index: ValidatorIndex(0),
+            committee_index: 0,
+            committee_length: 0,
+            committees_at_slot: 0,
+            validator_committee_index: 0,
+            validator_sync_committee_indices: Default::default(),
+        }
+    }
+
+    #[test]
+    /// Tests that BeaconBlock::from_ssz_bytes_for_fork round-trips successfully through the
+    /// SSZ bytes for a Gloas block variant.
+    fn decode_gloas_block_round_trip() {
+        let spec = ChainSpec::mainnet();
+        let block = BeaconBlock::Gloas(BeaconBlockGloas::<MainnetEthSpec>::empty(&spec));
+
+        let consensus_data = ProposerConsensusData {
+            duty: test_proposer_duty(),
+            version: DataVersion::from(ForkName::Gloas),
+            data_ssz: VariableList::new(block.as_ssz_bytes())
+                .expect("Gloas block bytes should fit in DataSSZ"),
+        };
+
+        let decoded = consensus_data
+            .decode_gloas_block::<MainnetEthSpec>()
+            .expect("Gloas block should decode from DataSSZ");
+
+        assert_eq!(
+            decoded, block,
+            "decoded Gloas block should equal the original block"
+        );
+    }
+
+    #[test]
+    /// Tests Gloas (EIP-7732) implication that both decoders converge on the same header for Gloas input.
+    fn decode_gloas_block_header_matches_blinded_decode() {
+        let spec = ChainSpec::mainnet();
+        let block = BeaconBlock::Gloas(BeaconBlockGloas::<MainnetEthSpec>::empty(&spec));
+
+        let consensus_data = ProposerConsensusData {
+            duty: test_proposer_duty(),
+            version: DataVersion::from(ForkName::Gloas),
+            data_ssz: VariableList::new(block.as_ssz_bytes())
+                .expect("Gloas block bytes should fit in DataSSZ"),
+        };
+
+        let gloas_header = consensus_data
+            .decode_gloas_block::<MainnetEthSpec>()
+            .expect("Gloas block should decode via decode_gloas_block")
+            .block_header();
+        let blinded_header = consensus_data
+            .decode_blinded_block::<MainnetEthSpec>()
+            .expect("Gloas block bytes also decode as a blinded block (identical SSZ)")
+            .block_header();
+
+        assert_eq!(
+            gloas_header, blinded_header,
+            "decode_gloas_block header should match the blinded-decode header for Gloas bytes"
+        );
+    }
+
+    #[test]
+    /// Tests `DataVersion` and `ForkName` are deducible from Gloas encoded bytes.
+    fn data_version_gloas_ssz_round_trip() {
+        let version = DataVersion::from(ForkName::Gloas);
+
+        let encoded = version.as_ssz_bytes();
+        let decoded =
+            DataVersion::from_ssz_bytes(&encoded).expect("Gloas DataVersion should decode");
+
+        assert_eq!(
+            decoded, version,
+            "DataVersion should round-trip through SSZ for Gloas"
+        );
+        assert_eq!(
+            ForkName::from(decoded),
+            ForkName::Gloas,
+            "decoded DataVersion should map back to ForkName::Gloas"
+        );
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════════════
+    // validate_block_proposal Fork-Branch Tests
+    // ═══════════════════════════════════════════════════════════════════════════════
+
+    /// Builds a `ProposerConsensusDataValidator` with slashing protection disabled.
+    ///
+    /// The `SlashingDatabase` is constructed (no path-less constructor exists) but never
+    /// exercised because `disable_slashing_protection` is `true`. The caller must keep the
+    /// returned `TempDir` alive for the lifetime of the validator.
+    fn test_block_proposal_validator() -> (
+        tempfile::TempDir,
+        ProposerConsensusDataValidator<MainnetEthSpec>,
+    ) {
+        let dir = tempfile::TempDir::new().expect("tempdir should succeed");
+        let slashing_db = Arc::new(
+            SlashingDatabase::open_or_create(&dir.path().join("slashing.sqlite"))
+                .expect("slashing DB should open"),
+        );
+        let validator = ProposerConsensusDataValidator::<MainnetEthSpec>::new(
+            slashing_db,
+            true,
+            Arc::new(ChainSpec::mainnet()),
+            PublicKeyBytes::empty(),
+            Hash256::zero(),
+        );
+        (dir, validator)
+    }
+
+    #[test]
+    /// Tests that
+    fn validate_block_proposal_gloas_decodes_directly() {
+        let spec = ChainSpec::mainnet();
+        let block = BeaconBlock::Gloas(BeaconBlockGloas::<MainnetEthSpec>::empty(&spec));
+        let consensus_data = ProposerConsensusData {
+            duty: test_proposer_duty(),
+            version: DataVersion::from(ForkName::Gloas),
+            data_ssz: VariableList::new(block.as_ssz_bytes())
+                .expect("Gloas block bytes should fit in DataSSZ"),
+        };
+
+        let (_dir, validator) = test_block_proposal_validator();
+        let result = validator.validate_block_proposal(&consensus_data);
+
+        assert!(
+            result.is_ok(),
+            "Gloas block proposal should validate via the Gloas decode branch, got {:?}",
+            result.err()
+        );
+    }
+
+    #[test]
+    /// Tests that decoding failures when processing garbage SSZ block bytes are correctly propagated by the Gloas branch.
+    fn validate_block_proposal_gloas_rejects_invalid_bytes() {
+        let consensus_data = ProposerConsensusData {
+            duty: test_proposer_duty(),
+            version: DataVersion::from(ForkName::Gloas),
+            data_ssz: VariableList::new(vec![0xff; 32]).expect("32 bytes should fit in DataSSZ"),
+        };
+
+        let (_dir, validator) = test_block_proposal_validator();
+
+        assert!(
+            validator.validate_block_proposal(&consensus_data).is_err(),
+            "Gloas branch should reject undecodable block bytes"
+        );
+    }
+
+    #[test]
+    /// Tests that existing blinded-then-full pre-gloas behavior is intact with a `FullBlockContents`
+    /// shape via `decode_block_contents`.
+    fn validate_block_proposal_pre_gloas_unchanged() {
+        let spec = ChainSpec::mainnet();
+        let block = BeaconBlock::Deneb(BeaconBlockDeneb::<MainnetEthSpec>::empty(&spec));
+        let block_contents = FullBlockContents::<MainnetEthSpec>::new(
+            block,
+            Some((VariableList::empty(), VariableList::empty())),
+        );
+        let consensus_data = ProposerConsensusData {
+            duty: test_proposer_duty(),
+            version: DataVersion::from(ForkName::Deneb),
+            data_ssz: VariableList::new(block_contents.as_ssz_bytes())
+                .expect("Deneb block contents bytes should fit in DataSSZ"),
+        };
+
+        let (_dir, validator) = test_block_proposal_validator();
+        let result = validator.validate_block_proposal(&consensus_data);
+
+        assert!(
+            result.is_ok(),
+            "pre-Gloas (Deneb) block proposal should validate via the existing fallback, got {:?}",
+            result.err()
+        );
     }
 }

--- a/anchor/common/ssv_types/src/consensus.rs
+++ b/anchor/common/ssv_types/src/consensus.rs
@@ -251,6 +251,9 @@ impl ProposerConsensusData {
     /// Decode the block data as a blinded beacon block.
     pub fn decode_blinded_block<E: EthSpec>(&self) -> Result<BlindedBeaconBlock<E>, DecodeError> {
         let fork = ForkName::from(self.version);
+        if fork >= ForkName::Gloas {
+            return Err(DecodeError::NoMatchingVariant);
+        }
         BlindedBeaconBlock::from_ssz_bytes_for_fork(&self.data_ssz, fork)
     }
 
@@ -2494,9 +2497,8 @@ mod tests {
     }
 
     #[test]
-    /// Tests Gloas (EIP-7732) implication that both decoders converge on the same header for Gloas
-    /// input. Passes because blinded == full for Gloas (EIP-7732 variant).
-    fn decode_block_header_matches_blinded_decode() {
+    /// Tests that `decode_blinded_block` rejects Gloas input with `DecodeError::NoMatchingVariant`.
+    fn decode_blinded_block_rejects_gloas() {
         let spec = ChainSpec::mainnet();
         let block = BeaconBlock::Gloas(BeaconBlockGloas::<MainnetEthSpec>::empty(&spec));
 
@@ -2507,18 +2509,11 @@ mod tests {
                 .expect("Gloas block bytes should fit in DataSSZ"),
         };
 
-        let gloas_header = consensus_data
-            .decode_block::<MainnetEthSpec>()
-            .expect("Gloas block should decode via decode_block")
-            .block_header();
-        let blinded_header = consensus_data
-            .decode_blinded_block::<MainnetEthSpec>()
-            .expect("Gloas block bytes also decode as a blinded block (identical SSZ)")
-            .block_header();
+        let result = consensus_data.decode_blinded_block::<MainnetEthSpec>();
 
-        assert_eq!(
-            gloas_header, blinded_header,
-            "decode_block header should match the blinded-decode header for Gloas bytes"
+        assert!(
+            matches!(result, Err(DecodeError::NoMatchingVariant)),
+            "decode_blinded_block must reject Gloas with DecodeError::NoMatchingVariant, got {result:?}"
         );
     }
 

--- a/anchor/common/ssv_types/src/consensus.rs
+++ b/anchor/common/ssv_types/src/consensus.rs
@@ -2316,7 +2316,8 @@ mod tests {
     }
 
     #[test]
-    /// Tests Gloas (EIP-7732) implication that both decoders converge on the same header for Gloas input.
+    /// Tests Gloas (EIP-7732) implication that both decoders converge on the same header for Gloas
+    /// input.
     fn decode_gloas_block_header_matches_blinded_decode() {
         let spec = ChainSpec::mainnet();
         let block = BeaconBlock::Gloas(BeaconBlockGloas::<MainnetEthSpec>::empty(&spec));
@@ -2414,7 +2415,8 @@ mod tests {
     }
 
     #[test]
-    /// Tests that decoding failures when processing garbage SSZ block bytes are correctly propagated by the Gloas branch.
+    /// Tests that decoding failures when processing garbage SSZ block bytes are correctly
+    /// propagated by the Gloas branch.
     fn validate_block_proposal_gloas_rejects_invalid_bytes() {
         let consensus_data = ProposerConsensusData {
             duty: test_proposer_duty(),
@@ -2431,8 +2433,8 @@ mod tests {
     }
 
     #[test]
-    /// Tests that existing blinded-then-full pre-gloas behavior is intact with a `FullBlockContents`
-    /// shape via `decode_block_contents`.
+    /// Tests that existing blinded-then-full pre-gloas behavior is intact with a
+    /// `FullBlockContents` shape via `decode_block_contents`.
     fn validate_block_proposal_pre_gloas_unchanged() {
         let spec = ChainSpec::mainnet();
         let block = BeaconBlock::Deneb(BeaconBlockDeneb::<MainnetEthSpec>::empty(&spec));

--- a/anchor/common/ssv_types/src/consensus.rs
+++ b/anchor/common/ssv_types/src/consensus.rs
@@ -260,8 +260,8 @@ impl ProposerConsensusData {
         FullBlockContents::from_ssz_bytes_for_fork(&self.data_ssz, fork)
     }
 
-    /// Decode the block data as a Gloas beacon block (block-only, no envelope/blobs/KZG).
-    pub fn decode_gloas_block<E: EthSpec>(&self) -> Result<BeaconBlock<E>, DecodeError> {
+    /// Decode as a full beacon block shape.
+    pub fn decode_block<E: EthSpec>(&self) -> Result<BeaconBlock<E>, DecodeError> {
         let fork = ForkName::from(self.version);
         BeaconBlock::from_ssz_bytes_for_fork(&self.data_ssz, fork)
     }

--- a/anchor/common/ssv_types/src/consensus.rs
+++ b/anchor/common/ssv_types/src/consensus.rs
@@ -389,13 +389,13 @@ impl<E: EthSpec> ProposerConsensusDataValidator<E> {
         // protection is disabled). Under Gloas (EIP-7732), DataSSZ is decoded directly as a plain
         // BeaconBlock. This behaviour is not behaviourally load-bearing as the execution
         // payload is decoupled from the block body. The outcome of `decode_blinded_block`
-        // and `decode_gloas_block` are identical for this variant. The Pre-Gloas branch
+        // and `decode_block` are identical for this variant. The Pre-Gloas branch
         // preserves the existing try-blinded-then-full fallback.
         let fork = ForkName::from(value.version);
 
         let header = if fork >= ForkName::Gloas {
             value
-                .decode_gloas_block::<E>()
+                .decode_block::<E>()
                 .map(|block| block.block_header())
                 .map_err(DataValidationError::DecodeError)?
         } else {
@@ -2295,7 +2295,7 @@ mod tests {
     #[test]
     /// Tests that BeaconBlock::from_ssz_bytes_for_fork round-trips successfully through the
     /// SSZ bytes for a Gloas block variant.
-    fn decode_gloas_block_round_trip() {
+    fn decode_block_round_trip() {
         let spec = ChainSpec::mainnet();
         let block = BeaconBlock::Gloas(BeaconBlockGloas::<MainnetEthSpec>::empty(&spec));
 
@@ -2307,7 +2307,7 @@ mod tests {
         };
 
         let decoded = consensus_data
-            .decode_gloas_block::<MainnetEthSpec>()
+            .decode_block::<MainnetEthSpec>()
             .expect("Gloas block should decode from DataSSZ");
 
         assert_eq!(
@@ -2319,7 +2319,7 @@ mod tests {
     #[test]
     /// Tests Gloas (EIP-7732) implication that both decoders converge on the same header for Gloas
     /// input. Passes because blinded == full for Gloas (EIP-7732 variant).
-    fn decode_gloas_block_header_matches_blinded_decode() {
+    fn decode_block_header_matches_blinded_decode() {
         let spec = ChainSpec::mainnet();
         let block = BeaconBlock::Gloas(BeaconBlockGloas::<MainnetEthSpec>::empty(&spec));
 
@@ -2331,8 +2331,8 @@ mod tests {
         };
 
         let gloas_header = consensus_data
-            .decode_gloas_block::<MainnetEthSpec>()
-            .expect("Gloas block should decode via decode_gloas_block")
+            .decode_block::<MainnetEthSpec>()
+            .expect("Gloas block should decode via decode_block")
             .block_header();
         let blinded_header = consensus_data
             .decode_blinded_block::<MainnetEthSpec>()
@@ -2341,7 +2341,7 @@ mod tests {
 
         assert_eq!(
             gloas_header, blinded_header,
-            "decode_gloas_block header should match the blinded-decode header for Gloas bytes"
+            "decode_block header should match the blinded-decode header for Gloas bytes"
         );
     }
 

--- a/anchor/common/ssv_types/src/consensus.rs
+++ b/anchor/common/ssv_types/src/consensus.rs
@@ -262,7 +262,8 @@ impl ProposerConsensusData {
 
     /// Decode the block data as a Gloas beacon block (block-only, no envelope/blobs/KZG).
     pub fn decode_gloas_block<E: EthSpec>(&self) -> Result<BeaconBlock<E>, DecodeError> {
-        BeaconBlock::from_ssz_bytes_for_fork(&self.data_ssz, ForkName::Gloas)
+        let fork = ForkName::from(self.version);
+        BeaconBlock::from_ssz_bytes_for_fork(&self.data_ssz, fork)
     }
 }
 
@@ -2317,7 +2318,7 @@ mod tests {
 
     #[test]
     /// Tests Gloas (EIP-7732) implication that both decoders converge on the same header for Gloas
-    /// input.
+    /// input. Passes because blinded == full for Gloas (EIP-7732 variant).
     fn decode_gloas_block_header_matches_blinded_decode() {
         let spec = ChainSpec::mainnet();
         let block = BeaconBlock::Gloas(BeaconBlockGloas::<MainnetEthSpec>::empty(&spec));
@@ -2393,7 +2394,7 @@ mod tests {
     }
 
     #[test]
-    /// Tests that
+    /// Tests `validate_block_proposal` Gloas block success case.
     fn validate_block_proposal_gloas_decodes_directly() {
         let spec = ChainSpec::mainnet();
         let block = BeaconBlock::Gloas(BeaconBlockGloas::<MainnetEthSpec>::empty(&spec));


### PR DESCRIPTION
## Problem, Evidence, and Context

- Under Gloas (EIP-7732), the execution payload is decoupled from the beacon block body. The SSV cluster signs only `BeaconBlock` under `Domain::BeaconProposer` — no envelope, blobs, or KZG proofs enter consensus (SIP-94).
- `ProposerConsensusData` needs a dedicated decode path that makes this contract explicit rather than relying on the incidental success of the blinded-block decoder.
- Resolves #1014.

## Change Overview

- Modifies `consensus.rs` in the `ssv_types` crate.
- Adds `ProposerConsensusData::decode_block<E>()` — decodes `DataSSZ` as a plain `BeaconBlock` via `from_ssz_bytes_for_fork(.., self.version)`.
- Fork-gates `decode_blinded_block<E>()` to reject Gloas-and-later with `NoMatchingVariant`. The removed blinded proposer path cannot be reached under EIP-7732.
- Fork-branches `validate_block_proposal`: `fork >= Gloas` uses the new decoder directly; pre-Gloas preserves the existing blinded-then-full fallback unchanged.
- Adds 5 and adjusts 1 unit test covering the decode round-trip, the fork-branch happy/error paths, a negative test that blinded decoding rejects Gloas, and a pre-Gloas regression guard.
- `tempfile` added as a dev-dependency for test fixture construction.

## Risks, Trade-offs, and Mitigations

- **Not behaviourally load-bearing for valid Gloas input today.** EIP-7732 removes the payload-parameterized field from `BeaconBlockBodyGloas`, making full and blinded SSZ byte-identical. The old fallback would also succeed. The branch is intentional — it documents the SIP-94 contract, avoids redundant decode attempts, and anchors the path for downstream consumer changes.
- **Blinded decoder now rejects Gloas.** Decoding is gated on `self.version` so that the SIP-94 contract (blinded proposer path removed under Gloas) is enforced at the decoder rather than relying on incidental fallback success.
- **Blast radius:** confined to `ssv_types` crate; no downstream crate changes.

## Validation

- `cargo test -p ssv_types`
- `make cargo-fmt && make cargo-fmt-check`
- `make lint`
- `cargo build --release`

## Rollback

- Revert single commit; no data, config, or runtime impact.