### PR TITLE
chore: bump crossbeam-epoch for RUSTSEC-2026-0204

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2073,9 +2073,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
## Problem, Evidence, and Context (Required)

- RUSTSEC-2026-0204 (published 2026-07-06) flags `crossbeam-epoch` 0.9.18: invalid pointer dereference in the `fmt::Pointer` impl for `Atomic` and `Shared` when the underlying pointer is invalid.
- `cargo audit` in the check-code job now fails on every PR (e.g. https://github.com/sigp/anchor/actions/runs/28830197559/job/85502192879), blocking CI repo-wide.
- Advisory: https://rustsec.org/advisories/RUSTSEC-2026-0204

## Change Overview (Required)

- Lockfile-only bump of `crossbeam-epoch` 0.9.18 -> 0.9.20 (the advisory's stated solution is >=0.9.20). It is a transitive dependency; no manifest changes.
- Nothing else changed; the remaining audit output is the same 8 allowed warnings as before.

## Risks, Trade-offs, and Mitigations (Required)

- Minimal: semver-compatible patch bump of a single transitive crate.

## Validation (Required)

- `cargo audit --ignore RUSTSEC-2026-0118 --ignore RUSTSEC-2026-0119` (same invocation as `make audit-CI`) passes locally after the bump: 0 vulnerabilities, 8 allowed warnings.

## Rollback (Required for behavior or runtime changes; optional otherwise)

- Revert the lockfile change (reintroduces the audit failure).