### PR TITLE
feat(ssv_types): retarget PTC role to validator-scoped PTCAttester

### DIFF
--- a/anchor/common/ssv_types/src/msgid.rs
+++ b/anchor/common/ssv_types/src/msgid.rs
@@ -79,11 +79,11 @@ impl Role {
         }
     }
 
-    /// Returns true if this role is validator-scoped and does not run a QBFT
-    /// consensus round (ValidatorRegistration, VoluntaryExit, PTCAttester),
-    /// i.e. it has no max QBFT round.
-    pub fn is_non_qbft_role(self) -> bool {
-        self.max_round().is_none()
+    /// Returns true if this role runs a QBFT consensus round, i.e. it has a
+    /// max QBFT round. The validator-scoped roles that do not
+    /// (ValidatorRegistration, VoluntaryExit, PTCAttester) return false.
+    pub fn is_qbft_role(self) -> bool {
+        self.max_round().is_some()
     }
 }
 
@@ -348,6 +348,35 @@ mod tests {
         // giving it a max round would compile silently; this pins the values.
         assert!(!Role::PTCAttester.is_committee_role());
         assert_eq!(Role::PTCAttester.max_round(), None);
-        assert!(Role::PTCAttester.is_non_qbft_role());
+        assert!(!Role::PTCAttester.is_qbft_role());
+    }
+
+    #[test]
+    fn role_qbft_classification_is_pinned() {
+        // Adding a new Role forces a decision in max_round()'s exhaustive
+        // match, but nothing checks the decision is right: a role landing in
+        // the wrong arm silently flips its consensus-message and routing
+        // behavior. Pin every existing role on both sides of the partition.
+        for role in [
+            Role::Committee,
+            Role::Aggregator,
+            Role::AggregatorCommittee,
+            Role::Proposer,
+            Role::SyncCommittee,
+        ] {
+            assert!(role.is_qbft_role(), "{role:?} runs QBFT");
+            assert!(role.max_round().is_some(), "{role:?} must have a max round");
+        }
+        for role in [
+            Role::ValidatorRegistration,
+            Role::VoluntaryExit,
+            Role::PTCAttester,
+        ] {
+            assert!(!role.is_qbft_role(), "{role:?} must not run QBFT");
+            assert!(
+                role.max_round().is_none(),
+                "{role:?} must not have a max round"
+            );
+        }
     }
 }

--- a/anchor/common/ssv_types/src/msgid.rs
+++ b/anchor/common/ssv_types/src/msgid.rs
@@ -21,7 +21,7 @@ pub enum Role {
     ValidatorRegistration,
     VoluntaryExit,
     AggregatorCommittee,
-    PTCCommittee,
+    PTCAttester,
 }
 
 impl From<Role> for [u8; 4] {
@@ -34,7 +34,7 @@ impl From<Role> for [u8; 4] {
             Role::ValidatorRegistration => [4, 0, 0, 0],
             Role::VoluntaryExit => [5, 0, 0, 0],
             Role::AggregatorCommittee => [6, 0, 0, 0],
-            Role::PTCCommittee => [7, 0, 0, 0],
+            Role::PTCAttester => [7, 0, 0, 0],
         }
     }
 }
@@ -51,15 +51,14 @@ impl TryFrom<&[u8]> for Role {
             [4, 0, 0, 0] => Ok(Role::ValidatorRegistration),
             [5, 0, 0, 0] => Ok(Role::VoluntaryExit),
             [6, 0, 0, 0] => Ok(Role::AggregatorCommittee),
-            [7, 0, 0, 0] => Ok(Role::PTCCommittee),
+            [7, 0, 0, 0] => Ok(Role::PTCAttester),
             _ => Err(DecodeError::NoMatchingVariant),
         }
     }
 }
 
 impl Role {
-    /// Returns true if this role is a committee-based role (Committee, AggregatorCommittee, or
-    /// PTCCommittee).
+    /// Returns true if this role is a committee-based role (Committee or AggregatorCommittee).
     ///
     /// Committee roles handle multiple validators in batched operations and have relaxed
     /// validation rules compared to per-validator roles:
@@ -67,10 +66,7 @@ impl Role {
     /// - Skip slot advancement checks (allow processing "older" slots within 34-slot window)
     /// - Have different message count limits and validator index occurrence limits
     pub fn is_committee_role(self) -> bool {
-        matches!(
-            self,
-            Role::Committee | Role::AggregatorCommittee | Role::PTCCommittee
-        )
+        matches!(self, Role::Committee | Role::AggregatorCommittee)
     }
 
     pub fn max_round(self) -> Option<u64> {
@@ -78,15 +74,16 @@ impl Role {
         match self {
             Role::Committee | Role::Aggregator | Role::AggregatorCommittee => Some(12),
             Role::Proposer | Role::SyncCommittee => Some(6),
-            // PTC is expected near 75% of a 12s slot, leaving about 3s.
-            // With 2s quick round timeouts, only round 1 is likely to finish
-            // before slot end. Allow up to 4 rounds as a small local grace
-            // window for delayed starts or message loss; this is not a
-            // consensus-spec requirement.
-            Role::PTCCommittee => Some(4),
             // These roles don't use QBFT consensus
-            Role::ValidatorRegistration | Role::VoluntaryExit => None,
+            Role::ValidatorRegistration | Role::VoluntaryExit | Role::PTCAttester => None,
         }
+    }
+
+    /// Returns true if this role is validator-scoped and does not run a QBFT
+    /// consensus round (ValidatorRegistration, VoluntaryExit, PTCAttester),
+    /// i.e. it has no max QBFT round.
+    pub fn is_non_qbft_role(self) -> bool {
+        self.max_round().is_none()
     }
 }
 
@@ -156,14 +153,15 @@ impl MessageId {
     pub fn duty_executor(&self) -> Option<DutyExecutor> {
         // which kind of executor we need to get depends on the role
         match self.role()? {
-            Role::Committee | Role::AggregatorCommittee | Role::PTCCommittee => {
+            Role::Committee | Role::AggregatorCommittee => {
                 self.0[24..].try_into().ok().map(DutyExecutor::Committee)
             }
             Role::Aggregator
             | Role::Proposer
             | Role::SyncCommittee
             | Role::ValidatorRegistration
-            | Role::VoluntaryExit => PublicKeyBytes::deserialize(&self.0[8..])
+            | Role::VoluntaryExit
+            | Role::PTCAttester => PublicKeyBytes::deserialize(&self.0[8..])
                 .ok()
                 .map(DutyExecutor::Validator),
         }
@@ -322,38 +320,23 @@ mod tests {
     }
 
     #[test]
-    fn ptc_uses_committee_duty_executor() {
-        // PTCCommittee must use Committee-style duty executor (CommitteeId),
-        // not Validator-style (PublicKeyBytes)
+    fn ptc_attester_uses_validator_duty_executor() {
+        // PTCAttester is validator-scoped: it must use Validator-style duty
+        // executor (PublicKeyBytes), not Committee-style (CommitteeId).
         let domain = DomainType([0, 0, 0, 0]);
-        let committee_id = CommitteeId::from(vec![OperatorId(100), OperatorId(200)]);
-        let duty_executor = DutyExecutor::Committee(committee_id);
+        let public_key = PublicKeyBytes::empty();
+        let duty_executor = DutyExecutor::Validator(public_key);
 
-        let msg_id = MessageId::new(&domain, Role::PTCCommittee, &duty_executor);
+        let msg_id = MessageId::new(&domain, Role::PTCAttester, &duty_executor);
 
-        assert_eq!(msg_id.role(), Some(Role::PTCCommittee));
+        assert_eq!(msg_id.role(), Some(Role::PTCAttester));
 
         match msg_id.duty_executor() {
-            Some(DutyExecutor::Committee(id)) => assert_eq!(id, committee_id),
-            Some(DutyExecutor::Validator(_)) => {
-                panic!("PTCCommittee should use Committee duty executor, not Validator")
+            Some(DutyExecutor::Validator(pk)) => assert_eq!(pk, public_key),
+            Some(DutyExecutor::Committee(_)) => {
+                panic!("PTCAttester should use Validator duty executor, not Committee")
             }
             None => panic!("Failed to extract duty executor"),
         }
-    }
-
-    #[test]
-    fn ptc_max_round_is_four() {
-        // PTC duty starts at 75% slot; Some(4) is the deliberate cap distinct
-        // from Committee's Some(12). Regressions copying the Committee value
-        // would compile silently — this guards against that.
-        assert_eq!(Role::PTCCommittee.max_round(), Some(4));
-    }
-
-    #[test]
-    fn ptc_is_committee_role() {
-        // is_committee_role drives the validator-index-mismatch skip and
-        // slot-advancement skip in message_validator. PTC must qualify.
-        assert!(Role::PTCCommittee.is_committee_role());
     }
 }

--- a/anchor/common/ssv_types/src/msgid.rs
+++ b/anchor/common/ssv_types/src/msgid.rs
@@ -339,4 +339,15 @@ mod tests {
             None => panic!("Failed to extract duty executor"),
         }
     }
+
+    #[test]
+    fn ptc_attester_is_validator_scoped_non_qbft() {
+        // Every behavior flip in the PTCAttester retarget rides on these three
+        // classifications (validation bucketing, consensus-message rejection,
+        // qbft_manager routing). Re-adding PTCAttester to the committee arm or
+        // giving it a max round would compile silently; this pins the values.
+        assert!(!Role::PTCAttester.is_committee_role());
+        assert_eq!(Role::PTCAttester.max_round(), None);
+        assert!(Role::PTCAttester.is_non_qbft_role());
+    }
 }

--- a/anchor/common/ssv_types/src/partial_sig.rs
+++ b/anchor/common/ssv_types/src/partial_sig.rs
@@ -37,6 +37,9 @@ pub enum PartialSignatureKind {
     // AggregatorCommitteePartialSig is a partial signature for combined aggregator and sync
     // committee selection proofs (committee-based batching)
     AggregatorCommitteePartialSig = 6,
+    // PTCAttester is a standalone single-validator partial signature over PayloadAttestationData
+    // (validator-scoped, leaderless; not a QBFT consensus value)
+    PTCAttester = 7,
 }
 
 impl TryFrom<u64> for PartialSignatureKind {
@@ -51,6 +54,7 @@ impl TryFrom<u64> for PartialSignatureKind {
             4 => Ok(PartialSignatureKind::ValidatorRegistration),
             5 => Ok(PartialSignatureKind::VoluntaryExit),
             6 => Ok(PartialSignatureKind::AggregatorCommitteePartialSig),
+            7 => Ok(PartialSignatureKind::PTCAttester),
             _ => Err(()),
         }
     }
@@ -187,6 +191,7 @@ mod tests {
             PartialSignatureKind::ValidatorRegistration,
             PartialSignatureKind::VoluntaryExit,
             PartialSignatureKind::AggregatorCommitteePartialSig,
+            PartialSignatureKind::PTCAttester,
         ];
 
         for variant in variants {
@@ -219,6 +224,7 @@ mod tests {
             (PartialSignatureKind::ValidatorRegistration, 4u64),
             (PartialSignatureKind::VoluntaryExit, 5u64),
             (PartialSignatureKind::AggregatorCommitteePartialSig, 6u64),
+            (PartialSignatureKind::PTCAttester, 7u64),
         ];
 
         for (variant, expected_value) in test_cases {
@@ -236,7 +242,7 @@ mod tests {
 
     #[test]
     fn partial_signature_kind_ssz_decode_invalid_variant() {
-        let invalid_value = 7u64.to_le_bytes();
+        let invalid_value = 8u64.to_le_bytes();
         let result = PartialSignatureKind::from_ssz_bytes(&invalid_value);
         assert!(matches!(result, Err(DecodeError::NoMatchingVariant)));
     }
@@ -300,11 +306,15 @@ mod tests {
             PartialSignatureKind::try_from(6u64).unwrap(),
             PartialSignatureKind::AggregatorCommitteePartialSig
         );
+        assert_eq!(
+            PartialSignatureKind::try_from(7u64).unwrap(),
+            PartialSignatureKind::PTCAttester
+        );
     }
 
     #[test]
     fn partial_signature_kind_try_from_u64_invalid_values() {
-        assert!(PartialSignatureKind::try_from(7u64).is_err());
+        assert!(PartialSignatureKind::try_from(8u64).is_err());
         assert!(PartialSignatureKind::try_from(100u64).is_err());
         assert!(PartialSignatureKind::try_from(u64::MAX).is_err());
     }
@@ -331,6 +341,7 @@ mod tests {
             PartialSignatureKind::ValidatorRegistration,
             PartialSignatureKind::VoluntaryExit,
             PartialSignatureKind::AggregatorCommitteePartialSig,
+            PartialSignatureKind::PTCAttester,
         ];
 
         let hashes: Vec<_> = variants.iter().map(|v| v.tree_hash_root()).collect();

--- a/anchor/message_validator/src/consensus_message.rs
+++ b/anchor/message_validator/src/consensus_message.rs
@@ -974,34 +974,44 @@ mod tests {
     fn test_consensus_message_for_non_consensus_role() {
         let committee_info = create_committee_info(SINGLE_NODE_COMMITTEE);
 
-        // Create a consensus message for a non-consensus role (ValidatorRegistration)
-        let msg_id = create_message_id_for_test(Role::ValidatorRegistration);
-        let qbft_message =
-            QbftMessageBuilder::new(Role::ValidatorRegistration, QbftMessageType::Proposal)
+        // Every non-QBFT role must reject consensus messages, including
+        // PTCAttester (leaderless, no QBFT round since the SIP-94 rewrite).
+        for role in [
+            Role::ValidatorRegistration,
+            Role::VoluntaryExit,
+            Role::PTCAttester,
+        ] {
+            let msg_id = create_message_id_for_test(role);
+            let qbft_message = QbftMessageBuilder::new(role, QbftMessageType::Proposal)
                 .with_identifier(msg_id.clone())
                 .build();
 
-        let qbft_bytes = qbft_message.as_ssz_bytes();
-        let ssv_msg = SSVMessage::new(MsgType::SSVConsensusMsgType, msg_id, qbft_bytes)
-            .expect("SSVMessage should be created");
-        let signed_msg = SignedSSVMessage::new(
-            vec![[0xAA; RSA_SIGNATURE_SIZE]],
-            vec![OperatorId(1)],
-            ssv_msg,
-            vec![],
-        )
-        .expect("SignedSSVMessage should be created");
+            let qbft_bytes = qbft_message.as_ssz_bytes();
+            let ssv_msg = SSVMessage::new(MsgType::SSVConsensusMsgType, msg_id, qbft_bytes)
+                .expect("SSVMessage should be created");
+            let signed_msg = SignedSSVMessage::new(
+                vec![[0xAA; RSA_SIGNATURE_SIZE]],
+                vec![OperatorId(1)],
+                ssv_msg,
+                vec![],
+            )
+            .expect("SignedSSVMessage should be created");
 
-        let map = create_operator_pub_keys(committee_info.committee_members.clone(), vec![]);
+            let map = create_operator_pub_keys(committee_info.committee_members.clone(), vec![]);
 
-        let result =
-            validate_consensus_message_semantics(&signed_msg, &qbft_message, &committee_info, &map);
+            let result = validate_consensus_message_semantics(
+                &signed_msg,
+                &qbft_message,
+                &committee_info,
+                &map,
+            );
 
-        assert_validation_error(
-            result,
-            |failure| matches!(failure, ValidationFailure::UnexpectedConsensusMessage),
-            "UnexpectedConsensusMessage",
-        );
+            assert_validation_error(
+                result,
+                |failure| matches!(failure, ValidationFailure::UnexpectedConsensusMessage),
+                &format!("UnexpectedConsensusMessage ({role:?})"),
+            );
+        }
     }
 
     #[test]

--- a/anchor/message_validator/src/consensus_message.rs
+++ b/anchor/message_validator/src/consensus_message.rs
@@ -8,7 +8,6 @@ use ssv_types::{
     CommitteeInfo, IndexSet, OperatorId, Round, Slot, VariableList,
     consensus::{QbftMessage, QbftMessageType},
     message::SignedSSVMessage,
-    msgid::Role,
     quorum_size,
 };
 use ssz::Decode;
@@ -118,10 +117,11 @@ pub(crate) fn validate_consensus_message_semantics(
         return Err(ValidationFailure::ZeroRound);
     }
 
-    // Rule: Duty role has consensus (true except for ValidatorRegistration and VoluntaryExit)
+    // Rule: only roles that run a QBFT consensus round may carry a consensus
+    // message; validator-scoped non-QBFT roles must not.
     if matches!(
         signed_ssv_message.ssv_message().msg_id().role(),
-        Some(Role::ValidatorRegistration) | Some(Role::VoluntaryExit)
+        Some(role) if role.is_non_qbft_role()
     ) {
         return Err(ValidationFailure::UnexpectedConsensusMessage);
     }
@@ -486,7 +486,7 @@ mod tests {
     use bls::{Hash256, PublicKeyBytes};
     use openssl::hash::MessageDigest;
     use ssv_types::{
-        CommitteeId, OperatorId, RSA_SIGNATURE_SIZE, ValidatorIndex, VariableList,
+        OperatorId, RSA_SIGNATURE_SIZE, ValidatorIndex, VariableList,
         consensus::{QbftMessage, QbftMessageType},
         domain_type::DomainType,
         message::{MsgType, SSVMessage, SignedSSVMessage},
@@ -1718,7 +1718,7 @@ mod tests {
     }
 
     #[test]
-    fn test_duty_limit_ptc_committee() {
+    fn test_duty_limit_ptc_attester() {
         let now = SystemTime::now();
         let slot_clock = ManualSlotClock::new(
             Slot::new(100),
@@ -1728,8 +1728,8 @@ mod tests {
 
         let msg_id = MessageId::new(
             &DomainType([0, 0, 0, 1]),
-            Role::PTCCommittee,
-            &DutyExecutor::Committee(CommitteeId([0u8; 32])),
+            Role::PTCAttester,
+            &DutyExecutor::Validator(PublicKeyBytes::empty()),
         );
         let ssv_msg = SSVMessage::new(MsgType::SSVConsensusMsgType, msg_id, vec![1, 2, 3])
             .expect("SSVMessage should be created");
@@ -1750,7 +1750,7 @@ mod tests {
         let validation_context = ValidationContext {
             signed_ssv_message: &signed_msg,
             committee_info: &committee_info,
-            role: Role::PTCCommittee,
+            role: Role::PTCAttester,
             received_at: now,
             slots_per_epoch: 32,
             epochs_per_sync_committee_period: 256,
@@ -1762,25 +1762,24 @@ mod tests {
 
         let slot = slot_clock.now().unwrap();
 
-        // V < slots_per_epoch: V is the binding constraint.
-        let small_cluster = vec![ValidatorIndex(0); 4];
+        // PTC is validator-scoped: the duty counter is keyed per-validator, and the
+        // limit is a flat 2 (one expected PTC duty per epoch + a one-duty margin),
+        // independent of how many indices are passed. In production the validator
+        // path always supplies exactly one index.
+        let one_validator = vec![ValidatorIndex(0)];
         let result = duty_limit(
             &validation_context,
             slot,
-            &small_cluster,
+            &one_validator,
             mock_duties_provider.clone(),
         );
-        assert_eq!(result, Ok(Some(4)));
+        assert_eq!(result, Ok(Some(2)));
 
-        // V > slots_per_epoch: slot count is the binding constraint.
-        let large_cluster = vec![ValidatorIndex(0); 100];
-        let result = duty_limit(
-            &validation_context,
-            slot,
-            &large_cluster,
-            mock_duties_provider,
-        );
-        assert_eq!(result, Ok(Some(32)));
+        // The cap does not scale with the slice length (guards against the old
+        // cluster-wide `min(slots_per_epoch, V)` formula reappearing).
+        let many = vec![ValidatorIndex(0); 100];
+        let result = duty_limit(&validation_context, slot, &many, mock_duties_provider);
+        assert_eq!(result, Ok(Some(2)));
     }
 
     /// Helper function for testing role validation against fork schedules.

--- a/anchor/message_validator/src/consensus_message.rs
+++ b/anchor/message_validator/src/consensus_message.rs
@@ -121,20 +121,21 @@ pub(crate) fn validate_consensus_message_semantics(
     // message; validator-scoped non-QBFT roles must not.
     if matches!(
         signed_ssv_message.ssv_message().msg_id().role(),
-        Some(role) if role.is_non_qbft_role()
+        Some(role) if !role.is_qbft_role()
     ) {
         return Err(ValidationFailure::UnexpectedConsensusMessage);
     }
 
-    let max_round = match signed_ssv_message
+    let Some(max_round) = signed_ssv_message
         .ssv_message()
         .msg_id()
         .role()
         .unwrap()
         .max_round()
-    {
-        Some(max_round) => max_round,
-        None => return Err(ValidationFailure::FailedToGetMaxRound),
+    else {
+        // Defensive fallback: the guard above already rejected every role
+        // without a max round.
+        return Err(ValidationFailure::UnexpectedConsensusMessage);
     };
 
     if consensus_message.round > max_round {

--- a/anchor/message_validator/src/lib.rs
+++ b/anchor/message_validator/src/lib.rs
@@ -930,13 +930,12 @@ fn message_lateness(
     validation_context: &ValidationContext<impl SlotClock>,
 ) -> Result<Duration, ValidationFailure> {
     let ttl = match validation_context.role {
-        Role::Proposer | Role::SyncCommittee => 1 + LATE_SLOT_ALLOWANCE,
+        Role::Proposer | Role::SyncCommittee | Role::PTCAttester => 1 + LATE_SLOT_ALLOWANCE,
         Role::Committee
         | Role::Aggregator
         | Role::ValidatorRegistration
         | Role::VoluntaryExit
-        | Role::AggregatorCommittee
-        | Role::PTCAttester => validation_context.slots_per_epoch + LATE_SLOT_ALLOWANCE,
+        | Role::AggregatorCommittee => validation_context.slots_per_epoch + LATE_SLOT_ALLOWANCE,
     };
 
     let deadline = slot_start_time(slot + ttl, validation_context.slot_clock.clone())

--- a/anchor/message_validator/src/lib.rs
+++ b/anchor/message_validator/src/lib.rs
@@ -450,7 +450,7 @@ impl<S: SlotClock + 'static, D: DutiesProvider> Validator<S, D> {
         // Get committee info based on role and duty executor
         let network_state = self.network_state_rx.borrow();
         let committee_info = match role {
-            Role::Committee | Role::AggregatorCommittee | Role::PTCCommittee => {
+            Role::Committee | Role::AggregatorCommittee => {
                 let committee_id = committee_id.ok_or(ValidationFailure::NonExistentCommitteeID)?;
                 network_state
                     .get_committee_info_by_committee_id(&committee_id)
@@ -461,7 +461,8 @@ impl<S: SlotClock + 'static, D: DutiesProvider> Validator<S, D> {
             | Role::Proposer
             | Role::SyncCommittee
             | Role::ValidatorRegistration
-            | Role::VoluntaryExit => {
+            | Role::VoluntaryExit
+            | Role::PTCAttester => {
                 let validator_pk = match ssv_message.msg_id().duty_executor() {
                     Some(DutyExecutor::Validator(pk)) => pk,
                     _ => return Err(ValidationFailure::UnknownValidator),
@@ -859,8 +860,8 @@ pub(crate) fn validate_role_for_fork(
         });
     }
 
-    // Reject PTCCommittee before CStar fork (safety net)
-    if role == Role::PTCCommittee && active_fork < Fork::CStar {
+    // Reject PTCAttester before CStar fork (safety net)
+    if role == Role::PTCAttester && active_fork < Fork::CStar {
         return Err(ValidationFailure::RoleNotActiveBeforeFork {
             role,
             current_fork: active_fork,
@@ -935,7 +936,7 @@ fn message_lateness(
         | Role::ValidatorRegistration
         | Role::VoluntaryExit
         | Role::AggregatorCommittee
-        | Role::PTCCommittee => validation_context.slots_per_epoch + LATE_SLOT_ALLOWANCE,
+        | Role::PTCAttester => validation_context.slots_per_epoch + LATE_SLOT_ALLOWANCE,
     };
 
     let deadline = slot_start_time(slot + ttl, validation_context.slot_clock.clone())
@@ -1013,7 +1014,10 @@ fn duty_limit(
                 duty_provider.get_voluntary_exit_duty_count(slot, &pubkey),
             ))
         }
-        Role::Aggregator | Role::ValidatorRegistration => Ok(Some(2)),
+        // Validator-scoped roles with at most ~1 duty per validator per epoch
+        // (the duty counter is keyed per-validator); the limit of 2 leaves a
+        // one-duty margin for epoch-boundary/reorg edge cases.
+        Role::Aggregator | Role::ValidatorRegistration | Role::PTCAttester => Ok(Some(2)),
         // Committee roles (Committee and AggregatorCommittee) use the same duty limit formula:
         // min(slots_per_epoch, 2*validator_count), or slots_per_epoch if any validator is in sync
         // committee
@@ -1043,16 +1047,6 @@ fn duty_limit(
         }
         // Proposer and SyncCommittee have no duty limit
         Role::Proposer | Role::SyncCommittee => Ok(None),
-        // PTC: each validator is eligible for the PTC only in the one slot of the
-        // epoch where it has its attestation duty (PTC pool = union of beacon
-        // committees for that slot; see `compute_ptc` at
-        // https://github.com/ethereum/consensus-specs/blob/4a4937bea332d72a55a76aaebcb97fbcdc189f69/specs/gloas/beacon-chain.md#new-compute_ptc).
-        // So per-epoch max duties = min(slots_per_epoch, V) where V is the
-        // cluster's local validator count.
-        Role::PTCCommittee => Ok(Some(std::cmp::min(
-            validation_context.slots_per_epoch,
-            validator_indices.len() as u64,
-        ))),
     }
 }
 
@@ -1298,14 +1292,15 @@ mod tests {
     pub(crate) fn create_message_id_for_test(role: Role) -> MessageId {
         let domain = DomainType([0, 0, 0, 1]);
         let duty_executor = match role {
-            Role::Committee | Role::AggregatorCommittee | Role::PTCCommittee => {
+            Role::Committee | Role::AggregatorCommittee => {
                 DutyExecutor::Committee(CommitteeId([0u8; 32]))
             }
             Role::Aggregator
             | Role::Proposer
             | Role::SyncCommittee
             | Role::ValidatorRegistration
-            | Role::VoluntaryExit => DutyExecutor::Validator(PublicKeyBytes::empty()),
+            | Role::VoluntaryExit
+            | Role::PTCAttester => DutyExecutor::Validator(PublicKeyBytes::empty()),
         };
         MessageId::new(&domain, role, &duty_executor)
     }

--- a/anchor/message_validator/src/lib.rs
+++ b/anchor/message_validator/src/lib.rs
@@ -196,7 +196,6 @@ pub enum ValidationFailure {
         limit: usize,
     },
     EncodeOperators,
-    FailedToGetMaxRound,
     SlotStartTimeNotFound {
         slot: Slot,
     },

--- a/anchor/message_validator/src/message_counts.rs
+++ b/anchor/message_validator/src/message_counts.rs
@@ -66,7 +66,8 @@ impl MessageCounts {
             | PartialSignatureKind::ContributionProofs
             | PartialSignatureKind::ValidatorRegistration
             | PartialSignatureKind::VoluntaryExit
-            | PartialSignatureKind::AggregatorCommitteePartialSig => {
+            | PartialSignatureKind::AggregatorCommitteePartialSig
+            | PartialSignatureKind::PTCAttester => {
                 if self.pre_consensus >= MAX_MESSAGES_PER_ROUND {
                     return Err(ValidationFailure::InvalidPartialSignatureTypeCount {
                         got: format!("pre-consensus, having {self:?}"),
@@ -109,7 +110,8 @@ impl MessageCounts {
             | PartialSignatureKind::ContributionProofs
             | PartialSignatureKind::ValidatorRegistration
             | PartialSignatureKind::VoluntaryExit
-            | PartialSignatureKind::AggregatorCommitteePartialSig => self.pre_consensus += 1,
+            | PartialSignatureKind::AggregatorCommitteePartialSig
+            | PartialSignatureKind::PTCAttester => self.pre_consensus += 1,
             PartialSignatureKind::PostConsensus => self.post_consensus += 1,
         }
     }

--- a/anchor/message_validator/src/partial_signature.rs
+++ b/anchor/message_validator/src/partial_signature.rs
@@ -1208,9 +1208,9 @@ mod tests {
     const LATE_SLOT_ALLOWANCE_TEST: u64 = 2;
     const TTL_SLOTS: u64 = SLOTS_PER_EPOCH_TEST + LATE_SLOT_ALLOWANCE_TEST; // 34 slots
     const BEYOND_TTL_SLOTS: u64 = 40;
-    // Past the proposer/sync TTL (1 + LATE_SLOT_ALLOWANCE_TEST = 3 slots), well
-    // within the committee TTL (TTL_SLOTS = 34). Lets a test prove a role is in
-    // the committee TTL bucket rather than just inside the long-TTL boundary.
+    // Past the short slot-bound TTL (1 + LATE_SLOT_ALLOWANCE_TEST = 3 slots),
+    // well within the committee TTL (TTL_SLOTS = 34). Lets a test prove which
+    // TTL bucket a role is in, rather than just probing a boundary.
     const COMMITTEE_TTL_BUCKET_SLOTS: u64 = 20;
 
     // Helper to create validation context for TTL tests
@@ -1779,10 +1779,45 @@ mod tests {
             &private_key,
         );
 
-        // PTC is validator-scoped but keeps the long TTL (slots_per_epoch +
-        // LATE_SLOT_ALLOWANCE = 34). A message 20 slots late is past the
-        // proposer/sync TTL (3) yet still inside PTC's long TTL, so it is
-        // accepted.
+        // PTC output is only useful for its own slot (the aggregated payload
+        // attestation is gossip-valid for that slot and includable only at
+        // slot + 1), so PTCAttester uses the short TTL
+        // (1 + LATE_SLOT_ALLOWANCE = 3 slots). Two slots late is inside it.
+        let validation_context = create_ttl_validation_context(
+            &signed_msg,
+            &committee_info,
+            Role::PTCAttester,
+            &map,
+            LATE_SLOT_ALLOWANCE_TEST,
+            generate_fork_schedule(Fork::CStar),
+        );
+
+        let result = validate_partial_signature_message(
+            validation_context,
+            &mut DutyState::new(64),
+            Arc::new(MockDutiesProvider {
+                voluntary_exit_duty_count: 0,
+            }),
+        );
+
+        assert!(result.is_ok(), "Expected ok but got: {result:?}");
+    }
+
+    #[test]
+    fn test_ptc_attester_beyond_short_ttl_rejected() {
+        let committee_info = create_committee_info(FOUR_NODE_COMMITTEE);
+        let (private_key, public_key) = generate_test_key_pair();
+        let map =
+            create_operator_pub_keys(committee_info.committee_members.clone(), vec![public_key]);
+        let signed_msg = create_signed_partial_sig_message(
+            Role::PTCAttester,
+            PartialSignatureKind::PTCAttester,
+            OperatorId(1),
+            &private_key,
+        );
+
+        // 20 slots late would still be inside the long (committee) TTL of 34
+        // slots; rejecting it pins PTCAttester to the short slot-bound bucket.
         let validation_context = create_ttl_validation_context(
             &signed_msg,
             &committee_info,
@@ -1800,7 +1835,11 @@ mod tests {
             }),
         );
 
-        assert!(result.is_ok(), "Expected ok but got: {result:?}");
+        assert_validation_error(
+            result,
+            |failure| matches!(failure, ValidationFailure::LateSlotMessage { .. }),
+            "LateSlotMessage (PTCAttester past short TTL)",
+        );
     }
 
     #[test]

--- a/anchor/message_validator/src/partial_signature.rs
+++ b/anchor/message_validator/src/partial_signature.rs
@@ -5,10 +5,7 @@ use slot_clock::SlotClock;
 use ssv_types::{
     OperatorId,
     msgid::Role,
-    partial_sig::{
-        PartialSignatureKind, PartialSignatureMessage, PartialSignatureMessages,
-        PartialSignatureMessagesError,
-    },
+    partial_sig::{PartialSignatureKind, PartialSignatureMessages, PartialSignatureMessagesError},
 };
 use ssz::Decode;
 use types::consts::altair::SYNC_COMMITTEE_SUBNET_COUNT;
@@ -147,7 +144,8 @@ fn validate_partial_signature_message_semantics(
 
 fn partial_signature_type_matches_role(kind: PartialSignatureKind, role: Role) -> bool {
     match role {
-        Role::Committee | Role::PTCCommittee => kind == PartialSignatureKind::PostConsensus,
+        Role::Committee => kind == PartialSignatureKind::PostConsensus,
+        Role::PTCAttester => kind == PartialSignatureKind::PTCAttester,
         Role::Aggregator => {
             kind == PartialSignatureKind::PostConsensus
                 || kind == PartialSignatureKind::SelectionProofPartialSig
@@ -317,14 +315,12 @@ fn validate_partial_sig_messages_by_duty_logic(
                 }
             }
         }
-        Role::PTCCommittee => {
-            // PTC produces exactly one partial signature per locally-assigned
-            // validator per slot.
-            validate_ptc_committee_message_count(message_count, validator_count)?;
-            validate_validator_index_occurrence_limit(&partial_signature_messages.messages, 1)?;
-        }
         // Per-validator roles only allow one signature
-        Role::Aggregator | Role::Proposer | Role::ValidatorRegistration | Role::VoluntaryExit => {
+        Role::Aggregator
+        | Role::Proposer
+        | Role::ValidatorRegistration
+        | Role::VoluntaryExit
+        | Role::PTCAttester => {
             if message_count > 1 {
                 return Err(ValidationFailure::TooManyPartialSignatureMessages {
                     got: message_count,
@@ -334,40 +330,6 @@ fn validate_partial_sig_messages_by_duty_logic(
         }
     }
 
-    Ok(())
-}
-
-fn validate_validator_index_occurrence_limit(
-    messages: &[PartialSignatureMessage],
-    limit: usize,
-) -> Result<(), ValidationFailure> {
-    let mut validator_index_count = HashMap::new();
-    for message in messages {
-        let count = validator_index_count
-            .entry(message.validator_index)
-            .or_insert(0usize);
-        *count += 1;
-        if *count > limit {
-            return Err(ValidationFailure::TooManyValidatorIndexOccurrences {
-                validator_index: message.validator_index,
-                got: *count,
-                limit,
-            });
-        }
-    }
-    Ok(())
-}
-
-fn validate_ptc_committee_message_count(
-    message_count: usize,
-    validator_count: usize,
-) -> Result<(), ValidationFailure> {
-    if message_count > validator_count {
-        return Err(ValidationFailure::TooManyPartialSignatureMessages {
-            got: message_count,
-            limit: validator_count,
-        });
-    }
     Ok(())
 }
 
@@ -1679,56 +1641,93 @@ mod tests {
         );
     }
 
-    fn create_partial_sig_message(validator_index: ValidatorIndex) -> PartialSignatureMessage {
-        PartialSignatureMessage {
-            partial_signature: Signature::empty(),
-            signing_root: Hash256::from([0u8; 32]),
-            signer: OperatorId(1),
-            validator_index,
-        }
-    }
-
     #[test]
-    fn test_ptc_committee_validator_index_occurrence_limit() {
-        // PTC allows exactly 1 occurrence per validator index per partial-sig packet.
-        let one = vec![create_partial_sig_message(ValidatorIndex(100))];
-        assert!(validate_validator_index_occurrence_limit(&one, 1).is_ok());
+    fn test_ptc_attester_rejects_multiple_messages_per_packet() {
+        // PTC is validator-scoped: exactly one PayloadAttestationMessage per
+        // packet. The per-validator `> 1` bound rejects a second message, which
+        // also subsumes the validator-index occurrence cap (two messages for the
+        // same index would already trip `> 1`).
+        let committee_info = create_committee_info(FOUR_NODE_COMMITTEE);
+        let (private_key, public_key) = generate_test_key_pair();
+        let map =
+            create_operator_pub_keys(committee_info.committee_members.clone(), vec![public_key]);
 
-        let two = vec![
-            create_partial_sig_message(ValidatorIndex(100)),
-            create_partial_sig_message(ValidatorIndex(100)),
-        ];
+        // ValidatorIndex(123) is in the test committee's validator_indices, so
+        // each message passes the per-validator index check; the second message
+        // then trips the `> 1` packet bound.
+        let messages: Vec<_> = (0..2)
+            .map(|_| PartialSignatureMessage {
+                partial_signature: Signature::empty(),
+                signing_root: Hash256::from([0u8; 32]),
+                signer: OperatorId(1),
+                validator_index: ValidatorIndex(123),
+            })
+            .collect();
+
+        let partial_sig_messages = PartialSignatureMessages {
+            kind: PartialSignatureKind::PTCAttester,
+            slot: Slot::new(1),
+            messages: VariableList::new(messages).unwrap(),
+        };
+
+        let msg_id = create_message_id_for_test(Role::PTCAttester);
+        let ssv_msg = SSVMessage::new(
+            MsgType::SSVPartialSignatureMsgType,
+            msg_id,
+            partial_sig_messages.as_ssz_bytes(),
+        )
+        .unwrap();
+
+        let p_key = PKey::from_rsa(private_key).unwrap();
+        let mut signer = Signer::new(MessageDigest::sha256(), &p_key).unwrap();
+        signer.update(&ssv_msg.as_ssz_bytes()).unwrap();
+        let signature = signer.sign_to_vec().unwrap().try_into().unwrap();
+
+        let signed_msg =
+            SignedSSVMessage::new(vec![signature], vec![OperatorId(1)], ssv_msg, vec![]).unwrap();
+
+        let now = SystemTime::now();
+        let slot_clock = ManualSlotClock::new(
+            Slot::new(1),
+            now.duration_since(UNIX_EPOCH).unwrap(),
+            Duration::from_secs(12),
+        );
+
+        let validation_context = ValidationContext {
+            signed_ssv_message: &signed_msg,
+            committee_info: &committee_info,
+            role: Role::PTCAttester,
+            received_at: now,
+            slots_per_epoch: 32,
+            epochs_per_sync_committee_period: 256,
+            sync_committee_size: 512,
+            slot_clock,
+            operator_pub_keys: &map,
+            fork_schedule: generate_fork_schedule(Fork::CStar),
+        };
+
+        let result = validate_partial_signature_message(
+            validation_context,
+            &mut DutyState::new(64),
+            Arc::new(MockDutiesProvider {
+                voluntary_exit_duty_count: 0,
+            }),
+        );
+
         assert_validation_error(
-            validate_validator_index_occurrence_limit(&two, 1),
-            |f| {
+            result,
+            |failure| {
                 matches!(
-                    f,
-                    ValidationFailure::TooManyValidatorIndexOccurrences { limit: 1, .. }
+                    failure,
+                    ValidationFailure::TooManyPartialSignatureMessages { limit: 1, .. }
                 )
             },
-            "TooManyValidatorIndexOccurrences (PTC limit)",
+            "TooManyPartialSignatureMessages (PTC cap 1 per packet)",
         );
     }
 
     #[test]
-    fn test_ptc_committee_message_count_exceeds_validator_count() {
-        // V+1 messages trip the structural message-count cap (V).
-        let v = FOUR_NODE_COMMITTEE;
-        assert!(validate_ptc_committee_message_count(v, v).is_ok());
-        assert_validation_error(
-            validate_ptc_committee_message_count(v + 1, v),
-            |f| {
-                matches!(
-                    f,
-                    ValidationFailure::TooManyPartialSignatureMessages { limit, .. } if *limit == v
-                )
-            },
-            "TooManyPartialSignatureMessages (PTC count > V)",
-        );
-    }
-
-    #[test]
-    fn test_ptc_committee_rejected_before_cstar() {
+    fn test_ptc_attester_rejected_before_cstar() {
         use crate::validate_role_for_fork;
 
         let committee_info = create_committee_info(FOUR_NODE_COMMITTEE);
@@ -1736,8 +1735,8 @@ mod tests {
         let map =
             create_operator_pub_keys(committee_info.committee_members.clone(), vec![public_key]);
         let signed_msg = create_signed_partial_sig_message(
-            Role::PTCCommittee,
-            PartialSignatureKind::PostConsensus,
+            Role::PTCAttester,
+            PartialSignatureKind::PTCAttester,
             OperatorId(1),
             &private_key,
         );
@@ -1746,7 +1745,7 @@ mod tests {
         let validation_context = create_test_validation_context_with_fork(
             &signed_msg,
             &committee_info,
-            Role::PTCCommittee,
+            Role::PTCAttester,
             &map,
             Some(fork_schedule),
         );
@@ -1763,30 +1762,31 @@ mod tests {
                     }
                 )
             },
-            "RoleNotActiveBeforeFork (PTCCommittee pre-CStar)",
+            "RoleNotActiveBeforeFork (PTCAttester pre-CStar)",
         );
     }
 
     #[test]
-    fn test_ptc_committee_within_ttl_accepted() {
+    fn test_ptc_attester_within_ttl_accepted() {
         let committee_info = create_committee_info(FOUR_NODE_COMMITTEE);
         let (private_key, public_key) = generate_test_key_pair();
         let map =
             create_operator_pub_keys(committee_info.committee_members.clone(), vec![public_key]);
         let signed_msg = create_signed_partial_sig_message(
-            Role::PTCCommittee,
-            PartialSignatureKind::PostConsensus,
+            Role::PTCAttester,
+            PartialSignatureKind::PTCAttester,
             OperatorId(1),
             &private_key,
         );
 
-        // COMMITTEE_TTL_BUCKET_SLOTS = 20 is past the proposer/sync TTL (3) but
-        // well inside the committee TTL (34). Accepting here proves PTC is
-        // bucketed as committee, not just inside a long TTL.
+        // PTC is validator-scoped but keeps the long TTL (slots_per_epoch +
+        // LATE_SLOT_ALLOWANCE = 34). A message 20 slots late is past the
+        // proposer/sync TTL (3) yet still inside PTC's long TTL, so it is
+        // accepted.
         let validation_context = create_ttl_validation_context(
             &signed_msg,
             &committee_info,
-            Role::PTCCommittee,
+            Role::PTCAttester,
             &map,
             COMMITTEE_TTL_BUCKET_SLOTS,
             generate_fork_schedule(Fork::CStar),
@@ -1804,17 +1804,17 @@ mod tests {
     }
 
     #[test]
-    fn test_ptc_committee_binds_post_consensus_only() {
-        // PTC binds to PartialSignatureKind::PostConsensus.
-        // Mapping to ValidationFailure::PartialSignatureTypeRoleMismatch is covered
-        // end-to-end by test_partial_signature_message_with_invalid_type_for_role.
+    fn test_ptc_attester_binds_ptc_attester_kind() {
+        // PTC binds to its own PartialSignatureKind::PTCAttester (no longer
+        // PostConsensus). Mapping to ValidationFailure::PartialSignatureTypeRoleMismatch
+        // is covered end-to-end by test_partial_signature_message_with_invalid_type_for_role.
         assert!(partial_signature_type_matches_role(
-            PartialSignatureKind::PostConsensus,
-            Role::PTCCommittee,
+            PartialSignatureKind::PTCAttester,
+            Role::PTCAttester,
         ));
         assert!(!partial_signature_type_matches_role(
-            PartialSignatureKind::RandaoPartialSig,
-            Role::PTCCommittee,
+            PartialSignatureKind::PostConsensus,
+            Role::PTCAttester,
         ));
     }
 

--- a/anchor/qbft_manager/src/lib.rs
+++ b/anchor/qbft_manager/src/lib.rs
@@ -274,9 +274,11 @@ impl<E: EthSpec, S: SlotClock + Clone + 'static> QbftManager<E, S> {
                     Some(Role::Aggregator) => ValidatorDutyKind::Aggregator,
                     Some(Role::SyncCommittee) => ValidatorDutyKind::SyncCommitteeAggregator,
                     // Committee roles use DutyExecutor::Committee, not Validator
-                    Some(Role::Committee | Role::AggregatorCommittee | Role::PTCCommittee)
+                    Some(Role::Committee | Role::AggregatorCommittee)
                     // These roles don't use QBFT consensus
-                    | Some(Role::ValidatorRegistration | Role::VoluntaryExit)
+                    | Some(
+                        Role::ValidatorRegistration | Role::VoluntaryExit | Role::PTCAttester,
+                    )
                     | None => {
                         error!(?msg_id, "Unexpected role/executor combination in msg id");
                         return Err(QbftError::InconsistentMessageId);
@@ -338,15 +340,14 @@ impl<E: EthSpec, S: SlotClock + Clone + 'static> QbftManager<E, S> {
                             },
                         )
                     }
-                    Some(Role::PTCCommittee) => {
-                        // TODO(cstar): wire PTC instance routing and add pre-CStar
-                        // fork gate (mirror `AggregatorCommittee` arm above).
-                        let slot = types::Slot::new(qbft_message.height);
-                        warn!(%slot, "Ignoring PTCCommittee message; routing not wired");
-                        Err(QbftError::RoleNotActive)
-                    }
-                    // Validator roles should use DutyExecutor::Validator, not Committee
-                    Some(Role::Aggregator | Role::Proposer | Role::SyncCommittee)
+                    // Validator roles should use DutyExecutor::Validator, not
+                    // Committee
+                    Some(
+                        Role::Aggregator
+                        | Role::Proposer
+                        | Role::SyncCommittee
+                        | Role::PTCAttester,
+                    )
                     // These roles don't use QBFT consensus
                     | Some(Role::ValidatorRegistration | Role::VoluntaryExit)
                     | None => Err(QbftError::InconsistentMessageId),

--- a/anchor/qbft_manager/src/lib.rs
+++ b/anchor/qbft_manager/src/lib.rs
@@ -342,14 +342,11 @@ impl<E: EthSpec, S: SlotClock + Clone + 'static> QbftManager<E, S> {
                     }
                     // Validator roles should use DutyExecutor::Validator, not
                     // Committee
-                    Some(
-                        Role::Aggregator
-                        | Role::Proposer
-                        | Role::SyncCommittee
-                        | Role::PTCAttester,
-                    )
+                    Some(Role::Aggregator | Role::Proposer | Role::SyncCommittee)
                     // These roles don't use QBFT consensus
-                    | Some(Role::ValidatorRegistration | Role::VoluntaryExit)
+                    | Some(
+                        Role::ValidatorRegistration | Role::VoluntaryExit | Role::PTCAttester,
+                    )
                     | None => Err(QbftError::InconsistentMessageId),
                 }
             }


### PR DESCRIPTION
## Problem, Evidence, and Context

SIP-94 §3 was rewritten to a validator-scoped, leaderless PTC design (modeled on
the ProposerPreferences flow in §5): a payload-timeliness attestation is a
standalone single-validator signature with no QBFT consensus round. The role
that merged earlier (#1033) modeled PTC as a committee-scoped, QBFT-bearing role,
which no longer matches the spec.

This PR retargets that role to a validator-scoped `PTCAttester` and gives PTC its
own partial-signature kind instead of overloading `PostConsensus`.

- Closes #1075 (issue 2 of the no-QBFT PTC milestone).
- Independent of #1074 / #1076 (disjoint symbols). Builds only on `Fork::CStar`.
  The later PTC sign path and client spawn build on this PR's new symbols.

## Change Overview

PTC moves out of the committee role-class into the validator-scoped, non-QBFT
class at every dispatch site: validator-scoped duty executor (not a committee
id), no max QBFT round, the pre-consensus message bucket, and a per-validator
one-signature-per-packet bound. It also gets a dedicated `PartialSignatureKind`,
so a PTC attestation is no longer indistinguishable on the wire from a
post-consensus signature.

Suggested reading order:
1. `ssv_types` (`msgid`, `partial_sig`): the role rename + reclassification and
   the new partial-signature kind. A small `is_qbft_role` predicate is
   introduced (positively named, mirroring `is_committee_role`) and negated
   at the consensus-message guard.
2. `message_validator`: the validation-path consequences (kind/role binding,
   packet bound, duty limit, and rejection of consensus messages for non-QBFT
   roles). Two committee-only helpers are deleted, subsumed by the shared
   per-validator bound.
3. `qbft_manager`: the PTC routing stub is removed; PTC now rejects QBFT
   messages as an inconsistent message id in both executor branches.

What intentionally did not change:
- Wire identifiers: the role byte stays `7`; the dedicated kind takes value `7`.
- The `Fork::CStar` activation gate.

## Risks, Trade-offs, and Mitigations

- Contained blast radius: every `Role` / `PartialSignatureKind` match in the
  touched crates is exhaustive (no `_` wildcard), so the compiler flagged each
  site that needed updating. `cargo check --workspace` is the gate.
- Behavior change: a PTC consensus (QBFT) message is now rejected rather than
  routed (matching the leaderless design), and PTC partial-sig packets are
  capped at one signature per validator per packet (the old committee occurrence
  cap is subsumed by this bound). The rejection is a `Reject` gossip verdict
  (peer penalty on synced nodes), which is intentional: post-`CStar` a PTC
  consensus message is a protocol violation under the leaderless design.
  Previously such a message was accepted and propagated, then dropped
  internally by the `qbft_manager` stub.
- Behavior change (bucketing flip): because `PTCAttester` leaves the committee
  role-class, two checks previously skipped for `PTCCommittee` now apply to PTC
  packets: the validator-index-in-committee check (`ValidatorIndexMismatch`) and
  the per-signer slot-advancement check (`SlotAlreadyAdvanced`). Both follow from
  validator-scoping (one validator per packet, monotonic per-validator slot).
- Behavior change (TTL tightened): `PTCAttester` moves from the epoch-long
  lateness/TTL bucket (`slots_per_epoch + 2` = 34 slots, inherited from the
  committee-scoped design) to the slot-bound Proposer/SyncCommittee bucket
  (3 slots). Per the Gloas spec, a payload attestation is gossip-valid only
  for its own slot and block-includable only at slot + 1, so older partials
  are useless and accepting them only widens the replay/relay surface.
- Wire compatibility: the role byte is unchanged, but a PTC packet's
  partial-signature kind flips from `PostConsensus` (`0`) to `PTCAttester`
  (`7`), and the byte-7 `MessageId` layout changes from `CommitteeId`
  (`[24..56]`) to validator pubkey (`[8..]`). No deployed impact: no producer
  emits PTC partial signatures yet and `CStar` has never been fork-active, so
  only an epbs devnet mixing pre- and post-retarget nodes would need a
  lockstep upgrade.

## Validation

- `cargo test -p ssv_types -p message_validator -p qbft_manager`: 98 / 63 / 19
  pass, 0 failures (plus doc-tests). Existing PTC tests were retargeted to the
  validator-scoped role; coverage asserts the validator duty executor, the
  non-QBFT classification (not committee-scoped, no max round), the dedicated
  kind's SSZ round-trip, the kind-to-role binding, the per-validator packet
  bound, the consensus-message rejection for `PTCAttester`, the pre-`CStar`
  fork reject, the flat duty limit, and the slot-bound TTL (accepted 2 slots
  late, rejected 20 slots late).
- `cargo +nightly fmt --all -- --check`: clean.
- `git grep PTCCommittee anchor/`: empty.

## Rollback

Revert the branch's four commits. No config, data, or migration impact; wire encodings
are unchanged, so there is no cross-version compatibility concern.

## Blockers / Dependencies

None for merge. Follow-ups that build on this PR's new symbols: the PTC sign path
and the client spawn wiring.
