### PR TITLE
ci: raise Claude review turn budget and bump to Opus 4.8

### DIFF
--- a/.github/prompts/review.md
+++ b/.github/prompts/review.md
@@ -20,5 +20,7 @@ Do NOT comment on:
 
 When you DO find issues:
 - Use inline comments with concrete fix suggestions
+- Post each inline comment as soon as the issue is confirmed; do not save
+  them all up for the end of the review
 - Post a brief summary comment ONLY listing the issues found
 - No preamble, no praise, no filler

--- a/.github/workflows/claude-mentions.yml
+++ b/.github/workflows/claude-mentions.yml
@@ -83,14 +83,14 @@ jobs:
 
             - name: Run Claude Code Action
               if: steps.check.outputs.is_member == 'true'
-              timeout-minutes: 15
+              timeout-minutes: 25
               uses: anthropics/claude-code-action@v1.0.127
               with:
                   github_token: ${{ steps.app-token.outputs.token }}
                   use_bedrock: "true"
                   claude_args: |
-                      --max-turns 50
-                      --model us.anthropic.claude-opus-4-7
+                      --max-turns 80
+                      --model us.anthropic.claude-opus-4-8
                       --allowedTools "Glob,Grep,LS,Read,mcp__github_comment__update_claude_comment,mcp__github_inline_comment__create_inline_comment,mcp__github_ci__get_ci_status,mcp__github_ci__get_workflow_run_details,mcp__github_ci__download_job_log,Bash(git status:*),Bash(git diff:*),Bash(git show:*),Bash(git log:*),Bash(git rev-parse:*),Bash(git merge-base:*),Bash(git grep:*)"
                       --disallowedTools "Edit,MultiEdit,Write,NotebookEdit,Bash(git add:*),Bash(git commit:*),Bash(git rm:*)"
                       --append-system-prompt "${{ steps.review-prompt.outputs.content }}"

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -102,9 +102,20 @@ jobs:
                     echo "PROMPT_EOF"
                   } >> "$GITHUB_OUTPUT"
 
+            # Save the diff to a file the agent can page through with Read.
+            # Reading it via `gh pr diff` wastes agent turns: large diffs
+            # overflow the tool-output limit and the tight tool allowlist
+            # blocks saving the output to a file.
+            - name: Save PR diff
+              if: steps.check.outputs.is_member == 'true'
+              run: |
+                  gh pr diff ${{ github.event.pull_request.number }} --repo ${{ github.repository }} > "${GITHUB_WORKSPACE}/.claude-pr-diff.txt"
+              env:
+                  GH_TOKEN: ${{ github.token }}
+
             - name: Run Claude Code Action
               if: steps.check.outputs.is_member == 'true'
-              timeout-minutes: 15
+              timeout-minutes: 25
               env:
                   ACTIONS_STEP_DEBUG: true
               uses: anthropics/claude-code-action@v1.0.127
@@ -114,6 +125,10 @@ jobs:
                   prompt: |
                       REPO: ${{ github.repository }}
                       PR NUMBER: ${{ github.event.pull_request.number }}
+
+                      The full unified diff of this PR is saved at .claude-pr-diff.txt in
+                      the repository root. Read it with the Read tool (use offset/limit to
+                      page through large diffs) instead of running `gh pr diff`.
 
                       You are an automated silent watchdog reviewer. Your job is to catch
                       real problems — NOT to provide a comprehensive review or commentary.
@@ -125,8 +140,8 @@ jobs:
 
                       ${{ steps.review-prompt.outputs.content }}
                   claude_args: |
-                      --max-turns 50
-                      --model us.anthropic.claude-opus-4-7
+                      --max-turns 80
+                      --model us.anthropic.claude-opus-4-8
                       --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Read,Grep,Bash(git status:*),Bash(git diff:*),Bash(git show:*),Bash(git log:*),Bash(git rev-parse:*),Bash(git merge-base:*),Bash(git grep:*)"
 
             - name: Remove claude-recheck label if present


### PR DESCRIPTION
## Problem, Evidence, and Context

Both Claude review workflows failed on PR #1128 with `Reached maximum number of turns (50)`, losing all review work roughly 13 minutes in and posting nothing:

- `claude-pr-review`: [run 29113701689](https://github.com/sigp/anchor/actions/runs/29113701689) - ~15 of 50 turns were wasted fighting the diff: `gh pr diff` output (~84KB) overflowed the tool-output limit, every attempt to save it to a file was blocked by the tool allowlist (no `Write`), and the agent fell back to re-paging the diff one `sed` slice per turn.
- `claude-mentions`: [run 29115026820](https://github.com/sigp/anchor/actions/runs/29115026820) - only 5 permission denials, so minimal friction, and it still exhausted 50 turns mid-review. The budget itself is too small for a ~1,400-line PR at Opus pace (~15s/turn, one tool call per turn).

Each failed attempt costs ~$3.30 in Bedrock spend with zero output.

## Change Overview

- Raise `--max-turns` 50 -> 80 and `timeout-minutes` 15 -> 25 in both workflows. These are the same limit at Opus pace (50 turns ~= 13.5 min), so they must move together.
- `claude-pr-review` only: pre-stage the PR diff into `.claude-pr-diff.txt` in a workflow step and point the prompt at it, so the agent reads it with the paginated `Read` tool instead of burning turns on `gh pr diff`. The file lives only on the ephemeral runner; nothing commits or uploads it.
- `review.md`: instruct the agent to post each inline comment as soon as it is confirmed, so a capped run still delivers partial findings instead of losing everything.
- Bump the model to `us.anthropic.claude-opus-4-8` in both workflows: same Bedrock pricing ($5/$25 per MTok), no API changes from 4.7, stronger at code review.

Intentionally unchanged: the tool allowlists and the silent-watchdog prompt semantics.

## Risks, Trade-offs, and Mitigations

- Worst-case cost/latency per review rises (80 turns / 25 min ceiling). Typical runs finish well under the old cap, so expected cost is nearly flat; only pathological runs use the headroom.
- Opus 4.8 follows conservative-reporting instructions more literally than 4.7, so borderline findings may drop slightly. That matches the silent-watchdog intent.
- Requires Opus 4.8 model access in the AWS account (us-west-2). If missing, the run fails fast with an access error rather than burning the turn budget.

## Validation

- Both workflow files parse as valid YAML.
- Failure analysis is from the run logs of the two failed jobs (turn counts, permission denials, and per-turn pacing).
- The end-to-end check requires this to land on `stable` first (`pull_request_target`/`issue_comment` run workflow files from the default branch); after merge, applying the `claude-recheck` label to PR #1128 re-runs the review and doubles as verification of Bedrock Opus 4.8 access.

## Rollback

Revert the commit. No config, data, or operational impact beyond the workflows themselves.

## Additional Info / Next Steps

After merge: apply `claude-recheck` to PR #1128 to confirm the review completes within budget.
