### PR TITLE
feat(validator_store): apply decided Gloas attestation index in committee signing

### DIFF
--- a/anchor/common/ssv_types/src/consensus.rs
+++ b/anchor/common/ssv_types/src/consensus.rs
@@ -2965,6 +2965,69 @@ mod tests {
         );
     }
 
+    /// The QBFT-decided hash is the partial-signature base and binds the SSV signing
+    /// root; for cluster-wide root agreement it MUST be sensitive to
+    /// `attestation_data_index`. This isolates that single-field binding: two votes that
+    /// agree on `block_root`/`source`/`target` and differ ONLY in
+    /// `attestation_data_index` must hash differently, while two votes equal in every
+    /// field must hash identically. (#1027 C3 support / #1061 hash-equality. The
+    /// index=0-vs-1 case is also exercised inside `test_gloas_beacon_vote_hash_deterministic`;
+    /// this test pins the binding contract on its own.)
+    #[test]
+    fn test_gloas_beacon_vote_hash_binds_attestation_data_index() {
+        // Arrange: a fixed (block_root, source, target) baseline shared by all votes so
+        // `attestation_data_index` is the only variable across the index pair.
+        let block_root = Hash256::from_low_u64_be(0xb10c);
+        let source_root = Hash256::from_low_u64_be(0x5005);
+        let target_root = Hash256::from_low_u64_be(0x7007);
+        let source_epoch = 3u64;
+        let target_epoch = 4u64;
+
+        let index_zero = create_gloas_beacon_vote(
+            block_root,
+            source_epoch,
+            source_root,
+            target_epoch,
+            target_root,
+            0,
+        );
+        let index_one = create_gloas_beacon_vote(
+            block_root,
+            source_epoch,
+            source_root,
+            target_epoch,
+            target_root,
+            1,
+        );
+        let index_zero_again = create_gloas_beacon_vote(
+            block_root,
+            source_epoch,
+            source_root,
+            target_epoch,
+            target_root,
+            0,
+        );
+
+        // Act
+        let hash_zero = index_zero.hash();
+        let hash_one = index_one.hash();
+        let hash_zero_again = index_zero_again.hash();
+
+        // Assert: differing only in `attestation_data_index` must change the decided hash.
+        assert_ne!(
+            hash_zero, hash_one,
+            "votes differing only in attestation_data_index (0 vs 1) must hash differently \
+             so the decided/signing root binds the index"
+        );
+
+        // Assert: fully identical fields must produce identical hashes (no
+        // identity/address dependence in the hash).
+        assert_eq!(
+            hash_zero, hash_zero_again,
+            "votes with fully identical fields must hash identically"
+        );
+    }
+
     #[test]
     fn test_beacon_vote_rejects_gloas_bytes() {
         // Arrange: encode a `GloasBeaconVote` (120 bytes).

--- a/anchor/validator_store/src/lib.rs
+++ b/anchor/validator_store/src/lib.rs
@@ -64,12 +64,12 @@ use tracing::{Instrument, Span, debug, error, field, info, info_span, trace, war
 use types::{
     AbstractExecPayload, Address, AggregateAndProof, AggregateAndProofBase,
     AggregateAndProofElectra, Attestation, AttestationBase, AttestationElectra, BeaconBlock,
-    BeaconBlockRef, BlindedPayload, ChainSpec, ContributionAndProof, Domain, Epoch, EthSpec,
-    ExecutionPayloadEnvelope, ForkName, FullPayload, Graffiti, Hash256, PayloadAttestationData,
-    PayloadAttestationMessage, ProposerPreferences, SelectionProof, SignedAggregateAndProof,
-    SignedBeaconBlock, SignedBlindedBeaconBlock, SignedContributionAndProof,
-    SignedExecutionPayloadEnvelope, SignedProposerPreferences, SignedRoot,
-    SignedValidatorRegistrationData, SignedVoluntaryExit, Slot, SlotData,
+    BeaconBlockRef, BlindedPayload, ChainSpec, Checkpoint, ContributionAndProof, Domain, Epoch,
+    EthSpec, ExecutionPayloadEnvelope, ForkName, FullPayload, Graffiti, Hash256,
+    PayloadAttestationData, PayloadAttestationMessage, ProposerPreferences, SelectionProof,
+    SignedAggregateAndProof, SignedBeaconBlock, SignedBlindedBeaconBlock,
+    SignedContributionAndProof, SignedExecutionPayloadEnvelope, SignedProposerPreferences,
+    SignedRoot, SignedValidatorRegistrationData, SignedVoluntaryExit, Slot, SlotData,
     SyncAggregatorSelectionData, SyncCommitteeContribution, SyncCommitteeMessage,
     SyncSelectionProof, SyncSubnetId, ValidatorRegistrationData, VoluntaryExit,
 };
@@ -1424,37 +1424,77 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> AnchorValidator
         let validator_attestation_committees =
             self.get_attesting_validators_in_committee(&voting_context, committee_id);
 
-        // Run QBFT consensus once for the entire committee
+        // Run QBFT consensus once for the entire committee. The start time mirrors the
+        // attestation path's fork-aware deadline: attestation and sync-committee duties for the
+        // same `(committee, slot)` share one QBFT instance, and the first caller's timing wins,
+        // so both must compute `instance_start_time` identically or round timing becomes
+        // call-order-dependent at Gloas.
         let timer = metrics::start_timer_vec(&metrics::CONSENSUS_TIMES, &[metrics::BEACON_VOTE]);
         let timeout_mode = TimeoutMode::SlotTime {
             instance_start_time: self
-                .get_instant_in_slot(slot, self.spec.get_slot_duration() / 3)?,
+                .get_instant_in_slot(slot, self.spec.get_attestation_due::<E>(slot))?,
         };
 
-        let completed = self
-            .consensus
-            .decide_instance(
-                CommitteeInstanceId {
-                    committee: committee_id,
-                    instance_height: slot.as_usize().into(),
-                },
-                voting_context.beacon_vote.clone(),
-                self.create_beacon_vote_validator(slot, validator_attestation_committees),
-                timeout_mode,
-                &cluster.cluster_members,
-            )
-            .await
-            .map_err(SpecificError::from)?;
-        drop(timer);
+        let instance_id = CommitteeInstanceId {
+            committee: committee_id,
+            instance_height: slot.as_usize().into(),
+        };
 
-        let data = match completed {
-            Completed::TimedOut => return Err(Error::SpecificError(SpecificError::Timeout)),
-            Completed::Success(data) => data,
+        // Decide over the fork-matching QBFT type so this call attaches to the SAME shared
+        // instance the attestation path creates (instances are keyed by `D` via `D::get_map`).
+        // Both paths build the seed from the same `voting_context.vote`, so the initial-value
+        // hashes match by construction and the sync caller joins the attestation instance via
+        // `on_completed` instead of spawning a sibling. Only `block_root` (the sync signing
+        // root) and the decided hash (the partial-signature base) are consumed downstream.
+        let vote = voting_context.vote.clone();
+        let (block_root, decided_hash) = if self.spec.fork_name_at_slot::<E>(slot).gloas_enabled() {
+            let completed = self
+                .consensus
+                .decide_instance(
+                    instance_id,
+                    GloasBeaconVote {
+                        block_root: vote.block_root(),
+                        source: vote.source(),
+                        target: vote.target(),
+                        attestation_data_index: vote.index(),
+                    },
+                    self.create_gloas_beacon_vote_validator(slot, validator_attestation_committees),
+                    timeout_mode,
+                    &cluster.cluster_members,
+                )
+                .await
+                .map_err(SpecificError::from)?;
+            drop(timer);
+            match completed {
+                Completed::TimedOut => return Err(Error::SpecificError(SpecificError::Timeout)),
+                Completed::Success(decided) => (decided.block_root, decided.hash()),
+            }
+        } else {
+            let completed = self
+                .consensus
+                .decide_instance(
+                    instance_id,
+                    BeaconVote {
+                        block_root: vote.block_root(),
+                        source: vote.source(),
+                        target: vote.target(),
+                    },
+                    self.create_beacon_vote_validator(slot, validator_attestation_committees),
+                    timeout_mode,
+                    &cluster.cluster_members,
+                )
+                .await
+                .map_err(SpecificError::from)?;
+            drop(timer);
+            match completed {
+                Completed::TimedOut => return Err(Error::SpecificError(SpecificError::Timeout)),
+                Completed::Success(decided) => (decided.block_root, decided.hash()),
+            }
         };
 
         // Prepare all validators (metadata already resolved by `group_by_committee`)
         let domain = self.get_domain(epoch, Domain::SyncCommittee);
-        let signing_root = data.block_root.signing_root(domain);
+        let signing_root = block_root.signing_root(domain);
 
         let prepared: Vec<SigningRequest<u64>> = messages
             .into_iter()
@@ -1477,7 +1517,7 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> AnchorValidator
                 slot,
                 &cluster,
                 validator_partial_signature_batch_size,
-                data.hash(),
+                decided_hash,
                 &prepared,
             )
             .await?;
@@ -1505,7 +1545,7 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> AnchorValidator
             );
             results.push(SyncCommitteeMessage {
                 slot,
-                beacon_block_root: data.block_root,
+                beacon_block_root: block_root,
                 validator_index,
                 signature,
             });
@@ -1529,7 +1569,6 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> AnchorValidator
             return Ok(vec![]);
         };
         let slot = first_attestation.attestation.data().slot;
-        let first_att_data = first_attestation.attestation.data();
 
         let voting_context_tx = self.get_voting_context(slot).await?;
         let validator_attestation_committees =
@@ -1547,7 +1586,9 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> AnchorValidator
             instance_height: slot.as_usize().into(),
         };
 
-        let (block_root, source, target, decided_hash) = if self
+        let vote = voting_context_tx.vote.clone();
+
+        let (block_root, source, target, decided_hash, decided_index) = if self
             .spec
             .fork_name_at_slot::<E>(slot)
             .gloas_enabled()
@@ -1557,10 +1598,10 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> AnchorValidator
                 .decide_instance(
                     instance_id,
                     GloasBeaconVote {
-                        block_root: first_att_data.beacon_block_root,
-                        source: first_att_data.source,
-                        target: first_att_data.target,
-                        attestation_data_index: first_att_data.index,
+                        block_root: vote.block_root(),
+                        source: vote.source(),
+                        target: vote.target(),
+                        attestation_data_index: vote.index(),
                     },
                     self.create_gloas_beacon_vote_validator(slot, validator_attestation_committees),
                     timeout_mode,
@@ -1573,13 +1614,12 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> AnchorValidator
                 Completed::TimedOut => {
                     return Err(Error::SpecificError(SpecificError::Timeout));
                 }
-                // TODO(#1027): apply `decided.attestation_data_index` to each validator's
-                // `attestation.data.index` before signing.
                 Completed::Success(decided) => (
                     decided.block_root,
                     decided.source,
                     decided.target,
                     decided.hash(),
+                    Some(decided.attestation_data_index),
                 ),
             }
         } else {
@@ -1588,9 +1628,9 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> AnchorValidator
                 .decide_instance(
                     instance_id,
                     BeaconVote {
-                        block_root: first_att_data.beacon_block_root,
-                        source: first_att_data.source,
-                        target: first_att_data.target,
+                        block_root: vote.block_root(),
+                        source: vote.source(),
+                        target: vote.target(),
                     },
                     self.create_beacon_vote_validator(slot, validator_attestation_committees),
                     timeout_mode,
@@ -1608,6 +1648,7 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> AnchorValidator
                     decided.source,
                     decided.target,
                     decided.hash(),
+                    None,
                 ),
             }
         };
@@ -1624,6 +1665,12 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> AnchorValidator
                 att.attestation.data_mut().beacon_block_root = block_root;
                 att.attestation.data_mut().source = source;
                 att.attestation.data_mut().target = target;
+                // Gloas: all operators sign over the single cluster-decided attestation index so
+                // signing roots match cluster-wide. Pre-Gloas (`None`) leaves the
+                // BN-supplied index untouched (`committee_index` pre-Electra, `0` at Electra+).
+                if let Some(index) = decided_index {
+                    att.attestation.data_mut().index = index;
+                }
 
                 let signing_root = att.attestation.data().signing_root(domain_hash);
                 SigningRequest {
@@ -2177,8 +2224,50 @@ fn decrypt_key_share(
 struct VotingContext {
     /// Cached voting assignments (computed at slot start, reused here)
     voting_assignments: Arc<VotingAssignments>,
-    /// The `BeaconVote` (only available at 1/3 slot from beacon node)
-    beacon_vote: BeaconVote,
+    /// The fork-tagged attestation vote for this slot (only available at 1/3 slot from the
+    /// beacon node).
+    vote: SlotVote,
+}
+
+/// The slot's agreed attestation vote, tagged by fork.
+///
+/// Pre-Gloas slots carry a [`BeaconVote`]; Gloas slots carry a [`GloasBeaconVote`], which adds
+/// the BN-supplied `attestation_data_index`. The committee QBFT decides over the fork-matching
+/// type, so the variant tracks the slot's fork. Collapses to a single variant once `BeaconVote`
+/// is retired post-fork.
+#[derive(Clone)]
+enum SlotVote {
+    Base(BeaconVote),
+    Gloas(GloasBeaconVote),
+}
+
+impl SlotVote {
+    fn block_root(&self) -> Hash256 {
+        match self {
+            SlotVote::Base(beacon_vote) => beacon_vote.block_root,
+            SlotVote::Gloas(gloas_beacon_vote) => gloas_beacon_vote.block_root,
+        }
+    }
+
+    fn source(&self) -> Checkpoint {
+        match self {
+            SlotVote::Base(beacon_vote) => beacon_vote.source,
+            SlotVote::Gloas(gloas_beacon_vote) => gloas_beacon_vote.source,
+        }
+    }
+    fn target(&self) -> Checkpoint {
+        match self {
+            SlotVote::Base(beacon_vote) => beacon_vote.target,
+            SlotVote::Gloas(gloas_beacon_vote) => gloas_beacon_vote.target,
+        }
+    }
+
+    fn index(&self) -> u64 {
+        match self {
+            SlotVote::Base(_) => 0,
+            SlotVote::Gloas(gloas_beacon_vote) => gloas_beacon_vote.attestation_data_index,
+        }
+    }
 }
 
 /// Cached validator voting assignments for a slot.
@@ -3725,5 +3814,64 @@ mod tests {
         assert_ne!(pre, post);
         assert_eq!(pre, spec.unaggregated_attestation_due);
         assert_eq!(post, spec.unaggregated_attestation_due_gloas);
+    }
+
+    // ==================== SlotVote accessor tests ====================
+
+    /// Builds a non-trivial checkpoint so accessor tests can distinguish source from target and
+    /// catch any accidental field swap in the `SlotVote` accessors.
+    fn distinct_checkpoint(epoch: u64, root_byte: u8) -> Checkpoint {
+        Checkpoint {
+            epoch: Epoch::new(epoch),
+            root: Hash256::repeat_byte(root_byte),
+        }
+    }
+
+    /// `SlotVote::index()` is the load-bearing accessor for the `#1027` Gloas change: it must
+    /// report `0` for the pre-Gloas `Base` variant (which carries no index) and the inner
+    /// `attestation_data_index` for the `Gloas` variant. The remaining accessors must surface the
+    /// inner `block_root`/`source`/`target` unchanged for both variants.
+    #[test]
+    fn slotvote_index_returns_zero_for_base_and_bn_index_for_gloas() {
+        // Arrange: distinct field values per variant so a wrong accessor cannot accidentally pass.
+        let base_block_root = Hash256::repeat_byte(0xAA);
+        let base_source = distinct_checkpoint(1, 0x11);
+        let base_target = distinct_checkpoint(2, 0x22);
+        let base = SlotVote::Base(BeaconVote {
+            block_root: base_block_root,
+            source: base_source,
+            target: base_target,
+        });
+
+        let gloas_block_root = Hash256::repeat_byte(0xBB);
+        let gloas_source = distinct_checkpoint(3, 0x33);
+        let gloas_target = distinct_checkpoint(4, 0x44);
+        let gloas = SlotVote::Gloas(GloasBeaconVote {
+            block_root: gloas_block_root,
+            source: gloas_source,
+            target: gloas_target,
+            attestation_data_index: 1,
+        });
+
+        // Act + Assert: index() is the fork-tagged accessor.
+        assert_eq!(
+            base.index(),
+            0,
+            "Base carries no attestation index, so index() must report 0"
+        );
+        assert_eq!(
+            gloas.index(),
+            1,
+            "Gloas must surface the inner attestation_data_index"
+        );
+
+        // Act + Assert: the remaining accessors must pass the inner fields straight through.
+        assert_eq!(base.block_root(), base_block_root);
+        assert_eq!(base.source(), base_source);
+        assert_eq!(base.target(), base_target);
+
+        assert_eq!(gloas.block_root(), gloas_block_root);
+        assert_eq!(gloas.source(), gloas_source);
+        assert_eq!(gloas.target(), gloas_target);
     }
 }

--- a/anchor/validator_store/src/lib.rs
+++ b/anchor/validator_store/src/lib.rs
@@ -41,7 +41,8 @@ use signature_collector::{
 use slashing_protection::{CheckSlashability, NotSafe, Safe, SlashingDatabase};
 use slot_clock::SlotClock;
 use ssv_types::{
-    Cluster, ClusterId, CommitteeId, ENCRYPTED_KEY_LENGTH, ValidatorIndex, ValidatorMetadata,
+    Cluster, ClusterId, CommitteeId, ENCRYPTED_KEY_LENGTH, IndexSet, OperatorId, ValidatorIndex,
+    ValidatorMetadata,
     consensus::{
         AggregatorCommitteeConsensusData, AggregatorCommitteeDataValidator, BEACON_ROLE_AGGREGATOR,
         BEACON_ROLE_PROPOSER, BEACON_ROLE_SYNC_COMMITTEE_CONTRIBUTION, BeaconVote,
@@ -106,6 +107,18 @@ struct SigningRequest<T> {
     validator: ValidatorMetadata,
     signing_root: Hash256,
     duty_data: T,
+}
+
+/// Fork-normalized result of a committee beacon-vote decision.
+///
+/// `decided_index` is present only for Gloas votes. Keeping it optional preserves the pre-Gloas
+/// contract that the beacon-node-supplied attestation index is not overwritten after consensus.
+struct DecidedVote {
+    block_root: Hash256,
+    source: Checkpoint,
+    target: Checkpoint,
+    decided_hash: Hash256,
+    decided_index: Option<u64>,
 }
 
 impl<T> SigningRequest<T> {
@@ -1404,6 +1417,86 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> AnchorValidator
         Ok(results)
     }
 
+    /// Run the shared committee beacon-vote consensus with fork-correct data and timing.
+    ///
+    /// Attestation and sync-message callers for the same `(committee, slot)` attach to one typed
+    /// QBFT instance. The first initialization owns the timeout configuration, so constructing the
+    /// instance ID and start time here prevents the two callers from drifting independently.
+    async fn decide_committee_vote(
+        &self,
+        committee_id: CommitteeId,
+        slot: Slot,
+        vote: SlotVote,
+        validator_attestation_committees: HashMap<PublicKeyBytes, u64>,
+        cluster_members: &IndexSet<OperatorId>,
+    ) -> Result<DecidedVote, Error> {
+        let timer = metrics::start_timer_vec(&metrics::CONSENSUS_TIMES, &[metrics::BEACON_VOTE]);
+        let timeout_mode = TimeoutMode::SlotTime {
+            instance_start_time: self
+                .get_instant_in_slot(slot, self.spec.get_attestation_due::<E>(slot))?,
+        };
+        let instance_id = CommitteeInstanceId {
+            committee: committee_id,
+            instance_height: slot.as_usize().into(),
+        };
+
+        let result = match vote {
+            SlotVote::Gloas(seed) => {
+                let completed = self
+                    .consensus
+                    .decide_instance(
+                        instance_id,
+                        seed,
+                        self.create_gloas_beacon_vote_validator(
+                            slot,
+                            validator_attestation_committees,
+                        ),
+                        timeout_mode,
+                        cluster_members,
+                    )
+                    .await
+                    .map_err(SpecificError::from)?;
+
+                match completed {
+                    Completed::TimedOut => Err(Error::SpecificError(SpecificError::Timeout)),
+                    Completed::Success(decided) => Ok(DecidedVote {
+                        block_root: decided.block_root,
+                        source: decided.source,
+                        target: decided.target,
+                        decided_hash: decided.hash(),
+                        decided_index: Some(decided.attestation_data_index),
+                    }),
+                }
+            }
+            SlotVote::Base(seed) => {
+                let completed = self
+                    .consensus
+                    .decide_instance(
+                        instance_id,
+                        seed,
+                        self.create_beacon_vote_validator(slot, validator_attestation_committees),
+                        timeout_mode,
+                        cluster_members,
+                    )
+                    .await
+                    .map_err(SpecificError::from)?;
+
+                match completed {
+                    Completed::TimedOut => Err(Error::SpecificError(SpecificError::Timeout)),
+                    Completed::Success(decided) => Ok(DecidedVote {
+                        block_root: decided.block_root,
+                        source: decided.source,
+                        target: decided.target,
+                        decided_hash: decided.hash(),
+                        decided_index: None,
+                    }),
+                }
+            }
+        };
+        drop(timer);
+        result
+    }
+
     /// Sign sync committee messages for all validators in a single SSV committee.
     ///
     /// Runs QBFT consensus once for the committee, then collects signatures for each validator.
@@ -1424,77 +1517,24 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> AnchorValidator
         let validator_attestation_committees =
             self.get_attesting_validators_in_committee(&voting_context, committee_id);
 
-        // Run QBFT consensus once for the entire committee. The start time mirrors the
-        // attestation path's fork-aware deadline: attestation and sync-committee duties for the
-        // same `(committee, slot)` share one QBFT instance, and the first caller's timing wins,
-        // so both must compute `instance_start_time` identically or round timing becomes
-        // call-order-dependent at Gloas.
-        let timer = metrics::start_timer_vec(&metrics::CONSENSUS_TIMES, &[metrics::BEACON_VOTE]);
-        let timeout_mode = TimeoutMode::SlotTime {
-            instance_start_time: self
-                .get_instant_in_slot(slot, self.spec.get_attestation_due::<E>(slot))?,
-        };
-
-        let instance_id = CommitteeInstanceId {
-            committee: committee_id,
-            instance_height: slot.as_usize().into(),
-        };
-
         // Decide over the fork-matching QBFT type so this call attaches to the SAME shared
         // instance the attestation path creates (instances are keyed by `D` via `D::get_map`).
-        // Both paths build the seed from the same `voting_context.vote`, so the initial-value
-        // hashes match by construction and the sync caller joins the attestation instance via
-        // `on_completed` instead of spawning a sibling. Only `block_root` (the sync signing
-        // root) and the decided hash (the partial-signature base) are consumed downstream.
-        let vote = voting_context.vote.clone();
-        let (block_root, decided_hash) = if self.spec.fork_name_at_slot::<E>(slot).gloas_enabled() {
-            let completed = self
-                .consensus
-                .decide_instance(
-                    instance_id,
-                    GloasBeaconVote {
-                        block_root: vote.block_root(),
-                        source: vote.source(),
-                        target: vote.target(),
-                        attestation_data_index: vote.index(),
-                    },
-                    self.create_gloas_beacon_vote_validator(slot, validator_attestation_committees),
-                    timeout_mode,
-                    &cluster.cluster_members,
-                )
-                .await
-                .map_err(SpecificError::from)?;
-            drop(timer);
-            match completed {
-                Completed::TimedOut => return Err(Error::SpecificError(SpecificError::Timeout)),
-                Completed::Success(decided) => (decided.block_root, decided.hash()),
-            }
-        } else {
-            let completed = self
-                .consensus
-                .decide_instance(
-                    instance_id,
-                    BeaconVote {
-                        block_root: vote.block_root(),
-                        source: vote.source(),
-                        target: vote.target(),
-                    },
-                    self.create_beacon_vote_validator(slot, validator_attestation_committees),
-                    timeout_mode,
-                    &cluster.cluster_members,
-                )
-                .await
-                .map_err(SpecificError::from)?;
-            drop(timer);
-            match completed {
-                Completed::TimedOut => return Err(Error::SpecificError(SpecificError::Timeout)),
-                Completed::Success(decided) => (decided.block_root, decided.hash()),
-            }
-        };
+        // Both paths pass the same `voting_context.vote`, so the initial-value hashes match by
+        // construction and the second caller joins through `on_completed` instead of spawning a
+        // sibling. The helper also makes the shared instance timing structural.
+        let decided = self
+            .decide_committee_vote(
+                committee_id,
+                slot,
+                voting_context.vote.clone(),
+                validator_attestation_committees,
+                &cluster.cluster_members,
+            )
+            .await?;
 
         // Prepare all validators (metadata already resolved by `group_by_committee`)
         let domain = self.get_domain(epoch, Domain::SyncCommittee);
-        let signing_root = block_root.signing_root(domain);
+        let signing_root = decided.block_root.signing_root(domain);
 
         let prepared: Vec<SigningRequest<u64>> = messages
             .into_iter()
@@ -1517,7 +1557,7 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> AnchorValidator
                 slot,
                 &cluster,
                 validator_partial_signature_batch_size,
-                decided_hash,
+                decided.decided_hash,
                 &prepared,
             )
             .await?;
@@ -1545,7 +1585,7 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> AnchorValidator
             );
             results.push(SyncCommitteeMessage {
                 slot,
-                beacon_block_root: block_root,
+                beacon_block_root: decided.block_root,
                 validator_index,
                 signature,
             });
@@ -1574,87 +1614,18 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> AnchorValidator
         let validator_attestation_committees =
             self.get_attesting_validators_in_committee(&voting_context_tx, committee_id);
 
-        // Run QBFT consensus once for the entire committee
-        let timer = metrics::start_timer_vec(&metrics::CONSENSUS_TIMES, &[metrics::BEACON_VOTE]);
-        let timeout_mode = TimeoutMode::SlotTime {
-            instance_start_time: self
-                .get_instant_in_slot(slot, self.spec.get_attestation_due::<E>(slot))?,
-        };
-
-        let instance_id = CommitteeInstanceId {
-            committee: committee_id,
-            instance_height: slot.as_usize().into(),
-        };
-
-        let vote = voting_context_tx.vote.clone();
-
-        let (block_root, source, target, decided_hash, decided_index) = if self
-            .spec
-            .fork_name_at_slot::<E>(slot)
-            .gloas_enabled()
-        {
-            let completed = self
-                .consensus
-                .decide_instance(
-                    instance_id,
-                    GloasBeaconVote {
-                        block_root: vote.block_root(),
-                        source: vote.source(),
-                        target: vote.target(),
-                        attestation_data_index: vote.index(),
-                    },
-                    self.create_gloas_beacon_vote_validator(slot, validator_attestation_committees),
-                    timeout_mode,
-                    &cluster.cluster_members,
-                )
-                .await
-                .map_err(SpecificError::from)?;
-            drop(timer);
-            match completed {
-                Completed::TimedOut => {
-                    return Err(Error::SpecificError(SpecificError::Timeout));
-                }
-                Completed::Success(decided) => (
-                    decided.block_root,
-                    decided.source,
-                    decided.target,
-                    decided.hash(),
-                    Some(decided.attestation_data_index),
-                ),
-            }
-        } else {
-            let completed = self
-                .consensus
-                .decide_instance(
-                    instance_id,
-                    BeaconVote {
-                        block_root: vote.block_root(),
-                        source: vote.source(),
-                        target: vote.target(),
-                    },
-                    self.create_beacon_vote_validator(slot, validator_attestation_committees),
-                    timeout_mode,
-                    &cluster.cluster_members,
-                )
-                .await
-                .map_err(SpecificError::from)?;
-            drop(timer);
-            match completed {
-                Completed::TimedOut => {
-                    return Err(Error::SpecificError(SpecificError::Timeout));
-                }
-                Completed::Success(decided) => (
-                    decided.block_root,
-                    decided.source,
-                    decided.target,
-                    decided.hash(),
-                    None,
-                ),
-            }
-        };
+        let decided = self
+            .decide_committee_vote(
+                committee_id,
+                slot,
+                voting_context_tx.vote.clone(),
+                validator_attestation_committees,
+                &cluster.cluster_members,
+            )
+            .await?;
 
         // Shared values for all validators in this committee
-        let domain_hash = self.get_domain(target.epoch, Domain::BeaconAttester);
+        let domain_hash = self.get_domain(decided.target.epoch, Domain::BeaconAttester);
 
         // Prepare all validators and apply consensus results upfront
         // (metadata already resolved by `group_by_committee`)
@@ -1662,13 +1633,13 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> AnchorValidator
             .into_iter()
             .map(|(validator, mut att)| {
                 // Apply consensus result to this attestation
-                att.attestation.data_mut().beacon_block_root = block_root;
-                att.attestation.data_mut().source = source;
-                att.attestation.data_mut().target = target;
+                att.attestation.data_mut().beacon_block_root = decided.block_root;
+                att.attestation.data_mut().source = decided.source;
+                att.attestation.data_mut().target = decided.target;
                 // Gloas: all operators sign over the single cluster-decided attestation index so
                 // signing roots match cluster-wide. Pre-Gloas (`None`) leaves the
                 // BN-supplied index untouched (`committee_index` pre-Electra, `0` at Electra+).
-                if let Some(index) = decided_index {
+                if let Some(index) = decided.decided_index {
                     att.attestation.data_mut().index = index;
                 }
 
@@ -1693,7 +1664,7 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> AnchorValidator
                 slot,
                 &cluster,
                 validator_partial_signature_batch_size,
-                decided_hash,
+                decided.decided_hash,
                 &prepared,
             )
             .await?;

--- a/anchor/validator_store/src/metadata_service.rs
+++ b/anchor/validator_store/src/metadata_service.rs
@@ -125,6 +125,49 @@ fn calculate_attestation_score(
     }
 }
 
+/// Build the fork-typed committee vote from one coherent beacon-node response.
+fn slot_vote_from_attestation_data<E: EthSpec>(
+    spec: &ChainSpec,
+    slot: Slot,
+    attestation_data: AttestationData,
+) -> SlotVote {
+    if spec.fork_name_at_slot::<E>(slot).gloas_enabled() {
+        SlotVote::Gloas(GloasBeaconVote {
+            block_root: attestation_data.beacon_block_root,
+            source: attestation_data.source,
+            target: attestation_data.target,
+            attestation_data_index: attestation_data.index,
+        })
+    } else {
+        SlotVote::Base(BeaconVote {
+            block_root: attestation_data.beacon_block_root,
+            source: attestation_data.source,
+            target: attestation_data.target,
+        })
+    }
+}
+
+/// Reconstruct the attestation data whose tree root is used for aggregate fetching.
+fn aggregate_fetch_attestation_data<E: EthSpec>(
+    spec: &ChainSpec,
+    slot: Slot,
+    vote: &SlotVote,
+    committee_index: u64,
+) -> AttestationData {
+    let fork_name = spec.fork_name_at_slot::<E>(slot);
+    AttestationData {
+        slot,
+        index: if fork_name < ForkName::Electra {
+            committee_index
+        } else {
+            vote.index()
+        },
+        beacon_block_root: vote.block_root(),
+        source: vote.source(),
+        target: vote.target(),
+    }
+}
+
 #[derive(Clone)]
 pub struct MetadataService<E: EthSpec, T: SlotClock + 'static> {
     duties_service: Arc<DutiesService<AnchorValidatorStore<T, E>, T>>,
@@ -433,20 +476,7 @@ impl<E: EthSpec, T: SlotClock + 'static> MetadataService<E, T> {
             None => self.fetch_attestation_data(slot).await?,
         };
 
-        let vote = if self.spec.fork_name_at_slot::<E>(slot).gloas_enabled() {
-            SlotVote::Gloas(GloasBeaconVote {
-                block_root: attestation_data.beacon_block_root,
-                source: attestation_data.source,
-                target: attestation_data.target,
-                attestation_data_index: attestation_data.index,
-            })
-        } else {
-            SlotVote::Base(BeaconVote {
-                block_root: attestation_data.beacon_block_root,
-                source: attestation_data.source,
-                target: attestation_data.target,
-            })
-        };
+        let vote = slot_vote_from_attestation_data::<E>(&self.spec, slot, attestation_data);
 
         let voting_context = VotingContext {
             voting_assignments,
@@ -901,30 +931,20 @@ impl<E: EthSpec, T: SlotClock + 'static> MetadataService<E, T> {
             &["aggregated_attestations"],
         );
 
-        // Determine fork version to handle pre-Electra vs Electra+ attestation data format.
-        // In Electra+ (EIP-7549), AttestationData.index is always 0 because the committee
-        // index moved to Attestation.committee_bits.
-        // In pre-Electra, AttestationData.index must equal the committee_index.
-        // Use slot as the canonical source for epoch since it's the authoritative parameter.
-        let fork_name = self
-            .spec
-            .fork_name_at_epoch(slot.epoch(E::slots_per_epoch()));
-
         // Create `FuturesUnordered` for concurrent execution with partial result collection
         let beacon_nodes = &self.beacon_nodes;
         let mut futures: FuturesUnordered<_> = attestation_committee_indexes
             .iter()
             .map(|&committee_index| {
                 // Reconstruct the attestation data to compute its tree hash root.
-                // Pre-Electra: index = committee_index
-                // Electra+: index = 0 (committee info moved to Attestation.committee_bits)
-                let attestation_data = AttestationData {
+                // Pre-Electra uses the committee index, Electra through pre-Gloas uses zero,
+                // and Gloas uses the BN-supplied index carried by the slot vote.
+                let attestation_data = aggregate_fetch_attestation_data::<E>(
+                    &self.spec,
                     slot,
-                    index: if fork_name < ForkName::Electra { committee_index } else { vote.index() },
-                    beacon_block_root: vote.block_root(),
-                    source: vote.source(),
-                    target: vote.target(),
-                };
+                    vote,
+                    committee_index,
+                );
                 let attestation_data_root = attestation_data.tree_hash_root();
 
                 async move {
@@ -1484,6 +1504,138 @@ mod tests {
             aggregation_bits: Default::default(),
             signature: AggregateSignature::infinity(),
         }
+    }
+
+    fn distinct_vote_fields() -> (Hash256, Checkpoint, Checkpoint) {
+        (
+            Hash256::repeat_byte(0xB1),
+            Checkpoint {
+                epoch: Epoch::new(5),
+                root: Hash256::repeat_byte(0x51),
+            },
+            Checkpoint {
+                epoch: Epoch::new(6),
+                root: Hash256::repeat_byte(0x71),
+            },
+        )
+    }
+
+    #[test]
+    fn slot_vote_preserves_the_fork_specific_attestation_shape() {
+        let slot = Slot::new(1);
+        let (block_root, source, target) = distinct_vote_fields();
+        let attestation_data = AttestationData {
+            slot,
+            index: 1,
+            beacon_block_root: block_root,
+            source,
+            target,
+        };
+
+        let mut pre_gloas_spec = ChainSpec::mainnet();
+        pre_gloas_spec.gloas_fork_epoch = None;
+        let base = slot_vote_from_attestation_data::<MainnetEthSpec>(
+            &pre_gloas_spec,
+            slot,
+            attestation_data.clone(),
+        );
+        match base {
+            SlotVote::Base(vote) => {
+                assert_eq!(vote.block_root, block_root);
+                assert_eq!(vote.source, source);
+                assert_eq!(vote.target, target);
+            }
+            SlotVote::Gloas(_) => panic!("pre-Gloas data must produce a Base vote"),
+        }
+
+        let mut gloas_spec = ChainSpec::mainnet();
+        gloas_spec.electra_fork_epoch = Some(Epoch::new(0));
+        gloas_spec.gloas_fork_epoch = Some(Epoch::new(0));
+        let gloas =
+            slot_vote_from_attestation_data::<MainnetEthSpec>(&gloas_spec, slot, attestation_data);
+        match gloas {
+            SlotVote::Gloas(vote) => {
+                assert_eq!(vote.block_root, block_root);
+                assert_eq!(vote.source, source);
+                assert_eq!(vote.target, target);
+                assert_eq!(vote.attestation_data_index, 1);
+            }
+            SlotVote::Base(_) => panic!("Gloas data must produce a Gloas vote"),
+        }
+    }
+
+    #[test]
+    fn aggregate_fetch_attestation_data_uses_the_fork_specific_index() {
+        let slot = Slot::new(1);
+        let committee_index = 7;
+        let (block_root, source, target) = distinct_vote_fields();
+        let base_vote = SlotVote::Base(BeaconVote {
+            block_root,
+            source,
+            target,
+        });
+
+        let mut pre_electra_spec = ChainSpec::mainnet();
+        pre_electra_spec.electra_fork_epoch = Some(Epoch::new(1));
+        pre_electra_spec.gloas_fork_epoch = None;
+        let pre_electra = aggregate_fetch_attestation_data::<MainnetEthSpec>(
+            &pre_electra_spec,
+            slot,
+            &base_vote,
+            committee_index,
+        );
+        assert_eq!(pre_electra.index, committee_index);
+        assert_eq!(pre_electra.slot, slot);
+        assert_eq!(pre_electra.beacon_block_root, block_root);
+        assert_eq!(pre_electra.source, source);
+        assert_eq!(pre_electra.target, target);
+
+        let mut electra_spec = ChainSpec::mainnet();
+        electra_spec.electra_fork_epoch = Some(Epoch::new(0));
+        electra_spec.gloas_fork_epoch = None;
+        let electra = aggregate_fetch_attestation_data::<MainnetEthSpec>(
+            &electra_spec,
+            slot,
+            &base_vote,
+            committee_index,
+        );
+        assert_eq!(electra.index, 0);
+        assert_eq!(electra.slot, slot);
+        assert_eq!(electra.beacon_block_root, block_root);
+        assert_eq!(electra.source, source);
+        assert_eq!(electra.target, target);
+
+        let mut gloas_spec = ChainSpec::mainnet();
+        gloas_spec.electra_fork_epoch = Some(Epoch::new(0));
+        gloas_spec.gloas_fork_epoch = Some(Epoch::new(0));
+        let gloas_vote = SlotVote::Gloas(GloasBeaconVote {
+            block_root,
+            source,
+            target,
+            attestation_data_index: 1,
+        });
+        let gloas = aggregate_fetch_attestation_data::<MainnetEthSpec>(
+            &gloas_spec,
+            slot,
+            &gloas_vote,
+            committee_index,
+        );
+        assert_eq!(gloas.index, 1);
+        assert_ne!(gloas.index, committee_index);
+        assert_eq!(gloas.slot, slot);
+        assert_eq!(gloas.beacon_block_root, block_root);
+        assert_eq!(gloas.source, source);
+        assert_eq!(gloas.target, target);
+
+        let gloas_with_zero_index = AttestationData {
+            index: 0,
+            ..gloas.clone()
+        };
+        assert_ne!(
+            gloas.tree_hash_root(),
+            gloas_with_zero_index.tree_hash_root(),
+            "the aggregate-fetch root must bind the Gloas attestation index"
+        );
     }
 
     // ═══════════════════════════════════════════════════════════════════════════════════

--- a/anchor/validator_store/src/metadata_service.rs
+++ b/anchor/validator_store/src/metadata_service.rs
@@ -15,7 +15,10 @@ use futures::stream::{FuturesUnordered, StreamExt};
 use slot_clock::SlotClock;
 use ssv_types::{
     CommitteeId, IndexSet, ValidatorIndex, VariableList,
-    consensus::{AggregatorCommitteeConsensusData, AssignedAggregator, BeaconVote, DataVersion},
+    consensus::{
+        AggregatorCommitteeConsensusData, AssignedAggregator, BeaconVote, DataVersion,
+        GloasBeaconVote,
+    },
 };
 use ssz::Encode;
 use task_executor::TaskExecutor;
@@ -32,7 +35,7 @@ use types::{
 use validator_services::duties_service::{DutiesService, DutyAndProof};
 
 use crate::{
-    AggregationAssignments, AnchorValidatorStore, ContributionWaiter, VotingAssignments,
+    AggregationAssignments, AnchorValidatorStore, ContributionWaiter, SlotVote, VotingAssignments,
     VotingContext, metrics,
 };
 
@@ -430,15 +433,24 @@ impl<E: EthSpec, T: SlotClock + 'static> MetadataService<E, T> {
             None => self.fetch_attestation_data(slot).await?,
         };
 
-        let beacon_vote = BeaconVote {
-            block_root: attestation_data.beacon_block_root,
-            source: attestation_data.source,
-            target: attestation_data.target,
+        let vote = if self.spec.fork_name_at_slot::<E>(slot).gloas_enabled() {
+            SlotVote::Gloas(GloasBeaconVote {
+                block_root: attestation_data.beacon_block_root,
+                source: attestation_data.source,
+                target: attestation_data.target,
+                attestation_data_index: attestation_data.index,
+            })
+        } else {
+            SlotVote::Base(BeaconVote {
+                block_root: attestation_data.beacon_block_root,
+                source: attestation_data.source,
+                target: attestation_data.target,
+            })
         };
 
         let voting_context = VotingContext {
             voting_assignments,
-            beacon_vote,
+            vote,
         };
 
         self.validator_store.update_voting_context(voting_context);
@@ -649,7 +661,7 @@ impl<E: EthSpec, T: SlotClock + 'static> MetadataService<E, T> {
         attestation_committee_indexes: HashSet<u64>,
         all_subnet_ids: HashSet<SyncSubnetId>,
     ) -> Result<HashMap<CommitteeId, Arc<AggregatorCommitteeConsensusData<E>>>, String> {
-        // Get `VotingContext` for `beacon_vote` (cached at 1/3 slot)
+        // Get `VotingContext` for the slot's `vote` (cached at 1/3 slot)
         let voting_context = self
             .validator_store
             .get_voting_context(slot)
@@ -663,13 +675,13 @@ impl<E: EthSpec, T: SlotClock + 'static> MetadataService<E, T> {
         let (aggregated_attestations, sync_contributions) = tokio::join!(
             self.fetch_aggregated_attestations(
                 slot,
-                &voting_context.beacon_vote,
+                &voting_context.vote,
                 &attestation_committee_indexes,
                 BEACON_API_FETCH_TIMEOUT,
             ),
             self.fetch_sync_contributions(
                 slot,
-                voting_context.beacon_vote.block_root,
+                voting_context.vote.block_root(),
                 &all_subnet_ids,
                 BEACON_API_FETCH_TIMEOUT,
             ),
@@ -880,7 +892,7 @@ impl<E: EthSpec, T: SlotClock + 'static> MetadataService<E, T> {
     async fn fetch_aggregated_attestations(
         &self,
         slot: Slot,
-        beacon_vote: &BeaconVote,
+        vote: &SlotVote,
         attestation_committee_indexes: &HashSet<u64>,
         timeout: Duration,
     ) -> HashMap<u64, Attestation<E>> {
@@ -908,10 +920,10 @@ impl<E: EthSpec, T: SlotClock + 'static> MetadataService<E, T> {
                 // Electra+: index = 0 (committee info moved to Attestation.committee_bits)
                 let attestation_data = AttestationData {
                     slot,
-                    index: if fork_name < ForkName::Electra { committee_index } else { 0 },
-                    beacon_block_root: beacon_vote.block_root,
-                    source: beacon_vote.source,
-                    target: beacon_vote.target,
+                    index: if fork_name < ForkName::Electra { committee_index } else { vote.index() },
+                    beacon_block_root: vote.block_root(),
+                    source: vote.source(),
+                    target: vote.target(),
                 };
                 let attestation_data_root = attestation_data.tree_hash_root();
 

--- a/anchor/validator_store/src/testing/committee_attestation_gloas.rs
+++ b/anchor/validator_store/src/testing/committee_attestation_gloas.rs
@@ -1,0 +1,430 @@
+//! Fork-aware tests for the committee attestation index, covering the `#1027`/`#1061` Gloas
+//! change in `sign_committee_attestations` and `sign_committee_sync_committee_signatures`.
+//!
+//! The change makes the committee QBFT decide a single `attestation_data_index` at Gloas and
+//! apply it to every validator's `attestation.data.index` before the signing root is computed,
+//! so all operators sign identical roots cluster-wide. Pre-Gloas, the BN-supplied index is left
+//! untouched.
+//!
+//! The mock decider (`common::MockConsensusDecider`) replaces real QBFT: it can echo the local
+//! seed back, or force every `GloasBeaconVote` to decide a chosen index. That lets these tests
+//! drive "decided index == local seed", "decided index != local seed", and "operators with
+//! divergent local seeds converge on the same decided index" without a live consensus network.
+use bls::FixedBytesExtended;
+use futures::StreamExt;
+use signature_collector::SignatureRequester;
+use ssv_types::{
+    OperatorId,
+    consensus::{GloasBeaconVote, QbftData},
+};
+use types::{
+    Attestation, AttestationData, ChainSpec, Checkpoint, Domain, EthSpec, Hash256, MainnetEthSpec,
+    SignedRoot, Slot,
+};
+use validator_store::ValidatorStore;
+
+use super::common::*;
+use crate::Error;
+
+type SignAttestationsResult = Vec<Result<Vec<(u64, Attestation<MainnetEthSpec>)>, Error>>;
+
+const COMMITTEE_OPERATORS: [OperatorId; 4] =
+    [OperatorId(1), OperatorId(2), OperatorId(3), OperatorId(4)];
+const OUR_OPERATOR: OperatorId = OperatorId(1);
+const COMMITTEE_VALIDATOR_COUNT: usize = 2;
+
+/// The cluster-decided attestation index used across the Gloas tests. Differs from the seed
+/// (`SEED_INDEX`) so the tests prove the decided value (not the local seed) reaches the signature.
+const DECIDED_INDEX: u64 = 1;
+/// The local seed index each operator proposes before consensus.
+const SEED_INDEX: u64 = 0;
+
+/// Recomputes the attester signing root the same way the production path does, so assertions can
+/// pin the exact signing root without re-deriving the domain logic by hand. `block_root`,
+/// `source`, and `target` are the all-zero values the harness seeds; `index` is the value under
+/// test.
+fn expected_attester_signing_root(
+    spec: &ChainSpec,
+    genesis_validators_root: Hash256,
+    slot: Slot,
+    index: u64,
+) -> Hash256 {
+    let epoch = slot.epoch(MainnetEthSpec::slots_per_epoch());
+    let domain = spec.get_domain(
+        epoch,
+        Domain::BeaconAttester,
+        &spec.fork_at_epoch(epoch),
+        genesis_validators_root,
+    );
+    let data = AttestationData {
+        slot,
+        index,
+        beacon_block_root: Hash256::zero(),
+        source: Checkpoint::default(),
+        target: Checkpoint::default(),
+    };
+    data.signing_root(domain)
+}
+
+/// Drives `sign_attestations` to completion and unwraps every committee batch.
+async fn run_sign_attestations(
+    harness: &ValidatorStoreTestHarness,
+    attestations: Vec<validator_store::AttestationToSign<MainnetEthSpec>>,
+) -> Vec<(u64, Attestation<MainnetEthSpec>)> {
+    let results: SignAttestationsResult = harness
+        .validator_store
+        .sign_attestations(attestations)
+        .collect()
+        .await;
+    results
+        .into_iter()
+        .flat_map(|batch| batch.expect("committee batch should succeed"))
+        .collect()
+}
+
+// ==================== Gloas: decided index applied ====================
+
+/// At Gloas, the single cluster-decided `attestation_data_index` must be written onto every
+/// validator's `attestation.data.index` BEFORE the signing root is computed, even when it differs
+/// from this operator's local seed. This is the core `#1027` apply step (C3/C6): without it, an
+/// operator would sign over its stale local index and diverge from the cluster.
+#[tokio::test(flavor = "multi_thread")]
+async fn gloas_decided_index_applied_to_every_validator_attestation() {
+    // Arrange: Gloas slot, local seed index 0, but the cluster decides index 1.
+    let committee = create_committee_setup(&COMMITTEE_OPERATORS, COMMITTEE_VALIDATOR_COUNT, 0);
+    let harness = ValidatorStoreTestHarness::new_with_options(
+        vec![committee],
+        OUR_OPERATOR,
+        HarnessOptions {
+            spec: gloas_at_genesis_spec(),
+            forced_gloas_index: Some(DECIDED_INDEX),
+            ..Default::default()
+        },
+    );
+    harness.seed_gloas_voting_context(SEED_INDEX);
+    let attestations = vec![
+        harness.create_attestation(0, 0),
+        harness.create_attestation(0, 1),
+    ];
+
+    // Act
+    let signed = run_sign_attestations(&harness, attestations).await;
+
+    // Assert: every produced attestation carries the decided index, not the seed.
+    assert_eq!(
+        signed.len(),
+        COMMITTEE_VALIDATOR_COUNT,
+        "expected one signed attestation per validator"
+    );
+    for (_, attestation) in &signed {
+        assert_eq!(
+            attestation.data().index,
+            DECIDED_INDEX,
+            "Gloas must apply the cluster-decided index to data.index, not the local seed"
+        );
+    }
+
+    // Assert: each captured signing root is the root over the decided index.
+    let expected_root = expected_attester_signing_root(
+        &harness.spec,
+        harness.genesis_validators_root,
+        Slot::new(TEST_SLOT),
+        DECIDED_INDEX,
+    );
+    let captured = harness.captured_calls.lock();
+    assert_eq!(
+        captured.len(),
+        COMMITTEE_VALIDATOR_COUNT,
+        "expected one sign_and_collect call per validator"
+    );
+    for call in captured.iter() {
+        assert_eq!(
+            call.signing_root, expected_root,
+            "each validator must sign the attester root computed over the decided index"
+        );
+    }
+}
+
+// ==================== Gloas: cluster-wide convergence ====================
+
+/// Two operators whose LOCAL seeds carry divergent attestation indices must still produce
+/// identical signing roots once they decide the SAME index. This models the cluster-wide
+/// agreement guarantee of `#1027` (C6): the signed root is a function of the decided index, never
+/// the per-operator seed. Modeled with two independent harnesses (one per operator) since the
+/// mock decider does not run a shared instance.
+#[tokio::test(flavor = "multi_thread")]
+async fn gloas_all_operators_converge_on_decided_index_signing_root() {
+    // Arrange: operator A seeds index 0, operator B seeds index 1; both decide index 1.
+    let operator_a_seed = 0;
+    let operator_b_seed = 1;
+
+    let committee_a = create_committee_setup(&COMMITTEE_OPERATORS, COMMITTEE_VALIDATOR_COUNT, 0);
+    let harness_a = ValidatorStoreTestHarness::new_with_options(
+        vec![committee_a],
+        OperatorId(1),
+        HarnessOptions {
+            spec: gloas_at_genesis_spec(),
+            forced_gloas_index: Some(DECIDED_INDEX),
+            ..Default::default()
+        },
+    );
+    harness_a.seed_gloas_voting_context(operator_a_seed);
+
+    let committee_b = create_committee_setup(&COMMITTEE_OPERATORS, COMMITTEE_VALIDATOR_COUNT, 0);
+    let harness_b = ValidatorStoreTestHarness::new_with_options(
+        vec![committee_b],
+        OperatorId(2),
+        HarnessOptions {
+            spec: gloas_at_genesis_spec(),
+            forced_gloas_index: Some(DECIDED_INDEX),
+            ..Default::default()
+        },
+    );
+    harness_b.seed_gloas_voting_context(operator_b_seed);
+
+    // Precondition: the two operators genuinely start from divergent local seeds.
+    assert_ne!(
+        operator_a_seed, operator_b_seed,
+        "test is only meaningful if local seeds diverge"
+    );
+
+    // Act
+    let signed_a =
+        run_sign_attestations(&harness_a, vec![harness_a.create_attestation(0, 0)]).await;
+    let signed_b =
+        run_sign_attestations(&harness_b, vec![harness_b.create_attestation(0, 0)]).await;
+
+    // Assert: both operators sign over the decided index, producing identical roots.
+    let expected_root = expected_attester_signing_root(
+        &harness_a.spec,
+        harness_a.genesis_validators_root,
+        Slot::new(TEST_SLOT),
+        DECIDED_INDEX,
+    );
+    let root_a = harness_a.captured_calls.lock()[0].signing_root;
+    let root_b = harness_b.captured_calls.lock()[0].signing_root;
+
+    assert_eq!(
+        root_a, root_b,
+        "operators with divergent local seeds must converge on one signing root"
+    );
+    assert_eq!(
+        root_a, expected_root,
+        "the converged root must be the root computed over the decided index"
+    );
+    assert_eq!(
+        signed_a[0].1.data().index,
+        DECIDED_INDEX,
+        "operator A must sign the decided index"
+    );
+    assert_eq!(
+        signed_b[0].1.data().index,
+        DECIDED_INDEX,
+        "operator B must sign the decided index"
+    );
+}
+
+// ==================== Pre-Gloas: index untouched ====================
+
+/// At Electra (post-Electra, pre-Gloas) the decider has no `decided_index` (`None`), so the apply
+/// step is skipped and `data.index` stays at its BN-supplied value, which is `0` at Electra+.
+/// This guards the `#1027` C5 boundary: the index-apply must NOT fire before Gloas.
+#[tokio::test(flavor = "multi_thread")]
+async fn pre_gloas_electra_attestation_index_is_zero_and_untouched() {
+    // Arrange: Electra-at-genesis spec (so TEST_SLOT is Electra, not Gloas), echo decider.
+    let committee = create_committee_setup(&COMMITTEE_OPERATORS, COMMITTEE_VALIDATOR_COUNT, 0);
+    let harness = ValidatorStoreTestHarness::new_with_options(
+        vec![committee],
+        OUR_OPERATOR,
+        HarnessOptions {
+            spec: electra_at_genesis_spec(),
+            ..Default::default()
+        },
+    );
+    // Pre-Gloas path uses the Base vote; the duty's data.index starts at 0.
+    harness.seed_voting_context();
+    let attestations = vec![
+        harness.create_attestation(0, 0),
+        harness.create_attestation(0, 1),
+    ];
+
+    // Act
+    let signed = run_sign_attestations(&harness, attestations).await;
+
+    // Assert: index stays 0 (Electra+ BN-supplied value), never overwritten.
+    assert_eq!(signed.len(), COMMITTEE_VALIDATOR_COUNT);
+    for (_, attestation) in &signed {
+        assert_eq!(
+            attestation.data().index,
+            0,
+            "pre-Gloas Electra attestation index must remain 0 and untouched"
+        );
+    }
+
+    // Assert: signing roots match the root over index 0.
+    let expected_root = expected_attester_signing_root(
+        &harness.spec,
+        harness.genesis_validators_root,
+        Slot::new(TEST_SLOT),
+        0,
+    );
+    for call in harness.captured_calls.lock().iter() {
+        assert_eq!(
+            call.signing_root, expected_root,
+            "pre-Gloas signing root must be computed over the untouched index 0"
+        );
+    }
+}
+
+/// Pre-Electra, the BN supplies `data.index == committee_index`, and the pre-Gloas path must
+/// leave it untouched (the guarded apply is skipped because `decided_index` is `None`). This
+/// covers the `#1027` C4 invariant.
+///
+/// `ChainSpec::mainnet()` places Electra far in the future, so the default harness spec already
+/// positions `TEST_SLOT` at a pre-Electra fork: no special spec is needed. The duty is seeded
+/// with a non-zero `data.index` so a regression that wrongly overwrites it (e.g. to 0 or to a
+/// decided value) would surface here.
+#[tokio::test(flavor = "multi_thread")]
+async fn pre_gloas_pre_electra_attestation_index_equals_committee_index() {
+    // Arrange: default mainnet spec => TEST_SLOT is pre-Electra; echo decider.
+    let committee_index: u64 = 3;
+    let committee = create_committee_setup(&COMMITTEE_OPERATORS, COMMITTEE_VALIDATOR_COUNT, 0);
+    let harness = ValidatorStoreTestHarness::new(vec![committee], OUR_OPERATOR);
+    harness.seed_voting_context();
+    // Seed each validator's duty with data.index == committee_index, as a pre-Electra BN would.
+    let attestations = vec![
+        harness.create_attestation_with_index(0, 0, committee_index),
+        harness.create_attestation_with_index(0, 1, committee_index),
+    ];
+
+    // Act
+    let signed = run_sign_attestations(&harness, attestations).await;
+
+    // Assert: the BN-supplied committee index survives unchanged.
+    assert_eq!(signed.len(), COMMITTEE_VALIDATOR_COUNT);
+    for (_, attestation) in &signed {
+        assert_eq!(
+            attestation.data().index,
+            committee_index,
+            "pre-Electra attestation index must equal the BN committee index, untouched"
+        );
+    }
+
+    // Assert: signing roots are computed over the untouched committee index.
+    let expected_root = expected_attester_signing_root(
+        &harness.spec,
+        harness.genesis_validators_root,
+        Slot::new(TEST_SLOT),
+        committee_index,
+    );
+    for call in harness.captured_calls.lock().iter() {
+        assert_eq!(
+            call.signing_root, expected_root,
+            "pre-Electra signing root must be computed over the untouched committee index"
+        );
+    }
+}
+
+// ==================== Gloas: attestation and sync paths share the seed ====================
+
+/// `#1061` (L2/L3/L4): for the same `(committee, slot)` at Gloas, the attestation path and the
+/// sync-committee path must seed the committee QBFT from the SAME `voting_context.vote`. With the
+/// mock decider both decide the same value, so the decided hash (the partial-signature base) and
+/// the `CommitteeInstanceId` must match across the two paths. Because the mock does not model a
+/// shared live instance, this asserts seed/hash/instance-id equality rather than a literal
+/// instance count.
+#[tokio::test(flavor = "multi_thread")]
+async fn sync_and_attestation_paths_seed_identical_gloas_instance() {
+    // Arrange: one Gloas committee, both an attestation duty and a sync duty for the same slot.
+    let committee = create_committee_setup(&COMMITTEE_OPERATORS, COMMITTEE_VALIDATOR_COUNT, 0);
+    let committee_id = committee.cluster.committee_id();
+    let harness = ValidatorStoreTestHarness::new_with_options(
+        vec![committee],
+        OUR_OPERATOR,
+        HarnessOptions {
+            spec: gloas_at_genesis_spec(),
+            forced_gloas_index: Some(DECIDED_INDEX),
+            ..Default::default()
+        },
+    );
+    harness.seed_gloas_voting_context(SEED_INDEX);
+
+    // The decided hash both paths feed into the signature collector is the hash of the decided
+    // GloasBeaconVote. Both paths build that vote from the same seed, so this is the shared base.
+    let expected_base_hash = GloasBeaconVote {
+        block_root: Hash256::zero(),
+        source: Checkpoint::default(),
+        target: Checkpoint::default(),
+        attestation_data_index: DECIDED_INDEX,
+    }
+    .hash();
+
+    // Act: drive the attestation path, capture its committee base hash + committee id.
+    let _attestation_signed =
+        run_sign_attestations(&harness, vec![harness.create_attestation(0, 0)]).await;
+    let (attestation_base_hash, attestation_committee_id) =
+        committee_call_base_hash_and_id(&harness);
+
+    // Reset captures so the sync path's calls are isolated.
+    harness.captured_calls.lock().clear();
+
+    // Act: drive the sync path over the same committee/slot.
+    let sync_results: Vec<_> = harness
+        .validator_store
+        .sign_sync_committee_signatures(vec![harness.create_sync_message(0, 0)])
+        .collect()
+        .await;
+    for result in &sync_results {
+        result
+            .as_ref()
+            .expect("sync committee batch should succeed");
+    }
+    let (sync_base_hash, sync_committee_id) = committee_call_base_hash_and_id(&harness);
+
+    // Assert: both paths feed the same decided hash as the partial-signature base.
+    assert_eq!(
+        attestation_base_hash, expected_base_hash,
+        "attestation path must base partial signatures on the decided GloasBeaconVote hash"
+    );
+    assert_eq!(
+        sync_base_hash, expected_base_hash,
+        "sync path must base partial signatures on the same decided GloasBeaconVote hash"
+    );
+    assert_eq!(
+        attestation_base_hash, sync_base_hash,
+        "both paths share one decided hash for the same (committee, slot) at Gloas"
+    );
+
+    // Assert: both target the same committee id (the CommitteeInstanceId committee component).
+    assert_eq!(attestation_committee_id, committee_id);
+    assert_eq!(sync_committee_id, committee_id);
+    assert_eq!(
+        attestation_committee_id, sync_committee_id,
+        "both paths address the same committee instance"
+    );
+}
+
+/// Reads the single committee `sign_and_collect` call captured so far, returning its
+/// partial-signature base hash and committee id. Panics if there is not exactly one committee
+/// call, so a test that captured nothing fails loudly instead of silently passing.
+fn committee_call_base_hash_and_id(
+    harness: &ValidatorStoreTestHarness,
+) -> (Hash256, ssv_types::CommitteeId) {
+    let captured = harness.captured_calls.lock();
+    let committee_calls: Vec<_> = captured
+        .iter()
+        .filter_map(|call| match &call.requester {
+            SignatureRequester::Committee { base_hash, .. } => {
+                Some((*base_hash, call.metadata.committee_id))
+            }
+            _ => None,
+        })
+        .collect();
+    assert_eq!(
+        committee_calls.len(),
+        1,
+        "expected exactly one committee sign_and_collect call, got {}",
+        committee_calls.len()
+    );
+    committee_calls[0]
+}

--- a/anchor/validator_store/src/testing/committee_attestation_gloas.rs
+++ b/anchor/validator_store/src/testing/committee_attestation_gloas.rs
@@ -419,8 +419,7 @@ async fn sync_and_attestation_paths_seed_identical_gloas_instance() {
     assert_ne!(duty.attestation.data().source, voting_source);
     assert_ne!(duty.attestation.data().target, voting_target);
     let attestation_signed = run_sign_attestations(&harness, vec![duty]).await;
-    let (attestation_base_hash, attestation_committee_id) =
-        committee_call_base_hash_and_id(&harness);
+    let (attestation_base_hash, attestation_committee_id, _) = committee_call_data(&harness);
 
     // Assert: the attestation path applies all decided voting-context fields, not the incoming
     // duty's fields. The mock changes only the index, preserving the remaining seed fields.
@@ -434,18 +433,36 @@ async fn sync_and_attestation_paths_seed_identical_gloas_instance() {
     // Reset captures so the sync path's calls are isolated.
     harness.captured_calls.lock().clear();
 
-    // Act: drive the sync path over the same committee/slot.
+    // Act: drive the sync path over the same committee/slot. Its incoming root deliberately
+    // differs from the voting-context root so the output assertions are non-vacuous.
+    let sync_duty = harness.create_sync_message(0, 0);
+    let duty_block_root = sync_duty.beacon_block_root;
+    assert_ne!(duty_block_root, voting_block_root);
     let sync_results: Vec<_> = harness
         .validator_store
-        .sign_sync_committee_signatures(vec![harness.create_sync_message(0, 0)])
+        .sign_sync_committee_signatures(vec![sync_duty])
         .collect()
         .await;
-    for result in &sync_results {
-        result
-            .as_ref()
-            .expect("sync committee batch should succeed");
-    }
-    let (sync_base_hash, sync_committee_id) = committee_call_base_hash_and_id(&harness);
+    assert_eq!(sync_results.len(), 1);
+    let sync_messages = sync_results[0]
+        .as_ref()
+        .expect("sync committee batch should succeed");
+    assert_eq!(sync_messages.len(), 1);
+    assert_eq!(sync_messages[0].beacon_block_root, voting_block_root);
+    let (sync_base_hash, sync_committee_id, sync_signing_root) = committee_call_data(&harness);
+
+    let slot = Slot::new(TEST_SLOT);
+    let epoch = slot.epoch(MainnetEthSpec::slots_per_epoch());
+    let sync_domain = harness.spec.get_domain(
+        epoch,
+        Domain::SyncCommittee,
+        &harness.spec.fork_at_epoch(epoch),
+        harness.genesis_validators_root,
+    );
+    let expected_sync_signing_root = voting_block_root.signing_root(sync_domain);
+    let duty_sync_signing_root = duty_block_root.signing_root(sync_domain);
+    assert_ne!(expected_sync_signing_root, duty_sync_signing_root);
+    assert_eq!(sync_signing_root, expected_sync_signing_root);
 
     // Assert: both paths feed the same decided hash as the partial-signature base.
     assert_eq!(
@@ -471,17 +488,17 @@ async fn sync_and_attestation_paths_seed_identical_gloas_instance() {
 }
 
 /// Reads the single committee `sign_and_collect` call captured so far, returning its
-/// partial-signature base hash and committee id. Panics if there is not exactly one committee
-/// call, so a test that captured nothing fails loudly instead of silently passing.
-fn committee_call_base_hash_and_id(
+/// partial-signature base hash, committee id, and signing root. Panics if there is not exactly one
+/// committee call, so a test that captured nothing fails loudly instead of silently passing.
+fn committee_call_data(
     harness: &ValidatorStoreTestHarness,
-) -> (Hash256, ssv_types::CommitteeId) {
+) -> (Hash256, ssv_types::CommitteeId, Hash256) {
     let captured = harness.captured_calls.lock();
     let committee_calls: Vec<_> = captured
         .iter()
         .filter_map(|call| match &call.requester {
             SignatureRequester::Committee { base_hash, .. } => {
-                Some((*base_hash, call.metadata.committee_id))
+                Some((*base_hash, call.metadata.committee_id, call.signing_root))
             }
             _ => None,
         })

--- a/anchor/validator_store/src/testing/committee_attestation_gloas.rs
+++ b/anchor/validator_store/src/testing/committee_attestation_gloas.rs
@@ -15,11 +15,11 @@ use futures::StreamExt;
 use signature_collector::SignatureRequester;
 use ssv_types::{
     OperatorId,
-    consensus::{GloasBeaconVote, QbftData},
+    consensus::{BeaconVote, GloasBeaconVote, QbftData},
 };
 use types::{
-    Attestation, AttestationData, ChainSpec, Checkpoint, Domain, EthSpec, Hash256, MainnetEthSpec,
-    SignedRoot, Slot,
+    Attestation, AttestationData, ChainSpec, Checkpoint, Domain, Epoch, EthSpec, Hash256,
+    MainnetEthSpec, SignedRoot, Slot,
 };
 use validator_store::ValidatorStore;
 
@@ -288,14 +288,35 @@ async fn pre_gloas_electra_attestation_index_is_zero_and_untouched() {
 async fn pre_gloas_pre_electra_attestation_index_equals_committee_index() {
     // Arrange: default mainnet spec => TEST_SLOT is pre-Electra; echo decider.
     let committee_index: u64 = 3;
+    let voting_block_root = Hash256::repeat_byte(0xBA);
+    let voting_source = Checkpoint {
+        epoch: Epoch::new(0),
+        root: Hash256::repeat_byte(0x51),
+    };
+    let voting_target = Checkpoint {
+        epoch: Epoch::new(0),
+        root: Hash256::repeat_byte(0x71),
+    };
+    let voting_vote = BeaconVote {
+        block_root: voting_block_root,
+        source: voting_source,
+        target: voting_target,
+    };
+    let expected_base_hash = voting_vote.hash();
     let committee = create_committee_setup(&COMMITTEE_OPERATORS, COMMITTEE_VALIDATOR_COUNT, 0);
     let harness = ValidatorStoreTestHarness::new(vec![committee], OUR_OPERATOR);
-    harness.seed_voting_context();
+    harness.seed_base_voting_context_with_vote(voting_vote);
     // Seed each validator's duty with data.index == committee_index, as a pre-Electra BN would.
     let attestations = vec![
         harness.create_attestation_with_index(0, 0, committee_index),
         harness.create_attestation_with_index(0, 1, committee_index),
     ];
+    for attestation in &attestations {
+        let duty_data = attestation.attestation.data();
+        assert_ne!(duty_data.beacon_block_root, voting_block_root);
+        assert_ne!(duty_data.source, voting_source);
+        assert_ne!(duty_data.target, voting_target);
+    }
 
     // Act
     let signed = run_sign_attestations(&harness, attestations).await;
@@ -308,20 +329,38 @@ async fn pre_gloas_pre_electra_attestation_index_equals_committee_index() {
             committee_index,
             "pre-Electra attestation index must equal the BN committee index, untouched"
         );
+        assert_eq!(attestation.data().beacon_block_root, voting_block_root);
+        assert_eq!(attestation.data().source, voting_source);
+        assert_eq!(attestation.data().target, voting_target);
     }
 
-    // Assert: signing roots are computed over the untouched committee index.
-    let expected_root = expected_attester_signing_root(
-        &harness.spec,
+    // Assert: consensus and signing use the shared voting-context vote, while retaining the
+    // pre-Electra duty index.
+    let slot = Slot::new(TEST_SLOT);
+    let epoch = slot.epoch(MainnetEthSpec::slots_per_epoch());
+    let domain = harness.spec.get_domain(
+        epoch,
+        Domain::BeaconAttester,
+        &harness.spec.fork_at_epoch(epoch),
         harness.genesis_validators_root,
-        Slot::new(TEST_SLOT),
-        committee_index,
     );
+    let expected_root = AttestationData {
+        slot,
+        index: committee_index,
+        beacon_block_root: voting_block_root,
+        source: voting_source,
+        target: voting_target,
+    }
+    .signing_root(domain);
     for call in harness.captured_calls.lock().iter() {
         assert_eq!(
             call.signing_root, expected_root,
-            "pre-Electra signing root must be computed over the untouched committee index"
+            "pre-Electra signing root must use the voting-context fields and untouched index"
         );
+        let SignatureRequester::Committee { base_hash, .. } = &call.requester else {
+            panic!("attestation signing must use the committee signature requester");
+        };
+        assert_eq!(*base_hash, expected_base_hash);
     }
 }
 
@@ -336,6 +375,21 @@ async fn pre_gloas_pre_electra_attestation_index_equals_committee_index() {
 #[tokio::test(flavor = "multi_thread")]
 async fn sync_and_attestation_paths_seed_identical_gloas_instance() {
     // Arrange: one Gloas committee, both an attestation duty and a sync duty for the same slot.
+    let voting_block_root = Hash256::repeat_byte(0xB1);
+    let voting_source = Checkpoint {
+        epoch: Epoch::new(0),
+        root: Hash256::repeat_byte(0x52),
+    };
+    let voting_target = Checkpoint {
+        epoch: Epoch::new(0),
+        root: Hash256::repeat_byte(0x72),
+    };
+    let voting_vote = GloasBeaconVote {
+        block_root: voting_block_root,
+        source: voting_source,
+        target: voting_target,
+        attestation_data_index: SEED_INDEX,
+    };
     let committee = create_committee_setup(&COMMITTEE_OPERATORS, COMMITTEE_VALIDATOR_COUNT, 0);
     let committee_id = committee.cluster.committee_id();
     let harness = ValidatorStoreTestHarness::new_with_options(
@@ -347,23 +401,35 @@ async fn sync_and_attestation_paths_seed_identical_gloas_instance() {
             ..Default::default()
         },
     );
-    harness.seed_gloas_voting_context(SEED_INDEX);
+    harness.seed_gloas_voting_context_with_vote(voting_vote);
 
     // The decided hash both paths feed into the signature collector is the hash of the decided
     // GloasBeaconVote. Both paths build that vote from the same seed, so this is the shared base.
     let expected_base_hash = GloasBeaconVote {
-        block_root: Hash256::zero(),
-        source: Checkpoint::default(),
-        target: Checkpoint::default(),
+        block_root: voting_block_root,
+        source: voting_source,
+        target: voting_target,
         attestation_data_index: DECIDED_INDEX,
     }
     .hash();
 
     // Act: drive the attestation path, capture its committee base hash + committee id.
-    let _attestation_signed =
-        run_sign_attestations(&harness, vec![harness.create_attestation(0, 0)]).await;
+    let duty = harness.create_attestation(0, 0);
+    assert_ne!(duty.attestation.data().beacon_block_root, voting_block_root);
+    assert_ne!(duty.attestation.data().source, voting_source);
+    assert_ne!(duty.attestation.data().target, voting_target);
+    let attestation_signed = run_sign_attestations(&harness, vec![duty]).await;
     let (attestation_base_hash, attestation_committee_id) =
         committee_call_base_hash_and_id(&harness);
+
+    // Assert: the attestation path applies all decided voting-context fields, not the incoming
+    // duty's fields. The mock changes only the index, preserving the remaining seed fields.
+    assert_eq!(attestation_signed.len(), 1);
+    let signed_data = attestation_signed[0].1.data();
+    assert_eq!(signed_data.beacon_block_root, voting_block_root);
+    assert_eq!(signed_data.source, voting_source);
+    assert_eq!(signed_data.target, voting_target);
+    assert_eq!(signed_data.index, DECIDED_INDEX);
 
     // Reset captures so the sync path's calls are isolated.
     harness.captured_calls.lock().clear();

--- a/anchor/validator_store/src/testing/common.rs
+++ b/anchor/validator_store/src/testing/common.rs
@@ -3,7 +3,7 @@
 //! Provides a `ValidatorStoreTestHarness` that wires up a real `AnchorValidatorStore` with
 //! in-memory database, mock consensus, and a mock signature collector.
 
-use std::{collections::HashMap, future::Future, pin::Pin, sync::Arc, time::Duration};
+use std::{any::Any, collections::HashMap, future::Future, pin::Pin, sync::Arc, time::Duration};
 
 use bls::{AggregateSignature, FixedBytesExtended, PublicKeyBytes, Signature};
 use database::{NetworkDatabase, PendingStateUpdates};
@@ -21,7 +21,8 @@ use ssv_types::{
     Cluster, ClusterId, ENCRYPTED_KEY_LENGTH, IndexSet, OperatorId, Share, ValidatorIndex,
     ValidatorMetadata,
     consensus::{
-        AggregatorCommitteeConsensusData, AssignedAggregator, DataVersion, QbftDataValidator,
+        AggregatorCommitteeConsensusData, AssignedAggregator, DataVersion, GloasBeaconVote,
+        QbftDataValidator,
     },
 };
 use ssz::Encode;
@@ -33,7 +34,7 @@ use types::{
     Attestation, AttestationBase, AttestationData, ChainSpec, Checkpoint, Epoch, EthSpec, Graffiti,
     Hash256, MainnetEthSpec, SelectionProof, Slot,
 };
-use validator_store::{AggregateToSign, AttestationToSign};
+use validator_store::{AggregateToSign, AttestationToSign, SyncMessageToSign};
 
 use crate::{AggregationAssignments, AnchorValidatorStore, VotingAssignments, VotingContext};
 
@@ -44,7 +45,32 @@ const SLOT_DURATION_SECS: u64 = 12;
 
 /// Mock that instantly returns `Completed::Success(initial)`, echoing back the proposed data.
 /// Removes the need for `QbftManager` infrastructure and lets the signing pipeline run fully.
-pub(super) struct MockConsensusDecider;
+///
+/// When `forced_gloas_index` is `Some`, a `GloasBeaconVote` seed is decided with its
+/// `attestation_data_index` overridden to that value (all other fields preserved). This lets
+/// tests exercise "the cluster-decided index differs from this operator's local seed", which is
+/// exactly the case `#1027` must apply. Non-Gloas seeds (`BeaconVote`) are always echoed back
+/// unchanged, since their decided value carries no index.
+pub(super) struct MockConsensusDecider {
+    forced_gloas_index: Option<u64>,
+}
+
+impl MockConsensusDecider {
+    /// Echoes every decided seed back unchanged (default behavior used by most tests).
+    pub(super) fn echoing() -> Self {
+        Self {
+            forced_gloas_index: None,
+        }
+    }
+
+    /// Decides every `GloasBeaconVote` seed with its `attestation_data_index` replaced by
+    /// `index`, modeling a cluster that agrees on an index that may differ from the local seed.
+    pub(super) fn forcing_gloas_index(index: u64) -> Self {
+        Self {
+            forced_gloas_index: Some(index),
+        }
+    }
+}
 
 impl<E: EthSpec> ConsensusDecider<E> for MockConsensusDecider {
     async fn decide_instance<D: QbftDecidable<E>>(
@@ -55,6 +81,33 @@ impl<E: EthSpec> ConsensusDecider<E> for MockConsensusDecider {
         _timeout_mode: TimeoutMode,
         _committee_members: &IndexSet<OperatorId>,
     ) -> Result<Completed<D>, QbftError> {
+        // `D: QbftDecidable<E>` requires `'static`, so this downcast is sound. Only the Gloas
+        // seed type carries `attestation_data_index`; every other `D` falls through to the echo.
+        if let Some(index) = self.forced_gloas_index {
+            let boxed: Box<dyn Any> = Box::new(initial);
+            match boxed.downcast::<GloasBeaconVote>() {
+                Ok(gloas_vote) => {
+                    let decided = GloasBeaconVote {
+                        attestation_data_index: index,
+                        ..*gloas_vote
+                    };
+                    // Re-box and downcast back to `D`; the inner type is `GloasBeaconVote == D`
+                    // here, so this recovers the concrete decided value the caller expects.
+                    let decided_any: Box<dyn Any> = Box::new(decided);
+                    let decided_d = decided_any
+                        .downcast::<D>()
+                        .expect("GloasBeaconVote round-trips to D when D == GloasBeaconVote");
+                    return Ok(Completed::Success(*decided_d));
+                }
+                Err(original) => {
+                    // Not a Gloas seed; recover the original value and echo it back unchanged.
+                    let echoed = original
+                        .downcast::<D>()
+                        .expect("downcast back to original D always succeeds");
+                    return Ok(Completed::Success(*echoed));
+                }
+            }
+        }
         Ok(Completed::Success(initial))
     }
 }
@@ -186,6 +239,13 @@ pub(super) struct HarnessOptions {
     /// When set, every `sign_and_collect` call fails with this error after being captured.
     pub(super) collector_failure: Option<CollectionError>,
     pub(super) disable_slashing_protection: bool,
+    /// Chain spec to wire into the store. Defaults to `ChainSpec::mainnet()`, under which
+    /// `TEST_SLOT` is pre-Electra. Tests that need a specific fork at `TEST_SLOT` (Electra or
+    /// Gloas) supply a spec with the matching `*_fork_epoch` set to genesis.
+    pub(super) spec: Arc<ChainSpec>,
+    /// When `Some`, the mock decides every `GloasBeaconVote` with this `attestation_data_index`,
+    /// modeling a cluster-decided index that may differ from each operator's local seed.
+    pub(super) forced_gloas_index: Option<u64>,
 }
 
 impl Default for HarnessOptions {
@@ -195,8 +255,28 @@ impl Default for HarnessOptions {
             // Slashing protection is disabled by default because the harness never registers
             // validators in the slashing DB, which would fail block/attestation signing paths.
             disable_slashing_protection: true,
+            spec: Arc::new(ChainSpec::mainnet()),
+            forced_gloas_index: None,
         }
     }
+}
+
+/// Builds a `ChainSpec` based on mainnet but with Gloas activated at genesis, so `TEST_SLOT`
+/// resolves to the Gloas fork and the committee QBFT decides over `GloasBeaconVote`.
+pub(super) fn gloas_at_genesis_spec() -> Arc<ChainSpec> {
+    let mut spec = ChainSpec::mainnet();
+    spec.gloas_fork_epoch = Some(Epoch::new(0));
+    Arc::new(spec)
+}
+
+/// Builds a `ChainSpec` based on mainnet but with Electra activated at genesis and Gloas
+/// disabled, so `TEST_SLOT` resolves to Electra (post-Electra, pre-Gloas). The committee QBFT
+/// decides over `BeaconVote` and the attestation index stays untouched at `0`.
+pub(super) fn electra_at_genesis_spec() -> Arc<ChainSpec> {
+    let mut spec = ChainSpec::mainnet();
+    spec.electra_fork_epoch = Some(Epoch::new(0));
+    spec.gloas_fork_epoch = None;
+    Arc::new(spec)
 }
 
 pub(super) struct ValidatorStoreTestHarness {
@@ -205,6 +285,12 @@ pub(super) struct ValidatorStoreTestHarness {
     committee_setups: Vec<CommitteeSetup>,
     pub(super) captured_calls: CapturedCalls,
     pub(super) is_synced_tx: watch::Sender<bool>,
+    /// The spec the store was built with, exposed so tests can recompute signing domains
+    /// without duplicating the store's fork-selection logic.
+    pub(super) spec: Arc<ChainSpec>,
+    /// Genesis validators root the store was built with (`Hash256::zero()`), needed alongside
+    /// `spec` to recompute signing roots.
+    pub(super) genesis_validators_root: Hash256,
     _slashing_db_dir: TempDir,
     _exit_signal: async_channel::Sender<()>,
 }
@@ -304,15 +390,23 @@ impl ValidatorStoreTestHarness {
 
         let (is_synced_tx, is_synced_rx) = watch::channel(true);
 
+        let decider = match options.forced_gloas_index {
+            Some(index) => MockConsensusDecider::forcing_gloas_index(index),
+            None => MockConsensusDecider::echoing(),
+        };
+
+        let spec = Arc::clone(&options.spec);
+        let genesis_validators_root = Hash256::zero();
+
         let validator_store = AnchorValidatorStore::new(
             database,
             mock_collector,
-            Arc::new(MockConsensusDecider),
+            Arc::new(decider),
             slashing_protection,
             options.disable_slashing_protection,
             slot_clock.clone(),
-            Arc::new(ChainSpec::mainnet()),
-            Hash256::zero(),
+            Arc::clone(&spec),
+            genesis_validators_root,
             None, // impostor mode: no RSA decryption needed
             fork_schedule,
             30_000_000,
@@ -328,13 +422,16 @@ impl ValidatorStoreTestHarness {
             committee_setups,
             captured_calls,
             is_synced_tx,
+            spec,
+            genesis_validators_root,
             _slashing_db_dir: slashing_db_dir,
             _exit_signal: exit_signal,
         }
     }
 
-    /// Seeds the `VotingContext` so `get_voting_context` returns immediately for `TEST_SLOT`.
-    pub(super) fn seed_voting_context(&self) {
+    /// Builds the `VotingAssignments` for `TEST_SLOT`, marking every validator in every committee
+    /// setup as attesting. Shared by the Base and Gloas seeders so they only differ in the vote.
+    fn test_slot_voting_assignments(&self) -> VotingAssignments {
         let mut attesting_committees = HashMap::new();
         let mut attesting_validators = Vec::new();
 
@@ -347,24 +444,46 @@ impl ValidatorStoreTestHarness {
             }
         }
 
+        VotingAssignments {
+            slot: Slot::new(TEST_SLOT),
+            attesting_validators,
+            attesting_committees,
+            sync_validators_by_subnet: HashMap::new(),
+        }
+    }
+
+    fn zero_checkpoint() -> Checkpoint {
+        Checkpoint {
+            epoch: Epoch::new(0),
+            root: Hash256::zero(),
+        }
+    }
+
+    /// Seeds the `VotingContext` with a pre-Gloas `BeaconVote` so `get_voting_context` returns
+    /// immediately for `TEST_SLOT`. Used by harnesses on a pre-Gloas spec (Base path).
+    pub(super) fn seed_voting_context(&self) {
         self.validator_store.update_voting_context(VotingContext {
-            voting_assignments: Arc::new(VotingAssignments {
-                slot: Slot::new(TEST_SLOT),
-                attesting_validators,
-                attesting_committees,
-                sync_validators_by_subnet: HashMap::new(),
-            }),
-            beacon_vote: ssv_types::consensus::BeaconVote {
+            voting_assignments: Arc::new(self.test_slot_voting_assignments()),
+            vote: crate::SlotVote::Base(ssv_types::consensus::BeaconVote {
                 block_root: Hash256::zero(),
-                source: Checkpoint {
-                    epoch: Epoch::new(0),
-                    root: Hash256::zero(),
-                },
-                target: Checkpoint {
-                    epoch: Epoch::new(0),
-                    root: Hash256::zero(),
-                },
-            },
+                source: Self::zero_checkpoint(),
+                target: Self::zero_checkpoint(),
+            }),
+        });
+    }
+
+    /// Seeds the `VotingContext` with a Gloas `GloasBeaconVote` carrying `attestation_data_index`,
+    /// modeling this operator's local seed for the committee QBFT. Used by harnesses on a
+    /// Gloas-enabled spec (Gloas path).
+    pub(super) fn seed_gloas_voting_context(&self, attestation_data_index: u64) {
+        self.validator_store.update_voting_context(VotingContext {
+            voting_assignments: Arc::new(self.test_slot_voting_assignments()),
+            vote: crate::SlotVote::Gloas(GloasBeaconVote {
+                block_root: Hash256::zero(),
+                source: Self::zero_checkpoint(),
+                target: Self::zero_checkpoint(),
+                attestation_data_index,
+            }),
         });
     }
 
@@ -486,6 +605,40 @@ impl ValidatorStoreTestHarness {
                 },
                 signature: AggregateSignature::infinity(),
             }),
+        }
+    }
+
+    /// Builds an attestation duty for `TEST_SLOT` whose `data.index` is pre-set to `index`,
+    /// modeling a BN-supplied attestation index (e.g. the committee index pre-Electra). Lets
+    /// tests assert whether the signing path leaves that index untouched or overwrites it.
+    pub(super) fn create_attestation_with_index(
+        &self,
+        committee_idx: usize,
+        validator_idx: usize,
+        index: u64,
+    ) -> AttestationToSign<MainnetEthSpec> {
+        let mut att = self.create_attestation(committee_idx, validator_idx);
+        att.attestation.data_mut().index = index;
+        att
+    }
+
+    /// Builds a sync-committee message duty for `TEST_SLOT`, so the sync signing path can be
+    /// driven over the same `(committee, slot)` as the attestation path.
+    pub(super) fn create_sync_message(
+        &self,
+        committee_idx: usize,
+        validator_idx: usize,
+    ) -> SyncMessageToSign {
+        let validator = &self.committee_setups[committee_idx].validators[validator_idx];
+        let validator_index = validator
+            .index
+            .expect("test validator should have an index");
+
+        SyncMessageToSign {
+            slot: Slot::new(TEST_SLOT),
+            beacon_block_root: Hash256::zero(),
+            validator_index: *validator_index as u64,
+            pubkey: validator.public_key,
         }
     }
 

--- a/anchor/validator_store/src/testing/common.rs
+++ b/anchor/validator_store/src/testing/common.rs
@@ -21,8 +21,8 @@ use ssv_types::{
     Cluster, ClusterId, ENCRYPTED_KEY_LENGTH, IndexSet, OperatorId, Share, ValidatorIndex,
     ValidatorMetadata,
     consensus::{
-        AggregatorCommitteeConsensusData, AssignedAggregator, DataVersion, GloasBeaconVote,
-        QbftDataValidator,
+        AggregatorCommitteeConsensusData, AssignedAggregator, BeaconVote, DataVersion,
+        GloasBeaconVote, QbftDataValidator,
     },
 };
 use ssz::Encode;
@@ -462,13 +462,19 @@ impl ValidatorStoreTestHarness {
     /// Seeds the `VotingContext` with a pre-Gloas `BeaconVote` so `get_voting_context` returns
     /// immediately for `TEST_SLOT`. Used by harnesses on a pre-Gloas spec (Base path).
     pub(super) fn seed_voting_context(&self) {
+        self.seed_base_voting_context_with_vote(BeaconVote {
+            block_root: Hash256::zero(),
+            source: Self::zero_checkpoint(),
+            target: Self::zero_checkpoint(),
+        });
+    }
+
+    /// Seeds the pre-Gloas voting context with an explicit vote, allowing tests to make the
+    /// shared metadata-service seed differ from the incoming attestation duty.
+    pub(super) fn seed_base_voting_context_with_vote(&self, vote: BeaconVote) {
         self.validator_store.update_voting_context(VotingContext {
             voting_assignments: Arc::new(self.test_slot_voting_assignments()),
-            vote: crate::SlotVote::Base(ssv_types::consensus::BeaconVote {
-                block_root: Hash256::zero(),
-                source: Self::zero_checkpoint(),
-                target: Self::zero_checkpoint(),
-            }),
+            vote: crate::SlotVote::Base(vote),
         });
     }
 
@@ -476,14 +482,20 @@ impl ValidatorStoreTestHarness {
     /// modeling this operator's local seed for the committee QBFT. Used by harnesses on a
     /// Gloas-enabled spec (Gloas path).
     pub(super) fn seed_gloas_voting_context(&self, attestation_data_index: u64) {
+        self.seed_gloas_voting_context_with_vote(GloasBeaconVote {
+            block_root: Hash256::zero(),
+            source: Self::zero_checkpoint(),
+            target: Self::zero_checkpoint(),
+            attestation_data_index,
+        });
+    }
+
+    /// Seeds the Gloas voting context with an explicit vote, allowing tests to distinguish the
+    /// shared metadata-service seed from the incoming attestation duty.
+    pub(super) fn seed_gloas_voting_context_with_vote(&self, vote: GloasBeaconVote) {
         self.validator_store.update_voting_context(VotingContext {
             voting_assignments: Arc::new(self.test_slot_voting_assignments()),
-            vote: crate::SlotVote::Gloas(GloasBeaconVote {
-                block_root: Hash256::zero(),
-                source: Self::zero_checkpoint(),
-                target: Self::zero_checkpoint(),
-                attestation_data_index,
-            }),
+            vote: crate::SlotVote::Gloas(vote),
         });
     }
 

--- a/anchor/validator_store/src/testing/mod.rs
+++ b/anchor/validator_store/src/testing/mod.rs
@@ -2,4 +2,5 @@ mod common;
 
 mod committee_aggregate;
 mod committee_attestation;
+mod committee_attestation_gloas;
 mod payload_attestation;

--- a/anchor/validator_store/src/testing/payload_attestation.rs
+++ b/anchor/validator_store/src/testing/payload_attestation.rs
@@ -165,6 +165,7 @@ async fn sign_payload_attestation_collection_failure_increments_no_signature_met
         HarnessOptions {
             collector_failure: Some(CollectionError::QueueClosedError),
             disable_slashing_protection: true,
+            ..Default::default()
         },
     );
     let data = create_payload_attestation_data();
@@ -219,6 +220,7 @@ async fn sign_payload_attestation_infra_failure_increments_infra_metric() {
         HarnessOptions {
             collector_failure: Some(CollectionError::EmptySignature),
             disable_slashing_protection: true,
+            ..Default::default()
         },
     );
     let data = create_payload_attestation_data();
@@ -286,6 +288,7 @@ async fn sign_payload_attestation_does_not_touch_slashing_db() {
         HarnessOptions {
             collector_failure: None,
             disable_slashing_protection: false,
+            ..Default::default()
         },
     );
     let data = create_payload_attestation_data();


### PR DESCRIPTION
## Problem, Evidence, and Context

Under Gloas (SIP-94 §2), `AttestationData.index` is BN-supplied and part of both the signed attestation root and the double-vote slashing predicate. #1025/#1026 added `GloasBeaconVote` and a fork-aware validator (range-check + slashing reconstruction with the index), but nothing threaded the decided index into the signed attestation — so divergent BN views would produce divergent signing roots.

Resolves #1027. Carries the production change for #1061 (this lands the sync-path migration).

## Change Overview

- `SlotVote { Base(BeaconVote), Gloas(GloasBeaconVote) }` fork-tagged enum on `VotingContext`, so the BN index rides through the slot's shared vote.
- Producer carries `attestation_data.index`; the aggregate-fetch root is computed with it.
- `sign_committee_attestations` applies the QBFT-decided index to each validator's `attestation.data.index` before signing (Gloas only).
- `sign_committee_sync_committee_signatures` decides over the fork-matching type from the same vote and aligns its QBFT start to `get_attestation_due`, restoring the shared committee instance at Gloas.
- Pre-Gloas attestation index and signing behavior are unchanged; committee QBFT seeding now uses the shared `VotingContext` source for both attestation and sync paths.

## Risks, Trade-offs, and Mitigations

- The decided index now lands in the signed root, matching #1026's slashing reconstruction.
- Pre-Gloas sync-QBFT start shifts 4000ms → 3999ms (immaterial) and removes a call-order-dependent divergence on the shared instance.
- Aggregation keys the fetch off the locally-cached index per SIP-94 §2; convergence is handled downstream by the AggregatorCommittee consensus — tracked as a follow-up.
- Deliberate `Base`/`Gloas` duplication collapses when `BeaconVote` retires.

## Validation

9 new tests (5 integration + 4 unit): decided-index application, cluster-wide signing-root agreement, pre-Gloas pre-Electra/Electra+ invariance, sync/attestation seed identity; non-vacuity confirmed. metadata-service fork and aggregate-root construction are unit-tested through production helpers (the crate avoids BN mocks). Workspace compiles; clippy + fmt clean.

## Rollback

Additive at the type/validator layer; reverting restores pre-Gloas behavior throughout.

