### PR TITLE
feat(client): spawn PayloadAttestationService gated on Gloas

### DIFF
--- a/anchor/client/src/lib.rs
+++ b/anchor/client/src/lib.rs
@@ -61,6 +61,7 @@ use validator_services::{
     duties_service,
     duties_service::{DutiesServiceBuilder, SelectionProofConfig},
     latency_service::start_latency_service,
+    payload_attestation_service::PayloadAttestationService,
     preparation_service::PreparationServiceBuilder,
     sync_committee_service::SyncCommitteeService,
 };
@@ -815,6 +816,24 @@ impl Client {
         registration_service
             .start_validator_registration_service(&spec)
             .map_err(|e| format!("Unable to start validator registration service: {e}"))?;
+
+        // PTC payload-attestation duty (Gloas / ePBS). Start only when Gloas is scheduled,
+        // mirroring LH's VC (validator_client/src/lib.rs:657). The service also self-gates per
+        // slot on `gloas_enabled()`, but gating the start avoids spawning a perpetual idle task
+        // on networks where Gloas is not scheduled.
+        // TODO(gloas, #1064): `ProposerPreferences` joins this block once implemented
+        if spec.is_gloas_scheduled() {
+            PayloadAttestationService::new(
+                duties_service.clone(),
+                validator_store.clone(),
+                slot_clock.clone(),
+                beacon_nodes.clone(),
+                executor.clone(),
+                spec.clone(),
+            )
+            .start_update_service()
+            .map_err(|e| format!("Unable to start payload attestation service: {e}"))?;
+        }
 
         http_api_shared_state.write().database_state = Some(database.watch());
 


### PR DESCRIPTION
## Problem, Evidence, and Context

Lighthouse's `PayloadAttestationService` exists in the pinned LH but was never spawned in Anchor's `client/`, so the PTC (Payload Timeliness Committee) duty never ran. This is the final wiring step: with it, a validator holding a PTC seat under a Gloas-scheduled spec signs and publishes its `PayloadAttestationMessage`.

- Deps already merged: PTC role/kind (#1080), `sign_payload_attestation` (#1082).
- PTC duties are already populated by LH's Gloas-gated `poll_beacon_ptc_attesters` in the existing duties service, so no extra duty wiring is needed.
- Closes #1078 (final issue of milestone #6, PTC / no-QBFT).

## Change Overview

Construct and start LH's `PayloadAttestationService` in `Client::run`, gated on `spec.is_gloas_scheduled()` to mirror LH's own validator client (`validator_client/src/lib.rs:657`). The service owns the per-slot PTC loop (fetch data at the 75% cutoff, abstain on no block, sign per validator, submit to the BN); the SSV partial-signature exchange and threshold reconstruction happen inside the existing `collect_signature` path, invisible to the LH service.

The change is one import plus one gated block. `ProposerPreferences` (#1064) is left a `TODO(gloas)` to join the same block once implemented.

Unchanged: the sign path, duty population, and every sibling service. No new types, no LH bump.

## Risks, Trade-offs, and Mitigations

- **Blast radius is ~zero on live networks.** `is_gloas_scheduled()` is false wherever no Gloas fork is configured (mainnet / hoodi / holesky today), so nothing is constructed or spawned; the new path only activates under a Gloas-scheduled spec.
- **The start is gated** (rather than relying on the service's own per-slot `gloas_enabled()` self-gate) to avoid spawning a perpetual idle task pre-Gloas, matching LH.
- Pre-existing LH property, not introduced here and out of scope for wiring: PTC duties are signed sequentially per validator (immaterial at current PTC seat counts).

## Validation

- `make cargo-fmt-check`: clean.
- `make lint` (`cargo clippy --workspace --tests -- -D warnings`): green, zero warnings, including after rebasing onto the just-merged #1090 (Fork::CStar removal).
- No new unit test: client startup is not unit-tested per service (mirrors `SyncCommitteeService`). Behavioral verification (the service starts and attempts PTC at the 75% cutoff under a Gloas-scheduled spec) belongs on a devnet.

## Rollback

Revert the single commit. No config, data, or operational impact (no-op until Gloas is scheduled).

## Blockers / Dependencies

Deps #1080 and #1082 are merged. Independent of #1090 (already merged; this branch is rebased on top).
