### PR TITLE
feat(fork): reorder fork ordinality so CStar can activate without Boole

### DIFF
--- a/anchor/common/fork/src/fork.rs
+++ b/anchor/common/fork/src/fork.rs
@@ -140,6 +140,21 @@ mod tests {
     }
 
     #[test]
+    fn test_all_forks_sorted_by_ord() {
+        // The fork machinery relies on `Fork::all()` being ordered identically to
+        // the derived `Ord` (activation order): `ForkSchedule::new` uses
+        // `take_while(|f| f <= &fork)` over `all()`, and `from_fork_configs`
+        // validates monotonic epochs by iterating a `BTreeMap<Fork, _>` (which
+        // orders by `Ord`). Assert that invariant directly so a future fork added
+        // in the wrong enum position, or an out-of-order edit to `all()`, fails
+        // here rather than silently mis-seeding or mis-validating schedules.
+        assert!(
+            Fork::all().windows(2).all(|pair| pair[0] < pair[1]),
+            "Fork::all() must be strictly increasing by Ord (activation order)"
+        );
+    }
+
+    #[test]
     fn test_cstar_topic_prefix() {
         let prefix = Fork::CStar.topic_prefix("mainnet");
         assert_eq!(prefix, "/ssv/mainnet/cstar/");

--- a/anchor/common/fork/src/fork.rs
+++ b/anchor/common/fork/src/fork.rs
@@ -27,33 +27,41 @@ pub enum Fork {
     /// - Topic format: `ssv.v2.<subnet>`
     Alan,
 
+    /// The CStar fork, the SSV-side rollout of Ethereum's Gloas (ePBS) features.
+    ///
+    /// Activates directly on top of Alan behavior: Boole is unscheduled and
+    /// none of its features (MinHash subnets, AggregatorCommittee roles,
+    /// epoch shift) are enabled by CStar.
+    ///
+    /// Characteristics:
+    /// - Subnet topology: inherits Alan behavior (no subnet change at this fork).
+    /// - Topic format: `/ssv/<network>/cstar/<subnet>`
+    CStar,
+
     /// The Boole fork introducing MinHash subnet topology.
+    ///
+    /// Deprioritized indefinitely by SSV core and unscheduled on all networks.
+    /// If it ever activates, it must do so after CStar; this variant ordering
+    /// makes schedule validation reject a boole epoch at or before cstar's.
     ///
     /// Characteristics:
     /// - Subnet topology: `min(SHA256(operator_id)) % 128`
     /// - Topic format: `/ssv/<network>/boole/<subnet>`
     Boole,
-
-    /// The CStar fork, the SSV-side rollout of Ethereum's Gloas (ePBS) features.
-    ///
-    /// Characteristics:
-    /// - Subnet topology: inherits Boole behavior (no subnet change at this fork).
-    /// - Topic format: `/ssv/<network>/cstar/<subnet>`
-    CStar,
 }
 
 impl Fork {
     /// Returns all known forks in chronological order.
     pub const fn all() -> &'static [Fork] {
-        &[Fork::Alan, Fork::Boole, Fork::CStar]
+        &[Fork::Alan, Fork::CStar, Fork::Boole]
     }
 
     /// Returns the name of this fork as a string.
     pub const fn name(&self) -> &'static str {
         match self {
             Fork::Alan => "alan",
-            Fork::Boole => "boole",
             Fork::CStar => "cstar",
+            Fork::Boole => "boole",
         }
     }
 
@@ -81,8 +89,8 @@ impl std::str::FromStr for Fork {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s.to_lowercase().as_str() {
             "alan" => Ok(Fork::Alan),
-            "boole" => Ok(Fork::Boole),
             "cstar" => Ok(Fork::CStar),
+            "boole" => Ok(Fork::Boole),
             _ => Err(format!("Unknown fork: {s}")),
         }
     }
@@ -94,8 +102,8 @@ mod tests {
 
     #[test]
     fn test_fork_ordering() {
-        assert!(Fork::Alan < Fork::Boole);
-        assert!(Fork::Boole < Fork::CStar);
+        assert!(Fork::Alan < Fork::CStar);
+        assert!(Fork::CStar < Fork::Boole);
     }
 
     #[test]
@@ -127,8 +135,8 @@ mod tests {
         let all = Fork::all();
         assert_eq!(all.len(), 3);
         assert_eq!(all[0], Fork::Alan);
-        assert_eq!(all[1], Fork::Boole);
-        assert_eq!(all[2], Fork::CStar);
+        assert_eq!(all[1], Fork::CStar);
+        assert_eq!(all[2], Fork::Boole);
     }
 
     #[test]

--- a/anchor/common/fork/src/lib.rs
+++ b/anchor/common/fork/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //! This crate provides types and utilities for managing SSV protocol forks:
 //!
-//! - [`Fork`]: Enum representing SSV protocol versions (Alan, Boole, CStar)
+//! - [`Fork`]: Enum representing SSV protocol versions (Alan, CStar, Boole)
 //! - [`ForkSchedule`]: Manages fork activation epochs and transition timing
 //! - [`ForkConfig`]: Complete configuration for a fork including topic prefix
 //! - [`ForkLifecycle`]: Fork lifecycle state distributed via `tokio::sync::watch`

--- a/anchor/common/fork/src/schedule.rs
+++ b/anchor/common/fork/src/schedule.rs
@@ -97,6 +97,11 @@ pub struct ForkSchedule {
 
 impl ForkSchedule {
     /// Create a new fork schedule with the given fork active from epoch 0.
+    ///
+    /// Seeds every fork up to and including `fork` in chronological (enum)
+    /// order, all at epoch 0. Note the chronology is `Alan < CStar < Boole`:
+    /// `new(Fork::CStar)` seeds Alan and CStar without Boole, while
+    /// `new(Fork::Boole)` seeds all three forks.
     pub fn new(fork: Fork, baseline_domain_type: DomainType, network_name: &str) -> Self {
         let mut configs = BTreeMap::new();
         for fork in Fork::all().iter().take_while(|&f| f <= &fork) {
@@ -224,11 +229,12 @@ mod tests {
     use super::*;
     use crate::fork::ALAN_TOPIC_PREFIX;
 
-    // Test constants
+    // Test constants. Domain values follow the wire-constants convention:
+    // CStar takes 0x00000002 and Boole (if ever scheduled) takes 0x00000003.
     const TEST_NETWORK: &str = "mainnet";
     const BASELINE_DOMAIN: DomainType = DomainType([0, 0, 0, 1]);
-    const BOOLE_DOMAIN: DomainType = DomainType([0, 0, 0, 2]);
-    const CSTAR_DOMAIN: DomainType = DomainType([0, 0, 0, 3]);
+    const CSTAR_DOMAIN: DomainType = DomainType([0, 0, 0, 2]);
+    const BOOLE_DOMAIN: DomainType = DomainType([0, 0, 0, 3]);
 
     fn schedule_with_boole(epoch: u64) -> ForkSchedule {
         let mut configs = BTreeMap::new();
@@ -323,17 +329,57 @@ mod tests {
     fn test_with_three_forks() {
         let mut configs = BTreeMap::new();
         configs.insert(Fork::Alan, (Epoch::new(0), BASELINE_DOMAIN));
-        configs.insert(Fork::Boole, (Epoch::new(100), BOOLE_DOMAIN));
-        configs.insert(Fork::CStar, (Epoch::new(200), CSTAR_DOMAIN));
+        configs.insert(Fork::CStar, (Epoch::new(100), CSTAR_DOMAIN));
+        configs.insert(Fork::Boole, (Epoch::new(200), BOOLE_DOMAIN));
 
         let schedule = ForkSchedule::from_fork_configs(configs, TEST_NETWORK).unwrap();
 
-        assert_eq!(schedule.active_fork(Epoch::new(199)), Fork::Boole);
-        assert_eq!(schedule.active_fork(Epoch::new(200)), Fork::CStar);
-        assert_eq!(schedule.active_fork(Epoch::new(1000)), Fork::CStar);
+        assert_eq!(schedule.active_fork(Epoch::new(99)), Fork::Alan);
+        assert_eq!(schedule.active_fork(Epoch::new(100)), Fork::CStar);
+        assert_eq!(schedule.active_fork(Epoch::new(199)), Fork::CStar);
+        assert_eq!(schedule.active_fork(Epoch::new(200)), Fork::Boole);
+        assert_eq!(schedule.active_fork(Epoch::new(1000)), Fork::Boole);
 
-        assert_eq!(schedule.fork_epoch(Fork::CStar), Some(Epoch::new(200)));
+        assert_eq!(schedule.fork_epoch(Fork::CStar), Some(Epoch::new(100)));
+        assert_eq!(schedule.fork_epoch(Fork::Boole), Some(Epoch::new(200)));
         assert_eq!(schedule.domain_type(Fork::CStar), Some(CSTAR_DOMAIN));
+        assert_eq!(schedule.domain_type(Fork::Boole), Some(BOOLE_DOMAIN));
+    }
+
+    #[test]
+    fn test_from_fork_configs_cstar_without_boole() {
+        const CSTAR_EPOCH: u64 = 100;
+
+        let mut configs = BTreeMap::new();
+        configs.insert(Fork::Alan, (Epoch::new(0), BASELINE_DOMAIN));
+        configs.insert(Fork::CStar, (Epoch::new(CSTAR_EPOCH), CSTAR_DOMAIN));
+
+        let schedule = ForkSchedule::from_fork_configs(configs, TEST_NETWORK)
+            .expect("alan + cstar without boole must be a valid schedule");
+
+        assert_eq!(
+            schedule.active_fork(Epoch::new(CSTAR_EPOCH - 1)),
+            Fork::Alan
+        );
+        assert_eq!(schedule.active_fork(Epoch::new(CSTAR_EPOCH)), Fork::CStar);
+        assert_eq!(
+            schedule.next_fork_after(Epoch::new(0)),
+            Some((Fork::CStar, Epoch::new(CSTAR_EPOCH)))
+        );
+        assert_eq!(schedule.fork_epoch(Fork::Boole), None);
+    }
+
+    #[test]
+    fn test_from_fork_configs_boole_before_cstar_rejected() {
+        // Boole must activate after CStar; scheduling it earlier is invalid.
+        let mut configs = BTreeMap::new();
+        configs.insert(Fork::Alan, (Epoch::new(0), BASELINE_DOMAIN));
+        configs.insert(Fork::CStar, (Epoch::new(200), CSTAR_DOMAIN));
+        configs.insert(Fork::Boole, (Epoch::new(100), BOOLE_DOMAIN));
+
+        let result = ForkSchedule::from_fork_configs(configs, TEST_NETWORK);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("scheduled before"));
     }
 
     #[test]

--- a/anchor/common/ssv_network_config/built_in_network_configs/holesky/ssv_fork_schedule.yaml
+++ b/anchor/common/ssv_network_config/built_in_network_configs/holesky/ssv_fork_schedule.yaml
@@ -2,10 +2,10 @@
 # Maps fork names directly to their configuration.
 # Note: Alan fork (genesis) is always at epoch 0 and should not be specified here.
 #
-# Example:
-# boole:
+# Example (cstar precedes boole; boole is unscheduled and may only follow cstar):
+# cstar:
 #   epoch: 12500
 #   domain_type: "00000002"
-# cstar:
+# boole:
 #   epoch: 13000
 #   domain_type: "00000003"

--- a/anchor/common/ssv_network_config/built_in_network_configs/hoodi/ssv_fork_schedule.yaml
+++ b/anchor/common/ssv_network_config/built_in_network_configs/hoodi/ssv_fork_schedule.yaml
@@ -2,10 +2,10 @@
 # Maps fork names directly to their configuration.
 # Note: Alan fork (genesis) is always at epoch 0 and should not be specified here.
 #
-# Example:
-# boole:
+# Example (cstar precedes boole; boole is unscheduled and may only follow cstar):
+# cstar:
 #   epoch: 12500
 #   domain_type: "00000002"
-# cstar:
+# boole:
 #   epoch: 13000
 #   domain_type: "00000003"

--- a/anchor/common/ssv_network_config/built_in_network_configs/mainnet/ssv_fork_schedule.yaml
+++ b/anchor/common/ssv_network_config/built_in_network_configs/mainnet/ssv_fork_schedule.yaml
@@ -2,10 +2,10 @@
 # Maps fork names directly to their configuration.
 # Note: Alan fork (genesis) is always at epoch 0 and should not be specified here.
 #
-# Example:
-# boole:
+# Example (cstar precedes boole; boole is unscheduled and may only follow cstar):
+# cstar:
 #   epoch: 12500
 #   domain_type: "00000002"
-# cstar:
+# boole:
 #   epoch: 13000
 #   domain_type: "00000003"

--- a/anchor/common/ssv_network_config/src/lib.rs
+++ b/anchor/common/ssv_network_config/src/lib.rs
@@ -220,14 +220,15 @@ mod tests {
     const TEST_CONTRACT_BLOCK: &str = "123456";
     const TEST_DOMAIN_TYPE_STR: &str = "00000001";
     const TEST_DOMAIN_TYPE: DomainType = DomainType([0, 0, 0, 1]);
-    const BOOLE_DOMAIN_TYPE: DomainType = DomainType([0, 0, 0, 2]);
-    const CSTAR_DOMAIN_TYPE: DomainType = DomainType([0, 0, 0, 3]);
+    const CSTAR_DOMAIN_TYPE: DomainType = DomainType([0, 0, 0, 2]);
+    const BOOLE_DOMAIN_TYPE: DomainType = DomainType([0, 0, 0, 3]);
 
-    // Fork activation epochs for tests. Scenario epochs (just before / just after
-    // activation) are derived inline at the use site.
+    // Fork activation epochs for tests, in chronological order (Alan < CStar
+    // < Boole). Scenario epochs (just before / just after activation) are
+    // derived inline at the use site.
     const ALAN_FORK_EPOCH: u64 = 0;
-    const BOOLE_FORK_EPOCH: u64 = 100;
-    const CSTAR_FORK_EPOCH: u64 = 200;
+    const CSTAR_FORK_EPOCH: u64 = 100;
+    const BOOLE_FORK_EPOCH: u64 = 200;
 
     /// Construct expected Boole topic prefix for a network.
     fn expected_boole_prefix(network: &str) -> String {
@@ -328,14 +329,14 @@ mod tests {
         // Arrange
         let yaml = format!(
             r#"
-boole:
+cstar:
   epoch: {}
   domain_type: "00000002"
-cstar:
+boole:
   epoch: {}
   domain_type: "00000003"
 "#,
-            BOOLE_FORK_EPOCH, CSTAR_FORK_EPOCH
+            CSTAR_FORK_EPOCH, BOOLE_FORK_EPOCH
         );
         let dir = create_test_config_dir(Some(&yaml));
 
@@ -496,20 +497,20 @@ cstar:
         // Arrange
         let yaml = format!(
             r#"
-boole:
+cstar:
   epoch: {}
   domain_type: "00000002"
-cstar:
+boole:
   epoch: {}
   domain_type: "00000003"
 "#,
-            BOOLE_FORK_EPOCH, CSTAR_FORK_EPOCH
+            CSTAR_FORK_EPOCH, BOOLE_FORK_EPOCH
         );
         let dir = create_test_config_dir(Some(&yaml));
         let config = SsvNetworkConfig::load(dir.path().to_path_buf()).unwrap();
         let network_name = config.network_name.as_str();
 
-        // Act & Assert: Before Boole activation - should use Alan prefix
+        // Act & Assert: Before CStar activation - should use Alan prefix
         let active_fork = config
             .fork_schedule
             .active_fork(Epoch::new(ALAN_FORK_EPOCH));
@@ -517,27 +518,10 @@ cstar:
 
         let active_fork = config
             .fork_schedule
-            .active_fork(Epoch::new(BOOLE_FORK_EPOCH - 1));
+            .active_fork(Epoch::new(CSTAR_FORK_EPOCH - 1));
         assert_eq!(active_fork.topic_prefix(network_name), ALAN_TOPIC_PREFIX);
 
-        // Act & Assert: Between Boole and CStar activation - should use Boole prefix
-        let active_fork = config
-            .fork_schedule
-            .active_fork(Epoch::new(BOOLE_FORK_EPOCH));
-        assert_eq!(
-            active_fork.topic_prefix(network_name),
-            expected_boole_prefix(TEST_NETWORK_NAME)
-        );
-
-        let active_fork = config
-            .fork_schedule
-            .active_fork(Epoch::new(CSTAR_FORK_EPOCH - 1));
-        assert_eq!(
-            active_fork.topic_prefix(network_name),
-            expected_boole_prefix(TEST_NETWORK_NAME)
-        );
-
-        // Act & Assert: At and after CStar activation - should use CStar prefix
+        // Act & Assert: Between CStar and Boole activation - should use CStar prefix
         let active_fork = config
             .fork_schedule
             .active_fork(Epoch::new(CSTAR_FORK_EPOCH));
@@ -548,10 +532,27 @@ cstar:
 
         let active_fork = config
             .fork_schedule
-            .active_fork(Epoch::new(CSTAR_FORK_EPOCH + 1));
+            .active_fork(Epoch::new(BOOLE_FORK_EPOCH - 1));
         assert_eq!(
             active_fork.topic_prefix(network_name),
             expected_cstar_prefix(TEST_NETWORK_NAME)
+        );
+
+        // Act & Assert: At and after Boole activation - should use Boole prefix
+        let active_fork = config
+            .fork_schedule
+            .active_fork(Epoch::new(BOOLE_FORK_EPOCH));
+        assert_eq!(
+            active_fork.topic_prefix(network_name),
+            expected_boole_prefix(TEST_NETWORK_NAME)
+        );
+
+        let active_fork = config
+            .fork_schedule
+            .active_fork(Epoch::new(BOOLE_FORK_EPOCH + 1));
+        assert_eq!(
+            active_fork.topic_prefix(network_name),
+            expected_boole_prefix(TEST_NETWORK_NAME)
         );
     }
 

--- a/anchor/message_validator/src/consensus_message.rs
+++ b/anchor/message_validator/src/consensus_message.rs
@@ -1341,6 +1341,59 @@ mod tests {
     }
 
     #[test]
+    fn test_round_robin_proposer_cstar_fork() {
+        let mut committee: IndexSet<OperatorId> = vec![OperatorId(1), OperatorId(2), OperatorId(3)]
+            .into_iter()
+            .collect();
+        let slots_per_epoch = 32;
+        // CStar fork precedes Boole, so eth_epoch is NOT included in the calculation
+        let fork_schedule = ForkSchedule::new(Fork::CStar, DomainType::default(), "testing"); // CStar active from epoch 0, Boole unscheduled
+
+        // Test basic round robin at height 0, epoch 0
+        // index = (0 + 1 - 1) % 3 = 0 -> OperatorId(1)
+        assert_eq!(
+            round_robin_proposer(
+                0,
+                FIRST_ROUND.into(),
+                &mut committee,
+                slots_per_epoch,
+                &fork_schedule
+            )
+            .unwrap(),
+            OperatorId(1)
+        );
+
+        // Test epoch boundaries WITHOUT epoch shift under CStar.
+        // Slot 32, epoch 1: index = (32 + 1 - 1) % 3 = 32 % 3 = 2 -> OperatorId(3)
+        // (with the Boole epoch shift this would be 33 % 3 = 0 -> OperatorId(1))
+        assert_eq!(
+            round_robin_proposer(
+                32,
+                FIRST_ROUND.into(),
+                &mut committee,
+                slots_per_epoch,
+                &fork_schedule
+            )
+            .unwrap(),
+            OperatorId(3)
+        );
+
+        // Slot 64, epoch 2: index = (64 + 1 - 1) % 3 = 64 % 3 = 1 -> OperatorId(2)
+        // (with the Boole epoch shift this would be 66 % 3 = 0 -> OperatorId(1))
+        assert_eq!(
+            round_robin_proposer(
+                64,
+                FIRST_ROUND.into(),
+                &mut committee,
+                slots_per_epoch,
+                &fork_schedule
+            )
+            .unwrap(),
+            OperatorId(2)
+        );
+    }
+
+    #[test]
     fn test_current_estimated_round() {
         // Test early rounds (quick timeout)
         assert_eq!(current_estimated_round(Duration::from_secs(0)), 1.into());
@@ -1793,12 +1846,13 @@ mod tests {
         assert_eq!(result, Ok(Some(2)));
     }
 
-    /// Helper function for testing role validation against fork schedules.
-    ///
-    /// Tests whether a consensus message for a given role is properly accepted or rejected
-    /// based on the fork schedule. Used to verify that deprecated roles (Aggregator and
-    /// SyncCommittee) are rejected after the Boole fork but accepted before it.
-    fn test_role_fork_validation(role: Role, is_after_boole: bool, should_be_rejected: bool) {
+    /// Runs full consensus-message validation for a role against a fork
+    /// schedule with `schedule_fork` (and all earlier forks) active from
+    /// epoch 0, returning the validation result.
+    fn run_role_fork_validation(
+        role: Role,
+        schedule_fork: Fork,
+    ) -> Result<ValidatedSSVMessage, ValidationFailure> {
         // Arrange: Set up test data and validation context
         let committee_info = create_committee_info(FOUR_NODE_COMMITTEE);
         let (private_key, public_key) = generate_test_key_pair();
@@ -1823,15 +1877,11 @@ mod tests {
         slot_clock.advance_slot();
         slot_clock.advance_time(slot_duration);
 
-        let fork_schedule = if is_after_boole {
-            Arc::new(ForkSchedule::new(
-                Fork::Boole,
-                DomainType::default(),
-                "testing",
-            ))
-        } else {
-            generate_fork_schedule()
-        };
+        let fork_schedule = Arc::new(ForkSchedule::new(
+            schedule_fork,
+            DomainType::default(),
+            "testing",
+        ));
 
         let validation_context = ValidationContext {
             signed_ssv_message: &signed_msg,
@@ -1847,13 +1897,23 @@ mod tests {
         };
 
         // Act: Validate the message
-        let result = validate_ssv_message(
+        validate_ssv_message(
             validation_context,
             &mut DutyState::new(64),
             Arc::new(MockDutiesProvider {
                 voluntary_exit_duty_count: 0,
             }),
-        );
+        )
+    }
+
+    /// Helper function for testing role validation against fork schedules.
+    ///
+    /// Tests whether a consensus message for a given role is properly accepted or rejected
+    /// based on the fork schedule. Used to verify that deprecated roles (Aggregator and
+    /// SyncCommittee) are rejected once Boole is active but accepted before it (including
+    /// under CStar, which precedes Boole in the chronology).
+    fn test_role_fork_validation(role: Role, schedule_fork: Fork, should_be_rejected: bool) {
+        let result = run_role_fork_validation(role, schedule_fork);
 
         // Assert: Verify the expected outcome
         if should_be_rejected {
@@ -1874,28 +1934,62 @@ mod tests {
         } else {
             assert_qbft_message_accepted(
                 result,
-                &format!("Expected {role:?} to be accepted before Boole fork"),
+                &format!("Expected {role:?} to be accepted with {schedule_fork:?} active"),
             );
         }
     }
 
     #[test]
     fn test_aggregator_consensus_message_rejected_after_boole() {
-        test_role_fork_validation(Role::Aggregator, true, true);
+        test_role_fork_validation(Role::Aggregator, Fork::Boole, true);
     }
 
     #[test]
     fn test_aggregator_consensus_message_accepted_before_boole() {
-        test_role_fork_validation(Role::Aggregator, false, false);
+        test_role_fork_validation(Role::Aggregator, Fork::Alan, false);
+    }
+
+    #[test]
+    fn test_aggregator_consensus_message_accepted_at_cstar() {
+        // CStar precedes Boole, so the legacy per-validator role is still active.
+        test_role_fork_validation(Role::Aggregator, Fork::CStar, false);
     }
 
     #[test]
     fn test_sync_committee_consensus_message_accepted_before_boole() {
-        test_role_fork_validation(Role::SyncCommittee, false, false);
+        test_role_fork_validation(Role::SyncCommittee, Fork::Alan, false);
+    }
+
+    #[test]
+    fn test_sync_committee_consensus_message_accepted_at_cstar() {
+        // CStar precedes Boole, so the legacy per-validator role is still active.
+        test_role_fork_validation(Role::SyncCommittee, Fork::CStar, false);
     }
 
     #[test]
     fn test_sync_committee_consensus_message_rejected_after_boole() {
-        test_role_fork_validation(Role::SyncCommittee, true, true);
+        test_role_fork_validation(Role::SyncCommittee, Fork::Boole, true);
+    }
+
+    #[test]
+    fn test_aggregator_committee_consensus_message_rejected_at_cstar() {
+        // CStar activates without Boole, so the Boole-only AggregatorCommittee
+        // role must be rejected as not yet active.
+        let result = run_role_fork_validation(Role::AggregatorCommittee, Fork::CStar);
+
+        assert_validation_error(
+            result,
+            |failure| {
+                matches!(
+                    failure,
+                    ValidationFailure::RoleNotActiveBeforeFork {
+                        role: Role::AggregatorCommittee,
+                        current_fork: Fork::CStar,
+                        minimum_fork: Fork::Boole,
+                    }
+                )
+            },
+            "RoleNotActiveBeforeFork for AggregatorCommittee",
+        );
     }
 }

--- a/anchor/message_validator/src/partial_signature.rs
+++ b/anchor/message_validator/src/partial_signature.rs
@@ -1741,7 +1741,9 @@ mod tests {
             &private_key,
         );
 
-        let fork_schedule = generate_fork_schedule(Fork::Boole);
+        // Alan-only schedule: CStar (and Boole) unscheduled, so PTCAttester is
+        // not yet active.
+        let fork_schedule = generate_fork_schedule(Fork::Alan);
         let validation_context = create_test_validation_context_with_fork(
             &signed_msg,
             &committee_info,

--- a/anchor/subnet_service/src/service.rs
+++ b/anchor/subnet_service/src/service.rs
@@ -101,11 +101,11 @@ impl<S: SlotClock> SubnetService<S> {
         let fork = self.router.active_fork_at_slot(slot);
 
         match fork {
-            Fork::Alan => Ok(SubnetId::from_committee_alan(committee_id, SUBNET_COUNT)),
-            Fork::Boole | Fork::CStar => {
-                SubnetId::from_operators(operator_ids, crate::SUBNET_COUNT_NZ)
-                    .map_err(SubnetServiceError::SubnetCalculation)
+            Fork::Alan | Fork::CStar => {
+                Ok(SubnetId::from_committee_alan(committee_id, SUBNET_COUNT))
             }
+            Fork::Boole => SubnetId::from_operators(operator_ids, crate::SUBNET_COUNT_NZ)
+                .map_err(SubnetServiceError::SubnetCalculation),
         }
     }
 

--- a/anchor/subnet_service/src/subnet.rs
+++ b/anchor/subnet_service/src/subnet.rs
@@ -114,13 +114,11 @@ impl SubnetId {
     ) -> Result<SubnetId, SubnetCalculationError> {
         let committee_id = CommitteeId::from(operator_ids);
         match fork {
-            Fork::Alan => Ok(SubnetId::from_committee_alan(
+            Fork::Alan | Fork::CStar => Ok(SubnetId::from_committee_alan(
                 committee_id,
                 crate::SUBNET_COUNT,
             )),
-            Fork::Boole | Fork::CStar => {
-                SubnetId::from_operators(operator_ids, crate::SUBNET_COUNT_NZ)
-            }
+            Fork::Boole => SubnetId::from_operators(operator_ids, crate::SUBNET_COUNT_NZ),
         }
     }
 }
@@ -286,6 +284,32 @@ mod tests {
             let subnet = SubnetId::from_committee_alan(committee_id, 128);
             assert!((*subnet) < 128);
         }
+    }
+
+    #[test]
+    fn test_from_operators_for_fork_cstar_inherits_committee_topology() {
+        // Operator set where the two topologies map to different subnets:
+        // committee-based gives SHA256(op ids as u32 LE) % 128 = 114, while
+        // MinHash gives 11 (see test_from_operators_minhash).
+        let operators = vec![OperatorId(1), OperatorId(2), OperatorId(3), OperatorId(4)];
+
+        let alan_subnet =
+            SubnetId::from_operators_for_fork(&operators, Fork::Alan).expect("valid operators");
+        let cstar_subnet =
+            SubnetId::from_operators_for_fork(&operators, Fork::CStar).expect("valid operators");
+        let boole_subnet =
+            SubnetId::from_operators_for_fork(&operators, Fork::Boole).expect("valid operators");
+
+        assert_eq!(
+            cstar_subnet, alan_subnet,
+            "CStar must inherit the Alan committee-based subnet topology"
+        );
+        assert_ne!(
+            cstar_subnet, boole_subnet,
+            "CStar must not use the Boole MinHash subnet topology"
+        );
+        assert_eq!(*cstar_subnet, 114, "committee-based subnet for [1,2,3,4]");
+        assert_eq!(*boole_subnet, 11, "MinHash subnet for [1,2,3,4]");
     }
 
     #[test]


### PR DESCRIPTION
## Problem, Evidence, and Context (Required)

SSV core has deprioritized the Boole fork indefinitely. CStar (the SSV-side Gloas rollout) now ships **first**, on a hard deadline tied to Ethereum's Gloas fork. Boole may still happen later, so its logic must be retained.

Anchor's fork machinery assumes the chronology `Alan < Boole < CStar`: `Fork` derives `Ord` from variant order, and every behavior gate is an ordinal comparison (`active_fork(epoch) >= Fork::X`). With that ordering, activating CStar makes every `>= Fork::Boole` gate evaluate true, silently switching on Boole behaviors (MinHash subnet topology, `AggregatorCommittee` wire roles, the QBFT epoch shift) that the network never agreed to. The scheduling layer already supports skipping Boole; the problem is purely the behavior layer.

Closes #1085.

## Change Overview (Required)

Reorder the `Fork` enum to `Alan, CStar, Boole` so the derived `Ord` becomes `Alan < CStar < Boole`. Because every gate is an ordinal comparison, this single change flips them all at once: `>= Fork::Boole` behaviors stay dormant while Boole is unscheduled, and the new ordering forces any future Boole activation to land *after* CStar. CStar therefore lands directly on Alan-era behavior.

Only one site needed a behavior re-key: the two subnet-topology match arms that explicitly grouped `Boole | CStar`. They now read `Fork::Alan | Fork::CStar => committee-based`, `Fork::Boole => MinHash`. No other ordinal gate needed a code change.

Reading order:
1. `common/fork/src/fork.rs` — the enum reorder (the conceptual core).
2. `subnet_service/src/{subnet,service}.rs` — the one behavior re-key.
3. `common/fork/src/schedule.rs` — schedule-validation tests (cstar-without-boole accepted; boole-before-cstar rejected). Note `from_fork_configs` needs no code change: it iterates a `BTreeMap<Fork, _>` in enum order, so the reorder makes the validation correct automatically.
4. The test additions in `message_validator` and `ssv_network_config`, plus the built-in fork-schedule example comments.

**What did not change:** Boole logic is fully retained (explicitly not removed). Name-based parsing, `Display`, and gossip topic strings are order-free and unchanged. Pre-CStar (Alan-only) behavior is byte-for-byte identical. No wire/serialization format changes (`Fork` serde is name-based; it is never serialized by ordinal).

## Risks, Trade-offs, and Mitigations (Required)

- **Blast radius:** the reorder ripples to every crate that gates on `Fork`, which is why the diff spans 4 crates. It is one atomic change and cannot be split. Each affected gate was audited; only the subnet match arms required a code change.
- **`ForkSchedule::new(fork)` semantics shift:** it seeds every fork `<= fork`, so `new(Fork::Boole)` now co-activates CStar. The validator_store committee-attestation harness uses a Boole schedule and consequently now exercises the real `GloasBeaconVote` path. This is the genuinely-correct behavior for a Boole network (which is necessarily post-CStar), so it is improved coverage, not a regression. Documented in the `new` doc comment.
- **Wire constants (provisional):** CStar takes domain `0x00000002` (the increment after Alan), Boole takes `0x00000003` if later activated. Anchor is the first mover; go-ssv has not started Gloas-fork planning. These anchor-side choices should be memorialized for eventual go-ssv parity. No built-in network schedules either fork today (they carry both only as commented examples), so nothing live is affected.

## Validation (Required)

- `make cargo-fmt-check` and `make lint` (clippy `-D warnings`): clean.
- Full `cargo test` on every affected crate passes: `fork`, `subnet_service` (55), `ssv_network_config`, `message_validator` (67), `qbft_manager` (31), `anchor_validator_store` (41), `network` (52).
- New tests encode the acceptance criteria: `alan@0 + cstar@N` (no boole) validates and `active_fork(N) == CStar`; a boole-before-cstar schedule is rejected; CStar inherits committee-based subnet topology; legacy `Aggregator`/`SyncCommittee` wire roles are accepted and `AggregatorCommittee` is rejected under CStar; no epoch shift in round-robin proposer selection under CStar.
- The rest of the workspace test run is green; the only failure is `spec_tests`, which requires Go-generated fixtures absent in a fresh checkout (environmental, unrelated to this diff).

## Rollback (Required for behavior or runtime changes; optional otherwise)

Revert the commit. No config, data, or operational impact: no production network schedules Boole or CStar today, and the change is a pure in-memory ordering with no wire-format effect.

## Additional Info / Next Steps (Optional)

The issue also proposed centralizing the scattered ordinal gates into `ForkSchedule` capability methods (`min_hash_subnets_active(epoch)`, etc.). That hardening is intentionally **deferred to a follow-up PR** to keep this one behavior-only and independently reviewable. The reorder is fully correct without it.