### PR TITLE
fix(message_validator): treat duty-limit breach as ignore, not reject

### DIFF
--- a/anchor/message_validator/src/lib.rs
+++ b/anchor/message_validator/src/lib.rs
@@ -118,7 +118,6 @@ pub enum ValidationFailure {
     NonExistentCommitteeID,
     RoundTooHigh,
     ValidatorIndexMismatch,
-    TooManyDutiesPerEpoch,
     NoDuty,
     EstimatedRoundNotInAllowedSpread {
         got: String,
@@ -249,7 +248,7 @@ impl From<&ValidationFailure> for MessageAcceptance {
             | ValidationFailure::RoundTooHigh
             | ValidationFailure::RoundOverflow
             | ValidationFailure::ValidatorIndexMismatch
-            | ValidationFailure::TooManyDutiesPerEpoch
+            | ValidationFailure::ExcessiveDutyCount { .. }
             | ValidationFailure::NoDuty
             | ValidationFailure::EstimatedRoundNotInAllowedSpread { .. } => {
                 MessageAcceptance::Ignore
@@ -1130,11 +1129,31 @@ mod tests {
     use ssz::Encode;
     use types::{Epoch, Slot};
 
-    use crate::{ValidationFailure, hash_data};
+    use crate::{MessageAcceptance, ValidationFailure, hash_data};
 
     // Constants for committee sizes in tests to improve readability.
     pub(crate) const SINGLE_NODE_COMMITTEE: usize = 1;
     pub(crate) const FOUR_NODE_COMMITTEE: usize = 4;
+
+    /// Test that an `ExcessiveDutyCount` maps to `Ignore`.
+    /// Duty-limit breach is a rate condition. An honest relayer can forward a message that
+    /// pushes a signer over its per-epoch duty count. Not a provable protocol violation.
+    #[test]
+    fn excessive_duty_count_maps_to_ignore() {
+        // Duty-limit breach (count over the per-epoch limit for a committee duty).
+        let failure = ValidationFailure::ExcessiveDutyCount {
+            got: 5,
+            limit: 4,
+            role: Role::Committee,
+        };
+
+        // Gossip classification must be Ignore, not Reject.
+        assert_eq!(
+            MessageAcceptance::from(&failure),
+            MessageAcceptance::Ignore,
+            "duty-limit breach (ExcessiveDutyCount) must classify as Ignore, not Reject."
+        );
+    }
 
     // Helper struct for directly creating consensus messages for tests
     pub(crate) struct QbftMessageBuilder {


### PR DESCRIPTION
Closes #1118

## Problem, Evidence, and Context (Required)

When a signer sends more messages than its allowed number of duties for an epoch, the message validator rejected the message. A reject also lowers the sending peer's gossip score, which can lead to an honest peer being disconnected.

Going over the duty limit is a rate condition and not proof that a peer is misbehaving. An honest relayer can forward a message that happens to push a signer over its limit. We should quietly drop (ignore) the message instead.

Evidence:
- The Go client (`go-ssv`) treats this case as ignore. Its error carries no reject flag.
- `SIP-94` section 7 lists the duty limit as an ignore case for the new roles.
- In our code the check builds a `ValidationFailure` value that was not listed in the ignore group, so it fell through to the default, which is reject.

## Change Overview (Required)

- A duty-limit breach now classifies as **ignore** rather than **reject**.
- Removed a second unused failure value (`TooManyDutiesPerEpoch`). It was already listed as ignore but was never used anywhere. The value produced is the one now correctly marked as ignore. It also carries additional details: the count seen, the limit, and the role.

What intentionally did not change: the point where the limit is checked, the limit values themselves, and the handling of every other failure value. This is a classification-only change.

## Risks, Trade-offs, and Mitigations (Required)

- Blast radius is very small: one file, one crate, classification only.
- Trade-off: an ignored message produces no gossip penalty which is correct.
- Mitigation: the check itself is unchanged, so over-limit messages are still not accepted or acted on but instead dropped without penalising the sender.

## Validation (Required)

- New regression test asserting that a duty-limit breach maps to ignore.
- Full crate test run: `cargo test -p message_validator`: 64 passed, 0 failed
- `make cargo-fmt-check`

## Rollback (Required for behavior or runtime changes; optional otherwise)

- Revert the single commit. No config, data, or migration impact.
- The change only affects how one failure case is scored for gossip, so reverting simply restores the previous reject behaviour.

## Blockers / Dependencies (Optional)

- It is a prerequisite for the follow-up work in #1120, which relies on the duty limit mapping to ignore for the new roles.

## Additional Info / Next Steps (Optional)

- This was a pre-existing issue affecting every role that has a per-epoch duty limit, not just the new roles. Fixing it here makes the behaviour correct before the follow-up work depends on it.
