### PR TITLE
chore: satisfy Rust 1.97 useless_borrows_in_formatting lint

### DIFF
--- a/anchor/eth/src/sync.rs
+++ b/anchor/eth/src/sync.rs
@@ -161,10 +161,7 @@ impl SsvEventSyncer {
             .connect_ws(ws)
             .await
             .map_err(|e| {
-                ExecutionError::SyncError(format!(
-                    "Failed to bind to WS: {}, {}",
-                    &config.ws_url, e
-                ))
+                ExecutionError::SyncError(format!("Failed to bind to WS: {}, {}", config.ws_url, e))
             })?;
         debug!("Created ws client");
 

--- a/anchor/logging/src/format.rs
+++ b/anchor/logging/src/format.rs
@@ -201,7 +201,7 @@ where
                     let dimmed = Style::new().dimmed();
                     write!(writer, " {}", dimmed.paint(&fields.fields))?;
                 } else {
-                    write!(writer, " {}", &fields.fields)?;
+                    write!(writer, " {}", fields.fields)?;
                 }
             }
         }


### PR DESCRIPTION
## Problem, Evidence, and Context

- CI's `check-code` job runs `make lint` against the latest stable Rust, which is now **1.97** (released 2026-07-07). Rust 1.97 tightened `clippy::useless_borrows_in_formatting`, which now fires on two pre-existing redundant references passed to `write!`/`format!` macros.
- Because the offending lines live on `unstable`, `check-code` is currently red on **every** open PR (e.g. #1105), not any single feature branch.
- Evidence: `cargo clippy --workspace --tests` under 1.97 fails with `redundant reference in write!/format! argument` at `logging/src/format.rs:204` and `eth/src/sync.rs:166`.

## Change Overview

- Drop the redundant `&` in two format-macro arguments:
  - `logging/src/format.rs` span-fields formatter
  - `eth/src/sync.rs` WS-bind error message
- No behavior change; purely satisfies the stricter lint. Nothing else was touched (Cargo.lock unchanged).

## Risks, Trade-offs, and Mitigations

- None of note. `Display` output is identical whether the value is borrowed or not; the `&` was always redundant.

## Validation

- `make lint` (clippy under Rust 1.97) passes clean across the full workspace after the change.
- `cargo fmt --check` passes.

## Rollback

- Revert the commit; no config, data, or runtime impact.
