### PR TITLE
feat(qbft_manager): start SlotTime QBFT instances immediately

### DIFF
--- a/anchor/qbft_manager/src/instance.rs
+++ b/anchor/qbft_manager/src/instance.rs
@@ -116,23 +116,16 @@ impl Uninitialized {
         init: QbftInitialization<D>,
         sender: &Arc<dyn MessageSender>,
     ) -> Initialized<D> {
-        // Sleep until the start time embedded in the timeout mode
-        let start_time = match init.timeout_mode {
-            TimeoutMode::SlotTime {
-                instance_start_time,
-            } => instance_start_time,
-            TimeoutMode::Relative {
-                current_round_start_time,
-            } => current_round_start_time,
-        };
-        tokio::time::sleep_until(start_time).await;
-
-        // For Relative mode, reset to Instant::now() after the sleep
+        // `SlotTime` instances start round 1 immediately: every call site is data-gated by
+        // its caller, and `round_deadline_origin` alone keeps round-change deadlines synchronized
+        // across operators. `Relative` instances (block proposals) still wait for the
+        // scheduled round start and then restart the round timer from now for per-round cadence.
         let mut timeout_mode = init.timeout_mode;
         if let TimeoutMode::Relative {
             current_round_start_time,
         } = &mut timeout_mode
         {
+            tokio::time::sleep_until(*current_round_start_time).await;
             *current_round_start_time = Instant::now();
         }
 

--- a/anchor/qbft_manager/src/lib.rs
+++ b/anchor/qbft_manager/src/lib.rs
@@ -52,9 +52,12 @@ const QBFT_RETAIN_SLOTS: u64 = 1;
 /// Determines how round timeouts are calculated.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TimeoutMode {
-    /// Cumulative timeouts from instance start. Never resets.
+    /// Cumulative timeouts measured from a fixed slot-relative instant: round N times out at
+    /// `round_deadline_origin + cumulative_timeout(N)`. The instance starts round 1 immediately
+    /// upon initialization; the origin only governs round-change deadlines, keeping the round
+    /// cadence synchronized across operators regardless of when each one initializes.
     /// Used for: attestations, aggregations, sync committee.
-    SlotTime { instance_start_time: Instant },
+    SlotTime { round_deadline_origin: Instant },
     /// Per-round timeouts. Resets on round changes.
     /// Used for: block proposals.
     Relative { current_round_start_time: Instant },

--- a/anchor/qbft_manager/src/tests.rs
+++ b/anchor/qbft_manager/src/tests.rs
@@ -355,6 +355,12 @@ where
     ) -> UnboundedReceiver<(Hash256, Result<Completed<D>, QbftError>)> {
         let (result_tx, result_rx) = mpsc::unbounded_channel();
 
+        // All operators share the same round-deadline origin, mirroring production where the origin
+        // is derived from the slot clock rather than each operator's own initialization
+        // time. Operators initialized with a delay start with (partially) expired round
+        // deadlines and must catch up to the committee's round cadence.
+        let round_deadline_origin = Instant::now();
+
         for (data, data_id) in all_data {
             let height = *data.instance_height(&data_id) as u64;
             self.identifiers.insert(height, data_id.clone());
@@ -399,7 +405,7 @@ where
                                 data_clone.clone(),
                                 Box::new(NoDataValidation),
                                 TimeoutMode::SlotTime {
-                                    instance_start_time: Instant::now(),
+                                    round_deadline_origin,
                                 },
                                 &cluster.cluster_members,
                             )
@@ -834,6 +840,33 @@ mod manager_tests {
         let initialization_delays = HashMap::from([
             (OperatorId(2), Duration::from_secs(3)), // Middle of round 2
             (OperatorId(3), Duration::from_secs(5)), // Middle of round 3
+        ]);
+
+        let mut context = TestContext::<types::MainnetEthSpec, BeaconVote>::new_with_delays(
+            setup.clock,
+            setup.executor,
+            CommitteeSize::Four,
+            setup.all_data,
+            initialization_delays,
+        )
+        .await;
+
+        context.verify_consensus().await;
+    }
+
+    #[tokio::test(start_paused = true)]
+    // Test operators initializing at different times against a shared round-deadline origin.
+    // All operators measure their round deadlines from the same instant, so late initializers
+    // start with already-expired round deadlines and rejoin the committee's cadence (the
+    // cascade itself is pinned by `test_slottime_late_init_cascades_round_changes`).
+    // Consensus must still be reached.
+    async fn test_slottime_init_skew_convergence() {
+        let setup = setup_test(1);
+
+        let initialization_delays = HashMap::from([
+            (OperatorId(2), Duration::from_secs(1)), // Middle of round 1
+            (OperatorId(3), Duration::from_secs(3)), // Middle of round 2
+            (OperatorId(4), Duration::from_secs(5)), // Middle of round 3
         ]);
 
         let mut context = TestContext::<types::MainnetEthSpec, BeaconVote>::new_with_delays(

--- a/anchor/qbft_manager/src/tests/timeout_tests.rs
+++ b/anchor/qbft_manager/src/tests/timeout_tests.rs
@@ -41,7 +41,7 @@ async fn test_timeout(round_timeout_to_test: usize) {
                     &DutyExecutor::Committee(CommitteeId::default()),
                 ),
                 timeout_mode: TimeoutMode::SlotTime {
-                    instance_start_time: qbft_start_time,
+                    round_deadline_origin: qbft_start_time,
                 },
                 config: qbft::ConfigBuilder::new(
                     OperatorId(1),
@@ -67,18 +67,11 @@ async fn test_timeout(round_timeout_to_test: usize) {
 
     // Calculate the expected timeout
     let mut expected_timeout = Duration::ZERO;
-    // first, the instance should not start until start time, so we add the difference from slot
-    // start to qbft start.
+    // The instance starts immediately, but the round deadlines are measured from
+    // `qbft_start_time`, so we add the difference from slot start to qbft start.
     expected_timeout += qbft_start_time - slot_start_time;
     // now, we account for the actual rounds:
-    for i in 1..=round_timeout_to_test {
-        // check if we use short round timeout or long round timeout for this round
-        if i <= 8 {
-            expected_timeout += Duration::from_secs(2);
-        } else {
-            expected_timeout += Duration::from_secs(120);
-        }
-    }
+    expected_timeout += cumulative_timeout(round_timeout_to_test);
     assert_eq!(timeout, expected_timeout);
 }
 
@@ -137,24 +130,25 @@ async fn test_relative_mode_timeout() {
     // - Round 3: 2 seconds
     // Total: 4 + 2 + 2 + 2 = 10 seconds
     //
-    // If it were SlotTime mode (cumulative), it would be:
-    // - Wait 4 seconds
-    // - Round 1 ends at start_time + 2 = 6 seconds total
-    // - Round 2 ends at start_time + 4 = 8 seconds total
-    // - Round 3 ends at start_time + 6 = 10 seconds total
+    // If it were SlotTime mode, the instance would start immediately, but the cumulative
+    // deadlines are measured from the same instant:
+    // - Round 1 ends at round_deadline_origin + 2 = 6 seconds total
+    // - Round 2 ends at round_deadline_origin + 4 = 8 seconds total
+    // - Round 3 ends at round_deadline_origin + 6 = 10 seconds total
     // Which happens to be the same for this test, but the key difference is
-    // Relative mode resets start_time to Instant::now() after sleep_until
+    // Relative mode sleeps until the round start and resets it to Instant::now()
 
     let expected = Duration::from_secs(4 + 2 + 2 + 2);
     assert_eq!(total_time, expected);
 }
 
-/// Test that SlotTime and Relative modes differ when start_time is in the past.
-/// This tests the key behavioral difference between the modes.
+/// Test that SlotTime and Relative modes compute their round deadlines differently.
+/// SlotTime measures cumulative deadlines from `round_deadline_origin`, while Relative restarts
+/// each round to `Instant::now()`.
 #[tokio::test(start_paused = true)]
 async fn test_relative_vs_slottime_timing_difference() {
-    // Test with start_time in the past - this highlights the difference
-    // between SlotTime (uses original instance_start_time) and Relative (uses Instant::now())
+    // With the origin at `now`, both modes complete at the same instant, but via
+    // different calculations (cumulative-from-origin vs per-round-from-now)
 
     async fn run_with_mode(use_relative: bool) -> Duration {
         let (sender_tx, _sender_rx) = unbounded_channel();
@@ -174,7 +168,7 @@ async fn test_relative_vs_slottime_timing_difference() {
             }
         } else {
             TimeoutMode::SlotTime {
-                instance_start_time: now,
+                round_deadline_origin: now,
             }
         };
 
@@ -212,11 +206,135 @@ async fn test_relative_vs_slottime_timing_difference() {
 
     // Both should complete in 4 seconds (2 rounds * 2 seconds each)
     // The difference is in HOW they calculate it:
-    // - SlotTime: cumulative from original instance_start_time
+    // - SlotTime: cumulative from the fixed round_deadline_origin
     // - Relative: single-round from current_round_start_time (reset each round)
     //
-    // When start_time is now, both should behave similarly for the first run,
-    // but the internal calculations differ.
+    // With the origin at now, both arrive at the same deadlines, but the internal
+    // calculations differ.
     assert_eq!(slottime_duration, Duration::from_secs(4));
     assert_eq!(relative_duration, Duration::from_secs(4));
+}
+
+/// Test that `SlotTime` round deadlines are a pure function of `round_deadline_origin`: an instance
+/// initialized before the origin must time out at the exact same instant as one initialized
+/// at the origin.
+#[tokio::test(start_paused = true)]
+async fn test_slottime_round_deadlines_invariant_under_early_init() {
+    // Origin 4 seconds after scenario start, matching the one-third-slot offset used in
+    // production for a 12 second slot
+    const ORIGIN_OFFSET: Duration = Duration::from_secs(4);
+
+    // `max_rounds = 9` crosses from the 2 second quick timeouts into the 120 second slow
+    // timeout for round 9
+    for max_rounds in [2, 9] {
+        // Arrange + Act: run the identical scenario twice, once initializing at scenario
+        // start (before the origin) and once initializing exactly at the origin
+        let early_init_elapsed =
+            run_slottime_scenario(ORIGIN_OFFSET, Duration::ZERO, max_rounds).await;
+        let at_origin_elapsed =
+            run_slottime_scenario(ORIGIN_OFFSET, ORIGIN_OFFSET, max_rounds).await;
+
+        // Assert: both time out at exactly `round_deadline_origin +
+        // cumulative_timeout(max_rounds)`, proving the deadlines depend on the origin, not
+        // on initialization time
+        let expected = ORIGIN_OFFSET + cumulative_timeout(max_rounds);
+        assert_eq!(early_init_elapsed, expected);
+        assert_eq!(at_origin_elapsed, expected);
+    }
+}
+
+/// Test that an instance initialized after `round_deadline_origin` cascades through the already
+/// expired rounds immediately and still times out at the origin-based deadline.
+#[tokio::test(start_paused = true)]
+async fn test_slottime_late_init_cascades_round_changes() {
+    // Arrange + Act: origin at scenario start, initialize 5 seconds later. Rounds 1 and 2
+    // (deadlines at origin + 2s/4s) are already expired at initialization and fire
+    // immediately, leaving only round 3's deadline at origin + 6s.
+    let elapsed = run_slottime_scenario(Duration::ZERO, Duration::from_secs(5), 3).await;
+
+    // Assert: the instance times out exactly 1 second after initialization, at the
+    // origin-based deadline of round 3
+    assert_eq!(elapsed, Duration::from_secs(6));
+}
+
+/// Run a single `SlotTime` instance whose `round_deadline_origin` lies `origin_offset` after the
+/// scenario start, sending the initialization after `init_delay`. Returns the elapsed time
+/// from scenario start until the instance reports `Completed::TimedOut`.
+async fn run_slottime_scenario(
+    origin_offset: Duration,
+    init_delay: Duration,
+    max_rounds: usize,
+) -> Duration {
+    let (sender_tx, mut sender_rx) = unbounded_channel();
+    let (message_tx, message_rx) = unbounded_channel();
+    let (result_tx, result_rx) = oneshot::channel();
+    let message_sender = MockMessageSender::new(sender_tx, OperatorId(1));
+    let _handle = tokio::spawn(qbft_instance::<BeaconVote>(
+        message_rx,
+        Arc::new(message_sender),
+    ));
+
+    let scenario_start = Instant::now();
+    let round_deadline_origin = scenario_start + origin_offset;
+
+    tokio::time::sleep(init_delay).await;
+
+    message_tx
+        .send(crate::QbftMessage {
+            kind: QbftMessageKind::Initialize(QbftInitialization {
+                initial: setup::generate_test_data(0).0,
+                validator: Box::new(NoDataValidation),
+                message_id: MessageId::new(
+                    &DomainType::default(),
+                    Role::Committee,
+                    &DutyExecutor::Committee(CommitteeId::default()),
+                ),
+                timeout_mode: TimeoutMode::SlotTime {
+                    round_deadline_origin,
+                },
+                config: qbft::ConfigBuilder::new(
+                    OperatorId(1),
+                    InstanceHeight::from(0),
+                    IndexSet::from([1, 2, 3, 4].map(OperatorId)),
+                )
+                .with_max_rounds(max_rounds)
+                .build()
+                .unwrap(),
+                on_completed: result_tx,
+            }),
+            drop_on_finish: None,
+        })
+        .unwrap();
+
+    if init_delay < origin_offset {
+        // The instance must not wait for the origin: operator 1 is the round 1 leader at
+        // instance height 0 under `DefaultLeaderFunction`, so its proposal must go out
+        // before the origin. Advance virtual time by 1ms so the instance task runs.
+        tokio::time::sleep(Duration::from_millis(1)).await;
+        assert!(
+            Instant::now() < round_deadline_origin,
+            "test setup error: still expected to be before the origin"
+        );
+        assert!(
+            sender_rx.try_recv().is_ok(),
+            "round 1 proposal should be emitted before the origin"
+        );
+    }
+
+    assert!(matches!(result_rx.await, Ok(Completed::TimedOut)));
+    Instant::now() - scenario_start
+}
+
+/// Cumulative round timeout as implemented in `crate::timeout`: rounds 1 to 8 add 2 seconds
+/// each, every round beyond adds 120 seconds.
+fn cumulative_timeout(max_rounds: usize) -> Duration {
+    let mut total = Duration::ZERO;
+    for round in 1..=max_rounds {
+        if round <= 8 {
+            total += Duration::from_secs(2);
+        } else {
+            total += Duration::from_secs(120);
+        }
+    }
+    total
 }

--- a/anchor/qbft_manager/src/timeout.rs
+++ b/anchor/qbft_manager/src/timeout.rs
@@ -10,8 +10,11 @@ const SLOW_TIMEOUT: u64 = 120; // 2 Minutes
 
 /// Calculate when the current round should timeout.
 ///
-/// For `SlotTime` mode: Cumulative timeout from instance start.
-///   Round N ends at: instance_start_time + sum of all round timeouts up to N.
+/// For `SlotTime` mode: Cumulative timeout from a fixed origin instant.
+///   Round N ends at: `round_deadline_origin` + sum of all round timeouts up to N.
+///   The instance may initialize before or after the origin without shifting the
+///   deadlines; a deadline already in the past fires immediately, cascading round
+///   changes until the rounds catch up.
 ///   Used for attestations, aggregations, sync committee duties.
 ///
 /// For `Relative` mode: Single round timeout from the current round's start time.
@@ -21,8 +24,8 @@ const SLOW_TIMEOUT: u64 = 120; // 2 Minutes
 pub fn calculate_round_timeout(round: u64, timeout_mode: TimeoutMode) -> Option<Instant> {
     match timeout_mode {
         TimeoutMode::SlotTime {
-            instance_start_time,
-        } => instance_start_time.checked_add(cumulative_timeout(round)?),
+            round_deadline_origin,
+        } => round_deadline_origin.checked_add(cumulative_timeout(round)?),
         TimeoutMode::Relative {
             current_round_start_time,
         } => current_round_start_time.checked_add(single_round_timeout(round)),

--- a/anchor/validator_store/src/lib.rs
+++ b/anchor/validator_store/src/lib.rs
@@ -419,7 +419,7 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> AnchorValidator
 
         let timer = metrics::start_timer_vec(&metrics::CONSENSUS_TIMES, &[metric_label]);
         let timeout_mode = TimeoutMode::SlotTime {
-            instance_start_time: self
+            round_deadline_origin: self
                 .get_instant_in_slot(slot, self.spec.get_slot_duration() * 2 / 3)?,
         };
 
@@ -1007,7 +1007,7 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> AnchorValidator
                 &[metrics::AGGREGATE_AND_PROOF],
             );
             let timeout_mode = TimeoutMode::SlotTime {
-                instance_start_time: self.get_instant_in_slot(
+                round_deadline_origin: self.get_instant_in_slot(
                     message.aggregate().data().slot,
                     self.spec.get_slot_duration() * 2 / 3,
                 )?,
@@ -1159,7 +1159,7 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> AnchorValidator
                 &[metrics::SYNC_CONTRIBUTION_AND_PROOF],
             );
             let timeout_mode = TimeoutMode::SlotTime {
-                instance_start_time: self
+                round_deadline_origin: self
                     .get_instant_in_slot(slot, self.spec.get_slot_duration() * 2 / 3)?,
             };
 
@@ -1421,7 +1421,8 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> AnchorValidator
     ///
     /// Attestation and sync-message callers for the same `(committee, slot)` attach to one typed
     /// QBFT instance. The first initialization owns the timeout configuration, so constructing the
-    /// instance ID and start time here prevents the two callers from drifting independently.
+    /// instance ID and round-deadline origin here prevents the two callers from drifting
+    /// independently.
     async fn decide_committee_vote(
         &self,
         committee_id: CommitteeId,
@@ -1432,7 +1433,7 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> AnchorValidator
     ) -> Result<DecidedVote, Error> {
         let timer = metrics::start_timer_vec(&metrics::CONSENSUS_TIMES, &[metrics::BEACON_VOTE]);
         let timeout_mode = TimeoutMode::SlotTime {
-            instance_start_time: self
+            round_deadline_origin: self
                 .get_instant_in_slot(slot, self.spec.get_attestation_due::<E>(slot))?,
         };
         let instance_id = CommitteeInstanceId {


### PR DESCRIPTION
## Problem, Evidence, and Context (Required)

Committee QBFT hard-sleeps to `attestation_due` (3.0s Gloas) before starting round 1, even when the head monitor has already delivered attestation data earlier in the slot. Consensus is therefore decided at ~+3.0s by construction, negating the eager-attest head start and leaving little margin under the tightened Gloas deadline. The sleeping task also pins an `urgent_consensus` processor permit for the full sleep.

Measured trace and full validation: #1092 and https://github.com/sigp/anchor/issues/1092#issuecomment-4952123445.

Closes #1133.

## Change Overview (Required)

**The real change is one hunk in `qbft_manager/src/instance.rs`**: `Uninitialized::initialize` no longer sleeps for `TimeoutMode::SlotTime`, so round 1 starts as soon as the instance is initialized. Every `SlotTime` call site is already data-gated by its caller, so the start now follows data availability instead of a fixed clock offset.

Everything else is the supporting rename: the field previously did two jobs (sleep target and round-deadline base) and now does one, so `instance_start_time` becomes `round_deadline_origin` (`lib.rs`, `timeout.rs`, four construction sites in `validator_store`, tests).

Suggested reading order: `instance.rs`, then `timeout.rs` (deadline math, unchanged), then the tests.

What did NOT change:

- **Round deadlines are byte-for-byte identical**: round N still times out at `round_deadline_origin + cumulative_timeout(N)` (slot-time based, 2s per round), so round-change cadence stays synchronized across operators regardless of when each one starts. The untouched expected values in the pre-existing timing tests demonstrate this.
- `Relative` mode (block proposals) is unchanged.
- The aggregator-path sleeps were already no-ops (callers fire at 2/3 slot).

This is go-ssv parity: it starts committee consensus immediately once duty data is ready and anchors round timeouts to absolute slot time, as pre-existing mainnet behavior.

## Risks, Trade-offs, and Mitigations (Required)

- Round-1 messages now appear on the wire before `attestation_due`. Both Anchor's and go-ssv's message validators accept early round-1 messages (earliness is checked against slot start), and go-ssv operators already send them on mainnet, so mixed clusters exercise this path today. Older Anchor peers buffer and replay them at their own initialization.
- `--disable-beacon-head-monitor` remains a full operational killswitch: without head events, timing is identical to today.
- `CONSENSUS_TIMES` previously included the sleep; it now measures true consensus latency, so dashboards derived from it will shift left.

## Validation (Required)

- New mock-clock tests: round-N deadlines invariant under early initialization; late initialization cascades expired rounds immediately and still times out at the origin-based deadline.
- New multi-operator init-skew integration test (operators initializing 0-5s apart converge; the harness now shares one deadline origin across operators, matching production).
- `cargo test -p qbft_manager` (34) and `cargo test -p anchor_validator_store` (54) pass; fmt and clippy clean.

## Rollback (Required for behavior or runtime changes; optional otherwise)

Revert the commit. No config, database, or network migration; `--disable-beacon-head-monitor` disables the early trigger operationally without a rollback.