### PR TITLE
feat(validator_store): implement sign_payload_attestation

### DIFF
--- a/anchor/validator_store/src/instrumentation.rs
+++ b/anchor/validator_store/src/instrumentation.rs
@@ -1,3 +1,5 @@
+use signature_collector::CollectionError;
+
 use crate::{Error, SpecificError};
 
 /// Outcome of a block signing attempt, used for metrics labeling.
@@ -19,6 +21,43 @@ pub mod checkpoints {
     pub const PUBLISH_BLOCK: &str = "publish_block";
     pub const DUTY_COMPLETED: &str = "duty_completed";
     pub const DUTY_FAILED: &str = "duty_failed";
+}
+
+/// Telemetry classification of `collect_signature` failures during PTC duties.
+///
+/// Returned as an enum rather than a label string because the class drives two independent
+/// effects in the caller: the log level and whether a reconstruction-failure metric is
+/// incremented at all.
+pub enum PtcFailureClass {
+    /// The committee never reached the partial signature threshold. This surfaces as
+    /// `QueueClosedError` because the collector is evicted after
+    /// `SIGNATURE_COLLECTOR_RETAIN_SLOTS`, dropping the result channel while we await it, so it
+    /// cannot be distinguished from a genuine channel close.
+    NoSignature,
+    /// Local infrastructure failed while collecting or reconstructing the signature.
+    Infra,
+    /// The failure happened before signature collection started (unknown pubkey, threshold
+    /// arithmetic, key share decryption, missing index).
+    NonCollection,
+}
+
+pub fn classify_ptc_collection_failure(error: &Error) -> PtcFailureClass {
+    match error {
+        // The inner match is deliberately wildcard-free so a future `CollectionError` variant
+        // forces a conscious classification decision here at compile time.
+        Error::SpecificError(SpecificError::SignatureCollectionFailed(collection_error)) => {
+            match collection_error {
+                CollectionError::QueueClosedError | CollectionError::CollectionTimeout => {
+                    PtcFailureClass::NoSignature
+                }
+                CollectionError::QueueFullError
+                | CollectionError::OwnOperatorIdUnknown
+                | CollectionError::EmptySignature
+                | CollectionError::RecoverError(_) => PtcFailureClass::Infra,
+            }
+        }
+        _ => PtcFailureClass::NonCollection,
+    }
 }
 
 /// Common reasons for block signing failures.

--- a/anchor/validator_store/src/lib.rs
+++ b/anchor/validator_store/src/lib.rs
@@ -80,6 +80,8 @@ use validator_store::{
     ValidatorStore,
 };
 
+use crate::instrumentation::PtcFailureClass;
+
 /// Number of epochs of slashing protection history to keep.
 ///
 /// This acts as a maximum safe-guard against clock drift.
@@ -846,6 +848,50 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> AnchorValidator
         };
 
         Ok(signed_exit)
+    }
+
+    /// LH's payload attestation service only crit-logs whatever error we return, so emit
+    /// operator-grade telemetry before surfacing collection failures.
+    fn report_ptc_collection_failure(
+        &self,
+        error: &Error,
+        validator_pubkey: &PublicKeyBytes,
+        slot: Slot,
+    ) {
+        match instrumentation::classify_ptc_collection_failure(error) {
+            PtcFailureClass::NoSignature => {
+                warn!(
+                    ?validator_pubkey,
+                    %slot,
+                    ?error,
+                    "Insufficient partial signatures for payload attestation"
+                );
+                metrics::inc_counter_vec(
+                    &metrics::PTC_RECONSTRUCTION_FAILURES,
+                    &[metrics::PTC_FAILURE_NO_SIGNATURE],
+                );
+            }
+            PtcFailureClass::Infra => {
+                error!(
+                    ?validator_pubkey,
+                    %slot,
+                    ?error,
+                    "Signature collection infrastructure failure for payload attestation"
+                );
+                metrics::inc_counter_vec(
+                    &metrics::PTC_RECONSTRUCTION_FAILURES,
+                    &[metrics::PTC_FAILURE_INFRA],
+                );
+            }
+            PtcFailureClass::NonCollection => {
+                error!(
+                    ?validator_pubkey,
+                    %slot,
+                    ?error,
+                    "Failed to sign payload attestation"
+                );
+            }
+        }
     }
 
     fn create_proposer_consensus_data_validator(
@@ -3263,11 +3309,45 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> ValidatorStore
 
     async fn sign_payload_attestation(
         &self,
-        _validator_pubkey: PublicKeyBytes,
-        _data: PayloadAttestationData,
+        validator_pubkey: PublicKeyBytes,
+        data: PayloadAttestationData,
     ) -> Result<PayloadAttestationMessage, Error> {
-        // TODO(cstar)
-        Err(Error::SpecificError(SpecificError::Unsupported))
+        // LH fetched `data` at the 75% slot cutoff and abstained on no-block already, so this
+        // method only signs what it is handed: no beacon node fetch and no slashing protection.
+        let (validator, cluster) = self.get_validator_and_cluster(validator_pubkey)?;
+        // Resolve the beacon index up front: the message needs it anyway, and a missing index
+        // must surface as a pre-collection error rather than routing through the
+        // collection-failure reporter.
+        let validator_index = validator.index.ok_or(SpecificError::MissingIndex)?;
+
+        let epoch = data.slot.epoch(E::slots_per_epoch());
+        let domain_hash = self.get_domain(epoch, Domain::PTCAttester);
+        let signing_root = data.signing_root(domain_hash);
+
+        let signature = match self
+            .collect_signature(
+                PartialSignatureKind::PTCAttester,
+                Role::PTCAttester,
+                CollectionMode::SingleValidator,
+                &validator,
+                &cluster,
+                signing_root,
+                data.slot,
+            )
+            .await
+        {
+            Ok(signature) => signature,
+            Err(err) => {
+                self.report_ptc_collection_failure(&err, &validator_pubkey, data.slot);
+                return Err(err);
+            }
+        };
+
+        Ok(PayloadAttestationMessage {
+            validator_index: validator_index.into(),
+            data,
+            signature,
+        })
     }
 
     async fn sign_proposer_preferences(

--- a/anchor/validator_store/src/metrics.rs
+++ b/anchor/validator_store/src/metrics.rs
@@ -104,3 +104,22 @@ pub static WAD_SOFT_TIMEOUT_TOTAL: LazyLock<Result<IntCounter>> = LazyLock::new(
         "Number of WAD fetches that returned at soft timeout with partial responses",
     )
 });
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// PTC (Payload Timeliness Committee) metrics
+// ═══════════════════════════════════════════════════════════════════════════════
+
+/// The committee never reached the partial signature threshold. At the current collector
+/// granularity this also covers genuine channel closes, so it is an upper bound on the true
+/// observation-divergence rate.
+pub const PTC_FAILURE_NO_SIGNATURE: &str = "no_signature";
+/// Local collection or reconstruction infrastructure fault.
+pub const PTC_FAILURE_INFRA: &str = "infra";
+
+pub static PTC_RECONSTRUCTION_FAILURES: LazyLock<Result<IntCounterVec>> = LazyLock::new(|| {
+    try_create_int_counter_vec(
+        "anchor_ptc_reconstruction_failures_total",
+        "Payload attestation signature collection failures by reason",
+        &["reason"],
+    )
+});

--- a/anchor/validator_store/src/testing/common.rs
+++ b/anchor/validator_store/src/testing/common.rs
@@ -66,33 +66,48 @@ pub(super) type CapturedCalls = Arc<Mutex<Vec<CapturedSignatureCall>>>;
 
 pub(super) struct CapturedSignatureCall {
     pub(super) requester: SignatureRequester,
+    pub(super) metadata: SignatureMetadata,
+    /// Only the root is captured, not the full `ValidatorSigningData`, so the capture never
+    /// holds key share material.
+    pub(super) signing_root: Hash256,
 }
 
-/// Mock that captures calls and returns a canned infinity signature.
+/// Mock that captures calls and returns a canned infinity signature, or a configured failure.
 struct MockSignatureCollector {
     captured: CapturedCalls,
+    failure: Option<CollectionError>,
 }
 
 impl SignatureCollecting for MockSignatureCollector {
     fn sign_and_collect(
         &self,
-        _metadata: SignatureMetadata,
+        metadata: SignatureMetadata,
         requester: SignatureRequester,
-        _signing_data: ValidatorSigningData,
+        signing_data: ValidatorSigningData,
     ) -> Pin<Box<dyn Future<Output = Result<Arc<Signature>, CollectionError>> + Send + '_>> {
-        self.captured
-            .lock()
-            .push(CapturedSignatureCall { requester });
+        // Capture before failing so tests can assert that the collection attempt happened even
+        // when the configured outcome is an error.
+        self.captured.lock().push(CapturedSignatureCall {
+            requester,
+            metadata,
+            signing_root: signing_data.root,
+        });
+        if let Some(failure) = self.failure.clone() {
+            return Box::pin(async move { Err(failure) });
+        }
         let sig = Signature::infinity().expect("infinity signature");
         Box::pin(async move { Ok(Arc::new(sig)) })
     }
 }
 
 /// Creates a mock signature collector and returns the shared captured calls handle.
-fn create_mock_collector() -> (Box<dyn SignatureCollecting>, CapturedCalls) {
+fn create_mock_collector(
+    failure: Option<CollectionError>,
+) -> (Box<dyn SignatureCollecting>, CapturedCalls) {
     let captured: CapturedCalls = Arc::new(Mutex::new(Vec::new()));
     let mock = MockSignatureCollector {
         captured: Arc::clone(&captured),
+        failure,
     };
     (Box::new(mock), captured)
 }
@@ -166,6 +181,24 @@ pub(super) fn create_committee_setup(
 
 // ==================== Test harness ====================
 
+/// Construction knobs that only some tests need to vary.
+pub(super) struct HarnessOptions {
+    /// When set, every `sign_and_collect` call fails with this error after being captured.
+    pub(super) collector_failure: Option<CollectionError>,
+    pub(super) disable_slashing_protection: bool,
+}
+
+impl Default for HarnessOptions {
+    fn default() -> Self {
+        Self {
+            collector_failure: None,
+            // Slashing protection is disabled by default because the harness never registers
+            // validators in the slashing DB, which would fail block/attestation signing paths.
+            disable_slashing_protection: true,
+        }
+    }
+}
+
 pub(super) struct ValidatorStoreTestHarness {
     pub(super) validator_store:
         Arc<AnchorValidatorStore<ManualSlotClock, MainnetEthSpec, MockConsensusDecider>>,
@@ -178,6 +211,14 @@ pub(super) struct ValidatorStoreTestHarness {
 
 impl ValidatorStoreTestHarness {
     pub(super) fn new(committee_setups: Vec<CommitteeSetup>, our_operator_id: OperatorId) -> Self {
+        Self::new_with_options(committee_setups, our_operator_id, HarnessOptions::default())
+    }
+
+    pub(super) fn new_with_options(
+        committee_setups: Vec<CommitteeSetup>,
+        our_operator_id: OperatorId,
+        options: HarnessOptions,
+    ) -> Self {
         // Dummy RSA key for database operator identification (not used for decryption)
         let rsa_pubkey = database::test_utils::generators::pubkey::random_rsa();
 
@@ -198,7 +239,7 @@ impl ValidatorStoreTestHarness {
             "test",
         ));
 
-        let (mock_collector, captured_calls) = create_mock_collector();
+        let (mock_collector, captured_calls) = create_mock_collector(options.collector_failure);
 
         // Database
         let database = Arc::new(
@@ -268,7 +309,7 @@ impl ValidatorStoreTestHarness {
             mock_collector,
             Arc::new(MockConsensusDecider),
             slashing_protection,
-            true, // disable slashing protection for simpler testing
+            options.disable_slashing_protection,
             slot_clock.clone(),
             Arc::new(ChainSpec::mainnet()),
             Hash256::zero(),

--- a/anchor/validator_store/src/testing/mod.rs
+++ b/anchor/validator_store/src/testing/mod.rs
@@ -2,3 +2,4 @@ mod common;
 
 mod committee_aggregate;
 mod committee_attestation;
+mod payload_attestation;

--- a/anchor/validator_store/src/testing/payload_attestation.rs
+++ b/anchor/validator_store/src/testing/payload_attestation.rs
@@ -1,4 +1,6 @@
 //! Integration tests for the PTC payload attestation path in `sign_payload_attestation()`.
+use std::sync::LazyLock;
+
 use bls::FixedBytesExtended;
 use signature_collector::{CollectionError, SignatureRequester};
 use ssv_types::{OperatorId, msgid::Role, partial_sig::PartialSignatureKind};
@@ -12,6 +14,13 @@ use crate::{Error, SpecificError};
 
 /// Non-zero so a correctly echoed beacon index is distinguishable from an accidental default 0.
 const STARTING_VALIDATOR_INDEX: usize = 5;
+
+/// Serializes the two metric tests against each other. Both read the same labels of the global
+/// prometheus `PTC_RECONSTRUCTION_FAILURES` counter, so concurrent execution would make their
+/// cross-label delta assertions racy. A tokio mutex rather than std because the guard is held
+/// across awaits on a multi-thread runtime.
+static METRIC_TEST_LOCK: LazyLock<tokio::sync::Mutex<()>> =
+    LazyLock::new(|| tokio::sync::Mutex::new(()));
 
 fn test_operator_ids() -> [OperatorId; 4] {
     [OperatorId(1), OperatorId(2), OperatorId(3), OperatorId(4)]
@@ -142,6 +151,10 @@ async fn sign_payload_attestation_missing_index_errors() {
 /// `no_signature` reconstruction-failure metric exactly once.
 #[tokio::test(flavor = "multi_thread")]
 async fn sign_payload_attestation_collection_failure_increments_no_signature_metric() {
+    // The global prometheus registry makes cross-label delta assertions racy between the two
+    // metric tests, so they serialize against each other.
+    let _guard = METRIC_TEST_LOCK.lock().await;
+
     // Arrange
     let our_operator_id = OperatorId(1);
     let committee = create_committee_setup(&test_operator_ids(), 1, STARTING_VALIDATOR_INDEX);
@@ -156,9 +169,9 @@ async fn sign_payload_attestation_collection_failure_increments_no_signature_met
     );
     let data = create_payload_attestation_data();
     // The metric lives in the global prometheus registry shared by every test in the process,
-    // so we assert on the delta. The delta assertion is only safe while this is the sole test
-    // incrementing the `no_signature` label; future failure tests should use distinct labels or
-    // compute their own deltas.
+    // so we assert on the delta. The infra metric test also touches this label (asserting a
+    // zero delta), so the delta is only reliable because both tests hold `METRIC_TEST_LOCK`;
+    // future failure tests must join that serialization or use distinct labels.
     let no_signature_counter = crate::metrics::PTC_RECONSTRUCTION_FAILURES
         .as_ref()
         .expect("metric should be created")
@@ -185,6 +198,72 @@ async fn sign_payload_attestation_collection_failure_increments_no_signature_met
         no_signature_counter.get() - count_before,
         1,
         "QueueClosedError should increment the no_signature reconstruction-failure metric once"
+    );
+}
+
+/// An infrastructure failure surfaces as `SignatureCollectionFailed` and increments the `infra`
+/// reconstruction-failure metric, leaving the `no_signature` metric untouched.
+#[tokio::test(flavor = "multi_thread")]
+async fn sign_payload_attestation_infra_failure_increments_infra_metric() {
+    // The global prometheus registry makes cross-label delta assertions racy between the two
+    // metric tests, so they serialize against each other.
+    let _guard = METRIC_TEST_LOCK.lock().await;
+
+    // Arrange
+    let our_operator_id = OperatorId(1);
+    let committee = create_committee_setup(&test_operator_ids(), 1, STARTING_VALIDATOR_INDEX);
+    let pubkey = committee.validators[0].public_key;
+    let harness = ValidatorStoreTestHarness::new_with_options(
+        vec![committee],
+        our_operator_id,
+        HarnessOptions {
+            collector_failure: Some(CollectionError::EmptySignature),
+            disable_slashing_protection: true,
+        },
+    );
+    let data = create_payload_attestation_data();
+    // The metric lives in the global prometheus registry shared by every test in the process,
+    // so we assert on deltas. The `no_signature` zero-delta read races with the QueueClosedError
+    // test's increment, so the deltas are only reliable because both tests hold
+    // `METRIC_TEST_LOCK`; future failure tests must join that serialization or use distinct
+    // labels.
+    let metric = crate::metrics::PTC_RECONSTRUCTION_FAILURES
+        .as_ref()
+        .expect("metric should be created");
+    let infra_counter = metric.with_label_values(&[crate::metrics::PTC_FAILURE_INFRA]);
+    let no_signature_counter =
+        metric.with_label_values(&[crate::metrics::PTC_FAILURE_NO_SIGNATURE]);
+    let infra_before = infra_counter.get();
+    let no_signature_before = no_signature_counter.get();
+
+    // Act
+    let result = harness
+        .validator_store
+        .sign_payload_attestation(pubkey, data)
+        .await;
+
+    // Assert
+    assert!(
+        matches!(
+            result,
+            Err(Error::SpecificError(
+                SpecificError::SignatureCollectionFailed(CollectionError::EmptySignature)
+            ))
+        ),
+        "expected EmptySignature surfaced as SignatureCollectionFailed, got: {result:?}"
+    );
+    assert_eq!(
+        infra_counter.get() - infra_before,
+        1,
+        "EmptySignature should increment the infra reconstruction-failure metric once"
+    );
+    // The zero delta pins the classification boundary: `no_signature` is the SIP-94
+    // observation-divergence upper bound, so an infra variant drifting into that bucket would
+    // silently inflate the divergence estimate.
+    assert_eq!(
+        no_signature_counter.get() - no_signature_before,
+        0,
+        "infra failures must not leak into the no_signature divergence metric"
     );
 }
 

--- a/anchor/validator_store/src/testing/payload_attestation.rs
+++ b/anchor/validator_store/src/testing/payload_attestation.rs
@@ -1,0 +1,227 @@
+//! Integration tests for the PTC payload attestation path in `sign_payload_attestation()`.
+use bls::FixedBytesExtended;
+use signature_collector::{CollectionError, SignatureRequester};
+use ssv_types::{OperatorId, msgid::Role, partial_sig::PartialSignatureKind};
+use types::{
+    ChainSpec, Domain, EthSpec, Hash256, MainnetEthSpec, PayloadAttestationData, SignedRoot, Slot,
+};
+use validator_store::ValidatorStore;
+
+use super::common::*;
+use crate::{Error, SpecificError};
+
+/// Non-zero so a correctly echoed beacon index is distinguishable from an accidental default 0.
+const STARTING_VALIDATOR_INDEX: usize = 5;
+
+fn test_operator_ids() -> [OperatorId; 4] {
+    [OperatorId(1), OperatorId(2), OperatorId(3), OperatorId(4)]
+}
+
+/// The store signs whatever data it is handed (LH already fetched it at the slot cutoff), so a
+/// fixed fixture is sufficient; no voting context seeding is needed.
+fn create_payload_attestation_data() -> PayloadAttestationData {
+    PayloadAttestationData {
+        beacon_block_root: Hash256::zero(),
+        slot: Slot::new(TEST_SLOT),
+        payload_present: true,
+        blob_data_available: true,
+    }
+}
+
+/// `sign_payload_attestation` resolves the validator's beacon index, collects a signature in
+/// single-validator mode, and echoes the input data back in the resulting message.
+#[tokio::test(flavor = "multi_thread")]
+async fn sign_payload_attestation_builds_message_with_validator_index() {
+    // Arrange
+    let our_operator_id = OperatorId(1);
+    let committee = create_committee_setup(&test_operator_ids(), 1, STARTING_VALIDATOR_INDEX);
+    let pubkey = committee.validators[0].public_key;
+    let harness = ValidatorStoreTestHarness::new(vec![committee], our_operator_id);
+    let data = create_payload_attestation_data();
+
+    // Act
+    let result = harness
+        .validator_store
+        .sign_payload_attestation(pubkey, data.clone())
+        .await;
+
+    // Assert
+    let message = result.expect("payload attestation signing should succeed");
+    assert_eq!(
+        message.validator_index, STARTING_VALIDATOR_INDEX as u64,
+        "message should carry the validator's beacon index"
+    );
+    assert_eq!(message.data, data, "message should echo the input data");
+
+    let captured = harness.captured_calls.lock();
+    assert_eq!(
+        captured.len(),
+        1,
+        "expected exactly one sign_and_collect call"
+    );
+    let call = &captured[0];
+    match &call.requester {
+        SignatureRequester::SingleValidator {
+            pubkey: requester_pubkey,
+        } => assert_eq!(
+            *requester_pubkey, pubkey,
+            "collection should be requested for the signing validator"
+        ),
+        other => panic!("expected SignatureRequester::SingleValidator, got: {other:?}"),
+    }
+    assert_eq!(
+        call.metadata.kind,
+        PartialSignatureKind::PTCAttester,
+        "partial signature messages should be tagged with the PTC attester kind"
+    );
+    assert_eq!(
+        call.metadata.role,
+        Role::PTCAttester,
+        "the network message should be routed under the PTC attester role"
+    );
+    assert_eq!(
+        call.metadata.slot, data.slot,
+        "collection should be scheduled for the attestation slot"
+    );
+
+    // Recompute the root independently (with the same mainnet spec and zero
+    // genesis_validators_root the harness uses) to lock the PTC-specific signing decisions that
+    // no other test covers: the `Domain::PTCAttester` choice, the epoch derived from the
+    // attestation slot, and the signed object being the `PayloadAttestationData` itself. A
+    // regression to e.g. `Domain::BeaconAttester` fails here.
+    let spec = ChainSpec::mainnet();
+    let epoch = data.slot.epoch(MainnetEthSpec::slots_per_epoch());
+    let domain = spec.get_domain(
+        epoch,
+        Domain::PTCAttester,
+        &spec.fork_at_epoch(epoch),
+        Hash256::zero(),
+    );
+    let expected_root = data.signing_root(domain);
+    assert_eq!(
+        call.signing_root, expected_root,
+        "signing root should commit to the payload attestation data under the PTC domain"
+    );
+}
+
+/// A validator without a beacon index fails fast with `MissingIndex` and never starts a partial
+/// signature round, because the index is resolved before collection.
+#[tokio::test(flavor = "multi_thread")]
+async fn sign_payload_attestation_missing_index_errors() {
+    // Arrange
+    let our_operator_id = OperatorId(1);
+    let mut committee = create_committee_setup(&test_operator_ids(), 1, STARTING_VALIDATOR_INDEX);
+    // The validators table stores the index in a nullable column and the in-memory state keeps
+    // metadata as passed, so a metadata gap flows through harness construction unchanged.
+    committee.validators[0].index = None;
+    let pubkey = committee.validators[0].public_key;
+    let harness = ValidatorStoreTestHarness::new(vec![committee], our_operator_id);
+    let data = create_payload_attestation_data();
+
+    // Act
+    let result = harness
+        .validator_store
+        .sign_payload_attestation(pubkey, data)
+        .await;
+
+    // Assert
+    assert!(
+        matches!(
+            result,
+            Err(Error::SpecificError(SpecificError::MissingIndex))
+        ),
+        "expected MissingIndex error, got: {result:?}"
+    );
+    assert!(
+        harness.captured_calls.lock().is_empty(),
+        "no signature round should start for a validator without an index"
+    );
+}
+
+/// A collection failure surfaces as `SignatureCollectionFailed` and increments the
+/// `no_signature` reconstruction-failure metric exactly once.
+#[tokio::test(flavor = "multi_thread")]
+async fn sign_payload_attestation_collection_failure_increments_no_signature_metric() {
+    // Arrange
+    let our_operator_id = OperatorId(1);
+    let committee = create_committee_setup(&test_operator_ids(), 1, STARTING_VALIDATOR_INDEX);
+    let pubkey = committee.validators[0].public_key;
+    let harness = ValidatorStoreTestHarness::new_with_options(
+        vec![committee],
+        our_operator_id,
+        HarnessOptions {
+            collector_failure: Some(CollectionError::QueueClosedError),
+            disable_slashing_protection: true,
+        },
+    );
+    let data = create_payload_attestation_data();
+    // The metric lives in the global prometheus registry shared by every test in the process,
+    // so we assert on the delta. The delta assertion is only safe while this is the sole test
+    // incrementing the `no_signature` label; future failure tests should use distinct labels or
+    // compute their own deltas.
+    let no_signature_counter = crate::metrics::PTC_RECONSTRUCTION_FAILURES
+        .as_ref()
+        .expect("metric should be created")
+        .with_label_values(&[crate::metrics::PTC_FAILURE_NO_SIGNATURE]);
+    let count_before = no_signature_counter.get();
+
+    // Act
+    let result = harness
+        .validator_store
+        .sign_payload_attestation(pubkey, data)
+        .await;
+
+    // Assert
+    assert!(
+        matches!(
+            result,
+            Err(Error::SpecificError(
+                SpecificError::SignatureCollectionFailed(CollectionError::QueueClosedError)
+            ))
+        ),
+        "expected QueueClosedError surfaced as SignatureCollectionFailed, got: {result:?}"
+    );
+    assert_eq!(
+        no_signature_counter.get() - count_before,
+        1,
+        "QueueClosedError should increment the no_signature reconstruction-failure metric once"
+    );
+}
+
+/// `sign_payload_attestation` succeeds with slashing protection enabled, proving the path never
+/// consults the slashing DB.
+///
+/// Tripwire mechanism: the harness slashing DB is created empty and no validator is ever
+/// registered in it, so any slashing-protection check would fail for an unregistered validator.
+/// If such a check were ever added to this code path, this call would flip from Ok to Err, which
+/// makes the success assertion a real behavioral assertion rather than a tautology.
+#[tokio::test(flavor = "multi_thread")]
+async fn sign_payload_attestation_does_not_touch_slashing_db() {
+    // Arrange
+    let our_operator_id = OperatorId(1);
+    let committee = create_committee_setup(&test_operator_ids(), 1, STARTING_VALIDATOR_INDEX);
+    let pubkey = committee.validators[0].public_key;
+    let harness = ValidatorStoreTestHarness::new_with_options(
+        vec![committee],
+        our_operator_id,
+        HarnessOptions {
+            collector_failure: None,
+            disable_slashing_protection: false,
+        },
+    );
+    let data = create_payload_attestation_data();
+
+    // Act
+    let result = harness
+        .validator_store
+        .sign_payload_attestation(pubkey, data.clone())
+        .await;
+
+    // Assert
+    let message = result.expect("signing should succeed despite slashing protection being enabled");
+    assert_eq!(
+        message.validator_index, STARTING_VALIDATOR_INDEX as u64,
+        "message should carry the validator's beacon index"
+    );
+    assert_eq!(message.data, data, "message should echo the input data");
+}


### PR DESCRIPTION
## Problem, Evidence, and Context

Under Gloas/ePBS, PTC validators must sign payload attestations (SSV-side section 3 of SIP-94). Lighthouse's `PayloadAttestationService` calls `sign_payload_attestation(pubkey, data)` per validator, but Anchor's implementation is an `Unsupported` stub, so the duty cannot run. Both dependencies are merged to `epbs`: #1076 (PTC value object removal) and #1080 (`Role::PTCAttester` + `PartialSignatureKind::PTCAttester`).

Addresses #1077.

## Change Overview

The method runs a SingleValidator partial-signature collection over the `PayloadAttestationData` LH passes in, signed under `Domain::PTCAttester`, mirroring the voluntary-exit flow (the one merged SingleValidator single-signature precedent). LH fetches the data once at the 75% slot cutoff and abstains on no-block, so the method only signs what it is handed.

Collection failures are classified for telemetry before the error is surfaced, because LH crit-logs whatever we return and the trait has no abstain path: a no-threshold miss (surfacing as `QueueClosedError` via collector eviction) warns and increments `anchor_ptc_reconstruction_failures_total{reason="no_signature"}`; local faults count as `reason="infra"`. Errors from the method's own validator/cluster/index resolution propagate untouched; non-collection errors raised inside `collect_signature` (share lookup, key decryption, threshold arithmetic) are error-logged for context but emit no metric.

Suggested reading order:
- `lib.rs`: `sign_payload_attestation` (the duty) and `report_ptc_collection_failure` (the effects)
- `instrumentation.rs`: pure failure classifier, next to the existing `failure_reason` mapper
- `metrics.rs`: the new counter
- `testing/`: harness extensions (failure injection, slashing flag, richer call capture) and the 5 new tests

Intentionally unchanged:
- No `PayloadAttestationService` spawning (#1078)
- No `signature_collector` changes; at current collector granularity a no-threshold miss and a genuine channel close are both `QueueClosedError`, so `reason="no_signature"` is an upper bound on true observation divergence. Clean measurement needs a collector change (separate follow-up issue).
- No `is_synced` gating: LH only schedules duties when synced. Flagging for reviewer confirmation.

## Risks, Trade-offs, and Mitigations

- Blast radius is small: nothing calls this method until #1078 spawns the service.
- On a minority split, the call blocks until the collector cleaner evicts (about 2 slots) and LH awaits validators sequentially. This is a pre-existing property of `collect_signature` shared by all duties, not introduced here.
- Recoverable no-threshold misses still surface through LH at `crit!`; unavoidable Anchor-side given the trait shape. The metric, not the log, is the measurement channel.

## Validation

`cargo test -p anchor_validator_store`: 44 passed (5 new). The new tests lock:
- message construction, and the signing root recomputed independently in the test (locks the `Domain::PTCAttester` choice, epoch derivation, and signed object), plus kind/role/slot wiring into the collector
- `MissingIndex` fails before any collection attempt
- `QueueClosedError` returns the original error and increments `{reason="no_signature"}`
- `EmptySignature` increments `{reason="infra"}` and leaves `{reason="no_signature"}` at zero delta, pinning that infra faults cannot leak into the divergence bucket
- slashing-DB tripwire: protection enabled against an empty slashing DB, so any future slashing check added to this path fails the test (payload attestations are not slashable)

`make cargo-fmt` and `make lint` clean.

## Rollback

Revert the commit; the method returns to the `Unsupported` stub. No config, data, or operational impact (no caller yet; the metric simply disappears).

## Blockers / Dependencies

None for merge. Follow-ups: #1078 (spawn the LH service) and a research issue for clean divergence measurement in `signature_collector`.
