### PR TITLE
fix(processor): raise urgent_consensus queue default

### DIFF
--- a/anchor/processor/src/lib.rs
+++ b/anchor/processor/src/lib.rs
@@ -75,7 +75,13 @@ impl QueueKind {
     fn default_size(self) -> usize {
         match self {
             QueueKind::Permitless => 1000,
-            QueueKind::UrgentConsensus => 1000,
+            // `urgent_consensus` is primarily inbound gossip validation
+            // (`message_receiver`). On high-footprint nodes, slot-boundary
+            // bursts overflow the old 1000 cap and drop messages, sometimes our
+            // own. 4096 is sized from measured mainnet load (#1088) to absorb
+            // those bursts; deeper sizing, work-item expiry, and a queue split
+            // are tracked in #254.
+            QueueKind::UrgentConsensus => 4096,
         }
     }
 

--- a/anchor/processor/tests/processor_tests.rs
+++ b/anchor/processor/tests/processor_tests.rs
@@ -1,19 +1,23 @@
-use std::{error::Error, sync::Arc, time::Duration};
+use std::{collections::HashMap, error::Error, sync::Arc, time::Duration};
 
 use task_executor::TaskExecutor;
 use tokio::{
     select,
-    sync::{Barrier, Notify, oneshot},
+    sync::{Barrier, Notify, mpsc::error::TrySendError, oneshot},
     time::sleep,
 };
 
-/// Workers for the burst test; kept small so a few blocking tasks saturate every
+/// Workers for the capacity tests; kept small so a few blocking tasks saturate every
 /// permit and stop the processor draining `urgent_consensus`.
 const BURST_TEST_MAX_WORKERS: usize = 3;
 
-/// Burst size for the capacity test: above the old 1000 cap and below the new 4096
-/// default, so every send succeeds now but would have overflowed before (#1088).
+/// Burst size for the positive capacity test: above the old 1000 cap and below the new
+/// 4096 default, so every send succeeds now but would have overflowed before (#1088).
 const BURST_TEST_ITEM_COUNT: usize = 1500;
+
+/// The previous `urgent_consensus` default. The negative test pins the queue here to prove
+/// the burst test is non-vacuous: at this cap the same burst really is rejected.
+const OLD_QUEUE_CAP: usize = 1000;
 
 #[tokio::test]
 async fn test_max_workers() -> Result<(), Box<dyn Error>> {
@@ -104,12 +108,58 @@ async fn test_max_workers() -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
-/// Verifies that with the default config the `urgent_consensus` queue absorbs a burst
-/// larger than its old 1000 cap without returning `TrySendError::Full` (#1088).
-///
-/// Determinism comes from saturating every worker permit before the burst, so the
-/// processor cannot drain `urgent_consensus` and the channel only fills; the inline
-/// comments justify each step.
+/// Handle returned by [`saturate_workers`]. Releasing it lets the parked blockers finish so
+/// the runtime can shut down cleanly.
+struct BlockerRelease {
+    release_blockers: Arc<Barrier>,
+}
+
+impl BlockerRelease {
+    async fn release(self) {
+        self.release_blockers.wait().await;
+    }
+}
+
+/// Saturates every worker permit with a parked task so the processor cannot drain
+/// `urgent_consensus`, isolating the channel's capacity from the worker pool. Returns once
+/// all permits are provably held; the returned handle frees the blockers afterwards.
+async fn saturate_workers(senders: &processor::Senders, max_workers: usize) -> BlockerRelease {
+    // Opens only once all blockers plus this task have arrived, proving the processor has
+    // spawned every blocker and therefore acquired every permit.
+    let permits_saturated = Arc::new(Barrier::new(max_workers + 1));
+    // A second barrier releases them. Unlike `Notify::notify_waiters`, a barrier cannot lose
+    // the wakeup if a blocker has not yet parked when the caller releases.
+    let release_blockers = Arc::new(Barrier::new(max_workers + 1));
+
+    // Occupy every worker permit with a task that parks without releasing its permit.
+    for _ in 0..max_workers {
+        let permits_saturated = permits_saturated.clone();
+        let release_blockers = release_blockers.clone();
+        senders
+            .urgent_consensus
+            .send_async(
+                async move {
+                    permits_saturated.wait().await;
+                    release_blockers.wait().await;
+                },
+                "saturate_blocker",
+            )
+            .expect("blocker should enqueue while the queue still has capacity");
+    }
+
+    // Wait until all permits are confirmed held. After this, the processor can no longer
+    // drain `urgent_consensus`, so the channel only accumulates work.
+    select! {
+        _ = sleep(Duration::from_secs(5)) => panic!("blockers should saturate all worker permits"),
+        _ = permits_saturated.wait() => {},
+    }
+
+    BlockerRelease { release_blockers }
+}
+
+/// Verifies that with the default config the `urgent_consensus` queue absorbs a burst larger
+/// than its old 1000 cap without returning `TrySendError::Full` (#1088). Determinism comes
+/// from saturating every worker permit first, so the processor cannot drain the channel.
 #[tokio::test]
 async fn test_urgent_consensus_absorbs_burst_above_old_cap() -> Result<(), Box<dyn Error>> {
     let handle = tokio::runtime::Handle::current();
@@ -122,34 +172,9 @@ async fn test_urgent_consensus_absorbs_burst_above_old_cap() -> Result<(), Box<d
         max_workers: BURST_TEST_MAX_WORKERS,
         queue_size: Default::default(),
     };
-
     let sender_queues = processor::spawn(config, executor);
 
-    // Barrier opens only once all blockers plus this thread have arrived; reaching it
-    // proves the processor has spawned every blocker and thus acquired every permit.
-    let permits_saturated = Arc::new(Barrier::new(BURST_TEST_MAX_WORKERS + 1));
-    // Holds the blockers (and their permits) until the capacity assertion is done.
-    let release_blockers = Arc::new(Notify::new());
-
-    // Occupy every worker permit with a task that parks without releasing its permit.
-    for _ in 0..BURST_TEST_MAX_WORKERS {
-        let permits_saturated = permits_saturated.clone();
-        let release_blockers = release_blockers.clone();
-        sender_queues.urgent_consensus.send_async(
-            async move {
-                permits_saturated.wait().await;
-                release_blockers.notified().await;
-            },
-            "burst_test_blocker",
-        )?;
-    }
-
-    // Wait until all permits are confirmed held. After this, the processor can no longer
-    // drain `urgent_consensus`, so the channel only accumulates work.
-    select! {
-        _ = sleep(Duration::from_secs(5)) => panic!("blockers should saturate all worker permits"),
-        _ = permits_saturated.wait() => {},
-    }
+    let release = saturate_workers(&sender_queues, BURST_TEST_MAX_WORKERS).await;
 
     // Submit a burst larger than the old 1000 cap. With the 4096 default every send must
     // succeed; under the old cap these would have started failing with `Full` past 1000.
@@ -165,8 +190,51 @@ async fn test_urgent_consensus_absorbs_burst_above_old_cap() -> Result<(), Box<d
             });
     }
 
-    // Release the blockers so the runtime can shut down cleanly.
-    release_blockers.notify_waiters();
+    release.release().await;
+    Ok(())
+}
 
+/// Backs the non-vacuity of the burst test above: with the queue pinned back to the old 1000
+/// cap and the same saturated workers, the channel accepts exactly `OLD_QUEUE_CAP` items and
+/// then rejects the next one with `TrySendError::Full` (#1088).
+#[tokio::test]
+async fn test_urgent_consensus_rejects_burst_past_old_cap() -> Result<(), Box<dyn Error>> {
+    let handle = tokio::runtime::Handle::current();
+    let (_signal, exit) = async_channel::bounded(1);
+    let (shutdown_tx, _) = futures::channel::mpsc::channel(1);
+    let executor = TaskExecutor::new(handle, exit, shutdown_tx);
+
+    // Pin the queue to the old cap so the same harness must reject once it is full.
+    let config = processor::Config {
+        max_workers: BURST_TEST_MAX_WORKERS,
+        queue_size: HashMap::from([(processor::QueueKind::UrgentConsensus, OLD_QUEUE_CAP)]),
+    };
+    let sender_queues = processor::spawn(config, executor);
+
+    let release = saturate_workers(&sender_queues, BURST_TEST_MAX_WORKERS).await;
+
+    // With workers saturated the empty channel accepts exactly `OLD_QUEUE_CAP` items.
+    for i in 0..OLD_QUEUE_CAP {
+        sender_queues
+            .urgent_consensus
+            .send_async(async {}, "fill_item")
+            .unwrap_or_else(|err| {
+                panic!("item {i} should fit in the {OLD_QUEUE_CAP}-cap queue: {err:?}")
+            });
+    }
+
+    // The next send overflows: this is the drop the 4096 default now prevents.
+    let overflow = sender_queues
+        .urgent_consensus
+        .send_async(async {}, "overflow_item");
+    assert!(
+        matches!(
+            &overflow,
+            Err(processor::Error::Queue(TrySendError::Full(_)))
+        ),
+        "the item past the {OLD_QUEUE_CAP}-cap queue must overflow with Full, got {overflow:?}"
+    );
+
+    release.release().await;
     Ok(())
 }

--- a/anchor/processor/tests/processor_tests.rs
+++ b/anchor/processor/tests/processor_tests.rs
@@ -7,6 +7,14 @@ use tokio::{
     time::sleep,
 };
 
+/// Workers for the burst test; kept small so a few blocking tasks saturate every
+/// permit and stop the processor draining `urgent_consensus`.
+const BURST_TEST_MAX_WORKERS: usize = 3;
+
+/// Burst size for the capacity test: above the old 1000 cap and below the new 4096
+/// default, so every send succeeds now but would have overflowed before (#1088).
+const BURST_TEST_ITEM_COUNT: usize = 1500;
+
 #[tokio::test]
 async fn test_max_workers() -> Result<(), Box<dyn Error>> {
     let handle = tokio::runtime::Handle::current();
@@ -92,6 +100,73 @@ async fn test_max_workers() -> Result<(), Box<dyn Error>> {
         _ = sleep(Duration::from_millis(100)) => panic!("the task should be executed now"),
         _ = did_run_rx => {},
     }
+
+    Ok(())
+}
+
+/// Verifies that with the default config the `urgent_consensus` queue absorbs a burst
+/// larger than its old 1000 cap without returning `TrySendError::Full` (#1088).
+///
+/// Determinism comes from saturating every worker permit before the burst, so the
+/// processor cannot drain `urgent_consensus` and the channel only fills; the inline
+/// comments justify each step.
+#[tokio::test]
+async fn test_urgent_consensus_absorbs_burst_above_old_cap() -> Result<(), Box<dyn Error>> {
+    let handle = tokio::runtime::Handle::current();
+    let (_signal, exit) = async_channel::bounded(1);
+    let (shutdown_tx, _) = futures::channel::mpsc::channel(1);
+    let executor = TaskExecutor::new(handle, exit, shutdown_tx);
+
+    // Default queue sizes: this exercises the `urgent_consensus` default of 4096.
+    let config = processor::Config {
+        max_workers: BURST_TEST_MAX_WORKERS,
+        queue_size: Default::default(),
+    };
+
+    let sender_queues = processor::spawn(config, executor);
+
+    // Barrier opens only once all blockers plus this thread have arrived; reaching it
+    // proves the processor has spawned every blocker and thus acquired every permit.
+    let permits_saturated = Arc::new(Barrier::new(BURST_TEST_MAX_WORKERS + 1));
+    // Holds the blockers (and their permits) until the capacity assertion is done.
+    let release_blockers = Arc::new(Notify::new());
+
+    // Occupy every worker permit with a task that parks without releasing its permit.
+    for _ in 0..BURST_TEST_MAX_WORKERS {
+        let permits_saturated = permits_saturated.clone();
+        let release_blockers = release_blockers.clone();
+        sender_queues.urgent_consensus.send_async(
+            async move {
+                permits_saturated.wait().await;
+                release_blockers.notified().await;
+            },
+            "burst_test_blocker",
+        )?;
+    }
+
+    // Wait until all permits are confirmed held. After this, the processor can no longer
+    // drain `urgent_consensus`, so the channel only accumulates work.
+    select! {
+        _ = sleep(Duration::from_secs(5)) => panic!("blockers should saturate all worker permits"),
+        _ = permits_saturated.wait() => {},
+    }
+
+    // Submit a burst larger than the old 1000 cap. With the 4096 default every send must
+    // succeed; under the old cap these would have started failing with `Full` past 1000.
+    for i in 0..BURST_TEST_ITEM_COUNT {
+        sender_queues
+            .urgent_consensus
+            .send_async(async {}, "burst_test_item")
+            .unwrap_or_else(|err| {
+                panic!(
+                    "urgent_consensus rejected burst item {i} of {BURST_TEST_ITEM_COUNT} \
+                     (queue should hold {BURST_TEST_ITEM_COUNT} > old 1000 cap): {err:?}"
+                )
+            });
+    }
+
+    // Release the blockers so the runtime can shut down cleanly.
+    release_blockers.notify_waiters();
 
     Ok(())
 }


### PR DESCRIPTION
## Problem, Evidence, and Context

A large mainnet operator (~75 committees, ~45% of all SSV subnets carried by a single node) is missing attestations because the processor's `urgent_consensus` queue drops inbound gossip during sub-second slot-boundary bursts, sometimes the node's own committee messages. The queue depth was a hardcoded `1000`, an underived placeholder from the original processor PR (#57); go-ssv tolerates the same load on comparable hardware because its validation pipeline buffers far more before dropping.

Measured on the mainnet Anchor canaries (read-only; full data in #1088): per-message validation is ~0.2-0.4 ms (so drain capacity is ~20k/s at 8 cores), average arrival is ~50-125 msg/s/node, and inbound gossip validation is the overwhelming majority of this queue's traffic. Zero drops occur at single-cluster footprint, confirming this is burst-vs-buffer, not a CPU shortage.

- Closes #1088
- Follow-up: #254 (deeper sizing, work-item expiry, queue split)

## Change Overview

Raise the `urgent_consensus` queue default from 1000 to **4096** so high-footprint nodes absorb slot-boundary bursts instead of dropping them. It is a value-only change: the queue name (the `--work-queue-size` CLI contract) and any operator overrides are unchanged.

Intentionally **not** changed: no work-item expiry, no queue split, no new config surface, and `permitless` stays at 1000. Those are deliberately deferred to #254, where the escalation path and its metric triggers are recorded.

## Risks, Trade-offs, and Mitigations

- **Memory:** the queue allocates lazily (tokio mpsc), so nodes that never burst pay ~0; worst-case held memory is roughly depth x real message size (~4 MB at 4096), bounded further by continuous draining.
- **Why 4096 and not go-ssv's 8192:** a deeper buffer would hold ~8x more before dropping, which on a *sustained*-overloaded node means grinding through more stale messages, so it would need an expiry guard to stay safe. 4096 sidesteps that while still covering the observed overshoot with margin. The deeper-buffer-plus-expiry path is documented in #254 if production shows 4096 is short.
- **Blast radius:** one queue default in one crate; no behavior change for nodes that never hit the old cap.

## Validation

- `cargo test -p processor`: existing tests plus a new deterministic burst-absorption test that saturates all worker permits, then confirms a burst above the old 1000 cap (and below 4096) all enqueues without `TrySendError::Full`. Verified non-vacuous (a 1000-capacity queue rejects at exactly item 1000).
- `make cargo-fmt-check` and `cargo clippy -p processor --tests`: clean.
- The affected operator is already running with `--work-queue-size urgent_consensus=...` as an interim workaround; this change makes a sane depth the default so other high-footprint operators are not silently affected.

## Rollback

Revert the single commit; the default returns to 1000. No config, data, or migration impact. Operators using `--work-queue-size` are unaffected either way.
