### PR TITLE
feat: add Role::ProposerPreferences with message-validator fork-gate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5605,6 +5605,7 @@ dependencies = [
 name = "operator_doppelganger"
 version = "0.1.0"
 dependencies = [
+ "bls",
  "database",
  "message_validator",
  "ssv_types",

--- a/anchor/common/ssv_types/src/msgid.rs
+++ b/anchor/common/ssv_types/src/msgid.rs
@@ -22,6 +22,7 @@ pub enum Role {
     VoluntaryExit,
     AggregatorCommittee,
     PTCAttester,
+    ProposerPreferences,
 }
 
 impl From<Role> for [u8; 4] {
@@ -35,6 +36,7 @@ impl From<Role> for [u8; 4] {
             Role::VoluntaryExit => [5, 0, 0, 0],
             Role::AggregatorCommittee => [6, 0, 0, 0],
             Role::PTCAttester => [7, 0, 0, 0],
+            Role::ProposerPreferences => [8, 0, 0, 0],
         }
     }
 }
@@ -52,6 +54,7 @@ impl TryFrom<&[u8]> for Role {
             [5, 0, 0, 0] => Ok(Role::VoluntaryExit),
             [6, 0, 0, 0] => Ok(Role::AggregatorCommittee),
             [7, 0, 0, 0] => Ok(Role::PTCAttester),
+            [8, 0, 0, 0] => Ok(Role::ProposerPreferences),
             _ => Err(DecodeError::NoMatchingVariant),
         }
     }
@@ -75,7 +78,10 @@ impl Role {
             Role::Committee | Role::Aggregator | Role::AggregatorCommittee => Some(12),
             Role::Proposer | Role::SyncCommittee => Some(6),
             // These roles don't use QBFT consensus
-            Role::ValidatorRegistration | Role::VoluntaryExit | Role::PTCAttester => None,
+            Role::ValidatorRegistration
+            | Role::VoluntaryExit
+            | Role::PTCAttester
+            | Role::ProposerPreferences => None,
         }
     }
 
@@ -161,7 +167,8 @@ impl MessageId {
             | Role::SyncCommittee
             | Role::ValidatorRegistration
             | Role::VoluntaryExit
-            | Role::PTCAttester => PublicKeyBytes::deserialize(&self.0[8..])
+            | Role::PTCAttester
+            | Role::ProposerPreferences => PublicKeyBytes::deserialize(&self.0[8..])
                 .ok()
                 .map(DutyExecutor::Validator),
         }
@@ -351,6 +358,42 @@ mod tests {
         assert!(!Role::PTCAttester.is_qbft_role());
     }
 
+    // ═══════════════════════════════════════════════════════════════════════════════
+    // ProposerPreferences Specific Tests
+    // ═══════════════════════════════════════════════════════════════════════════════
+
+    #[test]
+    fn proposer_preferences_uses_validator_duty_executor() {
+        // ProposerPreferences is validator-scoped: it must use Validator-style duty
+        // executor (PublicKeyBytes), not Committee-style (CommitteeId).
+        let domain = DomainType([0, 0, 0, 0]);
+        let public_key = PublicKeyBytes::empty();
+        let duty_executor = DutyExecutor::Validator(public_key);
+
+        let msg_id = MessageId::new(&domain, Role::ProposerPreferences, &duty_executor);
+
+        assert_eq!(msg_id.role(), Some(Role::ProposerPreferences));
+
+        match msg_id.duty_executor() {
+            Some(DutyExecutor::Validator(pk)) => assert_eq!(pk, public_key),
+            Some(DutyExecutor::Committee(_)) => {
+                panic!("ProposerPreferences should use Validator duty executor, not Committee")
+            }
+            None => panic!("Failed to extract duty executor"),
+        }
+    }
+
+    #[test]
+    fn proposer_preferences_is_validator_scoped_non_qbft() {
+        // Every behavior flip in the ProposerPreferences retarget rides on these
+        // three classifications (validation bucketing, consensus-message rejection,
+        // qbft_manager routing). Re-adding ProposerPreferences to the committee arm
+        // or giving it a max round would compile silently; this pins the values.
+        assert!(!Role::ProposerPreferences.is_committee_role());
+        assert_eq!(Role::ProposerPreferences.max_round(), None);
+        assert!(!Role::ProposerPreferences.is_qbft_role());
+    }
+
     #[test]
     fn role_qbft_classification_is_pinned() {
         // Adding a new Role forces a decision in max_round()'s exhaustive
@@ -371,6 +414,7 @@ mod tests {
             Role::ValidatorRegistration,
             Role::VoluntaryExit,
             Role::PTCAttester,
+            Role::ProposerPreferences,
         ] {
             assert!(!role.is_qbft_role(), "{role:?} must not run QBFT");
             assert!(

--- a/anchor/common/ssv_types/src/msgid.rs
+++ b/anchor/common/ssv_types/src/msgid.rs
@@ -91,6 +91,16 @@ impl Role {
     pub fn is_qbft_role(self) -> bool {
         self.max_round().is_some()
     }
+
+    /// monotonicSlotRole reports whether a role's signer advances through slots one at a time, so a
+    /// message for a slot below the signer's max is stale and must be rejected. False for
+    /// committee roles (state is slot-keyed across many validators) and for proposer
+    /// preferences (a signer holds its whole lookahead of proposal slots at once, so a lower
+    /// slot is a concurrent duty, not a stale one — its replay bound is the earliness/lateness
+    /// window instead)
+    pub fn monotonic_slot_role(self) -> bool {
+        !self.is_committee_role() && self != Role::ProposerPreferences
+    }
 }
 
 #[derive(Debug, Clone, Hash, Eq, PartialEq)]
@@ -420,6 +430,39 @@ mod tests {
             assert!(
                 role.max_round().is_none(),
                 "{role:?} must not have a max round"
+            );
+        }
+    }
+
+    #[test]
+    fn role_monotonic_slot_classification_is_pinned() {
+        // `monotonic_slot_role()` gates the stale-slot rejection in partial-signature
+        // validation. A role landing in the wrong partition silently flips whether an
+        // earlier-slot message is rejected as advanced or accepted as concurrent, so pin
+        // every role on both sides. Non-monotonic: committee roles (state is slot-keyed
+        // across many validators) and ProposerPreferences (a signer holds its whole
+        // lookahead of proposal slots at once). Monotonic: the remaining six.
+        for role in [
+            Role::Committee,
+            Role::AggregatorCommittee,
+            Role::ProposerPreferences,
+        ] {
+            assert!(
+                !role.monotonic_slot_role(),
+                "{role:?} must NOT be a monotonic-slot role"
+            );
+        }
+        for role in [
+            Role::Aggregator,
+            Role::Proposer,
+            Role::SyncCommittee,
+            Role::ValidatorRegistration,
+            Role::VoluntaryExit,
+            Role::PTCAttester,
+        ] {
+            assert!(
+                role.monotonic_slot_role(),
+                "{role:?} must be a monotonic-slot role"
             );
         }
     }

--- a/anchor/common/ssv_types/src/partial_sig.rs
+++ b/anchor/common/ssv_types/src/partial_sig.rs
@@ -40,6 +40,10 @@ pub enum PartialSignatureKind {
     // PTCAttester is a standalone single-validator partial signature over PayloadAttestationData
     // (validator-scoped, leaderless; not a QBFT consensus value)
     PTCAttester = 7,
+    // ProposerPreferences is a standalone single-validator partial signature over a
+    // ProposerPreferences object (validator-scoped, non-QBFT; the reconstructed
+    // SignedProposerPreferences is gossiped on the proposer_preferences topic)
+    ProposerPreferences = 8,
 }
 
 impl TryFrom<u64> for PartialSignatureKind {
@@ -55,6 +59,7 @@ impl TryFrom<u64> for PartialSignatureKind {
             5 => Ok(PartialSignatureKind::VoluntaryExit),
             6 => Ok(PartialSignatureKind::AggregatorCommitteePartialSig),
             7 => Ok(PartialSignatureKind::PTCAttester),
+            8 => Ok(PartialSignatureKind::ProposerPreferences),
             _ => Err(()),
         }
     }
@@ -192,6 +197,7 @@ mod tests {
             PartialSignatureKind::VoluntaryExit,
             PartialSignatureKind::AggregatorCommitteePartialSig,
             PartialSignatureKind::PTCAttester,
+            PartialSignatureKind::ProposerPreferences,
         ];
 
         for variant in variants {
@@ -225,6 +231,7 @@ mod tests {
             (PartialSignatureKind::VoluntaryExit, 5u64),
             (PartialSignatureKind::AggregatorCommitteePartialSig, 6u64),
             (PartialSignatureKind::PTCAttester, 7u64),
+            (PartialSignatureKind::ProposerPreferences, 8u64),
         ];
 
         for (variant, expected_value) in test_cases {
@@ -242,7 +249,7 @@ mod tests {
 
     #[test]
     fn partial_signature_kind_ssz_decode_invalid_variant() {
-        let invalid_value = 8u64.to_le_bytes();
+        let invalid_value = 9u64.to_le_bytes();
         let result = PartialSignatureKind::from_ssz_bytes(&invalid_value);
         assert!(matches!(result, Err(DecodeError::NoMatchingVariant)));
     }
@@ -310,11 +317,15 @@ mod tests {
             PartialSignatureKind::try_from(7u64).unwrap(),
             PartialSignatureKind::PTCAttester
         );
+        assert_eq!(
+            PartialSignatureKind::try_from(8u64).unwrap(),
+            PartialSignatureKind::ProposerPreferences
+        );
     }
 
     #[test]
     fn partial_signature_kind_try_from_u64_invalid_values() {
-        assert!(PartialSignatureKind::try_from(8u64).is_err());
+        assert!(PartialSignatureKind::try_from(9u64).is_err());
         assert!(PartialSignatureKind::try_from(100u64).is_err());
         assert!(PartialSignatureKind::try_from(u64::MAX).is_err());
     }
@@ -342,6 +353,7 @@ mod tests {
             PartialSignatureKind::VoluntaryExit,
             PartialSignatureKind::AggregatorCommitteePartialSig,
             PartialSignatureKind::PTCAttester,
+            PartialSignatureKind::ProposerPreferences,
         ];
 
         let hashes: Vec<_> = variants.iter().map(|v| v.tree_hash_root()).collect();
@@ -386,5 +398,35 @@ mod tests {
         // Should decode back to the same variant
         let decoded = PartialSignatureKind::from_ssz_bytes(&encoded).unwrap();
         assert_eq!(decoded, PartialSignatureKind::AggregatorCommitteePartialSig);
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════════════
+    // ProposerPreferences Specific Tests
+    // ═══════════════════════════════════════════════════════════════════════════════
+
+    #[test]
+    fn proposer_preferences_partial_sig_variant_value() {
+        assert_eq!(
+            PartialSignatureKind::ProposerPreferences as u64,
+            8,
+            "ProposerPreferences should have discriminant value 8"
+        );
+    }
+
+    #[test]
+    fn proposer_preferences_partial_sig_ssz_encoding() {
+        let variant = PartialSignatureKind::ProposerPreferences;
+        let encoded = variant.as_ssz_bytes();
+
+        // Should encode as 8 in little-endian format
+        assert_eq!(
+            encoded,
+            vec![8, 0, 0, 0, 0, 0, 0, 0],
+            "ProposerPreferences should encode as [8, 0, 0, 0, 0, 0, 0, 0]"
+        );
+
+        // Should decode back to the same variant
+        let decoded = PartialSignatureKind::from_ssz_bytes(&encoded).unwrap();
+        assert_eq!(decoded, PartialSignatureKind::ProposerPreferences);
     }
 }

--- a/anchor/message_validator/src/consensus_message.rs
+++ b/anchor/message_validator/src/consensus_message.rs
@@ -608,6 +608,7 @@ mod tests {
             &mut DutyState::new(2),
             Arc::new(MockDutiesProvider {
                 voluntary_exit_duty_count: expected_duty_count,
+                ..Default::default()
             }),
         );
 
@@ -657,6 +658,7 @@ mod tests {
             &mut DutyState::new(2),
             Arc::new(MockDutiesProvider {
                 voluntary_exit_duty_count: 0,
+                ..Default::default()
             }),
         );
 
@@ -713,6 +715,7 @@ mod tests {
             &mut DutyState::new(2),
             Arc::new(MockDutiesProvider {
                 voluntary_exit_duty_count: 0,
+                ..Default::default()
             }),
         );
 
@@ -766,6 +769,7 @@ mod tests {
             &mut DutyState::new(2),
             Arc::new(MockDutiesProvider {
                 voluntary_exit_duty_count: 0,
+                ..Default::default()
             }),
         );
 
@@ -1628,6 +1632,7 @@ mod tests {
             &mut duty_state,
             Arc::new(MockDutiesProvider {
                 voluntary_exit_duty_count: 0,
+                ..Default::default()
             }),
         );
 
@@ -1659,6 +1664,7 @@ mod tests {
             &mut duty_state,
             Arc::new(MockDutiesProvider {
                 voluntary_exit_duty_count: 0,
+                ..Default::default()
             }),
         );
 
@@ -1710,6 +1716,7 @@ mod tests {
         let expected_duty_count = 5;
         let mock_duties_provider = Arc::new(MockDutiesProvider {
             voluntary_exit_duty_count: expected_duty_count,
+            ..Default::default()
         });
 
         let map = create_operator_pub_keys(committee_info.committee_members.clone(), vec![]);
@@ -1763,6 +1770,7 @@ mod tests {
         let committee_info = create_committee_info(SINGLE_NODE_COMMITTEE);
         let mock_duties_provider = Arc::new(MockDutiesProvider {
             voluntary_exit_duty_count: 0,
+            ..Default::default()
         });
         let map = create_operator_pub_keys(committee_info.committee_members.clone(), vec![]);
 
@@ -1835,6 +1843,7 @@ mod tests {
         let committee_info = create_committee_info(SINGLE_NODE_COMMITTEE);
         let mock_duties_provider = Arc::new(MockDutiesProvider {
             voluntary_exit_duty_count: 0,
+            ..Default::default()
         });
         let map = create_operator_pub_keys(committee_info.committee_members.clone(), vec![]);
 
@@ -1933,6 +1942,7 @@ mod tests {
             &mut DutyState::new(64),
             Arc::new(MockDutiesProvider {
                 voluntary_exit_duty_count: 0,
+                ..Default::default()
             }),
         );
 

--- a/anchor/message_validator/src/consensus_message.rs
+++ b/anchor/message_validator/src/consensus_message.rs
@@ -980,11 +980,12 @@ mod tests {
         let committee_info = create_committee_info(SINGLE_NODE_COMMITTEE);
 
         // Every non-QBFT role must reject consensus messages, including
-        // PTCAttester (leaderless, no QBFT round since the SIP-94 rewrite).
+        // PTCAttester and ProposerPreferences (both leaderless, no QBFT round).
         for role in [
             Role::ValidatorRegistration,
             Role::VoluntaryExit,
             Role::PTCAttester,
+            Role::ProposerPreferences,
         ] {
             let msg_id = create_message_id_for_test(role);
             let qbft_message = QbftMessageBuilder::new(role, QbftMessageType::Proposal)
@@ -1799,6 +1800,77 @@ mod tests {
         let many = vec![ValidatorIndex(0); 100];
         let result = duty_limit(&validation_context, slot, &many, mock_duties_provider);
         assert_eq!(result, Ok(Some(2)));
+    }
+
+    #[test]
+    fn test_duty_limit_proposer_preferences() {
+        // Arrange: ProposerPreferences is validator-scoped and non-QBFT. Unlike the
+        // flat-2 per-validator roles, its duty limit is `slots_per_epoch` (a proposer
+        // may publish preferences across the whole lookahead window), independent of
+        // the validator-index slice length.
+        const SLOTS_PER_EPOCH: u64 = 32;
+
+        let now = SystemTime::now();
+        let slot_clock = ManualSlotClock::new(
+            Slot::new(100),
+            now.duration_since(UNIX_EPOCH).unwrap(),
+            Duration::from_secs(1),
+        );
+
+        let msg_id = MessageId::new(
+            &DomainType([0, 0, 0, 1]),
+            Role::ProposerPreferences,
+            &DutyExecutor::Validator(PublicKeyBytes::empty()),
+        );
+        let ssv_msg = SSVMessage::new(MsgType::SSVConsensusMsgType, msg_id, vec![1, 2, 3])
+            .expect("SSVMessage should be created");
+        let signed_msg = SignedSSVMessage::new(
+            vec![[0xAA; RSA_SIGNATURE_SIZE]],
+            vec![OperatorId(1)],
+            ssv_msg,
+            vec![],
+        )
+        .expect("SignedSSVMessage should be created");
+
+        let committee_info = create_committee_info(SINGLE_NODE_COMMITTEE);
+        let mock_duties_provider = Arc::new(MockDutiesProvider {
+            voluntary_exit_duty_count: 0,
+        });
+        let map = create_operator_pub_keys(committee_info.committee_members.clone(), vec![]);
+
+        let validation_context = ValidationContext {
+            signed_ssv_message: &signed_msg,
+            committee_info: &committee_info,
+            role: Role::ProposerPreferences,
+            received_at: now,
+            slots_per_epoch: SLOTS_PER_EPOCH,
+            epochs_per_sync_committee_period: 256,
+            sync_committee_size: 512,
+            slot_clock: slot_clock.clone(),
+            operator_pub_keys: &map,
+            fork_schedule: generate_fork_schedule(),
+            spec: Arc::new(types::ChainSpec::mainnet()),
+        };
+
+        let slot = slot_clock.now().unwrap();
+
+        // Act: the limit equals `slots_per_epoch` for a single validator index.
+        let one_validator = vec![ValidatorIndex(0)];
+        let result = duty_limit(
+            &validation_context,
+            slot,
+            &one_validator,
+            mock_duties_provider.clone(),
+        );
+
+        // Assert
+        assert_eq!(result, Ok(Some(SLOTS_PER_EPOCH)));
+
+        // The limit is fixed at `slots_per_epoch` and does not scale with the slice
+        // length.
+        let many = vec![ValidatorIndex(0); 100];
+        let result = duty_limit(&validation_context, slot, &many, mock_duties_provider);
+        assert_eq!(result, Ok(Some(SLOTS_PER_EPOCH)));
     }
 
     /// Helper function for testing role validation against fork schedules.

--- a/anchor/message_validator/src/duty_state.rs
+++ b/anchor/message_validator/src/duty_state.rs
@@ -7,8 +7,9 @@ use ssv_types::{
     CommitteeId, Epoch, OperatorId, Slot,
     consensus::{QbftMessage, QbftMessageType},
     message::SignedSSVMessage,
-    partial_sig::PartialSignatureMessages,
+    partial_sig::{PartialSignatureKind, PartialSignatureMessages},
 };
+use types::Hash256;
 
 use crate::{FIRST_ROUND, ValidationFailure, message_counts::MessageCounts};
 // duty_state.rs
@@ -96,6 +97,30 @@ impl DutyState {
                 )
             }
         };
+
+        // ProposerPreferences-specific per-slot signing-root dedup (not the shared pre_consensus
+        // counter): a validator legitimately signs multiple distinct preference roots at one send
+        // slot (the current + next-epoch lookahead batch), so we track the distinct roots.
+        if partial_signature_messages.kind == PartialSignatureKind::ProposerPreferences {
+            let root = partial_signature_messages
+                .messages
+                .first()
+                .ok_or(ValidationFailure::NoPartialSignatureMessages)?
+                .signing_root;
+            if signer_state.seen_preferences.len() as u64 >= 2 * slots_per_epoch {
+                return Err(ValidationFailure::InvalidPartialSignatureTypeCount {
+                    got: format!(
+                        "proposer-preferences distinct roots exceed cap {}",
+                        2 * slots_per_epoch
+                    ),
+                });
+            }
+            if !signer_state.seen_preferences.insert(root) {
+                return Err(ValidationFailure::DuplicatedMessage {
+                    got: format!("proposer-preferences root {root:?}"),
+                });
+            }
+        }
 
         // Record the partial signature (only once)
         signer_state
@@ -277,6 +302,9 @@ pub(crate) struct SignerState {
     pub(crate) proposal_hash: Option<[u8; 32]>,
     /// A set of CommitteeIds indicating which committees have already been seen.
     seen_signers: HashSet<CommitteeId>,
+    /// Distinct ProposerPreferences signing roots already seen for this
+    /// (MessageId, operator, slot), used to reject exact-duplicate resends.
+    seen_preferences: HashSet<Hash256>,
 }
 
 impl SignerState {
@@ -288,6 +316,7 @@ impl SignerState {
             message_counts: MessageCounts::default(),
             proposal_hash: None,
             seen_signers: HashSet::new(),
+            seen_preferences: HashSet::new(),
         }
     }
 

--- a/anchor/message_validator/src/duty_state.rs
+++ b/anchor/message_validator/src/duty_state.rs
@@ -132,6 +132,15 @@ impl DutyState {
                 .first()
                 .ok_or(ValidationFailure::NoPartialSignatureMessages)?
                 .signing_root;
+            // Duplicate identity takes precedence over capacity: an already-seen root is a
+            // Reject-class DuplicatedMessage even once the distinct-root set is full, whereas only
+            // a NEW root beyond the cap is the Ignore-class TooManyDistinctSigningRoots (SIP-94
+            // §7).
+            if signer_state.seen_preferences.contains(&root) {
+                return Err(ValidationFailure::DuplicatedMessage {
+                    got: format!("proposer-preferences root {root:?}"),
+                });
+            }
             if signer_state.seen_preferences.len() >= MAX_PROPOSER_PREFERENCES_DISTINCT_ROOTS {
                 return Err(ValidationFailure::TooManyDistinctSigningRoots {
                     got: format!(
@@ -140,11 +149,7 @@ impl DutyState {
                     ),
                 });
             }
-            if !signer_state.seen_preferences.insert(root) {
-                return Err(ValidationFailure::DuplicatedMessage {
-                    got: format!("proposer-preferences root {root:?}"),
-                });
-            }
+            signer_state.seen_preferences.insert(root);
         }
 
         // Record the partial signature (only once)

--- a/anchor/message_validator/src/duty_state.rs
+++ b/anchor/message_validator/src/duty_state.rs
@@ -21,6 +21,29 @@ use crate::{FIRST_ROUND, ValidationFailure, message_counts::MessageCounts};
 //  - SignerState: The state of a signer at a particular slot, including message counts and proposal
 //    data.
 
+/// Maximum distinct `ProposerPreferences` signing roots accepted per
+/// (`MessageId`, operator, `proposal_slot`).
+///
+/// A validator can legitimately sign several distinct roots for one `proposal_slot` when its
+/// preference inputs change between emissions — chiefly a `dependent_root` shift under reorg (the
+/// SIP-94 §5 re-emission trigger), and also `target_gas_limit` / `fee_recipient` config changes
+/// across operator restarts. Per SIP-94 §7 the cap is policy headroom for a few realistic
+/// reorg-driven corrections while bounding spam — not a safety/consensus bound. That is why
+/// exceeding it is an Ignore (`TooManyDistinctSigningRoots`), whereas a repeat of an already-seen
+/// root stays a Reject-class duplicate.
+const MAX_PROPOSER_PREFERENCES_DISTINCT_ROOTS: usize = 4;
+
+/// Test-only, crate-visible mirror of the private cap so pipeline tests in sibling modules
+/// (e.g. `partial_signature`) can reference the real value instead of hardcoding `4`. The
+/// compile-time assertion below makes the mirror impossible to drift from production.
+#[cfg(test)]
+pub(crate) const MAX_PROPOSER_PREFERENCES_DISTINCT_ROOTS_FOR_TEST: usize =
+    MAX_PROPOSER_PREFERENCES_DISTINCT_ROOTS;
+#[cfg(test)]
+const _: () = assert!(
+    MAX_PROPOSER_PREFERENCES_DISTINCT_ROOTS_FOR_TEST == MAX_PROPOSER_PREFERENCES_DISTINCT_ROOTS
+);
+
 /// DutyState manages the state for duty validation across operators and slots
 pub(crate) struct DutyState {
     /// Tracks the duty state for an operator
@@ -99,19 +122,21 @@ impl DutyState {
         };
 
         // ProposerPreferences-specific per-slot signing-root dedup (not the shared pre_consensus
-        // counter): a validator legitimately signs multiple distinct preference roots at one send
-        // slot (the current + next-epoch lookahead batch), so we track the distinct roots.
+        // counter): the envelope slot is the duty's proposal_slot, and a validator may sign several
+        // distinct roots for one proposal_slot as its preference inputs change between emissions
+        // (chiefly a dependent_root shift under reorg). Track the distinct roots per
+        // (MessageId, operator, proposal_slot), capped at MAX_PROPOSER_PREFERENCES_DISTINCT_ROOTS.
         if partial_signature_messages.kind == PartialSignatureKind::ProposerPreferences {
             let root = partial_signature_messages
                 .messages
                 .first()
                 .ok_or(ValidationFailure::NoPartialSignatureMessages)?
                 .signing_root;
-            if signer_state.seen_preferences.len() as u64 >= 2 * slots_per_epoch {
-                return Err(ValidationFailure::InvalidPartialSignatureTypeCount {
+            if signer_state.seen_preferences.len() >= MAX_PROPOSER_PREFERENCES_DISTINCT_ROOTS {
+                return Err(ValidationFailure::TooManyDistinctSigningRoots {
                     got: format!(
-                        "proposer-preferences distinct roots exceed cap {}",
-                        2 * slots_per_epoch
+                        "proposer-preferences distinct roots exceed cap \
+                         {MAX_PROPOSER_PREFERENCES_DISTINCT_ROOTS}"
                     ),
                 });
             }

--- a/anchor/message_validator/src/lib.rs
+++ b/anchor/message_validator/src/lib.rs
@@ -191,6 +191,9 @@ pub enum ValidationFailure {
     InvalidPartialSignatureTypeCount {
         got: String,
     },
+    TooManyDistinctSigningRoots {
+        got: String,
+    },
     TooManyPartialSignatureMessages {
         got: usize,
         limit: usize,
@@ -251,9 +254,8 @@ impl From<&ValidationFailure> for MessageAcceptance {
             | ValidationFailure::ValidatorIndexMismatch
             | ValidationFailure::TooManyDutiesPerEpoch
             | ValidationFailure::NoDuty
-            | ValidationFailure::EstimatedRoundNotInAllowedSpread { .. } => {
-                MessageAcceptance::Ignore
-            }
+            | ValidationFailure::EstimatedRoundNotInAllowedSpread { .. }
+            | ValidationFailure::TooManyDistinctSigningRoots { .. } => MessageAcceptance::Ignore,
             _ => MessageAcceptance::Reject,
         }
     }
@@ -500,7 +502,7 @@ impl<S: SlotClock + 'static, D: DutiesProvider> Validator<S, D> {
 
         drop(network_state);
 
-        let mut duty_state = self.get_duty_state(ssv_message.msg_id(), self.slots_per_epoch);
+        let mut duty_state = self.get_duty_state(ssv_message.msg_id(), role, self.slots_per_epoch);
 
         let validation_context = ValidationContext {
             signed_ssv_message,
@@ -528,12 +530,23 @@ impl<S: SlotClock + 'static, D: DutiesProvider> Validator<S, D> {
     fn get_duty_state(
         &self,
         message_id: &MessageId,
+        role: Role,
         slots_per_epoch: u64,
     ) -> RefMut<'_, MessageId, DutyState> {
         self.duty_state_map
             .entry(message_id.clone())
             .or_insert_with(|| {
-                let stored_slot_count = slots_per_epoch * 2; // Store last two epochs
+                // Default: keep the last two epochs. ProposerPreferences also spans the proposer
+                // lookahead into the future (its envelope slot is a future proposal_slot), so its
+                // ring must cover lookahead + default; otherwise a validly accepted future-slot
+                // write would evict a live slot's dedup state (the ring is indexed by slot % len).
+                let stored_slot_count = match role {
+                    Role::ProposerPreferences => {
+                        (1 + self.spec.min_seed_lookahead.as_u64()) * slots_per_epoch
+                            + slots_per_epoch * 2
+                    }
+                    _ => slots_per_epoch * 2,
+                };
 
                 DutyState::new(stored_slot_count as usize)
             })
@@ -820,6 +833,28 @@ pub(crate) fn validate_beacon_duty(
         }
     }
 
+    // Rule: For a proposer-preferences message, the validator must be the assigned proposer at the
+    // preference's `proposal_slot` (= `slot` here). Checked only once the slot-epoch's proposer
+    // duties are known locally, so a not-yet-fetched epoch is tolerated. No RANDAO tolerance:
+    // ProposerPreferences carries no RANDAO signature.
+    if role == Role::ProposerPreferences {
+        // Non-committee roles always have one validator index
+        let validator_index = validation_context
+            .committee_info
+            .validator_indices
+            .first()
+            .copied()
+            .ok_or(ValidationFailure::UnexpectedFailure {
+                msg: "Unexpected error when getting first validator index".to_string(),
+            })?;
+
+        if duty_provider.is_epoch_known_for_proposers(epoch)
+            && !duty_provider.is_validator_proposer_at_slot(slot, validator_index)
+        {
+            return Err(ValidationFailure::NoDuty);
+        }
+    }
+
     // Rule: For a sync committee duty message, check if the validator is assigned
     if role == Role::SyncCommittee {
         let period =
@@ -922,7 +957,7 @@ pub(crate) fn validate_slot_time(
 ) -> Result<(), ValidationFailure> {
     // Check if the message is too early
     let earliness = message_earliness(msg_slot, validation_context)?;
-    if earliness > CLOCK_ERROR_TOLERANCE {
+    if earliness > CLOCK_ERROR_TOLERANCE + early_slot_allowance(validation_context) {
         return Err(ValidationFailure::EarlySlotMessage {
             got: format!("early by {earliness:?}"),
         });
@@ -952,6 +987,27 @@ fn message_earliness(
         .unwrap_or_default())
 }
 
+/// Extra future-slot tolerance (on top of `CLOCK_ERROR_TOLERANCE`) allowed for a role's message
+/// slot. Only `ProposerPreferences` is non-zero: its envelope slot is the duty's future
+/// `proposal_slot`, so the whole proposer lookahead (current epoch + `min_seed_lookahead`) ahead of
+/// that slot must be accepted. Every other role keeps the strict no-future rule.
+fn early_slot_allowance(validation_context: &ValidationContext<impl SlotClock>) -> Duration {
+    match validation_context.role {
+        Role::ProposerPreferences => {
+            let allowance_slots = u32::try_from(
+                (1 + validation_context.spec.min_seed_lookahead.as_u64())
+                    * validation_context.slots_per_epoch,
+            )
+            .unwrap_or(u32::MAX);
+            validation_context
+                .slot_clock
+                .slot_duration()
+                .saturating_mul(allowance_slots)
+        }
+        _ => Duration::ZERO,
+    }
+}
+
 /// Returns how late a message is compared to its deadline based on role.
 /// If the message was received before the deadline, it returns 0.
 /// If the message was received after the deadline, it returns the duration by which it was late.
@@ -965,8 +1021,8 @@ fn message_lateness(
         | Role::Aggregator
         | Role::ValidatorRegistration
         | Role::VoluntaryExit
-        | Role::AggregatorCommittee
-        | Role::ProposerPreferences => validation_context.slots_per_epoch + LATE_SLOT_ALLOWANCE,
+        | Role::AggregatorCommittee => validation_context.slots_per_epoch + LATE_SLOT_ALLOWANCE,
+        Role::ProposerPreferences => LATE_SLOT_ALLOWANCE,
     };
 
     let deadline = slot_start_time(slot + ttl, validation_context.slot_clock.clone())
@@ -1364,10 +1420,30 @@ mod tests {
         }
     }
 
-    #[derive(Default)]
     pub struct MockDutiesProvider {
         pub(crate) voluntary_exit_duty_count: u64,
+        /// Value returned by `is_epoch_known_for_proposers`. Defaults to `true`
+        /// so existing tests keep the historical "epoch always known" behavior.
+        pub(crate) epoch_known_for_proposers: bool,
+        /// Value returned by `is_validator_proposer_at_slot`. Defaults to `true`
+        /// so existing tests keep the historical "validator is always proposer"
+        /// behavior.
+        pub(crate) validator_is_proposer: bool,
     }
+
+    // Manual `Default` (not derived) so the two proposer flags default to `true`,
+    // preserving the behavior all pre-existing tests relied on before these fields
+    // were added. New tests set them explicitly to drive the proposer-assignment arm.
+    impl Default for MockDutiesProvider {
+        fn default() -> Self {
+            Self {
+                voluntary_exit_duty_count: 0,
+                epoch_known_for_proposers: true,
+                validator_is_proposer: true,
+            }
+        }
+    }
+
     impl DutiesProvider for MockDutiesProvider {
         fn is_validator_in_sync_committee(
             &self,
@@ -1378,7 +1454,7 @@ mod tests {
         }
 
         fn is_epoch_known_for_proposers(&self, _epoch: Epoch) -> bool {
-            true
+            self.epoch_known_for_proposers
         }
 
         fn is_validator_proposer_at_slot(
@@ -1386,7 +1462,7 @@ mod tests {
             _slot: Slot,
             _validator_index: ValidatorIndex,
         ) -> bool {
-            true
+            self.validator_is_proposer
         }
 
         fn get_voluntary_exit_duty_count(&self, _slot: Slot, _pubkey: &PublicKeyBytes) -> u64 {

--- a/anchor/message_validator/src/lib.rs
+++ b/anchor/message_validator/src/lib.rs
@@ -535,21 +535,7 @@ impl<S: SlotClock + 'static, D: DutiesProvider> Validator<S, D> {
     ) -> RefMut<'_, MessageId, DutyState> {
         self.duty_state_map
             .entry(message_id.clone())
-            .or_insert_with(|| {
-                // Default: keep the last two epochs. ProposerPreferences also spans the proposer
-                // lookahead into the future (its envelope slot is a future proposal_slot), so its
-                // ring must cover lookahead + default; otherwise a validly accepted future-slot
-                // write would evict a live slot's dedup state (the ring is indexed by slot % len).
-                let stored_slot_count = match role {
-                    Role::ProposerPreferences => {
-                        (1 + self.spec.min_seed_lookahead.as_u64()) * slots_per_epoch
-                            + slots_per_epoch * 2
-                    }
-                    _ => slots_per_epoch * 2,
-                };
-
-                DutyState::new(stored_slot_count as usize)
-            })
+            .or_insert_with(|| DutyState::new(stored_slot_count(role, slots_per_epoch, &self.spec)))
     }
 
     async fn cleaner(self: Arc<Self>) {
@@ -702,6 +688,26 @@ impl<S: SlotClock + 'static, D: DutiesProvider> Validator<S, D> {
         trace!(subnet = ?expected_subnet, fork = ?expected_fork, "Topic validation passed");
         Ok(())
     }
+}
+
+/// Number of slots the `DutyState` ring must retain for `role`.
+///
+/// Default: keep the last two epochs. `ProposerPreferences` also spans the proposer lookahead into
+/// the future (its envelope slot is a future `proposal_slot`), so its ring must cover
+/// `lookahead + default`; otherwise a validly accepted future-slot write would evict a live slot's
+/// dedup state (the ring is indexed by `slot % len`).
+///
+/// Shared by the production selector (`get_duty_state`) and its regression test so neither can
+/// drift from the other.
+pub(crate) fn stored_slot_count(role: Role, slots_per_epoch: u64, spec: &ChainSpec) -> usize {
+    let default = slots_per_epoch * 2;
+    let count = match role {
+        Role::ProposerPreferences => {
+            (1 + spec.min_seed_lookahead.as_u64()) * slots_per_epoch + default
+        }
+        _ => default,
+    };
+    count as usize
 }
 
 fn validate_ssv_message(

--- a/anchor/message_validator/src/lib.rs
+++ b/anchor/message_validator/src/lib.rs
@@ -472,7 +472,8 @@ impl<S: SlotClock + 'static, D: DutiesProvider> Validator<S, D> {
             | Role::SyncCommittee
             | Role::ValidatorRegistration
             | Role::VoluntaryExit
-            | Role::PTCAttester => {
+            | Role::PTCAttester
+            | Role::ProposerPreferences => {
                 let validator_pk = match ssv_message.msg_id().duty_executor() {
                     Some(DutyExecutor::Validator(pk)) => pk,
                     _ => return Err(ValidationFailure::UnknownValidator),
@@ -846,6 +847,7 @@ pub(crate) fn validate_beacon_duty(
 /// - AggregatorCommittee before Boole fork (not yet active)
 /// - Aggregator and SyncCommittee after Boole fork (deprecated)
 /// - PTCAttester before the Ethereum Gloas (ePBS) fork (not yet active)
+/// - ProposerPreferences before the Ethereum Gloas (ePBS) fork (not yet active)
 pub(crate) fn validate_role_for_fork(
     slot: Slot,
     validation_context: &ValidationContext<impl SlotClock>,
@@ -874,6 +876,19 @@ pub(crate) fn validate_role_for_fork(
 
     // Reject PTCAttester before the Ethereum Gloas (ePBS) fork, read from the consensus spec.
     if role == Role::PTCAttester {
+        let current_fork = validation_context.spec.fork_name_at_epoch(epoch);
+        if !current_fork.gloas_enabled() {
+            return Err(ValidationFailure::RoleNotActiveBeforeEthFork {
+                role,
+                current_fork,
+                minimum_fork: ForkName::Gloas,
+            });
+        }
+    }
+
+    // Reject ProposerPreferences before the Ethereum Gloas (ePBS) fork, read from the consensus
+    // spec.
+    if role == Role::ProposerPreferences {
         let current_fork = validation_context.spec.fork_name_at_epoch(epoch);
         if !current_fork.gloas_enabled() {
             return Err(ValidationFailure::RoleNotActiveBeforeEthFork {
@@ -950,7 +965,8 @@ fn message_lateness(
         | Role::Aggregator
         | Role::ValidatorRegistration
         | Role::VoluntaryExit
-        | Role::AggregatorCommittee => validation_context.slots_per_epoch + LATE_SLOT_ALLOWANCE,
+        | Role::AggregatorCommittee
+        | Role::ProposerPreferences => validation_context.slots_per_epoch + LATE_SLOT_ALLOWANCE,
     };
 
     let deadline = slot_start_time(slot + ttl, validation_context.slot_clock.clone())
@@ -1061,6 +1077,7 @@ fn duty_limit(
         }
         // Proposer and SyncCommittee have no duty limit
         Role::Proposer | Role::SyncCommittee => Ok(None),
+        Role::ProposerPreferences => Ok(Some(validation_context.slots_per_epoch)),
     }
 }
 
@@ -1314,7 +1331,8 @@ mod tests {
             | Role::SyncCommittee
             | Role::ValidatorRegistration
             | Role::VoluntaryExit
-            | Role::PTCAttester => DutyExecutor::Validator(PublicKeyBytes::empty()),
+            | Role::PTCAttester
+            | Role::ProposerPreferences => DutyExecutor::Validator(PublicKeyBytes::empty()),
         };
         MessageId::new(&domain, role, &duty_executor)
     }

--- a/anchor/message_validator/src/message_counts.rs
+++ b/anchor/message_validator/src/message_counts.rs
@@ -81,6 +81,8 @@ impl MessageCounts {
                     });
                 }
             }
+            // ProposerPreferences does not use the shared pre_consensus round cap
+            PartialSignatureKind::ProposerPreferences => {}
         }
 
         Ok(())
@@ -113,6 +115,8 @@ impl MessageCounts {
             | PartialSignatureKind::AggregatorCommitteePartialSig
             | PartialSignatureKind::PTCAttester => self.pre_consensus += 1,
             PartialSignatureKind::PostConsensus => self.post_consensus += 1,
+            // Tracked per signing-root on `SignerState`, not via a shared counter.
+            PartialSignatureKind::ProposerPreferences => {}
         }
     }
 }

--- a/anchor/message_validator/src/partial_signature.rs
+++ b/anchor/message_validator/src/partial_signature.rs
@@ -188,9 +188,11 @@ fn validate_partial_sig_messages_by_duty_logic(
     // Get duty state for this signer
     let operator_state = duty_state.get_or_create_operator(signer);
 
-    // Rule: Slot must not be "old" - signer must not have already advanced to a later slot
-    // Skip for committee roles (Committee and AggregatorCommittee)
-    if !role.is_committee_role() {
+    // Rule: Slot must not be "old" - a monotonic-slot signer must not have already advanced to a
+    // later slot. Committee roles (batched, slot-keyed) and ProposerPreferences (holds its whole
+    // proposal-slot lookahead concurrently, so a lower slot is a concurrent duty, not a stale one)
+    // are exempt; their replay bound is the earliness/lateness window instead.
+    if role.monotonic_slot_role() {
         let max_slot = operator_state.max_slot();
         if max_slot.as_u64() != 0 && max_slot > message_slot {
             return Err(ValidationFailure::SlotAlreadyAdvanced {
@@ -358,9 +360,13 @@ mod tests {
     use types::{EthSpec, MainnetEthSpec, Slot};
 
     use super::*;
-    use crate::tests::{
-        FOUR_NODE_COMMITTEE, MockDutiesProvider, assert_validation_error, create_committee_info,
-        create_message_id_for_test, create_operator_pub_keys, generate_random_rsa_public_keys,
+    use crate::{
+        MessageAcceptance,
+        tests::{
+            FOUR_NODE_COMMITTEE, MockDutiesProvider, assert_validation_error,
+            create_committee_info, create_message_id_for_test, create_operator_pub_keys,
+            generate_random_rsa_public_keys,
+        },
     };
 
     // Options for creating test partial signature messages
@@ -595,6 +601,7 @@ mod tests {
             &mut DutyState::new(2),
             Arc::new(MockDutiesProvider {
                 voluntary_exit_duty_count: 0,
+                ..Default::default()
             }),
         );
 
@@ -647,6 +654,7 @@ mod tests {
             &mut DutyState::new(2),
             Arc::new(MockDutiesProvider {
                 voluntary_exit_duty_count: 0,
+                ..Default::default()
             }),
         );
 
@@ -689,6 +697,7 @@ mod tests {
             &mut DutyState::new(2),
             Arc::new(MockDutiesProvider {
                 voluntary_exit_duty_count: 0,
+                ..Default::default()
             }),
         );
 
@@ -731,6 +740,7 @@ mod tests {
             &mut DutyState::new(2),
             Arc::new(MockDutiesProvider {
                 voluntary_exit_duty_count: 0,
+                ..Default::default()
             }),
         );
 
@@ -773,6 +783,7 @@ mod tests {
             &mut DutyState::new(2),
             Arc::new(MockDutiesProvider {
                 voluntary_exit_duty_count: 0,
+                ..Default::default()
             }),
         );
 
@@ -814,6 +825,7 @@ mod tests {
             &mut DutyState::new(2),
             Arc::new(MockDutiesProvider {
                 voluntary_exit_duty_count: 0,
+                ..Default::default()
             }),
         );
 
@@ -866,6 +878,7 @@ mod tests {
             &mut DutyState::new(2),
             Arc::new(MockDutiesProvider {
                 voluntary_exit_duty_count: 0,
+                ..Default::default()
             }),
         );
 
@@ -914,6 +927,7 @@ mod tests {
             &mut DutyState::new(2),
             Arc::new(MockDutiesProvider {
                 voluntary_exit_duty_count: 0,
+                ..Default::default()
             }),
         );
 
@@ -965,6 +979,7 @@ mod tests {
             &mut DutyState::new(2),
             Arc::new(MockDutiesProvider {
                 voluntary_exit_duty_count: 0,
+                ..Default::default()
             }),
         );
 
@@ -1042,6 +1057,7 @@ mod tests {
             &mut DutyState::new(2),
             Arc::new(MockDutiesProvider {
                 voluntary_exit_duty_count: 0,
+                ..Default::default()
             }),
         )
     }
@@ -1089,6 +1105,7 @@ mod tests {
             &mut DutyState::new(2),
             Arc::new(MockDutiesProvider {
                 voluntary_exit_duty_count: 0,
+                ..Default::default()
             }),
         );
 
@@ -1200,6 +1217,7 @@ mod tests {
             &mut DutyState::new(2),
             Arc::new(MockDutiesProvider {
                 voluntary_exit_duty_count: 0,
+                ..Default::default()
             }),
         );
 
@@ -1319,6 +1337,7 @@ mod tests {
             &mut DutyState::new(64),
             Arc::new(MockDutiesProvider {
                 voluntary_exit_duty_count: 0,
+                ..Default::default()
             }),
         );
 
@@ -1356,6 +1375,7 @@ mod tests {
             &mut DutyState::new(64),
             Arc::new(MockDutiesProvider {
                 voluntary_exit_duty_count: 0,
+                ..Default::default()
             }),
         );
 
@@ -1397,6 +1417,7 @@ mod tests {
             &mut DutyState::new(64),
             Arc::new(MockDutiesProvider {
                 voluntary_exit_duty_count: 1,
+                ..Default::default()
             }),
         );
 
@@ -1489,6 +1510,7 @@ mod tests {
             &mut duty_state,
             Arc::new(MockDutiesProvider {
                 voluntary_exit_duty_count: 0,
+                ..Default::default()
             }),
         );
 
@@ -1574,6 +1596,7 @@ mod tests {
             &mut DutyState::new(2),
             Arc::new(MockDutiesProvider {
                 voluntary_exit_duty_count: 0,
+                ..Default::default()
             }),
         );
 
@@ -1642,6 +1665,7 @@ mod tests {
             &mut DutyState::new(2),
             Arc::new(MockDutiesProvider {
                 voluntary_exit_duty_count: 0,
+                ..Default::default()
             }),
         );
 
@@ -1728,6 +1752,7 @@ mod tests {
             &mut DutyState::new(64),
             Arc::new(MockDutiesProvider {
                 voluntary_exit_duty_count: 0,
+                ..Default::default()
             }),
         );
 
@@ -1816,6 +1841,7 @@ mod tests {
             &mut DutyState::new(64),
             Arc::new(MockDutiesProvider {
                 voluntary_exit_duty_count: 0,
+                ..Default::default()
             }),
         );
 
@@ -1853,6 +1879,7 @@ mod tests {
             &mut DutyState::new(64),
             Arc::new(MockDutiesProvider {
                 voluntary_exit_duty_count: 0,
+                ..Default::default()
             }),
         );
 
@@ -1882,9 +1909,20 @@ mod tests {
     //
     // ProposerPreferences (wire byte [8,0,0,0]) is validator-scoped and non-QBFT.
     // It mirrors PTCAttester's fork gate (post-Gloas only) and per-packet cap (1),
-    // but sits in the LONG TTL bucket (like ValidatorRegistration) and carries a
-    // novel per-slot signing-root dedup: a proposer legitimately signs multiple
-    // distinct preference roots at one send slot (the current + next-epoch batch).
+    // but its envelope slot is the duty's (possibly future) `proposal_slot`, not the
+    // current send slot. That single semantic change drives six role-scoped rules:
+    //   1. earliness: a future `proposal_slot` up to `(1 + spec.min_seed_lookahead) *
+    //      slots_per_epoch` ahead is accepted (`early_slot_allowance`), while every other role
+    //      keeps the strict no-future rule;
+    //   2. lateness: a TIGHT TTL of `LATE_SLOT_ALLOWANCE` slots past `proposal_slot`;
+    //   3. no monotonic slot-advance (a lower `proposal_slot` is a concurrent duty, not a stale
+    //      one);
+    //   4. proposer-assignment arm keyed on `proposal_slot` in `validate_beacon_duty`;
+    //   5. a per-role `DutyState` ring sized to cover the lookahead so a future-slot write cannot
+    //      evict a live slot's dedup state;
+    //   6. per-`proposal_slot` signing-root dedup capped at
+    //      `MAX_PROPOSER_PREFERENCES_DISTINCT_ROOTS` (over-cap → `TooManyDistinctSigningRoots` /
+    //      Ignore, exact-dup → `DuplicatedMessage` / Reject).
 
     /// Epoch at which the Ethereum Gloas fork activates in the ProposerPreferences
     /// fork-gate tests. Message slots below `GLOAS_ACTIVATION_EPOCH * SLOTS_PER_EPOCH_TEST`
@@ -1892,19 +1930,19 @@ mod tests {
     const GLOAS_ACTIVATION_EPOCH: u64 = 1;
 
     /// Builds a signed ProposerPreferences partial-signature packet with a caller-chosen
-    /// `signing_root` and envelope `slot`. The envelope slot is the CURRENT SEND SLOT;
-    /// the future `proposal_slot` a real body would carry is never on the wire, so only
-    /// the send-slot governs timing and per-slot dedup. Signed with `private_key` so it
-    /// passes signature verification end-to-end.
+    /// `signing_root` and envelope `proposal_slot`. The envelope slot IS the duty's
+    /// `proposal_slot` (a possibly-future slot), and it alone governs earliness, lateness,
+    /// the proposer-assignment check, and per-`proposal_slot` signing-root dedup. Signed with
+    /// `private_key` so it passes signature verification end-to-end.
     fn create_signed_proposer_preferences_message(
         signer_id: OperatorId,
         private_key: &Rsa<Private>,
-        slot: Slot,
+        proposal_slot: Slot,
         signing_root: Hash256,
     ) -> SignedSSVMessage {
         let partial_sig_messages = PartialSignatureMessages {
             kind: PartialSignatureKind::ProposerPreferences,
-            slot,
+            slot: proposal_slot,
             messages: VariableList::new(vec![PartialSignatureMessage {
                 partial_signature: Signature::empty(),
                 signing_root,
@@ -1931,18 +1969,21 @@ mod tests {
         SignedSSVMessage::new(vec![signature], vec![signer_id], ssv_msg, vec![]).unwrap()
     }
 
-    /// Builds a ProposerPreferences validation context whose send slot matches
-    /// the packet's envelope slot, so `validate_slot_time` sees an on-time message.
-    /// The Ethereum Gloas fork is active from epoch 0 unless overridden by the caller.
+    /// Builds a ProposerPreferences validation context whose wall clock currently reads
+    /// `current_slot`, with `received_at` pinned to the start of that slot. When the packet's
+    /// envelope `proposal_slot` equals `current_slot` the message is exactly on time; when
+    /// `proposal_slot > current_slot` it is early by `(proposal_slot - current_slot)` slots,
+    /// which the earliness tests use to probe `early_slot_allowance`. The Ethereum Gloas fork
+    /// is active from epoch 0.
     fn create_proposer_preferences_context<'a>(
         signed_msg: &'a SignedSSVMessage,
         committee_info: &'a crate::CommitteeInfo,
         operator_pub_keys: &'a HashMap<OperatorId, Rsa<Public>>,
-        send_slot: Slot,
+        current_slot: Slot,
     ) -> ValidationContext<'a, ManualSlotClock> {
         let now = SystemTime::now();
         let slot_clock = ManualSlotClock::new(
-            send_slot,
+            current_slot,
             now.duration_since(UNIX_EPOCH).unwrap(),
             Duration::from_secs(12),
         );
@@ -1961,6 +2002,46 @@ mod tests {
             // ProposerPreferences only exists post-Gloas; activate from epoch 0.
             spec: spec_with_gloas(Some(0)),
         }
+    }
+
+    /// Slot duration used by the ProposerPreferences timing helpers/tests.
+    const PROPOSER_PREFERENCES_SLOT_DURATION: Duration = Duration::from_secs(12);
+
+    /// Builds a ProposerPreferences context anchored at genesis slot 0 (start = `genesis`),
+    /// with `received_at` set explicitly. Lets the tight-TTL tests place `received_at` exactly
+    /// at, and just past, the lateness deadline `slot_start(proposal_slot + LATE_SLOT_ALLOWANCE)
+    /// + LATE_MESSAGE_MARGIN`. `slot_start(slot) = genesis + slot * slot_duration`.
+    fn create_proposer_preferences_context_at<'a>(
+        signed_msg: &'a SignedSSVMessage,
+        committee_info: &'a crate::CommitteeInfo,
+        operator_pub_keys: &'a HashMap<OperatorId, Rsa<Public>>,
+        genesis: SystemTime,
+        received_at: SystemTime,
+    ) -> ValidationContext<'a, ManualSlotClock> {
+        let slot_clock = ManualSlotClock::new(
+            Slot::new(0),
+            genesis.duration_since(UNIX_EPOCH).unwrap(),
+            PROPOSER_PREFERENCES_SLOT_DURATION,
+        );
+
+        ValidationContext {
+            signed_ssv_message: signed_msg,
+            committee_info,
+            role: Role::ProposerPreferences,
+            received_at,
+            slots_per_epoch: SLOTS_PER_EPOCH_TEST,
+            epochs_per_sync_committee_period: 256,
+            sync_committee_size: 512,
+            slot_clock,
+            operator_pub_keys,
+            fork_schedule: generate_fork_schedule(Fork::Boole),
+            spec: spec_with_gloas(Some(0)),
+        }
+    }
+
+    /// Start-of-slot time for a genesis-slot-0 clock: `genesis + slot * slot_duration`.
+    fn proposer_preferences_slot_start(genesis: SystemTime, slot: u64) -> SystemTime {
+        genesis + PROPOSER_PREFERENCES_SLOT_DURATION * (slot as u32)
     }
 
     #[test]
@@ -2074,6 +2155,7 @@ mod tests {
             &mut DutyState::new(64),
             Arc::new(MockDutiesProvider {
                 voluntary_exit_duty_count: 0,
+                ..Default::default()
             }),
         );
 
@@ -2105,6 +2187,7 @@ mod tests {
             &mut DutyState::new(64),
             Arc::new(MockDutiesProvider {
                 voluntary_exit_duty_count: 0,
+                ..Default::default()
             }),
         );
 
@@ -2118,9 +2201,13 @@ mod tests {
 
     #[test]
     fn test_proposer_preferences_within_ttl_accepted() {
-        // Arrange: ProposerPreferences sits in the LONG (committee-style) TTL bucket
-        // of slots_per_epoch + LATE_SLOT_ALLOWANCE = 34 slots, unlike PTCAttester's
-        // short 3-slot window. A message exactly TTL_SLOTS late is still inside it.
+        // Retargeted for the reworked TIGHT TTL. The envelope slot is now the duty's
+        // `proposal_slot`, so lateness is measured from it with the short
+        // `ttl = LATE_SLOT_ALLOWANCE` (2) bucket — NOT the old long
+        // `slots_per_epoch + LATE_SLOT_ALLOWANCE` (34) bucket. Accepted through the exact
+        // deadline `slot_start(proposal_slot + LATE_SLOT_ALLOWANCE) + LATE_MESSAGE_MARGIN`.
+        //
+        // The packet built by `create_signed_partial_sig_message` carries proposal_slot = 1.
         let committee_info = create_committee_info(FOUR_NODE_COMMITTEE);
         let (private_key, public_key) = generate_test_key_pair();
         let map =
@@ -2132,35 +2219,42 @@ mod tests {
             &private_key,
         );
 
-        let mut validation_context = create_ttl_validation_context(
+        const PROPOSAL_SLOT: u64 = 1;
+        let genesis = SystemTime::now();
+        // Deadline: last instant still accepted. `received_at` exactly at the deadline yields
+        // zero lateness, which is `<= CLOCK_ERROR_TOLERANCE`, so it is accepted.
+        let deadline =
+            proposer_preferences_slot_start(genesis, PROPOSAL_SLOT + crate::LATE_SLOT_ALLOWANCE)
+                + crate::LATE_MESSAGE_MARGIN;
+
+        let validation_context = create_proposer_preferences_context_at(
             &signed_msg,
             &committee_info,
-            Role::ProposerPreferences,
             &map,
-            TTL_SLOTS,
-            generate_fork_schedule(Fork::Boole),
+            genesis,
+            deadline, // received exactly at the deadline
         );
-        // ProposerPreferences only exists post-Gloas; the role gate reads the Ethereum fork.
-        validation_context.spec = spec_with_gloas(Some(0));
 
         // Act
         let result = validate_partial_signature_message(
             validation_context,
             &mut DutyState::new(64),
-            Arc::new(MockDutiesProvider {
-                voluntary_exit_duty_count: 0,
-            }),
+            Arc::new(MockDutiesProvider::default()),
         );
 
         // Assert
-        assert!(result.is_ok(), "Expected ok but got: {result:?}");
+        assert!(
+            result.is_ok(),
+            "Expected ProposerPreferences at the tight-TTL deadline to be accepted, got: {result:?}"
+        );
     }
 
     #[test]
     fn test_proposer_preferences_beyond_ttl_rejected() {
-        // Arrange: a message BEYOND_TTL_SLOTS (40) late is past the long 34-slot
-        // window, so it is rejected as late. This pins ProposerPreferences to the
-        // long bucket rather than the short slot-bound one.
+        // Retargeted for the reworked TIGHT TTL. One slot-duration past the deadline
+        // `slot_start(proposal_slot + LATE_SLOT_ALLOWANCE) + LATE_MESSAGE_MARGIN` is late.
+        // This is the explicit boundary partner of the accepted case above: the previous
+        // long-bucket value (34 slots) would now be far past the tight deadline.
         let committee_info = create_committee_info(FOUR_NODE_COMMITTEE);
         let (private_key, public_key) = generate_test_key_pair();
         let map =
@@ -2172,30 +2266,34 @@ mod tests {
             &private_key,
         );
 
-        let mut validation_context = create_ttl_validation_context(
+        const PROPOSAL_SLOT: u64 = 1;
+        let genesis = SystemTime::now();
+        let deadline =
+            proposer_preferences_slot_start(genesis, PROPOSAL_SLOT + crate::LATE_SLOT_ALLOWANCE)
+                + crate::LATE_MESSAGE_MARGIN;
+        // One full slot past the deadline is unambiguously beyond CLOCK_ERROR_TOLERANCE.
+        let received_at = deadline + PROPOSER_PREFERENCES_SLOT_DURATION;
+
+        let validation_context = create_proposer_preferences_context_at(
             &signed_msg,
             &committee_info,
-            Role::ProposerPreferences,
             &map,
-            BEYOND_TTL_SLOTS,
-            generate_fork_schedule(Fork::Boole),
+            genesis,
+            received_at,
         );
-        validation_context.spec = spec_with_gloas(Some(0));
 
         // Act
         let result = validate_partial_signature_message(
             validation_context,
             &mut DutyState::new(64),
-            Arc::new(MockDutiesProvider {
-                voluntary_exit_duty_count: 0,
-            }),
+            Arc::new(MockDutiesProvider::default()),
         );
 
         // Assert
         assert_validation_error(
             result,
             |failure| matches!(failure, ValidationFailure::LateSlotMessage { .. }),
-            "LateSlotMessage (ProposerPreferences past long TTL)",
+            "LateSlotMessage (ProposerPreferences past tight TTL)",
         );
     }
 
@@ -2248,6 +2346,7 @@ mod tests {
             &mut DutyState::new(64),
             Arc::new(MockDutiesProvider {
                 voluntary_exit_duty_count: 0,
+                ..Default::default()
             }),
         );
 
@@ -2264,148 +2363,256 @@ mod tests {
         );
     }
 
+    // Earliness allowance is `(1 + spec.min_seed_lookahead) * slots_per_epoch` slots. The test
+    // spec is mainnet, where `min_seed_lookahead = 1`, so the allowance is `2 * slots_per_epoch`
+    // (= 64 with SLOTS_PER_EPOCH_TEST = 32). A ProposerPreferences `proposal_slot` this far in
+    // the future is accepted; one slot further out is `EarlySlotMessage`.
+    const PROPOSER_PREFERENCES_EARLINESS_ALLOWANCE_SLOTS: u64 = 2 * SLOTS_PER_EPOCH_TEST;
+
     #[test]
-    fn test_proposer_preferences_future_proposal_slot_in_body_not_early() {
-        // A ProposerPreferences body describes a FUTURE proposal_slot, but that
-        // field is not on the wire: only the envelope (send) slot is. As long as
-        // the envelope slot equals the current send slot, validate_slot_time must
-        // accept it (no EarlySlotMessage), even though the intended proposal is
-        // for a later slot.
+    fn test_proposer_preferences_future_proposal_slot_within_allowance_accepted() {
+        // The envelope slot IS the duty's `proposal_slot`. A future `proposal_slot` up to the
+        // proposer lookahead (`(1 + min_seed_lookahead) * slots_per_epoch` slots) ahead of the
+        // current slot must be accepted, because a proposer commits preferences for its whole
+        // lookahead of future proposal slots at once.
         let committee_info = create_committee_info(FOUR_NODE_COMMITTEE);
         let (private_key, public_key) = generate_test_key_pair();
         let map =
             create_operator_pub_keys(committee_info.committee_members.clone(), vec![public_key]);
 
-        // Envelope slot is the current send slot (100); a real body would carry a
-        // far-future proposal_slot, but that never reaches the validator.
-        let send_slot = Slot::new(100);
+        let current_slot = Slot::new(1);
+        // Envelope `proposal_slot` exactly at the far edge of the allowance.
+        let proposal_slot =
+            current_slot + Slot::new(PROPOSER_PREFERENCES_EARLINESS_ALLOWANCE_SLOTS);
         let signed_msg = create_signed_proposer_preferences_message(
             OperatorId(1),
             &private_key,
-            send_slot,
+            proposal_slot,
             Hash256::from([1u8; 32]),
         );
 
+        // Ring must span the lookahead so the future-slot write does not collide; size it
+        // like production's ProposerPreferences ring.
+        let ring = ((1 + 1) * SLOTS_PER_EPOCH_TEST + 2 * SLOTS_PER_EPOCH_TEST) as usize;
         let validation_context =
-            create_proposer_preferences_context(&signed_msg, &committee_info, &map, send_slot);
+            create_proposer_preferences_context(&signed_msg, &committee_info, &map, current_slot);
 
         // Act
         let result = validate_partial_signature_message(
             validation_context,
-            &mut DutyState::new(256),
-            Arc::new(MockDutiesProvider {
-                voluntary_exit_duty_count: 0,
-            }),
+            &mut DutyState::new(ring),
+            Arc::new(MockDutiesProvider::default()),
         );
 
         // Assert: accepted; specifically NOT rejected as early.
         assert!(
             result.is_ok(),
-            "Expected on-time ProposerPreferences (envelope==send slot) to be accepted, got: {result:?}"
+            "Expected future proposal_slot within the earliness allowance to be accepted, got: {result:?}"
         );
     }
 
     #[test]
-    fn test_proposer_preferences_distinct_roots_same_send_slot_accepted() {
-        // A proposer legitimately signs multiple distinct preference roots at one
-        // send slot (current + next-epoch lookahead batch). Two packets from the
-        // same (validator, operator, envelope slot) with DIFFERENT signing roots
-        // must BOTH be accepted through a shared DutyState.
+    fn test_proposer_preferences_future_proposal_slot_beyond_allowance_early() {
+        // One slot past the earliness allowance must be rejected as `EarlySlotMessage`.
+        // This is the boundary partner of the accepted case above.
+        let committee_info = create_committee_info(FOUR_NODE_COMMITTEE);
+        let (private_key, public_key) = generate_test_key_pair();
+        let map =
+            create_operator_pub_keys(committee_info.committee_members.clone(), vec![public_key]);
+
+        let current_slot = Slot::new(1);
+        let proposal_slot =
+            current_slot + Slot::new(PROPOSER_PREFERENCES_EARLINESS_ALLOWANCE_SLOTS + 1);
+        let signed_msg = create_signed_proposer_preferences_message(
+            OperatorId(1),
+            &private_key,
+            proposal_slot,
+            Hash256::from([1u8; 32]),
+        );
+
+        let ring = ((1 + 1) * SLOTS_PER_EPOCH_TEST + 2 * SLOTS_PER_EPOCH_TEST) as usize;
+        let validation_context =
+            create_proposer_preferences_context(&signed_msg, &committee_info, &map, current_slot);
+
+        // Act
+        let result = validate_partial_signature_message(
+            validation_context,
+            &mut DutyState::new(ring),
+            Arc::new(MockDutiesProvider::default()),
+        );
+
+        // Assert
+        assert_validation_error(
+            result,
+            |failure| matches!(failure, ValidationFailure::EarlySlotMessage { .. }),
+            "EarlySlotMessage (ProposerPreferences one slot past the earliness allowance)",
+        );
+    }
+
+    #[test]
+    fn test_non_proposer_preferences_future_slot_still_early() {
+        // Regression pin: the earliness allowance is STRICTLY role-scoped to
+        // ProposerPreferences (`early_slot_allowance` returns `Duration::ZERO` for every
+        // other role). A non-role-8 message (ValidatorRegistration) with a future envelope
+        // slot must still be rejected as early — even one slot ahead, which is well inside
+        // the ProposerPreferences allowance but not available to any other role.
+        let committee_info = create_committee_info(FOUR_NODE_COMMITTEE);
+        let (private_key, public_key) = generate_test_key_pair();
+        let map =
+            create_operator_pub_keys(committee_info.committee_members.clone(), vec![public_key]);
+
+        // ValidatorRegistration packet whose envelope slot is 1.
+        let signed_msg = create_signed_partial_sig_message(
+            Role::ValidatorRegistration,
+            PartialSignatureKind::ValidatorRegistration,
+            OperatorId(1),
+            &private_key,
+        );
+
+        // Clock currently reads slot 0, so the envelope slot 1 is one slot in the future.
+        let now = SystemTime::now();
+        let slot_clock = ManualSlotClock::new(
+            Slot::new(0),
+            now.duration_since(UNIX_EPOCH).unwrap(),
+            Duration::from_secs(12),
+        );
+        let validation_context = ValidationContext {
+            signed_ssv_message: &signed_msg,
+            committee_info: &committee_info,
+            role: Role::ValidatorRegistration,
+            received_at: now, // received at slot-0 start; envelope slot 1 is 12s early
+            slots_per_epoch: SLOTS_PER_EPOCH_TEST,
+            epochs_per_sync_committee_period: 256,
+            sync_committee_size: 512,
+            slot_clock,
+            operator_pub_keys: &map,
+            fork_schedule: generate_fork_schedule(Fork::Alan),
+            spec: spec_with_gloas(None),
+        };
+
+        // Act
+        let result = validate_partial_signature_message(
+            validation_context,
+            &mut DutyState::new(64),
+            Arc::new(MockDutiesProvider::default()),
+        );
+
+        // Assert
+        assert_validation_error(
+            result,
+            |failure| matches!(failure, ValidationFailure::EarlySlotMessage { .. }),
+            "EarlySlotMessage (non-ProposerPreferences role has no future-slot allowance)",
+        );
+    }
+
+    #[test]
+    fn test_proposer_preferences_distinct_roots_same_proposal_slot_accepted() {
+        // A proposer legitimately signs multiple distinct preference roots for one
+        // `proposal_slot` when its inputs change between emissions (chiefly a
+        // `dependent_root` shift under reorg). Two packets from the same
+        // (validator, operator, proposal_slot) with DIFFERENT signing roots must BOTH be
+        // accepted through a shared DutyState, well under the distinct-root cap of
+        // `MAX_PROPOSER_PREFERENCES_DISTINCT_ROOTS`.
         let committee_info = create_committee_info(FOUR_NODE_COMMITTEE);
         let (private_key, public_key) = generate_test_key_pair();
         let map =
             create_operator_pub_keys(committee_info.committee_members.clone(), vec![public_key]);
         let signer_id = OperatorId(1);
-        let send_slot = Slot::new(1);
+        let proposal_slot = Slot::new(1);
         let mut duty_state = DutyState::new(64);
 
         // First packet: root A.
         let signed_a = create_signed_proposer_preferences_message(
             signer_id,
             &private_key,
-            send_slot,
+            proposal_slot,
             Hash256::from([0xAA; 32]),
         );
         let context_a =
-            create_proposer_preferences_context(&signed_a, &committee_info, &map, send_slot);
+            create_proposer_preferences_context(&signed_a, &committee_info, &map, proposal_slot);
         let result_a = validate_partial_signature_message(
             context_a,
             &mut duty_state,
-            Arc::new(MockDutiesProvider {
-                voluntary_exit_duty_count: 0,
-            }),
+            Arc::new(MockDutiesProvider::default()),
         );
         assert!(
             result_a.is_ok(),
             "Expected first distinct-root packet to be accepted, got: {result_a:?}"
         );
 
-        // Second packet: DIFFERENT root B at the SAME send slot.
+        // Second packet: DIFFERENT root B at the SAME proposal_slot.
         let signed_b = create_signed_proposer_preferences_message(
             signer_id,
             &private_key,
-            send_slot,
+            proposal_slot,
             Hash256::from([0xBB; 32]),
         );
         let context_b =
-            create_proposer_preferences_context(&signed_b, &committee_info, &map, send_slot);
+            create_proposer_preferences_context(&signed_b, &committee_info, &map, proposal_slot);
         let result_b = validate_partial_signature_message(
             context_b,
             &mut duty_state,
-            Arc::new(MockDutiesProvider {
-                voluntary_exit_duty_count: 0,
-            }),
+            Arc::new(MockDutiesProvider::default()),
         );
 
         // Assert: the second distinct root is also accepted (NOT falsely rejected
-        // as a pre-consensus duplicate).
+        // as a duplicate).
         assert!(
             result_b.is_ok(),
-            "Expected second distinct-root packet at same send slot to be accepted, got: {result_b:?}"
+            "Expected second distinct-root packet at same proposal_slot to be accepted, got: {result_b:?}"
         );
     }
 
     #[test]
-    fn test_proposer_preferences_duplicate_root_same_slot_rejected() {
-        // An exact-duplicate signing_root at the same send slot is a resend and
-        // must be rejected as a duplicate, via the per-slot seen_preferences set.
+    fn test_proposer_preferences_duplicate_root_same_proposal_slot_rejected() {
+        // An exact-duplicate signing_root for the same `proposal_slot` is a resend and
+        // must be rejected as a `DuplicatedMessage` (Reject class), via the per-slot
+        // `seen_preferences` set.
         let committee_info = create_committee_info(FOUR_NODE_COMMITTEE);
         let (private_key, public_key) = generate_test_key_pair();
         let map =
             create_operator_pub_keys(committee_info.committee_members.clone(), vec![public_key]);
         let signer_id = OperatorId(1);
-        let send_slot = Slot::new(1);
+        let proposal_slot = Slot::new(1);
         let root = Hash256::from([0xCC; 32]);
         let mut duty_state = DutyState::new(64);
 
         // First packet with root R is accepted.
-        let signed_first =
-            create_signed_proposer_preferences_message(signer_id, &private_key, send_slot, root);
-        let context_first =
-            create_proposer_preferences_context(&signed_first, &committee_info, &map, send_slot);
+        let signed_first = create_signed_proposer_preferences_message(
+            signer_id,
+            &private_key,
+            proposal_slot,
+            root,
+        );
+        let context_first = create_proposer_preferences_context(
+            &signed_first,
+            &committee_info,
+            &map,
+            proposal_slot,
+        );
         let result_first = validate_partial_signature_message(
             context_first,
             &mut duty_state,
-            Arc::new(MockDutiesProvider {
-                voluntary_exit_duty_count: 0,
-            }),
+            Arc::new(MockDutiesProvider::default()),
         );
         assert!(
             result_first.is_ok(),
             "Expected first packet to be accepted, got: {result_first:?}"
         );
 
-        // Second packet: EXACT-DUPLICATE root R at the SAME send slot.
-        let signed_dup =
-            create_signed_proposer_preferences_message(signer_id, &private_key, send_slot, root);
+        // Second packet: EXACT-DUPLICATE root R at the SAME proposal_slot.
+        let signed_dup = create_signed_proposer_preferences_message(
+            signer_id,
+            &private_key,
+            proposal_slot,
+            root,
+        );
         let context_dup =
-            create_proposer_preferences_context(&signed_dup, &committee_info, &map, send_slot);
+            create_proposer_preferences_context(&signed_dup, &committee_info, &map, proposal_slot);
         let result_dup = validate_partial_signature_message(
             context_dup,
             &mut duty_state,
-            Arc::new(MockDutiesProvider {
-                voluntary_exit_duty_count: 0,
-            }),
+            Arc::new(MockDutiesProvider::default()),
         );
 
         // Assert
@@ -2418,62 +2625,59 @@ mod tests {
 
     #[test]
     fn test_proposer_preferences_root_cap_enforced() {
-        // The distinct-root set for one (validator, operator, send slot) is capped
-        // at 2 * slots_per_epoch. Feeding exactly that many distinct roots all pass;
-        // one more distinct root is rejected as an invalid type count.
+        // Retargeted for the reworked cap. The distinct-root set for one
+        // (validator, operator, proposal_slot) is capped at
+        // `MAX_PROPOSER_PREFERENCES_DISTINCT_ROOTS` (referenced, never hardcoded). Feeding
+        // exactly that many distinct roots all pass; one more distinct root is an Ignore-class
+        // `TooManyDistinctSigningRoots` (NOT the old `InvalidPartialSignatureTypeCount`).
+        use crate::duty_state::MAX_PROPOSER_PREFERENCES_DISTINCT_ROOTS_FOR_TEST as CAP;
+
         let committee_info = create_committee_info(FOUR_NODE_COMMITTEE);
         let (private_key, public_key) = generate_test_key_pair();
         let map =
             create_operator_pub_keys(committee_info.committee_members.clone(), vec![public_key]);
         let signer_id = OperatorId(1);
-        let send_slot = Slot::new(1);
+        let proposal_slot = Slot::new(1);
         let mut duty_state = DutyState::new(64);
 
-        // Use the harness slots_per_epoch so the loop stays small (2 * 32 = 64).
-        let cap = 2 * SLOTS_PER_EPOCH_TEST;
-
-        // Feed `cap` distinct roots; all must be accepted.
-        for i in 0..cap {
+        // Feed `CAP` distinct roots; all must be accepted.
+        for i in 0..CAP {
             let mut root_bytes = [0u8; 32];
-            root_bytes[0..8].copy_from_slice(&i.to_le_bytes());
+            root_bytes[0..8].copy_from_slice(&(i as u64).to_le_bytes());
             let signed = create_signed_proposer_preferences_message(
                 signer_id,
                 &private_key,
-                send_slot,
+                proposal_slot,
                 Hash256::from(root_bytes),
             );
             let context =
-                create_proposer_preferences_context(&signed, &committee_info, &map, send_slot);
+                create_proposer_preferences_context(&signed, &committee_info, &map, proposal_slot);
             let result = validate_partial_signature_message(
                 context,
                 &mut duty_state,
-                Arc::new(MockDutiesProvider {
-                    voluntary_exit_duty_count: 0,
-                }),
+                Arc::new(MockDutiesProvider::default()),
             );
             assert!(
                 result.is_ok(),
-                "Expected distinct root #{i} (within cap {cap}) to be accepted, got: {result:?}"
+                "Expected distinct root #{i} (within cap {CAP}) to be accepted, got: {result:?}"
             );
         }
 
-        // One more distinct root exceeds the cap and is rejected.
+        // One more distinct root exceeds the cap and is rejected as an Ignore.
         let mut over_cap_bytes = [0u8; 32];
-        over_cap_bytes[0..8].copy_from_slice(&cap.to_le_bytes());
+        over_cap_bytes[0..8].copy_from_slice(&(CAP as u64).to_le_bytes());
         let signed_over = create_signed_proposer_preferences_message(
             signer_id,
             &private_key,
-            send_slot,
+            proposal_slot,
             Hash256::from(over_cap_bytes),
         );
         let context_over =
-            create_proposer_preferences_context(&signed_over, &committee_info, &map, send_slot);
+            create_proposer_preferences_context(&signed_over, &committee_info, &map, proposal_slot);
         let result_over = validate_partial_signature_message(
             context_over,
             &mut duty_state,
-            Arc::new(MockDutiesProvider {
-                voluntary_exit_duty_count: 0,
-            }),
+            Arc::new(MockDutiesProvider::default()),
         );
 
         // Assert
@@ -2482,10 +2686,359 @@ mod tests {
             |failure| {
                 matches!(
                     failure,
-                    ValidationFailure::InvalidPartialSignatureTypeCount { .. }
+                    ValidationFailure::TooManyDistinctSigningRoots { .. }
                 )
             },
-            "InvalidPartialSignatureTypeCount (ProposerPreferences distinct-root cap)",
+            "TooManyDistinctSigningRoots (ProposerPreferences distinct-root cap exceeded)",
+        );
+    }
+
+    #[test]
+    fn test_proposer_preferences_earlier_proposal_slot_after_later_accepted() {
+        // Slot-advance exemption: ProposerPreferences is NOT a `monotonic_slot_role()`, because
+        // a signer holds its whole lookahead of proposal slots at once. After a role-8 message
+        // for a LATER `proposal_slot`, a role-8 message for an EARLIER `proposal_slot` (still
+        // inside the lateness window) must be ACCEPTED — the stale-slot rejection does not apply.
+        let committee_info = create_committee_info(FOUR_NODE_COMMITTEE);
+        let (private_key, public_key) = generate_test_key_pair();
+        let map =
+            create_operator_pub_keys(committee_info.committee_members.clone(), vec![public_key]);
+        let signer_id = OperatorId(1);
+        let later_slot = Slot::new(3);
+        let earlier_slot = Slot::new(2);
+        let mut duty_state = DutyState::new(64);
+
+        // Genesis-slot-0 clock so `slot_start(earlier_slot)` is representable; `received_at` at
+        // the later slot's start keeps both messages within earliness/lateness.
+        let genesis = SystemTime::now();
+        let received_at = proposer_preferences_slot_start(genesis, later_slot.as_u64());
+
+        // First: process the LATER proposal_slot (advances the operator's max_slot).
+        let signed_later = create_signed_proposer_preferences_message(
+            signer_id,
+            &private_key,
+            later_slot,
+            Hash256::from([0x11; 32]),
+        );
+        let context_later = create_proposer_preferences_context_at(
+            &signed_later,
+            &committee_info,
+            &map,
+            genesis,
+            received_at,
+        );
+        let result_later = validate_partial_signature_message(
+            context_later,
+            &mut duty_state,
+            Arc::new(MockDutiesProvider::default()),
+        );
+        assert!(
+            result_later.is_ok(),
+            "Expected later proposal_slot message to be accepted, got: {result_later:?}"
+        );
+
+        // Then: an EARLIER proposal_slot must still be accepted (no `SlotAlreadyAdvanced`).
+        let signed_earlier = create_signed_proposer_preferences_message(
+            signer_id,
+            &private_key,
+            earlier_slot,
+            Hash256::from([0x22; 32]),
+        );
+        let context_earlier = create_proposer_preferences_context_at(
+            &signed_earlier,
+            &committee_info,
+            &map,
+            genesis,
+            received_at,
+        );
+        let result_earlier = validate_partial_signature_message(
+            context_earlier,
+            &mut duty_state,
+            Arc::new(MockDutiesProvider::default()),
+        );
+
+        // Assert
+        assert!(
+            result_earlier.is_ok(),
+            "Expected earlier proposal_slot after a later one to be accepted (role-8 is not \
+             monotonic), got: {result_earlier:?}"
+        );
+    }
+
+    #[test]
+    fn test_monotonic_role_earlier_slot_after_later_rejected() {
+        // Contrast to the ProposerPreferences exemption above: a monotonic-slot role
+        // (Aggregator) that has advanced to a later slot must REJECT an earlier slot with
+        // `SlotAlreadyAdvanced`. The slot-advance check runs before timing, so a lenient
+        // pre-Boole fork and long TTL keep the earlier message reaching that check.
+        let committee_info = create_committee_info(FOUR_NODE_COMMITTEE);
+        let (private_key, public_key) = generate_test_key_pair();
+        let map =
+            create_operator_pub_keys(committee_info.committee_members.clone(), vec![public_key]);
+        let signer_id = OperatorId(1);
+        let mut duty_state = DutyState::new(64);
+
+        // Pre-advance the operator's max_slot to slot 5 with a dummy Aggregator message.
+        let dummy = PartialSignatureMessages {
+            kind: PartialSignatureKind::SelectionProofPartialSig,
+            slot: Slot::new(5),
+            messages: VariableList::new(vec![PartialSignatureMessage {
+                partial_signature: Signature::empty(),
+                signing_root: Hash256::from([0u8; 32]),
+                signer: signer_id,
+                validator_index: ValidatorIndex(0),
+            }])
+            .unwrap(),
+        };
+        duty_state
+            .update_for_partial_signature(&dummy, &signer_id, SLOTS_PER_EPOCH_TEST)
+            .unwrap();
+
+        // Now an Aggregator message for an EARLIER slot (2) must be rejected.
+        let (mut earlier_msgs, _) = create_test_partial_signature(
+            Role::Aggregator,
+            PartialSignatureKind::SelectionProofPartialSig,
+            signer_id,
+            PartialSigTestOptions::default(),
+            Some(private_key.clone()),
+        );
+        earlier_msgs.slot = Slot::new(2);
+        let msg_id = create_message_id_for_test(Role::Aggregator);
+        let ssv_msg = SSVMessage::new(
+            MsgType::SSVPartialSignatureMsgType,
+            msg_id,
+            earlier_msgs.as_ssz_bytes(),
+        )
+        .unwrap();
+        let p_key = PKey::from_rsa(private_key).unwrap();
+        let mut s = Signer::new(MessageDigest::sha256(), &p_key).unwrap();
+        s.update(&ssv_msg.as_ssz_bytes()).unwrap();
+        let signature = s.sign_to_vec().unwrap().try_into().unwrap();
+        let signed_msg =
+            SignedSSVMessage::new(vec![signature], vec![signer_id], ssv_msg, vec![]).unwrap();
+
+        let now = SystemTime::now();
+        let slot_clock = ManualSlotClock::new(
+            Slot::new(2),
+            now.duration_since(UNIX_EPOCH).unwrap(),
+            Duration::from_secs(12),
+        );
+        let validation_context = ValidationContext {
+            signed_ssv_message: &signed_msg,
+            committee_info: &committee_info,
+            role: Role::Aggregator,
+            received_at: now,
+            slots_per_epoch: SLOTS_PER_EPOCH_TEST,
+            epochs_per_sync_committee_period: 256,
+            sync_committee_size: 512,
+            slot_clock,
+            operator_pub_keys: &map,
+            // Pre-Boole: Aggregator is still an active role.
+            fork_schedule: generate_fork_schedule(Fork::Alan),
+            spec: spec_with_gloas(None),
+        };
+
+        let result = validate_partial_signature_message(
+            validation_context,
+            &mut duty_state,
+            Arc::new(MockDutiesProvider::default()),
+        );
+
+        // Assert
+        assert_validation_error(
+            result,
+            |failure| matches!(failure, ValidationFailure::SlotAlreadyAdvanced { .. }),
+            "SlotAlreadyAdvanced (monotonic role rejects an earlier slot)",
+        );
+    }
+
+    // ==================== ProposerPreferences proposer-assignment arm ====================
+    //
+    // `validate_beacon_duty` gained a `Role::ProposerPreferences` arm keyed on the envelope
+    // `proposal_slot`. It rejects with `NoDuty` (Ignore) only when the slot's epoch is known
+    // AND the validator is NOT the assigned proposer; an unknown epoch is tolerated (accepted),
+    // and no RANDAO tolerance applies. These three cases drive the mock's
+    // `is_epoch_known_for_proposers` / `is_validator_proposer_at_slot`.
+
+    /// Runs the full ProposerPreferences pipeline with a mock configured for the given
+    /// proposer-assignment knobs, returning the validation result.
+    fn run_proposer_preferences_with_duties(
+        epoch_known_for_proposers: bool,
+        validator_is_proposer: bool,
+    ) -> Result<ValidatedSSVMessage, ValidationFailure> {
+        let committee_info = create_committee_info(FOUR_NODE_COMMITTEE);
+        let (private_key, public_key) = generate_test_key_pair();
+        let map =
+            create_operator_pub_keys(committee_info.committee_members.clone(), vec![public_key]);
+        let signed_msg = create_signed_proposer_preferences_message(
+            OperatorId(1),
+            &private_key,
+            Slot::new(1),
+            Hash256::from([0x33; 32]),
+        );
+        let validation_context =
+            create_proposer_preferences_context(&signed_msg, &committee_info, &map, Slot::new(1));
+
+        validate_partial_signature_message(
+            validation_context,
+            &mut DutyState::new(64),
+            Arc::new(MockDutiesProvider {
+                voluntary_exit_duty_count: 0,
+                epoch_known_for_proposers,
+                validator_is_proposer,
+            }),
+        )
+    }
+
+    #[test]
+    fn test_proposer_preferences_assigned_proposer_accepted() {
+        // Known epoch + validator IS the assigned proposer → accepted.
+        let result = run_proposer_preferences_with_duties(true, true);
+        assert!(
+            result.is_ok(),
+            "Expected assigned proposer to be accepted, got: {result:?}"
+        );
+    }
+
+    #[test]
+    fn test_proposer_preferences_known_epoch_not_assigned_no_duty() {
+        // Known epoch + validator is NOT the assigned proposer → `NoDuty` (maps to Ignore).
+        let result = run_proposer_preferences_with_duties(true, false);
+        assert_validation_error(
+            result,
+            |failure| matches!(failure, ValidationFailure::NoDuty),
+            "NoDuty (known epoch, validator not the assigned proposer)",
+        );
+        // Pin the Ignore mapping so a future reclassification of NoDuty is caught here.
+        // `MessageAcceptance` does not implement `PartialEq`, so match on the variant.
+        assert!(
+            matches!(
+                MessageAcceptance::from(&ValidationFailure::NoDuty),
+                MessageAcceptance::Ignore
+            ),
+            "NoDuty must map to Ignore"
+        );
+    }
+
+    #[test]
+    fn test_proposer_preferences_unknown_epoch_tolerated() {
+        // Unknown epoch → the assignment check is skipped and the message is accepted
+        // (tolerated while proposer duties for that epoch are not yet fetched). The
+        // not-assigned flag is irrelevant here because the `&&` short-circuits on the
+        // unknown epoch.
+        let result = run_proposer_preferences_with_duties(false, false);
+        assert!(
+            result.is_ok(),
+            "Expected unknown-epoch ProposerPreferences to be tolerated (accepted), got: {result:?}"
+        );
+    }
+
+    #[test]
+    fn test_proposer_preferences_ring_avoids_lookahead_collision() {
+        // Mirrors go's TestProposerPreferencesRingAvoidsLookaheadCollision. The
+        // ProposerPreferences `DutyState` ring is sized to cover the proposer lookahead so a
+        // validly accepted future-slot write cannot evict a live slot's dedup state. Two
+        // accepted role-8 messages — one for the current slot S and one for S + 2*spe (the
+        // earliness bound) — must retain DISTINCT per-slot signer states. Concretely, after the
+        // S + 2*spe message, a NEW distinct-root at S is still accepted (its `seen_preferences`
+        // survived), rather than being reset by a ring-index collision.
+        let committee_info = create_committee_info(FOUR_NODE_COMMITTEE);
+        let (private_key, public_key) = generate_test_key_pair();
+        let map =
+            create_operator_pub_keys(committee_info.committee_members.clone(), vec![public_key]);
+        let signer_id = OperatorId(1);
+
+        // Production ProposerPreferences ring size:
+        // (1 + min_seed_lookahead) * spe + spe * 2, with min_seed_lookahead = 1.
+        let ring = ((1 + 1) * SLOTS_PER_EPOCH_TEST + 2 * SLOTS_PER_EPOCH_TEST) as usize;
+        let mut duty_state = DutyState::new(ring);
+
+        let slot_s = Slot::new(1);
+        let far_slot = slot_s + Slot::new(2 * SLOTS_PER_EPOCH_TEST); // earliness bound
+        // Note: slot_s and far_slot differ by exactly 2*spe = 64. The ring length is 128, so
+        // they map to DISTINCT indices only because the ring covers the whole lookahead; a
+        // 2*spe-sized ring (64) would alias them and this test would fail.
+
+        // 1) Accept a first root at slot S.
+        let signed_s1 = create_signed_proposer_preferences_message(
+            signer_id,
+            &private_key,
+            slot_s,
+            Hash256::from([0xA1; 32]),
+        );
+        let ctx_s1 = create_proposer_preferences_context(&signed_s1, &committee_info, &map, slot_s);
+        assert!(
+            validate_partial_signature_message(
+                ctx_s1,
+                &mut duty_state,
+                Arc::new(MockDutiesProvider::default()),
+            )
+            .is_ok(),
+            "Expected first root at slot S to be accepted"
+        );
+
+        // 2) Accept a root at the far slot S + 2*spe (still within the earliness allowance).
+        let signed_far = create_signed_proposer_preferences_message(
+            signer_id,
+            &private_key,
+            far_slot,
+            Hash256::from([0xB1; 32]),
+        );
+        // Current slot stays S; the far slot is a future proposal_slot inside the allowance.
+        let ctx_far =
+            create_proposer_preferences_context(&signed_far, &committee_info, &map, slot_s);
+        assert!(
+            validate_partial_signature_message(
+                ctx_far,
+                &mut duty_state,
+                Arc::new(MockDutiesProvider::default()),
+            )
+            .is_ok(),
+            "Expected root at far slot S + 2*spe to be accepted"
+        );
+
+        // 3) A NEW distinct root at slot S must still be accepted: slot S's `seen_preferences`
+        //    survived the far-slot write (no ring-index collision reset it).
+        let signed_s2 = create_signed_proposer_preferences_message(
+            signer_id,
+            &private_key,
+            slot_s,
+            Hash256::from([0xA2; 32]),
+        );
+        let ctx_s2 = create_proposer_preferences_context(&signed_s2, &committee_info, &map, slot_s);
+        let result_s2 = validate_partial_signature_message(
+            ctx_s2,
+            &mut duty_state,
+            Arc::new(MockDutiesProvider::default()),
+        );
+
+        // Assert: accepted as a genuinely new distinct root (state preserved), not treated as
+        // slot S's first message (which a collision-reset would have produced).
+        assert!(
+            result_s2.is_ok(),
+            "Expected a new distinct root at slot S to be accepted (ring preserved S's dedup \
+             state across the far-slot write), got: {result_s2:?}"
+        );
+
+        // Cross-check that slot S really did accumulate two distinct roots (dedup state alive):
+        // an EXACT-duplicate of the first root at S is now rejected as a duplicate.
+        let signed_dup = create_signed_proposer_preferences_message(
+            signer_id,
+            &private_key,
+            slot_s,
+            Hash256::from([0xA1; 32]), // same as signed_s1
+        );
+        let ctx_dup =
+            create_proposer_preferences_context(&signed_dup, &committee_info, &map, slot_s);
+        let result_dup = validate_partial_signature_message(
+            ctx_dup,
+            &mut duty_state,
+            Arc::new(MockDutiesProvider::default()),
+        );
+        assert_validation_error(
+            result_dup,
+            |failure| matches!(failure, ValidationFailure::DuplicatedMessage { .. }),
+            "DuplicatedMessage (slot S retained its first root across the far-slot write)",
         );
     }
 
@@ -2519,6 +3072,7 @@ mod tests {
             &mut DutyState::new(64),
             Arc::new(MockDutiesProvider {
                 voluntary_exit_duty_count: 1,
+                ..Default::default()
             }),
         );
 
@@ -2561,6 +3115,7 @@ mod tests {
             &mut DutyState::new(64),
             Arc::new(MockDutiesProvider {
                 voluntary_exit_duty_count: 0,
+                ..Default::default()
             }),
         );
 

--- a/anchor/message_validator/src/partial_signature.rs
+++ b/anchor/message_validator/src/partial_signature.rs
@@ -146,6 +146,7 @@ fn partial_signature_type_matches_role(kind: PartialSignatureKind, role: Role) -
     match role {
         Role::Committee => kind == PartialSignatureKind::PostConsensus,
         Role::PTCAttester => kind == PartialSignatureKind::PTCAttester,
+        Role::ProposerPreferences => kind == PartialSignatureKind::ProposerPreferences,
         Role::Aggregator => {
             kind == PartialSignatureKind::PostConsensus
                 || kind == PartialSignatureKind::SelectionProofPartialSig
@@ -320,7 +321,8 @@ fn validate_partial_sig_messages_by_duty_logic(
         | Role::Proposer
         | Role::ValidatorRegistration
         | Role::VoluntaryExit
-        | Role::PTCAttester => {
+        | Role::PTCAttester
+        | Role::ProposerPreferences => {
             if message_count > 1 {
                 return Err(ValidationFailure::TooManyPartialSignatureMessages {
                     got: message_count,
@@ -1874,6 +1876,617 @@ mod tests {
             PartialSignatureKind::PostConsensus,
             Role::PTCAttester,
         ));
+    }
+
+    // ==================== ProposerPreferences tests ====================
+    //
+    // ProposerPreferences (wire byte [8,0,0,0]) is validator-scoped and non-QBFT.
+    // It mirrors PTCAttester's fork gate (post-Gloas only) and per-packet cap (1),
+    // but sits in the LONG TTL bucket (like ValidatorRegistration) and carries a
+    // novel per-slot signing-root dedup: a proposer legitimately signs multiple
+    // distinct preference roots at one send slot (the current + next-epoch batch).
+
+    /// Epoch at which the Ethereum Gloas fork activates in the ProposerPreferences
+    /// fork-gate tests. Message slots below `GLOAS_ACTIVATION_EPOCH * SLOTS_PER_EPOCH_TEST`
+    /// are pre-Gloas and must be rejected.
+    const GLOAS_ACTIVATION_EPOCH: u64 = 1;
+
+    /// Builds a signed ProposerPreferences partial-signature packet with a caller-chosen
+    /// `signing_root` and envelope `slot`. The envelope slot is the CURRENT SEND SLOT;
+    /// the future `proposal_slot` a real body would carry is never on the wire, so only
+    /// the send-slot governs timing and per-slot dedup. Signed with `private_key` so it
+    /// passes signature verification end-to-end.
+    fn create_signed_proposer_preferences_message(
+        signer_id: OperatorId,
+        private_key: &Rsa<Private>,
+        slot: Slot,
+        signing_root: Hash256,
+    ) -> SignedSSVMessage {
+        let partial_sig_messages = PartialSignatureMessages {
+            kind: PartialSignatureKind::ProposerPreferences,
+            slot,
+            messages: VariableList::new(vec![PartialSignatureMessage {
+                partial_signature: Signature::empty(),
+                signing_root,
+                signer: signer_id,
+                // ValidatorIndex(0) is in the test committee's validator_indices.
+                validator_index: ValidatorIndex(0),
+            }])
+            .unwrap(),
+        };
+
+        let msg_id = create_message_id_for_test(Role::ProposerPreferences);
+        let ssv_msg = SSVMessage::new(
+            MsgType::SSVPartialSignatureMsgType,
+            msg_id,
+            partial_sig_messages.as_ssz_bytes(),
+        )
+        .unwrap();
+
+        let p_key = PKey::from_rsa(private_key.clone()).unwrap();
+        let mut signer = Signer::new(MessageDigest::sha256(), &p_key).unwrap();
+        signer.update(&ssv_msg.as_ssz_bytes()).unwrap();
+        let signature = signer.sign_to_vec().unwrap().try_into().unwrap();
+
+        SignedSSVMessage::new(vec![signature], vec![signer_id], ssv_msg, vec![]).unwrap()
+    }
+
+    /// Builds a ProposerPreferences validation context whose send slot matches
+    /// the packet's envelope slot, so `validate_slot_time` sees an on-time message.
+    /// The Ethereum Gloas fork is active from epoch 0 unless overridden by the caller.
+    fn create_proposer_preferences_context<'a>(
+        signed_msg: &'a SignedSSVMessage,
+        committee_info: &'a crate::CommitteeInfo,
+        operator_pub_keys: &'a HashMap<OperatorId, Rsa<Public>>,
+        send_slot: Slot,
+    ) -> ValidationContext<'a, ManualSlotClock> {
+        let now = SystemTime::now();
+        let slot_clock = ManualSlotClock::new(
+            send_slot,
+            now.duration_since(UNIX_EPOCH).unwrap(),
+            Duration::from_secs(12),
+        );
+
+        ValidationContext {
+            signed_ssv_message: signed_msg,
+            committee_info,
+            role: Role::ProposerPreferences,
+            received_at: now,
+            slots_per_epoch: SLOTS_PER_EPOCH_TEST,
+            epochs_per_sync_committee_period: 256,
+            sync_committee_size: 512,
+            slot_clock,
+            operator_pub_keys,
+            fork_schedule: generate_fork_schedule(Fork::Boole),
+            // ProposerPreferences only exists post-Gloas; activate from epoch 0.
+            spec: spec_with_gloas(Some(0)),
+        }
+    }
+
+    #[test]
+    fn test_proposer_preferences_rejected_before_gloas() {
+        use crate::validate_role_for_fork;
+
+        // Arrange: a ProposerPreferences packet plus a spec whose Gloas fork
+        // activates at GLOAS_ACTIVATION_EPOCH. Slots before that epoch are pre-Gloas.
+        let committee_info = create_committee_info(FOUR_NODE_COMMITTEE);
+        let (private_key, public_key) = generate_test_key_pair();
+        let map =
+            create_operator_pub_keys(committee_info.committee_members.clone(), vec![public_key]);
+        let signed_msg = create_signed_partial_sig_message(
+            Role::ProposerPreferences,
+            PartialSignatureKind::ProposerPreferences,
+            OperatorId(1),
+            &private_key,
+        );
+
+        let mut validation_context = create_test_validation_context_with_fork(
+            &signed_msg,
+            &committee_info,
+            Role::ProposerPreferences,
+            &map,
+            Some(generate_fork_schedule(Fork::Boole)),
+        );
+        validation_context.spec = spec_with_gloas(Some(GLOAS_ACTIVATION_EPOCH));
+
+        // Act + Assert: slot 0 (epoch 0) is before Gloas activation → rejected.
+        let pre_gloas_slot = Slot::new(0);
+        let result = validate_role_for_fork(pre_gloas_slot, &validation_context);
+        assert_validation_error(
+            result,
+            |failure| {
+                matches!(
+                    failure,
+                    ValidationFailure::RoleNotActiveBeforeEthFork {
+                        minimum_fork: types::ForkName::Gloas,
+                        ..
+                    }
+                )
+            },
+            "RoleNotActiveBeforeEthFork (ProposerPreferences pre-Gloas)",
+        );
+
+        // Boundary: the last slot of the epoch immediately before activation is
+        // still pre-Gloas → rejected.
+        let boundary_slot = Slot::new(GLOAS_ACTIVATION_EPOCH * SLOTS_PER_EPOCH_TEST - 1);
+        let result = validate_role_for_fork(boundary_slot, &validation_context);
+        assert_validation_error(
+            result,
+            |failure| {
+                matches!(
+                    failure,
+                    ValidationFailure::RoleNotActiveBeforeEthFork {
+                        minimum_fork: types::ForkName::Gloas,
+                        ..
+                    }
+                )
+            },
+            "RoleNotActiveBeforeEthFork (ProposerPreferences at activation boundary)",
+        );
+
+        // Post-Gloas: the first slot of the activation epoch passes the fork gate.
+        let post_gloas_slot = Slot::new(GLOAS_ACTIVATION_EPOCH * SLOTS_PER_EPOCH_TEST);
+        let result = validate_role_for_fork(post_gloas_slot, &validation_context);
+        assert!(
+            result.is_ok(),
+            "Expected ProposerPreferences to pass the fork gate at Gloas activation, got: {result:?}"
+        );
+
+        // A spec where Gloas never activates rejects at every slot.
+        validation_context.spec = spec_with_gloas(None);
+        let result = validate_role_for_fork(post_gloas_slot, &validation_context);
+        assert_validation_error(
+            result,
+            |failure| {
+                matches!(
+                    failure,
+                    ValidationFailure::RoleNotActiveBeforeEthFork {
+                        minimum_fork: types::ForkName::Gloas,
+                        ..
+                    }
+                )
+            },
+            "RoleNotActiveBeforeEthFork (ProposerPreferences, Gloas never activates)",
+        );
+    }
+
+    #[test]
+    fn test_proposer_preferences_accepted_at_gloas() {
+        // Arrange: at/after Gloas activation the role passes the full pipeline.
+        let committee_info = create_committee_info(FOUR_NODE_COMMITTEE);
+        let (private_key, public_key) = generate_test_key_pair();
+        let map =
+            create_operator_pub_keys(committee_info.committee_members.clone(), vec![public_key]);
+        let signed_msg = create_signed_partial_sig_message(
+            Role::ProposerPreferences,
+            PartialSignatureKind::ProposerPreferences,
+            OperatorId(1),
+            &private_key,
+        );
+
+        // The signed packet's envelope slot is 1; send from slot 1 so timing is on-time.
+        let validation_context =
+            create_proposer_preferences_context(&signed_msg, &committee_info, &map, Slot::new(1));
+
+        // Act
+        let result = validate_partial_signature_message(
+            validation_context,
+            &mut DutyState::new(64),
+            Arc::new(MockDutiesProvider {
+                voluntary_exit_duty_count: 0,
+            }),
+        );
+
+        // Assert
+        assert!(result.is_ok(), "Expected ok but got: {result:?}");
+    }
+
+    #[test]
+    fn test_proposer_preferences_invalid_partial_sig_kind_rejected() {
+        // Arrange: a packet declaring Role::ProposerPreferences but carrying a
+        // non-ProposerPreferences kind must be rejected by the role/kind binding.
+        let committee_info = create_committee_info(FOUR_NODE_COMMITTEE);
+        let (private_key, public_key) = generate_test_key_pair();
+        let map =
+            create_operator_pub_keys(committee_info.committee_members.clone(), vec![public_key]);
+        let signed_msg = create_signed_partial_sig_message(
+            Role::ProposerPreferences,
+            PartialSignatureKind::PostConsensus, // Invalid for ProposerPreferences
+            OperatorId(1),
+            &private_key,
+        );
+
+        let validation_context =
+            create_proposer_preferences_context(&signed_msg, &committee_info, &map, Slot::new(1));
+
+        // Act
+        let result = validate_partial_signature_message(
+            validation_context,
+            &mut DutyState::new(64),
+            Arc::new(MockDutiesProvider {
+                voluntary_exit_duty_count: 0,
+            }),
+        );
+
+        // Assert
+        assert_validation_error(
+            result,
+            |failure| matches!(failure, ValidationFailure::PartialSignatureTypeRoleMismatch),
+            "PartialSignatureTypeRoleMismatch (ProposerPreferences kind mismatch)",
+        );
+    }
+
+    #[test]
+    fn test_proposer_preferences_within_ttl_accepted() {
+        // Arrange: ProposerPreferences sits in the LONG (committee-style) TTL bucket
+        // of slots_per_epoch + LATE_SLOT_ALLOWANCE = 34 slots, unlike PTCAttester's
+        // short 3-slot window. A message exactly TTL_SLOTS late is still inside it.
+        let committee_info = create_committee_info(FOUR_NODE_COMMITTEE);
+        let (private_key, public_key) = generate_test_key_pair();
+        let map =
+            create_operator_pub_keys(committee_info.committee_members.clone(), vec![public_key]);
+        let signed_msg = create_signed_partial_sig_message(
+            Role::ProposerPreferences,
+            PartialSignatureKind::ProposerPreferences,
+            OperatorId(1),
+            &private_key,
+        );
+
+        let mut validation_context = create_ttl_validation_context(
+            &signed_msg,
+            &committee_info,
+            Role::ProposerPreferences,
+            &map,
+            TTL_SLOTS,
+            generate_fork_schedule(Fork::Boole),
+        );
+        // ProposerPreferences only exists post-Gloas; the role gate reads the Ethereum fork.
+        validation_context.spec = spec_with_gloas(Some(0));
+
+        // Act
+        let result = validate_partial_signature_message(
+            validation_context,
+            &mut DutyState::new(64),
+            Arc::new(MockDutiesProvider {
+                voluntary_exit_duty_count: 0,
+            }),
+        );
+
+        // Assert
+        assert!(result.is_ok(), "Expected ok but got: {result:?}");
+    }
+
+    #[test]
+    fn test_proposer_preferences_beyond_ttl_rejected() {
+        // Arrange: a message BEYOND_TTL_SLOTS (40) late is past the long 34-slot
+        // window, so it is rejected as late. This pins ProposerPreferences to the
+        // long bucket rather than the short slot-bound one.
+        let committee_info = create_committee_info(FOUR_NODE_COMMITTEE);
+        let (private_key, public_key) = generate_test_key_pair();
+        let map =
+            create_operator_pub_keys(committee_info.committee_members.clone(), vec![public_key]);
+        let signed_msg = create_signed_partial_sig_message(
+            Role::ProposerPreferences,
+            PartialSignatureKind::ProposerPreferences,
+            OperatorId(1),
+            &private_key,
+        );
+
+        let mut validation_context = create_ttl_validation_context(
+            &signed_msg,
+            &committee_info,
+            Role::ProposerPreferences,
+            &map,
+            BEYOND_TTL_SLOTS,
+            generate_fork_schedule(Fork::Boole),
+        );
+        validation_context.spec = spec_with_gloas(Some(0));
+
+        // Act
+        let result = validate_partial_signature_message(
+            validation_context,
+            &mut DutyState::new(64),
+            Arc::new(MockDutiesProvider {
+                voluntary_exit_duty_count: 0,
+            }),
+        );
+
+        // Assert
+        assert_validation_error(
+            result,
+            |failure| matches!(failure, ValidationFailure::LateSlotMessage { .. }),
+            "LateSlotMessage (ProposerPreferences past long TTL)",
+        );
+    }
+
+    #[test]
+    fn test_proposer_preferences_message_count_at_most_one() {
+        // Arrange: ProposerPreferences is per-validator; a packet with two
+        // PartialSignatureMessages trips the `> 1` per-packet bound.
+        let committee_info = create_committee_info(FOUR_NODE_COMMITTEE);
+        let (private_key, public_key) = generate_test_key_pair();
+        let map =
+            create_operator_pub_keys(committee_info.committee_members.clone(), vec![public_key]);
+
+        let messages: Vec<_> = (0..2)
+            .map(|_| PartialSignatureMessage {
+                partial_signature: Signature::empty(),
+                signing_root: Hash256::from([0u8; 32]),
+                signer: OperatorId(1),
+                validator_index: ValidatorIndex(0),
+            })
+            .collect();
+
+        let partial_sig_messages = PartialSignatureMessages {
+            kind: PartialSignatureKind::ProposerPreferences,
+            slot: Slot::new(1),
+            messages: VariableList::new(messages).unwrap(),
+        };
+
+        let msg_id = create_message_id_for_test(Role::ProposerPreferences);
+        let ssv_msg = SSVMessage::new(
+            MsgType::SSVPartialSignatureMsgType,
+            msg_id,
+            partial_sig_messages.as_ssz_bytes(),
+        )
+        .unwrap();
+
+        let p_key = PKey::from_rsa(private_key).unwrap();
+        let mut signer = Signer::new(MessageDigest::sha256(), &p_key).unwrap();
+        signer.update(&ssv_msg.as_ssz_bytes()).unwrap();
+        let signature = signer.sign_to_vec().unwrap().try_into().unwrap();
+
+        let signed_msg =
+            SignedSSVMessage::new(vec![signature], vec![OperatorId(1)], ssv_msg, vec![]).unwrap();
+
+        let validation_context =
+            create_proposer_preferences_context(&signed_msg, &committee_info, &map, Slot::new(1));
+
+        // Act
+        let result = validate_partial_signature_message(
+            validation_context,
+            &mut DutyState::new(64),
+            Arc::new(MockDutiesProvider {
+                voluntary_exit_duty_count: 0,
+            }),
+        );
+
+        // Assert
+        assert_validation_error(
+            result,
+            |failure| {
+                matches!(
+                    failure,
+                    ValidationFailure::TooManyPartialSignatureMessages { limit: 1, .. }
+                )
+            },
+            "TooManyPartialSignatureMessages (ProposerPreferences cap 1 per packet)",
+        );
+    }
+
+    #[test]
+    fn test_proposer_preferences_future_proposal_slot_in_body_not_early() {
+        // A ProposerPreferences body describes a FUTURE proposal_slot, but that
+        // field is not on the wire: only the envelope (send) slot is. As long as
+        // the envelope slot equals the current send slot, validate_slot_time must
+        // accept it (no EarlySlotMessage), even though the intended proposal is
+        // for a later slot.
+        let committee_info = create_committee_info(FOUR_NODE_COMMITTEE);
+        let (private_key, public_key) = generate_test_key_pair();
+        let map =
+            create_operator_pub_keys(committee_info.committee_members.clone(), vec![public_key]);
+
+        // Envelope slot is the current send slot (100); a real body would carry a
+        // far-future proposal_slot, but that never reaches the validator.
+        let send_slot = Slot::new(100);
+        let signed_msg = create_signed_proposer_preferences_message(
+            OperatorId(1),
+            &private_key,
+            send_slot,
+            Hash256::from([1u8; 32]),
+        );
+
+        let validation_context =
+            create_proposer_preferences_context(&signed_msg, &committee_info, &map, send_slot);
+
+        // Act
+        let result = validate_partial_signature_message(
+            validation_context,
+            &mut DutyState::new(256),
+            Arc::new(MockDutiesProvider {
+                voluntary_exit_duty_count: 0,
+            }),
+        );
+
+        // Assert: accepted; specifically NOT rejected as early.
+        assert!(
+            result.is_ok(),
+            "Expected on-time ProposerPreferences (envelope==send slot) to be accepted, got: {result:?}"
+        );
+    }
+
+    #[test]
+    fn test_proposer_preferences_distinct_roots_same_send_slot_accepted() {
+        // A proposer legitimately signs multiple distinct preference roots at one
+        // send slot (current + next-epoch lookahead batch). Two packets from the
+        // same (validator, operator, envelope slot) with DIFFERENT signing roots
+        // must BOTH be accepted through a shared DutyState.
+        let committee_info = create_committee_info(FOUR_NODE_COMMITTEE);
+        let (private_key, public_key) = generate_test_key_pair();
+        let map =
+            create_operator_pub_keys(committee_info.committee_members.clone(), vec![public_key]);
+        let signer_id = OperatorId(1);
+        let send_slot = Slot::new(1);
+        let mut duty_state = DutyState::new(64);
+
+        // First packet: root A.
+        let signed_a = create_signed_proposer_preferences_message(
+            signer_id,
+            &private_key,
+            send_slot,
+            Hash256::from([0xAA; 32]),
+        );
+        let context_a =
+            create_proposer_preferences_context(&signed_a, &committee_info, &map, send_slot);
+        let result_a = validate_partial_signature_message(
+            context_a,
+            &mut duty_state,
+            Arc::new(MockDutiesProvider {
+                voluntary_exit_duty_count: 0,
+            }),
+        );
+        assert!(
+            result_a.is_ok(),
+            "Expected first distinct-root packet to be accepted, got: {result_a:?}"
+        );
+
+        // Second packet: DIFFERENT root B at the SAME send slot.
+        let signed_b = create_signed_proposer_preferences_message(
+            signer_id,
+            &private_key,
+            send_slot,
+            Hash256::from([0xBB; 32]),
+        );
+        let context_b =
+            create_proposer_preferences_context(&signed_b, &committee_info, &map, send_slot);
+        let result_b = validate_partial_signature_message(
+            context_b,
+            &mut duty_state,
+            Arc::new(MockDutiesProvider {
+                voluntary_exit_duty_count: 0,
+            }),
+        );
+
+        // Assert: the second distinct root is also accepted (NOT falsely rejected
+        // as a pre-consensus duplicate).
+        assert!(
+            result_b.is_ok(),
+            "Expected second distinct-root packet at same send slot to be accepted, got: {result_b:?}"
+        );
+    }
+
+    #[test]
+    fn test_proposer_preferences_duplicate_root_same_slot_rejected() {
+        // An exact-duplicate signing_root at the same send slot is a resend and
+        // must be rejected as a duplicate, via the per-slot seen_preferences set.
+        let committee_info = create_committee_info(FOUR_NODE_COMMITTEE);
+        let (private_key, public_key) = generate_test_key_pair();
+        let map =
+            create_operator_pub_keys(committee_info.committee_members.clone(), vec![public_key]);
+        let signer_id = OperatorId(1);
+        let send_slot = Slot::new(1);
+        let root = Hash256::from([0xCC; 32]);
+        let mut duty_state = DutyState::new(64);
+
+        // First packet with root R is accepted.
+        let signed_first =
+            create_signed_proposer_preferences_message(signer_id, &private_key, send_slot, root);
+        let context_first =
+            create_proposer_preferences_context(&signed_first, &committee_info, &map, send_slot);
+        let result_first = validate_partial_signature_message(
+            context_first,
+            &mut duty_state,
+            Arc::new(MockDutiesProvider {
+                voluntary_exit_duty_count: 0,
+            }),
+        );
+        assert!(
+            result_first.is_ok(),
+            "Expected first packet to be accepted, got: {result_first:?}"
+        );
+
+        // Second packet: EXACT-DUPLICATE root R at the SAME send slot.
+        let signed_dup =
+            create_signed_proposer_preferences_message(signer_id, &private_key, send_slot, root);
+        let context_dup =
+            create_proposer_preferences_context(&signed_dup, &committee_info, &map, send_slot);
+        let result_dup = validate_partial_signature_message(
+            context_dup,
+            &mut duty_state,
+            Arc::new(MockDutiesProvider {
+                voluntary_exit_duty_count: 0,
+            }),
+        );
+
+        // Assert
+        assert_validation_error(
+            result_dup,
+            |failure| matches!(failure, ValidationFailure::DuplicatedMessage { .. }),
+            "DuplicatedMessage (ProposerPreferences exact-duplicate root)",
+        );
+    }
+
+    #[test]
+    fn test_proposer_preferences_root_cap_enforced() {
+        // The distinct-root set for one (validator, operator, send slot) is capped
+        // at 2 * slots_per_epoch. Feeding exactly that many distinct roots all pass;
+        // one more distinct root is rejected as an invalid type count.
+        let committee_info = create_committee_info(FOUR_NODE_COMMITTEE);
+        let (private_key, public_key) = generate_test_key_pair();
+        let map =
+            create_operator_pub_keys(committee_info.committee_members.clone(), vec![public_key]);
+        let signer_id = OperatorId(1);
+        let send_slot = Slot::new(1);
+        let mut duty_state = DutyState::new(64);
+
+        // Use the harness slots_per_epoch so the loop stays small (2 * 32 = 64).
+        let cap = 2 * SLOTS_PER_EPOCH_TEST;
+
+        // Feed `cap` distinct roots; all must be accepted.
+        for i in 0..cap {
+            let mut root_bytes = [0u8; 32];
+            root_bytes[0..8].copy_from_slice(&i.to_le_bytes());
+            let signed = create_signed_proposer_preferences_message(
+                signer_id,
+                &private_key,
+                send_slot,
+                Hash256::from(root_bytes),
+            );
+            let context =
+                create_proposer_preferences_context(&signed, &committee_info, &map, send_slot);
+            let result = validate_partial_signature_message(
+                context,
+                &mut duty_state,
+                Arc::new(MockDutiesProvider {
+                    voluntary_exit_duty_count: 0,
+                }),
+            );
+            assert!(
+                result.is_ok(),
+                "Expected distinct root #{i} (within cap {cap}) to be accepted, got: {result:?}"
+            );
+        }
+
+        // One more distinct root exceeds the cap and is rejected.
+        let mut over_cap_bytes = [0u8; 32];
+        over_cap_bytes[0..8].copy_from_slice(&cap.to_le_bytes());
+        let signed_over = create_signed_proposer_preferences_message(
+            signer_id,
+            &private_key,
+            send_slot,
+            Hash256::from(over_cap_bytes),
+        );
+        let context_over =
+            create_proposer_preferences_context(&signed_over, &committee_info, &map, send_slot);
+        let result_over = validate_partial_signature_message(
+            context_over,
+            &mut duty_state,
+            Arc::new(MockDutiesProvider {
+                voluntary_exit_duty_count: 0,
+            }),
+        );
+
+        // Assert
+        assert_validation_error(
+            result_over,
+            |failure| {
+                matches!(
+                    failure,
+                    ValidationFailure::InvalidPartialSignatureTypeCount { .. }
+                )
+            },
+            "InvalidPartialSignatureTypeCount (ProposerPreferences distinct-root cap)",
+        );
     }
 
     #[test]

--- a/anchor/message_validator/src/partial_signature.rs
+++ b/anchor/message_validator/src/partial_signature.rs
@@ -2663,6 +2663,41 @@ mod tests {
             );
         }
 
+        // While the set is exactly full (CAP distinct roots), a resend of the FIRST already-seen
+        // root must be a Reject-class `DuplicatedMessage` — identity takes precedence over the cap,
+        // NOT the Ignore-class `TooManyDistinctSigningRoots`.
+        let mut first_root_bytes = [0u8; 32];
+        first_root_bytes[0..8].copy_from_slice(&0u64.to_le_bytes());
+        let signed_dup = create_signed_proposer_preferences_message(
+            signer_id,
+            &private_key,
+            proposal_slot,
+            Hash256::from(first_root_bytes),
+        );
+        let context_dup =
+            create_proposer_preferences_context(&signed_dup, &committee_info, &map, proposal_slot);
+        let result_dup = validate_partial_signature_message(
+            context_dup,
+            &mut duty_state,
+            Arc::new(MockDutiesProvider::default()),
+        );
+        assert_validation_error(
+            result_dup,
+            |failure| matches!(failure, ValidationFailure::DuplicatedMessage { .. }),
+            "DuplicatedMessage (already-seen root takes precedence over cap)",
+        );
+        // Pin the Reject mapping so a future reclassification is caught here. `MessageAcceptance`
+        // has no `PartialEq`, so match on the variant.
+        assert!(
+            matches!(
+                MessageAcceptance::from(&ValidationFailure::DuplicatedMessage {
+                    got: String::new()
+                }),
+                MessageAcceptance::Reject
+            ),
+            "DuplicatedMessage must map to Reject"
+        );
+
         // One more distinct root exceeds the cap and is rejected as an Ignore.
         let mut over_cap_bytes = [0u8; 32];
         over_cap_bytes[0..8].copy_from_slice(&(CAP as u64).to_le_bytes());
@@ -2948,10 +2983,19 @@ mod tests {
             create_operator_pub_keys(committee_info.committee_members.clone(), vec![public_key]);
         let signer_id = OperatorId(1);
 
-        // Production ProposerPreferences ring size:
-        // (1 + min_seed_lookahead) * spe + spe * 2, with min_seed_lookahead = 1.
-        let ring = ((1 + 1) * SLOTS_PER_EPOCH_TEST + 2 * SLOTS_PER_EPOCH_TEST) as usize;
+        // Exercise the production ring-size selector so this test fails if the role-8 arm ever
+        // loses its lookahead-sized ring. `spec_with_gloas(None)` is mainnet-based
+        // (`min_seed_lookahead` = 1), so the selected ring is (1 + 1) * spe + 2 * spe = 128.
+        let spec = spec_with_gloas(None);
+        let ring = crate::stored_slot_count(Role::ProposerPreferences, SLOTS_PER_EPOCH_TEST, &spec);
         let mut duty_state = DutyState::new(ring);
+
+        // Guard: a representative non-role-8 role keeps the plain two-epoch default, confirming the
+        // lookahead expansion is specific to `ProposerPreferences`.
+        assert_eq!(
+            crate::stored_slot_count(Role::Proposer, SLOTS_PER_EPOCH_TEST, &spec),
+            (2 * SLOTS_PER_EPOCH_TEST) as usize,
+        );
 
         let slot_s = Slot::new(1);
         let far_slot = slot_s + Slot::new(2 * SLOTS_PER_EPOCH_TEST); // earliness bound

--- a/anchor/operator_doppelganger/Cargo.toml
+++ b/anchor/operator_doppelganger/Cargo.toml
@@ -12,5 +12,6 @@ tracing = { workspace = true }
 types = { workspace = true }
 
 [dev-dependencies]
+bls = { workspace = true }
 tokio = { workspace = true, features = ["test-util"] }
 types = { workspace = true }

--- a/anchor/operator_doppelganger/src/service.rs
+++ b/anchor/operator_doppelganger/src/service.rs
@@ -5,7 +5,7 @@ use std::{
 
 use database::OwnOperatorId;
 use message_validator::ValidatedSSVMessage;
-use ssv_types::{Slot, message::SignedSSVMessage};
+use ssv_types::{Slot, message::SignedSSVMessage, msgid::Role};
 use tokio::sync::watch;
 use tracing::{error, info};
 
@@ -145,6 +145,16 @@ impl OperatorDoppelgangerService {
             return false;
         }
 
+        // Role-aware freshness exemption: a `ProposerPreferences` envelope slot is the duty's
+        // FUTURE `proposal_slot`, not the message's emission time, so `msg_slot > startup_slot` is
+        // not evidence of a live twin. Replaying a valid packet signed by a prior process (for a
+        // proposal_slot still ahead of this instance's startup) would otherwise false-positive and
+        // abort a legitimate replacement. The wire carries no authenticated emission time, so
+        // slot-based freshness cannot distinguish an old packet from a twin here; exclude the role.
+        if signed_message.ssv_message().msg_id().role() == Some(Role::ProposerPreferences) {
+            return false;
+        }
+
         // Extract slot from validated message (no decoding needed)
         let msg_slot = extract_message_slot(validated_message);
 
@@ -239,13 +249,15 @@ impl OperatorDoppelgangerService {
 mod tests {
     use std::time::Duration;
 
+    use bls::{PublicKeyBytes, Signature};
     use database::OwnOperatorId;
     use ssv_types::{
-        CommitteeId, OperatorId, RSA_SIGNATURE_SIZE, VariableList,
+        CommitteeId, OperatorId, RSA_SIGNATURE_SIZE, ValidatorIndex, VariableList,
         consensus::{QbftMessage, QbftMessageType},
         domain_type::DomainType,
         message::{MsgType, SSVMessage, SignedSSVMessage},
         msgid::{DutyExecutor, MessageId, Role},
+        partial_sig::{PartialSignatureKind, PartialSignatureMessage, PartialSignatureMessages},
     };
     use types::Hash256;
 
@@ -326,6 +338,66 @@ mod tests {
         (signed_message, validated_message)
     }
 
+    /// Helper to build a single-signer validator-scoped `PartialSignatureMessages` for
+    /// doppelgänger detection.
+    ///
+    /// The `MessageId` is validator-scoped (`DutyExecutor::Validator`) so
+    /// `signed_message.ssv_message().msg_id().role()` reads `role`, which drives the role-aware
+    /// freshness exemption in `is_doppelganger`. The envelope `slot` populates
+    /// `PartialSignatureMessages::slot`, the value `extract_message_slot` reads.
+    ///
+    /// # Arguments
+    /// * `role` - The role encoded into the `MessageId`
+    /// * `kind` - The `PartialSignatureKind` carried by the envelope
+    /// * `signer` - The single signing `OperatorId`
+    /// * `slot` - The envelope slot (a `proposal_slot` for `ProposerPreferences`)
+    fn create_partial_sig_message(
+        role: Role,
+        kind: PartialSignatureKind,
+        signer: OperatorId,
+        slot: Slot,
+    ) -> (SignedSSVMessage, ValidatedSSVMessage) {
+        // Validator-scoped MessageId so `msg_id().role()` returns `role`.
+        let message_id = MessageId::new(
+            &DomainType([0; 4]),
+            role,
+            &DutyExecutor::Validator(PublicKeyBytes::empty()),
+        );
+
+        let partial_sig_messages = PartialSignatureMessages {
+            kind,
+            slot,
+            messages: VariableList::new(vec![PartialSignatureMessage {
+                partial_signature: Signature::empty(),
+                signing_root: Hash256::from([0u8; 32]),
+                signer,
+                validator_index: ValidatorIndex(0),
+            }])
+            .unwrap(),
+        };
+
+        // Payload bytes are irrelevant to detection: `is_doppelganger` reads the pre-decoded
+        // `ValidatedSSVMessage`, so a minimal placeholder mirrors `create_test_message`.
+        let ssv_message = SSVMessage::new(
+            MsgType::SSVPartialSignatureMsgType,
+            message_id,
+            vec![0u8; 100],
+        )
+        .expect("should create SSVMessage");
+
+        let signed_message = SignedSSVMessage::new(
+            vec![[0u8; RSA_SIGNATURE_SIZE]],
+            vec![signer],
+            ssv_message,
+            vec![],
+        )
+        .expect("should create SignedSSVMessage");
+
+        let validated_message = ValidatedSSVMessage::PartialSignatureMessages(partial_sig_messages);
+
+        (signed_message, validated_message)
+    }
+
     #[test]
     fn test_service_creation() {
         let service = create_service_with_slot(Slot::new(100));
@@ -373,6 +445,62 @@ mod tests {
         // This should detect a twin (message slot > startup_slot)
         let result = service.is_doppelganger(&signed_message, &validated_message);
         assert!(result, "Message for slot after startup should detect twin");
+    }
+
+    #[test]
+    fn test_no_twin_proposer_preferences_future_proposal_slot() {
+        // A `ProposerPreferences` envelope slot is the duty's FUTURE `proposal_slot`, not the
+        // message's emission time. A valid packet signed by a PRIOR process (for a `proposal_slot`
+        // still ahead of this instance's `startup_slot`) can be replayed on the wire; without the
+        // role-aware exemption its `slot > startup_slot` would false-positive as a live twin and
+        // abort a legitimate replacement.
+
+        // Arrange: startup_slot = 100; a single-signer role-8 packet from our own `OperatorId(1)`
+        // whose envelope slot 120 is a future proposal_slot (> startup).
+        let service = create_service_with_slot(Slot::new(100));
+        let (signed_message, validated_message) = create_partial_sig_message(
+            Role::ProposerPreferences,
+            PartialSignatureKind::ProposerPreferences,
+            OperatorId(1),
+            Slot::new(120),
+        );
+
+        // Act
+        let result = service.is_doppelganger(&signed_message, &validated_message);
+
+        // Assert: the future proposal_slot must NOT be treated as twin evidence.
+        assert!(
+            !result,
+            "ProposerPreferences future proposal_slot should NOT detect twin (replayed prior-process packet)"
+        );
+    }
+
+    #[test]
+    fn test_twin_detected_non_exempt_partial_sig_future_slot() {
+        // Contrast to `test_no_twin_proposer_preferences_future_proposal_slot`: the freshness
+        // exemption is specific to `Role::ProposerPreferences`, NOT a blanket skip of all
+        // validator-scoped partial-signature messages. `Role::PTCAttester` is a non-exempt
+        // partial-sig role whose envelope slot IS the emission slot, so a future-slot packet
+        // signed with our own operator ID still indicates a live twin.
+
+        // Arrange: startup_slot = 100; a single-signer `PTCAttester` packet from our own
+        // `OperatorId(1)` whose envelope slot 101 is after startup.
+        let service = create_service_with_slot(Slot::new(100));
+        let (signed_message, validated_message) = create_partial_sig_message(
+            Role::PTCAttester,
+            PartialSignatureKind::PTCAttester,
+            OperatorId(1),
+            Slot::new(101),
+        );
+
+        // Act
+        let result = service.is_doppelganger(&signed_message, &validated_message);
+
+        // Assert: a non-exempt role for slot > startup_slot detects a twin.
+        assert!(
+            result,
+            "Non-exempt PTCAttester message for slot after startup should detect twin"
+        );
     }
 
     #[test]

--- a/anchor/qbft_manager/src/lib.rs
+++ b/anchor/qbft_manager/src/lib.rs
@@ -283,7 +283,7 @@ impl<E: EthSpec, S: SlotClock + Clone + 'static> QbftManager<E, S> {
                     Some(Role::Committee | Role::AggregatorCommittee)
                     // These roles don't use QBFT consensus
                     | Some(
-                        Role::ValidatorRegistration | Role::VoluntaryExit | Role::PTCAttester,
+                        Role::ValidatorRegistration | Role::VoluntaryExit | Role::PTCAttester | Role::ProposerPreferences,
                     )
                     | None => {
                         error!(?msg_id, "Unexpected role/executor combination in msg id");
@@ -352,7 +352,7 @@ impl<E: EthSpec, S: SlotClock + Clone + 'static> QbftManager<E, S> {
                     Some(Role::Aggregator | Role::Proposer | Role::SyncCommittee)
                     // These roles don't use QBFT consensus
                     | Some(
-                        Role::ValidatorRegistration | Role::VoluntaryExit | Role::PTCAttester,
+                        Role::ValidatorRegistration | Role::VoluntaryExit | Role::PTCAttester | Role::ProposerPreferences,
                     )
                     | None => Err(QbftError::InconsistentMessageId),
                 }


### PR DESCRIPTION
Closes #1062 (ePBS Proposer Preferences duty milestone, SIP-94 §5).

Wire surface + inbound message validation for the new ProposerPreferences duty:

- `Role::ProposerPreferences` (wire byte `[8,0,0,0]`) and `PartialSignatureKind::ProposerPreferences = 8`; validator-scoped, non-QBFT.
- message-validator: Gloas fork-gate, TTL, duty limit, partial-sig kind binding, per-packet bound, and a per-slot signing-root dedup (accepts a validator's multiple lookahead preference roots, rejects exact-duplicate resends and anti-spam overflow).
- `qbft_manager` non-QBFT arms.

Sign path and service wiring land in follow-up milestone issues.