### PR TITLE
refactor!: gate ePBS on Ethereum Gloas fork, remove SSV Fork::CStar

### DIFF
--- a/anchor/client/src/lib.rs
+++ b/anchor/client/src/lib.rs
@@ -549,6 +549,7 @@ impl Client {
             slot_clock.clone(),
             subnet_service.clone(),
             fork_schedule.clone(),
+            spec.clone(),
             &executor,
         );
 
@@ -590,6 +591,7 @@ impl Client {
             message_sender,
             NonZeroU64::new(E::slots_per_epoch()).expect("slots_per_epoch is non-zero"),
             fork_schedule.clone(),
+            spec.clone(),
         )
         .map_err(|e| format!("Unable to initialize qbft manager: {e:?}"))?;
 

--- a/anchor/common/fork/src/fork.rs
+++ b/anchor/common/fork/src/fork.rs
@@ -33,19 +33,12 @@ pub enum Fork {
     /// - Subnet topology: `min(SHA256(operator_id)) % 128`
     /// - Topic format: `/ssv/<network>/boole/<subnet>`
     Boole,
-
-    /// The CStar fork, the SSV-side rollout of Ethereum's Gloas (ePBS) features.
-    ///
-    /// Characteristics:
-    /// - Subnet topology: inherits Boole behavior (no subnet change at this fork).
-    /// - Topic format: `/ssv/<network>/cstar/<subnet>`
-    CStar,
 }
 
 impl Fork {
     /// Returns all known forks in chronological order.
     pub const fn all() -> &'static [Fork] {
-        &[Fork::Alan, Fork::Boole, Fork::CStar]
+        &[Fork::Alan, Fork::Boole]
     }
 
     /// Returns the name of this fork as a string.
@@ -53,7 +46,6 @@ impl Fork {
         match self {
             Fork::Alan => "alan",
             Fork::Boole => "boole",
-            Fork::CStar => "cstar",
         }
     }
 
@@ -82,7 +74,6 @@ impl std::str::FromStr for Fork {
         match s.to_lowercase().as_str() {
             "alan" => Ok(Fork::Alan),
             "boole" => Ok(Fork::Boole),
-            "cstar" => Ok(Fork::CStar),
             _ => Err(format!("Unknown fork: {s}")),
         }
     }
@@ -95,21 +86,18 @@ mod tests {
     #[test]
     fn test_fork_ordering() {
         assert!(Fork::Alan < Fork::Boole);
-        assert!(Fork::Boole < Fork::CStar);
     }
 
     #[test]
     fn test_fork_names() {
         assert_eq!(Fork::Alan.name(), "alan");
         assert_eq!(Fork::Boole.name(), "boole");
-        assert_eq!(Fork::CStar.name(), "cstar");
     }
 
     #[test]
     fn test_fork_display() {
         assert_eq!(format!("{}", Fork::Alan), "alan");
         assert_eq!(format!("{}", Fork::Boole), "boole");
-        assert_eq!(format!("{}", Fork::CStar), "cstar");
     }
 
     #[test]
@@ -117,26 +105,23 @@ mod tests {
         assert_eq!("alan".parse::<Fork>().unwrap(), Fork::Alan);
         assert_eq!("Boole".parse::<Fork>().unwrap(), Fork::Boole);
         assert_eq!("ALAN".parse::<Fork>().unwrap(), Fork::Alan);
-        assert_eq!("cstar".parse::<Fork>().unwrap(), Fork::CStar);
-        assert_eq!("CSTAR".parse::<Fork>().unwrap(), Fork::CStar);
         assert!("unknown".parse::<Fork>().is_err());
     }
 
     #[test]
     fn test_all_forks() {
         let all = Fork::all();
-        assert_eq!(all.len(), 3);
+        assert_eq!(all.len(), 2);
         assert_eq!(all[0], Fork::Alan);
         assert_eq!(all[1], Fork::Boole);
-        assert_eq!(all[2], Fork::CStar);
     }
 
     #[test]
-    fn test_cstar_topic_prefix() {
-        let prefix = Fork::CStar.topic_prefix("mainnet");
-        assert_eq!(prefix, "/ssv/mainnet/cstar/");
+    fn test_boole_topic_prefix() {
+        let prefix = Fork::Boole.topic_prefix("mainnet");
+        assert_eq!(prefix, "/ssv/mainnet/boole/");
 
-        let prefix_holesky = Fork::CStar.topic_prefix("holesky");
-        assert_eq!(prefix_holesky, "/ssv/holesky/cstar/");
+        let prefix_holesky = Fork::Boole.topic_prefix("holesky");
+        assert_eq!(prefix_holesky, "/ssv/holesky/boole/");
     }
 }

--- a/anchor/common/fork/src/lib.rs
+++ b/anchor/common/fork/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //! This crate provides types and utilities for managing SSV protocol forks:
 //!
-//! - [`Fork`]: Enum representing SSV protocol versions (Alan, Boole, CStar)
+//! - [`Fork`]: Enum representing SSV protocol versions (Alan, Boole)
 //! - [`ForkSchedule`]: Manages fork activation epochs and transition timing
 //! - [`ForkConfig`]: Complete configuration for a fork including topic prefix
 //! - [`ForkLifecycle`]: Fork lifecycle state distributed via `tokio::sync::watch`

--- a/anchor/common/fork/src/schedule.rs
+++ b/anchor/common/fork/src/schedule.rs
@@ -228,7 +228,6 @@ mod tests {
     const TEST_NETWORK: &str = "mainnet";
     const BASELINE_DOMAIN: DomainType = DomainType([0, 0, 0, 1]);
     const BOOLE_DOMAIN: DomainType = DomainType([0, 0, 0, 2]);
-    const CSTAR_DOMAIN: DomainType = DomainType([0, 0, 0, 3]);
 
     fn schedule_with_boole(epoch: u64) -> ForkSchedule {
         let mut configs = BTreeMap::new();
@@ -317,23 +316,6 @@ mod tests {
         assert_eq!(schedule.fork_epoch(Fork::Boole), Some(Epoch::new(100)));
         assert_eq!(schedule.domain_type(Fork::Alan), Some(BASELINE_DOMAIN));
         assert_eq!(schedule.domain_type(Fork::Boole), Some(BOOLE_DOMAIN));
-    }
-
-    #[test]
-    fn test_with_three_forks() {
-        let mut configs = BTreeMap::new();
-        configs.insert(Fork::Alan, (Epoch::new(0), BASELINE_DOMAIN));
-        configs.insert(Fork::Boole, (Epoch::new(100), BOOLE_DOMAIN));
-        configs.insert(Fork::CStar, (Epoch::new(200), CSTAR_DOMAIN));
-
-        let schedule = ForkSchedule::from_fork_configs(configs, TEST_NETWORK).unwrap();
-
-        assert_eq!(schedule.active_fork(Epoch::new(199)), Fork::Boole);
-        assert_eq!(schedule.active_fork(Epoch::new(200)), Fork::CStar);
-        assert_eq!(schedule.active_fork(Epoch::new(1000)), Fork::CStar);
-
-        assert_eq!(schedule.fork_epoch(Fork::CStar), Some(Epoch::new(200)));
-        assert_eq!(schedule.domain_type(Fork::CStar), Some(CSTAR_DOMAIN));
     }
 
     #[test]

--- a/anchor/common/ssv_network_config/built_in_network_configs/holesky/ssv_fork_schedule.yaml
+++ b/anchor/common/ssv_network_config/built_in_network_configs/holesky/ssv_fork_schedule.yaml
@@ -6,6 +6,3 @@
 # boole:
 #   epoch: 12500
 #   domain_type: "00000002"
-# cstar:
-#   epoch: 13000
-#   domain_type: "00000003"

--- a/anchor/common/ssv_network_config/built_in_network_configs/hoodi/ssv_fork_schedule.yaml
+++ b/anchor/common/ssv_network_config/built_in_network_configs/hoodi/ssv_fork_schedule.yaml
@@ -6,6 +6,3 @@
 # boole:
 #   epoch: 12500
 #   domain_type: "00000002"
-# cstar:
-#   epoch: 13000
-#   domain_type: "00000003"

--- a/anchor/common/ssv_network_config/built_in_network_configs/mainnet/ssv_fork_schedule.yaml
+++ b/anchor/common/ssv_network_config/built_in_network_configs/mainnet/ssv_fork_schedule.yaml
@@ -6,6 +6,3 @@
 # boole:
 #   epoch: 12500
 #   domain_type: "00000002"
-# cstar:
-#   epoch: 13000
-#   domain_type: "00000003"

--- a/anchor/common/ssv_network_config/src/lib.rs
+++ b/anchor/common/ssv_network_config/src/lib.rs
@@ -221,22 +221,15 @@ mod tests {
     const TEST_DOMAIN_TYPE_STR: &str = "00000001";
     const TEST_DOMAIN_TYPE: DomainType = DomainType([0, 0, 0, 1]);
     const BOOLE_DOMAIN_TYPE: DomainType = DomainType([0, 0, 0, 2]);
-    const CSTAR_DOMAIN_TYPE: DomainType = DomainType([0, 0, 0, 3]);
 
     // Fork activation epochs for tests. Scenario epochs (just before / just after
     // activation) are derived inline at the use site.
     const ALAN_FORK_EPOCH: u64 = 0;
     const BOOLE_FORK_EPOCH: u64 = 100;
-    const CSTAR_FORK_EPOCH: u64 = 200;
 
     /// Construct expected Boole topic prefix for a network.
     fn expected_boole_prefix(network: &str) -> String {
         format!("/ssv/{}/boole/", network)
-    }
-
-    /// Construct expected CStar topic prefix for a network.
-    fn expected_cstar_prefix(network: &str) -> String {
-        format!("/ssv/{}/cstar/", network)
     }
 
     /// Asserts that a config has a valid fork schedule with Alan at epoch 0.
@@ -331,11 +324,8 @@ mod tests {
 boole:
   epoch: {}
   domain_type: "00000002"
-cstar:
-  epoch: {}
-  domain_type: "00000003"
 "#,
-            BOOLE_FORK_EPOCH, CSTAR_FORK_EPOCH
+            BOOLE_FORK_EPOCH
         );
         let dir = create_test_config_dir(Some(&yaml));
 
@@ -352,20 +342,12 @@ cstar:
             Some(Epoch::new(BOOLE_FORK_EPOCH))
         );
         assert_eq!(
-            config.fork_schedule.fork_epoch(Fork::CStar),
-            Some(Epoch::new(CSTAR_FORK_EPOCH))
-        );
-        assert_eq!(
             config.fork_schedule.domain_type(Fork::Alan),
             Some(TEST_DOMAIN_TYPE)
         );
         assert_eq!(
             config.fork_schedule.domain_type(Fork::Boole),
             Some(BOOLE_DOMAIN_TYPE)
-        );
-        assert_eq!(
-            config.fork_schedule.domain_type(Fork::CStar),
-            Some(CSTAR_DOMAIN_TYPE)
         );
     }
 
@@ -499,11 +481,8 @@ cstar:
 boole:
   epoch: {}
   domain_type: "00000002"
-cstar:
-  epoch: {}
-  domain_type: "00000003"
 "#,
-            BOOLE_FORK_EPOCH, CSTAR_FORK_EPOCH
+            BOOLE_FORK_EPOCH
         );
         let dir = create_test_config_dir(Some(&yaml));
         let config = SsvNetworkConfig::load(dir.path().to_path_buf()).unwrap();
@@ -520,7 +499,7 @@ cstar:
             .active_fork(Epoch::new(BOOLE_FORK_EPOCH - 1));
         assert_eq!(active_fork.topic_prefix(network_name), ALAN_TOPIC_PREFIX);
 
-        // Act & Assert: Between Boole and CStar activation - should use Boole prefix
+        // Act & Assert: At and after Boole activation - should use Boole prefix
         let active_fork = config
             .fork_schedule
             .active_fork(Epoch::new(BOOLE_FORK_EPOCH));
@@ -531,27 +510,10 @@ cstar:
 
         let active_fork = config
             .fork_schedule
-            .active_fork(Epoch::new(CSTAR_FORK_EPOCH - 1));
+            .active_fork(Epoch::new(BOOLE_FORK_EPOCH + 1));
         assert_eq!(
             active_fork.topic_prefix(network_name),
             expected_boole_prefix(TEST_NETWORK_NAME)
-        );
-
-        // Act & Assert: At and after CStar activation - should use CStar prefix
-        let active_fork = config
-            .fork_schedule
-            .active_fork(Epoch::new(CSTAR_FORK_EPOCH));
-        assert_eq!(
-            active_fork.topic_prefix(network_name),
-            expected_cstar_prefix(TEST_NETWORK_NAME)
-        );
-
-        let active_fork = config
-            .fork_schedule
-            .active_fork(Epoch::new(CSTAR_FORK_EPOCH + 1));
-        assert_eq!(
-            active_fork.topic_prefix(network_name),
-            expected_cstar_prefix(TEST_NETWORK_NAME)
         );
     }
 

--- a/anchor/message_validator/src/consensus_message.rs
+++ b/anchor/message_validator/src/consensus_message.rs
@@ -599,6 +599,7 @@ mod tests {
             slot_clock,
             operator_pub_keys: &map,
             fork_schedule: generate_fork_schedule(),
+            spec: Arc::new(types::ChainSpec::mainnet()),
         };
 
         let expected_duty_count = 5;
@@ -648,6 +649,7 @@ mod tests {
             slot_clock,
             operator_pub_keys: &HashMap::new(),
             fork_schedule: generate_fork_schedule(),
+            spec: Arc::new(types::ChainSpec::mainnet()),
         };
 
         let result = validate_ssv_message(
@@ -703,6 +705,7 @@ mod tests {
             slot_clock,
             operator_pub_keys: &HashMap::new(),
             fork_schedule: generate_fork_schedule(),
+            spec: Arc::new(types::ChainSpec::mainnet()),
         };
 
         let result = validate_ssv_message(
@@ -755,6 +758,7 @@ mod tests {
             ),
             operator_pub_keys: &map,
             fork_schedule: generate_fork_schedule(),
+            spec: Arc::new(types::ChainSpec::mainnet()),
         };
 
         let result = validate_ssv_message(
@@ -1599,6 +1603,7 @@ mod tests {
             slot_clock,
             operator_pub_keys: &map,
             fork_schedule,
+            spec: Arc::new(types::ChainSpec::mainnet()),
         };
 
         // Create a duty state where the operator has already advanced to slot 10
@@ -1644,6 +1649,7 @@ mod tests {
             slot_clock: validation_context.slot_clock.clone(),
             operator_pub_keys: &map,
             fork_schedule: validation_context.fork_schedule.clone(),
+            spec: validation_context.spec.clone(),
         };
 
         let result = validate_qbft_message_by_duty_logic(
@@ -1719,6 +1725,7 @@ mod tests {
             slot_clock: slot_clock.clone(),
             operator_pub_keys: &map,
             fork_schedule: generate_fork_schedule(),
+            spec: Arc::new(types::ChainSpec::mainnet()),
         };
 
         let slot = slot_clock.now().unwrap();
@@ -1769,6 +1776,7 @@ mod tests {
             slot_clock: slot_clock.clone(),
             operator_pub_keys: &map,
             fork_schedule: generate_fork_schedule(),
+            spec: Arc::new(types::ChainSpec::mainnet()),
         };
 
         let slot = slot_clock.now().unwrap();
@@ -1844,6 +1852,7 @@ mod tests {
             slot_clock,
             operator_pub_keys: &map,
             fork_schedule,
+            spec: Arc::new(types::ChainSpec::mainnet()),
         };
 
         // Act: Validate the message

--- a/anchor/message_validator/src/lib.rs
+++ b/anchor/message_validator/src/lib.rs
@@ -225,6 +225,7 @@ pub enum ValidationFailure {
     /// activated.
     RoleNotActiveBeforeEthFork {
         role: Role,
+        current_fork: ForkName,
         minimum_fork: ForkName,
     },
 }
@@ -844,6 +845,7 @@ pub(crate) fn validate_beacon_duty(
 /// Rejects:
 /// - AggregatorCommittee before Boole fork (not yet active)
 /// - Aggregator and SyncCommittee after Boole fork (deprecated)
+/// - PTCAttester before the Ethereum Gloas (ePBS) fork (not yet active)
 pub(crate) fn validate_role_for_fork(
     slot: Slot,
     validation_context: &ValidationContext<impl SlotClock>,
@@ -871,16 +873,15 @@ pub(crate) fn validate_role_for_fork(
     }
 
     // Reject PTCAttester before the Ethereum Gloas (ePBS) fork, read from the consensus spec.
-    if role == Role::PTCAttester
-        && !validation_context
-            .spec
-            .fork_name_at_epoch(epoch)
-            .gloas_enabled()
-    {
-        return Err(ValidationFailure::RoleNotActiveBeforeEthFork {
-            role,
-            minimum_fork: ForkName::Gloas,
-        });
+    if role == Role::PTCAttester {
+        let current_fork = validation_context.spec.fork_name_at_epoch(epoch);
+        if !current_fork.gloas_enabled() {
+            return Err(ValidationFailure::RoleNotActiveBeforeEthFork {
+                role,
+                current_fork,
+                minimum_fork: ForkName::Gloas,
+            });
+        }
     }
 
     Ok(())

--- a/anchor/message_validator/src/lib.rs
+++ b/anchor/message_validator/src/lib.rs
@@ -35,7 +35,7 @@ use subnet_service::topic::ParsedTopic;
 use task_executor::TaskExecutor;
 use tokio::{sync::watch::Receiver, time::sleep};
 use tracing::{debug, trace};
-use types::{Epoch, Slot};
+use types::{ChainSpec, Epoch, ForkName, Slot};
 
 use crate::{
     consensus_message::validate_consensus_message,
@@ -221,6 +221,12 @@ pub enum ValidationFailure {
         current_fork: fork::Fork,
         deprecated_since_fork: fork::Fork,
     },
+    /// A role that only exists at/after an Ethereum hard fork was seen before that fork
+    /// activated.
+    RoleNotActiveBeforeEthFork {
+        role: Role,
+        minimum_fork: ForkName,
+    },
 }
 
 impl From<&ValidationFailure> for MessageAcceptance {
@@ -357,6 +363,7 @@ struct ValidationContext<'a, S> {
     pub slot_clock: S,
     pub operator_pub_keys: &'a HashMap<OperatorId, Rsa<Public>>,
     pub fork_schedule: Arc<ForkSchedule>,
+    pub spec: Arc<ChainSpec>,
 }
 
 pub struct Validator<S: SlotClock, D: DutiesProvider> {
@@ -369,6 +376,7 @@ pub struct Validator<S: SlotClock, D: DutiesProvider> {
     slot_clock: S,
     subnet_service: Arc<subnet_service::SubnetService<S>>,
     fork_schedule: Arc<ForkSchedule>,
+    spec: Arc<ChainSpec>,
 }
 
 impl<S: SlotClock + 'static, D: DutiesProvider> Validator<S, D> {
@@ -382,6 +390,7 @@ impl<S: SlotClock + 'static, D: DutiesProvider> Validator<S, D> {
         slot_clock: S,
         subnet_service: Arc<subnet_service::SubnetService<S>>,
         fork_schedule: Arc<ForkSchedule>,
+        spec: Arc<ChainSpec>,
         task_executor: &TaskExecutor,
     ) -> Arc<Self> {
         let validator = Arc::new(Self {
@@ -394,6 +403,7 @@ impl<S: SlotClock + 'static, D: DutiesProvider> Validator<S, D> {
             slot_clock,
             subnet_service,
             fork_schedule,
+            spec,
         });
 
         task_executor.spawn(Arc::clone(&validator).cleaner(), VALIDATOR_CLEANER_NAME);
@@ -501,6 +511,7 @@ impl<S: SlotClock + 'static, D: DutiesProvider> Validator<S, D> {
             slot_clock: self.slot_clock.clone(),
             operator_pub_keys,
             fork_schedule: Arc::clone(&self.fork_schedule),
+            spec: Arc::clone(&self.spec),
         };
 
         validate_ssv_message(
@@ -859,12 +870,16 @@ pub(crate) fn validate_role_for_fork(
         });
     }
 
-    // Reject PTCAttester before CStar fork (safety net)
-    if role == Role::PTCAttester && active_fork < Fork::CStar {
-        return Err(ValidationFailure::RoleNotActiveBeforeFork {
+    // Reject PTCAttester before the Ethereum Gloas (ePBS) fork, read from the consensus spec.
+    if role == Role::PTCAttester
+        && !validation_context
+            .spec
+            .fork_name_at_epoch(epoch)
+            .gloas_enabled()
+    {
+        return Err(ValidationFailure::RoleNotActiveBeforeEthFork {
             role,
-            current_fork: active_fork,
-            minimum_fork: Fork::CStar,
+            minimum_fork: ForkName::Gloas,
         });
     }
 

--- a/anchor/message_validator/src/partial_signature.rs
+++ b/anchor/message_validator/src/partial_signature.rs
@@ -481,11 +481,21 @@ mod tests {
             ),
             operator_pub_keys,
             fork_schedule,
+            spec: spec_with_gloas(None),
         }
     }
 
     fn generate_fork_schedule(fork: Fork) -> Arc<ForkSchedule> {
         Arc::new(ForkSchedule::new(fork, DomainType::default(), "testing"))
+    }
+
+    /// Build a `ChainSpec` whose Ethereum Gloas (ePBS) fork activates at
+    /// `gloas_fork_epoch` (`None` = "Gloas never happens"). Used to gate
+    /// post-Gloas roles such as `PTCAttester`.
+    fn spec_with_gloas(gloas_fork_epoch: Option<u64>) -> Arc<types::ChainSpec> {
+        let mut spec = types::ChainSpec::mainnet();
+        spec.gloas_fork_epoch = gloas_fork_epoch.map(types::Epoch::new);
+        Arc::new(spec)
     }
 
     #[test]
@@ -1241,6 +1251,7 @@ mod tests {
             slot_clock,
             operator_pub_keys,
             fork_schedule,
+            spec: spec_with_gloas(None),
         }
     }
 
@@ -1449,6 +1460,7 @@ mod tests {
             slot_clock,
             operator_pub_keys: &map,
             fork_schedule,
+            spec: spec_with_gloas(None),
         };
 
         // Create a duty state where the operator has already advanced to slot 10
@@ -1551,6 +1563,7 @@ mod tests {
             slot_clock,
             operator_pub_keys: &map,
             fork_schedule: fork_schedule.clone(),
+            spec: spec_with_gloas(None),
         };
 
         // Should succeed with 5 occurrences
@@ -1618,6 +1631,7 @@ mod tests {
             slot_clock: slot_clock2,
             operator_pub_keys: &map,
             fork_schedule,
+            spec: spec_with_gloas(None),
         };
 
         // Should fail with 6 occurrences
@@ -1703,7 +1717,8 @@ mod tests {
             sync_committee_size: 512,
             slot_clock,
             operator_pub_keys: &map,
-            fork_schedule: generate_fork_schedule(Fork::CStar),
+            fork_schedule: generate_fork_schedule(Fork::Boole),
+            spec: spec_with_gloas(Some(0)),
         };
 
         let result = validate_partial_signature_message(
@@ -1727,7 +1742,7 @@ mod tests {
     }
 
     #[test]
-    fn test_ptc_attester_rejected_before_cstar() {
+    fn test_ptc_attester_rejected_before_gloas() {
         use crate::validate_role_for_fork;
 
         let committee_info = create_committee_info(FOUR_NODE_COMMITTEE);
@@ -1756,13 +1771,13 @@ mod tests {
             |failure| {
                 matches!(
                     failure,
-                    ValidationFailure::RoleNotActiveBeforeFork {
-                        minimum_fork: Fork::CStar,
+                    ValidationFailure::RoleNotActiveBeforeEthFork {
+                        minimum_fork: types::ForkName::Gloas,
                         ..
                     }
                 )
             },
-            "RoleNotActiveBeforeFork (PTCAttester pre-CStar)",
+            "RoleNotActiveBeforeEthFork (PTCAttester pre-Gloas)",
         );
     }
 
@@ -1783,14 +1798,16 @@ mod tests {
         // attestation is gossip-valid for that slot and includable only at
         // slot + 1), so PTCAttester uses the short TTL
         // (1 + LATE_SLOT_ALLOWANCE = 3 slots). Two slots late is inside it.
-        let validation_context = create_ttl_validation_context(
+        let mut validation_context = create_ttl_validation_context(
             &signed_msg,
             &committee_info,
             Role::PTCAttester,
             &map,
             LATE_SLOT_ALLOWANCE_TEST,
-            generate_fork_schedule(Fork::CStar),
+            generate_fork_schedule(Fork::Boole),
         );
+        // PTCAttester only exists post-Gloas; the role gate reads the Ethereum fork from the spec.
+        validation_context.spec = spec_with_gloas(Some(0));
 
         let result = validate_partial_signature_message(
             validation_context,
@@ -1818,14 +1835,16 @@ mod tests {
 
         // 20 slots late would still be inside the long (committee) TTL of 34
         // slots; rejecting it pins PTCAttester to the short slot-bound bucket.
-        let validation_context = create_ttl_validation_context(
+        let mut validation_context = create_ttl_validation_context(
             &signed_msg,
             &committee_info,
             Role::PTCAttester,
             &map,
             COMMITTEE_TTL_BUCKET_SLOTS,
-            generate_fork_schedule(Fork::CStar),
+            generate_fork_schedule(Fork::Boole),
         );
+        // PTCAttester only exists post-Gloas; the role gate reads the Ethereum fork from the spec.
+        validation_context.spec = spec_with_gloas(Some(0));
 
         let result = validate_partial_signature_message(
             validation_context,

--- a/anchor/qbft_manager/src/lib.rs
+++ b/anchor/qbft_manager/src/lib.rs
@@ -31,7 +31,7 @@ use tokio::{
     time::{Instant, sleep},
 };
 use tracing::{Instrument, debug_span, error, warn};
-use types::{Epoch, EthSpec, Hash256, Slot};
+use types::{ChainSpec, Epoch, EthSpec, Hash256, Slot};
 
 use crate::instance::qbft_instance;
 
@@ -151,6 +151,8 @@ pub struct QbftManager<E: EthSpec, S: SlotClock> {
     slots_per_epoch: NonZeroU64,
     // Fork schedule for looking up the active fork's domain type
     fork_schedule: Arc<ForkSchedule>,
+    // Ethereum consensus spec, used to gate behavior on Ethereum hard forks (e.g. Gloas/ePBS)
+    spec: Arc<ChainSpec>,
     // Slot clock for determining the current epoch
     slot_clock: S,
 }
@@ -164,6 +166,7 @@ impl<E: EthSpec, S: SlotClock + Clone + 'static> QbftManager<E, S> {
         message_sender: Arc<dyn MessageSender>,
         slots_per_epoch: NonZeroU64,
         fork_schedule: Arc<ForkSchedule>,
+        spec: Arc<ChainSpec>,
     ) -> Result<Arc<Self>, QbftError> {
         let manager = Arc::new(QbftManager {
             processor,
@@ -175,6 +178,7 @@ impl<E: EthSpec, S: SlotClock + Clone + 'static> QbftManager<E, S> {
             message_sender,
             slots_per_epoch,
             fork_schedule,
+            spec,
             slot_clock: slot_clock.clone(),
         });
 
@@ -303,7 +307,6 @@ impl<E: EthSpec, S: SlotClock + Clone + 'static> QbftManager<E, S> {
                 match msg_id.role() {
                     Some(Role::Committee) => {
                         let slot = types::Slot::new(qbft_message.height);
-                        let epoch = slot.epoch(E::slots_per_epoch());
                         let id = CommitteeInstanceId {
                             committee,
                             instance_height,
@@ -313,7 +316,9 @@ impl<E: EthSpec, S: SlotClock + Clone + 'static> QbftManager<E, S> {
                             qbft_message,
                         };
 
-                        if self.fork_schedule.active_fork(epoch) >= Fork::CStar {
+                        // Gate the Gloas beacon-vote shape on Ethereum's Gloas (ePBS) fork,
+                        // read from the consensus spec, rather than an SSV-internal fork.
+                        if self.spec.fork_name_at_slot::<E>(slot).gloas_enabled() {
                             self.pass_to_instance::<GloasBeaconVote>(id, wrapped)
                         } else {
                             self.pass_to_instance::<BeaconVote>(id, wrapped)

--- a/anchor/qbft_manager/src/tests.rs
+++ b/anchor/qbft_manager/src/tests.rs
@@ -294,6 +294,8 @@ where
 
         // Create a test fork schedule with a default domain type
         let fork_schedule = Arc::new(ForkSchedule::new(Fork::Alan, DomainType::default(), "test"));
+        // Gloas not scheduled: committee consensus uses the legacy BeaconVote path.
+        let spec = Arc::new(types::ChainSpec::mainnet());
 
         // Construct and save a manager for each operator in the committee. By having access to all
         // the managers in the committee, we can direct messages to the proper place and
@@ -309,6 +311,7 @@ where
                 Arc::new(MockMessageSender::new(network_tx.clone(), operator_id)),
                 NonZeroU64::new(32).expect("slots_per_epoch is non-zero"),
                 fork_schedule.clone(),
+                spec.clone(),
             )
             .expect("Creation should not fail");
 
@@ -877,6 +880,7 @@ mod manager_tests {
             Arc::new(MockMessageSender::new(network_tx, OperatorId(1))),
             NonZeroU64::new(32).expect("slots_per_epoch is non-zero"),
             Arc::new(fork_schedule),
+            Arc::new(types::ChainSpec::mainnet()),
         )
         .expect("Manager creation should succeed");
 

--- a/anchor/qbft_manager/src/tests/aggregator_tests.rs
+++ b/anchor/qbft_manager/src/tests/aggregator_tests.rs
@@ -30,6 +30,7 @@ async fn test_aggregator_committee_rejected_before_boole() {
         Arc::new(MockMessageSender::new(network_tx, OperatorId(1))),
         NonZeroU64::new(32).expect("slots_per_epoch is non-zero"),
         Arc::new(ForkSchedule::new(Fork::Alan, DomainType::default(), "test")), // No Boole fork
+        Arc::new(types::ChainSpec::mainnet()), // Gloas not scheduled
     )
     .expect("Manager creation should succeed");
 

--- a/anchor/qbft_manager/src/tests/gloas_dispatch_tests.rs
+++ b/anchor/qbft_manager/src/tests/gloas_dispatch_tests.rs
@@ -1,11 +1,11 @@
-//! `Role::Committee` dispatch tests for the CStar (Gloas) fork.
+//! `Role::Committee` dispatch tests for the Ethereum Gloas (ePBS) fork.
 //!
-//! These exercise the fork-gated routing added in #1025 inside
-//! `QbftManager::receive_data`: at or after CStar a committee message must spawn
-//! a `GloasBeaconVote` instance, before CStar a `BeaconVote` instance. The
-//! `DashMap` entry is inserted synchronously inside `get_or_spawn_instance`
-//! before the processor task is even dispatched, so map sizes are deterministic
-//! immediately after `receive_data` returns.
+//! These exercise the fork-gated routing inside `QbftManager::receive_data`: at
+//! or after the Ethereum Gloas fork (read from the `ChainSpec`) a committee
+//! message must spawn a `GloasBeaconVote` instance, before Gloas a `BeaconVote`
+//! instance. The `DashMap` entry is inserted synchronously inside
+//! `get_or_spawn_instance` before the processor task is even dispatched, so map
+//! sizes are deterministic immediately after `receive_data` returns.
 
 use fork::ForkSchedule;
 use message_sender::testing::MockMessageSender;
@@ -15,20 +15,31 @@ use ssv_types::{
     message::{MsgType, SSVMessage, SignedSSVMessage},
 };
 use ssz::Encode;
+use types::{ChainSpec, Epoch};
 
 use super::{setup::setup_test, *};
 
-// Slot picked well past any baseline-epoch boundary so the chosen fork schedule
+// Slot picked well past any baseline-epoch boundary so the chosen Gloas schedule
 // dominates routing rather than any genesis edge case (`slot 100` mirrors the
 // existing aggregator dispatch test).
 const TEST_SLOT_HEIGHT: u64 = 100;
 
-/// Build a single-operator `QbftManager` with the supplied `ForkSchedule`,
+/// Build a `ChainSpec` whose Gloas fork activates at `gloas_fork_epoch`
+/// (`None` = "Gloas never happens").
+fn spec_with_gloas(gloas_fork_epoch: Option<u64>) -> Arc<ChainSpec> {
+    let mut spec = ChainSpec::mainnet();
+    spec.gloas_fork_epoch = gloas_fork_epoch.map(Epoch::new);
+    Arc::new(spec)
+}
+
+/// Build a single-operator `QbftManager` with the supplied `ChainSpec`,
 /// mirroring the canonical setup from
-/// `aggregator_tests::test_aggregator_committee_rejected_before_boole`.
+/// `aggregator_tests::test_aggregator_committee_rejected_before_boole`. The SSV
+/// `ForkSchedule` no longer drives committee routing (the Ethereum Gloas fork
+/// does), so a plain Alan-genesis schedule is used here.
 fn build_manager(
     setup: &super::setup::Setup,
-    fork_schedule: ForkSchedule,
+    spec: Arc<ChainSpec>,
 ) -> Arc<QbftManager<types::MainnetEthSpec, ManualSlotClock>> {
     let config = processor::Config {
         max_workers: 4,
@@ -43,7 +54,8 @@ fn build_manager(
         setup.clock.clone(),
         Arc::new(MockMessageSender::new(network_tx, OperatorId(1))),
         NonZeroU64::new(32).expect("slots_per_epoch is non-zero"),
-        Arc::new(fork_schedule),
+        Arc::new(ForkSchedule::new(Fork::Alan, DomainType::default(), "test")),
+        spec,
     )
     .expect("Manager creation should succeed")
 }
@@ -87,17 +99,14 @@ fn build_committee_message(slot_height: u64) -> (SignedSSVMessage, QbftMessage) 
     (signed_msg, qbft_message)
 }
 
-/// With `Fork::CStar` active from genesis, a `Role::Committee` message must
-/// spawn a `GloasBeaconVote` instance and leave the legacy `BeaconVote` map
+/// With the Ethereum Gloas fork active from genesis, a `Role::Committee` message
+/// must spawn a `GloasBeaconVote` instance and leave the legacy `BeaconVote` map
 /// untouched.
 #[tokio::test]
-async fn test_committee_message_routes_to_gloas_at_cstar() {
+async fn test_committee_message_routes_to_gloas_at_fork() {
     // Arrange
     let setup = setup_test(1);
-    let manager = build_manager(
-        &setup,
-        ForkSchedule::new(Fork::CStar, DomainType::default(), "test"),
-    );
+    let manager = build_manager(&setup, spec_with_gloas(Some(0)));
     let (signed_msg, qbft_message) = build_committee_message(TEST_SLOT_HEIGHT);
 
     // Act
@@ -106,32 +115,29 @@ async fn test_committee_message_routes_to_gloas_at_cstar() {
     // Assert
     assert!(
         result.is_ok(),
-        "receive_data should succeed at CStar, got: {:?}",
+        "receive_data should succeed at Gloas, got: {:?}",
         result
     );
     assert_eq!(
         manager.gloas_beacon_vote_instances.len(),
         1,
-        "Committee message at CStar must spawn a GloasBeaconVote instance"
+        "Committee message at Gloas must spawn a GloasBeaconVote instance"
     );
     assert_eq!(
         manager.beacon_vote_instances.len(),
         0,
-        "Committee message at CStar must NOT spawn a legacy BeaconVote instance"
+        "Committee message at Gloas must NOT spawn a legacy BeaconVote instance"
     );
 }
 
-/// Before CStar (here: `Fork::Alan` active from genesis), the existing
-/// `BeaconVote` routing must remain in force and the new `GloasBeaconVote` map
-/// must stay empty. This is the "BeaconVote unaffected" acceptance criterion.
+/// Before Gloas (here: Gloas never scheduled), the existing `BeaconVote` routing
+/// must remain in force and the new `GloasBeaconVote` map must stay empty. This
+/// is the "BeaconVote unaffected" acceptance criterion.
 #[tokio::test]
-async fn test_committee_message_routes_to_beacon_pre_cstar() {
+async fn test_committee_message_routes_to_beacon_pre_gloas() {
     // Arrange
     let setup = setup_test(1);
-    let manager = build_manager(
-        &setup,
-        ForkSchedule::new(Fork::Alan, DomainType::default(), "test"),
-    );
+    let manager = build_manager(&setup, spec_with_gloas(None));
     let (signed_msg, qbft_message) = build_committee_message(TEST_SLOT_HEIGHT);
 
     // Act
@@ -140,57 +146,44 @@ async fn test_committee_message_routes_to_beacon_pre_cstar() {
     // Assert
     assert!(
         result.is_ok(),
-        "receive_data should succeed pre-CStar, got: {:?}",
+        "receive_data should succeed pre-Gloas, got: {:?}",
         result
     );
     assert_eq!(
         manager.beacon_vote_instances.len(),
         1,
-        "Committee message pre-CStar must spawn a BeaconVote instance"
+        "Committee message pre-Gloas must spawn a BeaconVote instance"
     );
     assert_eq!(
         manager.gloas_beacon_vote_instances.len(),
         0,
-        "Committee message pre-CStar must NOT spawn a GloasBeaconVote instance"
+        "Committee message pre-Gloas must NOT spawn a GloasBeaconVote instance"
     );
 }
 
-/// Pin the slot-to-epoch + `active_fork(epoch)` + `>= Fork::CStar` composition
-/// at the activation boundary. Off-by-one in any of the three would flip
-/// exactly one of the assertions below.
+/// Pin the slot-to-fork composition at the Gloas activation boundary. An
+/// off-by-one in `fork_name_at_slot` / `gloas_enabled` would flip exactly one of
+/// the assertions below.
 #[tokio::test]
-async fn test_committee_message_routes_at_cstar_activation_boundary() {
-    use std::collections::BTreeMap;
-
-    use types::Epoch;
-
-    const CSTAR_ACTIVATION_EPOCH: u64 = 5;
+async fn test_committee_message_routes_at_gloas_activation_boundary() {
+    const GLOAS_ACTIVATION_EPOCH: u64 = 5;
     const SLOTS_PER_EPOCH: u64 = 32;
 
     let setup = setup_test(1);
+    let manager = build_manager(&setup, spec_with_gloas(Some(GLOAS_ACTIVATION_EPOCH)));
 
-    let mut configs = BTreeMap::new();
-    configs.insert(Fork::Alan, (Epoch::new(0), DomainType::default()));
-    configs.insert(
-        Fork::CStar,
-        (Epoch::new(CSTAR_ACTIVATION_EPOCH), DomainType::default()),
-    );
-    let schedule = ForkSchedule::from_fork_configs(configs, "test")
-        .expect("Alan@0 + CStar@5 is a valid schedule");
-    let manager = build_manager(&setup, schedule);
-
-    let last_pre_cstar = CSTAR_ACTIVATION_EPOCH * SLOTS_PER_EPOCH - 1;
-    let (signed, qbft) = build_committee_message(last_pre_cstar);
+    let last_pre_gloas = GLOAS_ACTIVATION_EPOCH * SLOTS_PER_EPOCH - 1;
+    let (signed, qbft) = build_committee_message(last_pre_gloas);
     manager
         .receive_data(signed, qbft)
-        .expect("pre-CStar dispatch");
+        .expect("pre-Gloas dispatch");
     assert_eq!(manager.beacon_vote_instances.len(), 1);
     assert_eq!(manager.gloas_beacon_vote_instances.len(), 0);
 
-    let first_cstar = CSTAR_ACTIVATION_EPOCH * SLOTS_PER_EPOCH;
-    let (signed, qbft) = build_committee_message(first_cstar);
-    manager.receive_data(signed, qbft).expect("CStar dispatch");
+    let first_gloas = GLOAS_ACTIVATION_EPOCH * SLOTS_PER_EPOCH;
+    let (signed, qbft) = build_committee_message(first_gloas);
+    manager.receive_data(signed, qbft).expect("Gloas dispatch");
     assert_eq!(manager.gloas_beacon_vote_instances.len(), 1);
-    // BeaconVote map still holds the pre-CStar instance.
+    // BeaconVote map still holds the pre-Gloas instance.
     assert_eq!(manager.beacon_vote_instances.len(), 1);
 }

--- a/anchor/subnet_service/src/service.rs
+++ b/anchor/subnet_service/src/service.rs
@@ -102,10 +102,8 @@ impl<S: SlotClock> SubnetService<S> {
 
         match fork {
             Fork::Alan => Ok(SubnetId::from_committee_alan(committee_id, SUBNET_COUNT)),
-            Fork::Boole | Fork::CStar => {
-                SubnetId::from_operators(operator_ids, crate::SUBNET_COUNT_NZ)
-                    .map_err(SubnetServiceError::SubnetCalculation)
-            }
+            Fork::Boole => SubnetId::from_operators(operator_ids, crate::SUBNET_COUNT_NZ)
+                .map_err(SubnetServiceError::SubnetCalculation),
         }
     }
 

--- a/anchor/subnet_service/src/subnet.rs
+++ b/anchor/subnet_service/src/subnet.rs
@@ -118,9 +118,7 @@ impl SubnetId {
                 committee_id,
                 crate::SUBNET_COUNT,
             )),
-            Fork::Boole | Fork::CStar => {
-                SubnetId::from_operators(operator_ids, crate::SUBNET_COUNT_NZ)
-            }
+            Fork::Boole => SubnetId::from_operators(operator_ids, crate::SUBNET_COUNT_NZ),
         }
     }
 }

--- a/anchor/validator_store/src/lib.rs
+++ b/anchor/validator_store/src/lib.rs
@@ -1548,9 +1548,9 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> AnchorValidator
         };
 
         let (block_root, source, target, decided_hash) = if self
-            .fork_schedule
-            .active_fork(slot.epoch(E::slots_per_epoch()))
-            >= Fork::CStar
+            .spec
+            .fork_name_at_slot::<E>(slot)
+            .gloas_enabled()
         {
             let completed = self
                 .consensus
@@ -3317,7 +3317,7 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> ValidatorStore
         _validator_pubkey: PublicKeyBytes,
         _envelope: ExecutionPayloadEnvelope<E>,
     ) -> Result<SignedExecutionPayloadEnvelope<E>, Error> {
-        // TODO(cstar)
+        // TODO(gloas)
         Err(Error::SpecificError(SpecificError::Unsupported))
     }
 
@@ -3369,7 +3369,7 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> ValidatorStore
         _validator_pubkey: PublicKeyBytes,
         _preferences: ProposerPreferences,
     ) -> Result<SignedProposerPreferences, Error> {
-        // TODO(cstar)
+        // TODO(gloas)
         Err(Error::SpecificError(SpecificError::Unsupported))
     }
 }


### PR DESCRIPTION
## Problem, Evidence, and Context

ePBS (Gloas) behavior on the `epbs` branch is gated behind a placeholder SSV protocol fork, `Fork::CStar`, that has never had a real schedule entry (only commented-out examples in the built-in `ssv_fork_schedule.yaml` files). That couples an Ethereum consensus-layer transition (Gloas / EIP-7732) to an SSV-invented fork ordinal, so the fork boundary effectively lives in two places (the SSV fork schedule *and* the eth2 `config.yaml`) and can drift, risking ePBS activating at the wrong slot.

Our pinned Lighthouse `ChainSpec` already exposes the Gloas boundary directly (`gloas_fork_epoch`, `fork_name_at_slot` / `fork_name_at_epoch`, `gloas_enabled()`), so the canonical source of truth is already in hand. This aligns with SIP-94, which frames ePBS as an Ethereum-fork-driven change rather than a new SSV network fork.

## Change Overview

Gate the Gloas-specific paths on the Ethereum Gloas fork from the `ChainSpec` instead of the SSV fork:

```
active_fork(epoch) >= Fork::CStar
  ->  spec.fork_name_at_slot::<E>(slot).gloas_enabled()
```

- Remove the `Fork::CStar` variant; `Fork` is now `{Alan, Boole}`.
- Thread `spec: Arc<ChainSpec>` into `QbftManager` and the message `Validator` (`validator_store` already held one).
- Add a `RoleNotActiveBeforeEthFork` validation failure for `PTCAttester` messages received before the Gloas fork.
- Drop the `cstar` entries from the built-in `ssv_fork_schedule.yaml` files.

**Reading order:** start with `common/fork/src/fork.rs` + `schedule.rs` (the variant removal), then `qbft_manager/src/lib.rs` and `validator_store/src/lib.rs` (gate swap + dispatch), then `message_validator/src/lib.rs` (role gate + new failure variant), then the tests.

**What did NOT change:** `BeaconVote` <-> `GloasBeaconVote` dispatch behavior, domain types, and gossip topic prefixes. The SSV `Fork` schedule still governs SSV-only concerns (Alan/Boole gates, deprecated roles). Only the *source* of the Gloas boundary moved, from the SSV fork ordinal to the eth `ChainSpec`.

## Risks, Trade-offs, and Mitigations

- **Blast radius:** 7 crates, but the change is an atomic enum-variant removal plus signature threading; it cannot be split without breaking compilation at intermediate steps. Net diff is small (+145 / -181).
- **Operational:** ePBS now activates from `GLOAS_FORK_EPOCH` in the eth2 network config. This is the same config that already drives every other Ethereum fork transition (Electra, Fulu), so there is no new operational surface, and it removes the prior risk of the SSV schedule and eth2 config disagreeing.
- **Trade-off:** the `spec.fork_name_at_*(...).gloas_enabled()` gate is open-coded at 3 sites rather than wrapped in a helper. This deliberately matches the existing house idiom (`metadata_service` gates Electra the same way); a wrapper was not added for 3 callers.

## Validation

- `cargo +nightly fmt --all -- --check`: clean.
- `cargo check --workspace --all-targets`: clean.
- Tests pass: `anchor_validator_store` 46, `message_validator` 63, `qbft_manager` 31. The `qbft_manager` Gloas-dispatch and `message_validator` `PTCAttester` tests were rewritten to drive the boundary via a `spec_with_gloas(Option<epoch>)` helper that sets `ChainSpec::gloas_fork_epoch`, covering pre-Gloas, at-activation-boundary, and post-Gloas.
- Rebased on the latest `epbs` (including #1082 `sign_payload_attestation`) before pushing.

## Rollback

Pure `git revert` restores the `Fork::CStar` gate. No migrations, persisted state, or config changes are involved, and `CStar` had no real schedule entry, so there is no runtime/operational impact.

## Additional Info / Next Steps

Follow-on ePBS attestation/sync work can gate on the same `gloas_enabled()` predicate rather than CStar, which also removes the need to keep Gloas on the SSV `Fork` ordinal axis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)