### PR TITLE
feat(validator_store): fork-gate RegistrationService at GLOAS_FORK_EPOCH

### DIFF
--- a/anchor/validator_store/src/registration_service.rs
+++ b/anchor/validator_store/src/registration_service.rs
@@ -234,9 +234,8 @@ impl<S: ValidatorStore + 'static, T: SlotClock + 'static> Inner<S, T> {
     }
 }
 
-/// Whether the periodic registration publish should be skipped because the slot's fork is
-/// Gloas. SIP-94 §4: the relay-builder registration flow is gone under Gloas, replaced by
-/// the `proposer_preferences` p2p mechanism.
+/// Whether the periodic registration publish should be skipped because `slot`'s fork is
+/// Gloas or later. See the call site for the rationale.
 fn should_skip_for_gloas<E: EthSpec>(spec: &ChainSpec, slot: Slot) -> bool {
     spec.fork_name_at_slot::<E>(slot).gloas_enabled()
 }
@@ -261,32 +260,6 @@ mod tests {
     use types::{Epoch, MainnetEthSpec};
 
     use super::*;
-
-    #[test]
-    fn should_skip_for_gloas_returns_true_after_fork() {
-        // Arrange: Gloas is scheduled from genesis.
-        let mut spec = ChainSpec::mainnet();
-        spec.gloas_fork_epoch = Some(Epoch::new(0));
-
-        // Act
-        let skip = should_skip_for_gloas::<MainnetEthSpec>(&spec, Slot::new(0));
-
-        // Assert
-        assert!(skip, "registrations must be skipped once Gloas is active");
-    }
-
-    #[test]
-    fn should_skip_for_gloas_returns_false_before_fork() {
-        // Arrange: Gloas is scheduled far in the future; the queried slot is pre-fork.
-        let mut spec = ChainSpec::mainnet();
-        spec.gloas_fork_epoch = Some(Epoch::new(100_000));
-
-        // Act
-        let skip = should_skip_for_gloas::<MainnetEthSpec>(&spec, Slot::new(32));
-
-        // Assert
-        assert!(!skip, "registrations must continue before the Gloas fork");
-    }
 
     #[test]
     fn should_skip_for_gloas_flips_exactly_at_fork_boundary() {

--- a/anchor/validator_store/src/registration_service.rs
+++ b/anchor/validator_store/src/registration_service.rs
@@ -68,6 +68,22 @@ impl<S: ValidatorStore + 'static, T: SlotClock + 'static> RegistrationService<S,
         let validator_registration_fut = async move {
             loop {
                 if let Some(slot) = self.inner.slot_clock.now() {
+                    // SIP-94 §4: under Gloas, the relay-builder registration mechanism is
+                    // removed along with blinded blocks, so registrations no longer feed
+                    // block production. Skip the periodic publish to avoid wasted RPC and
+                    // operator-log noise. The service stays spawned and re-evaluates each
+                    // wakeup so pre-Gloas networks and the transition window are unaffected.
+                    if should_skip_for_gloas::<S::E>(&spec, slot) {
+                        debug!(%slot, "Skipping validator registration, deprecated since Gloas");
+                        let sleep_duration = self
+                            .inner
+                            .slot_clock
+                            .duration_to_next_epoch(S::E::slots_per_epoch())
+                            .unwrap_or_else(|| slot_duration * S::E::slots_per_epoch() as u32);
+                        sleep(sleep_duration).await;
+                        continue;
+                    }
+
                     let inner = self.inner.clone();
                     let executor = inner.executor.clone();
                     let future = async move {
@@ -218,6 +234,13 @@ impl<S: ValidatorStore + 'static, T: SlotClock + 'static> Inner<S, T> {
     }
 }
 
+/// Whether the periodic registration publish should be skipped because the slot's fork is
+/// Gloas. SIP-94 §4: the relay-builder registration flow is gone under Gloas, replaced by
+/// the `proposer_preferences` p2p mechanism.
+fn should_skip_for_gloas<E: EthSpec>(spec: &ChainSpec, slot: Slot) -> bool {
+    spec.fork_name_at_slot::<E>(slot).gloas_enabled()
+}
+
 /// To not sign for all validators at once, select based on the current slot.
 /// Note that it is important that this is the same across client implementations, as else
 /// the nodes broadcast partial signatures for their validators at varying times.
@@ -231,4 +254,76 @@ fn is_scheduled_for_slot(
     number_of_slots_between_registrations: u64,
 ) -> bool {
     slot % number_of_slots_between_registrations != index % number_of_slots_between_registrations
+}
+
+#[cfg(test)]
+mod tests {
+    use types::{Epoch, MainnetEthSpec};
+
+    use super::*;
+
+    #[test]
+    fn should_skip_for_gloas_returns_true_after_fork() {
+        // Arrange: Gloas is scheduled from genesis.
+        let mut spec = ChainSpec::mainnet();
+        spec.gloas_fork_epoch = Some(Epoch::new(0));
+
+        // Act
+        let skip = should_skip_for_gloas::<MainnetEthSpec>(&spec, Slot::new(0));
+
+        // Assert
+        assert!(skip, "registrations must be skipped once Gloas is active");
+    }
+
+    #[test]
+    fn should_skip_for_gloas_returns_false_before_fork() {
+        // Arrange: Gloas is scheduled far in the future; the queried slot is pre-fork.
+        let mut spec = ChainSpec::mainnet();
+        spec.gloas_fork_epoch = Some(Epoch::new(100_000));
+
+        // Act
+        let skip = should_skip_for_gloas::<MainnetEthSpec>(&spec, Slot::new(32));
+
+        // Assert
+        assert!(!skip, "registrations must continue before the Gloas fork");
+    }
+
+    #[test]
+    fn should_skip_for_gloas_flips_exactly_at_fork_boundary() {
+        // Arrange: Gloas is scheduled mid-chain; the fork activates at the first slot of
+        // its epoch (inclusive boundary).
+        let mut spec = ChainSpec::mainnet();
+        spec.gloas_fork_epoch = Some(Epoch::new(100));
+        let fork_slot = Epoch::new(100).start_slot(MainnetEthSpec::slots_per_epoch());
+
+        // Act
+        let skip_before = should_skip_for_gloas::<MainnetEthSpec>(&spec, fork_slot - 1);
+        let skip_at_fork = should_skip_for_gloas::<MainnetEthSpec>(&spec, fork_slot);
+
+        // Assert
+        assert!(
+            !skip_before,
+            "registrations must continue at the last pre-Gloas slot"
+        );
+        assert!(
+            skip_at_fork,
+            "registrations must be skipped from the first slot of the Gloas fork epoch"
+        );
+    }
+
+    #[test]
+    fn should_skip_for_gloas_returns_false_when_unscheduled() {
+        // Arrange: Gloas is not scheduled at all.
+        let mut spec = ChainSpec::mainnet();
+        spec.gloas_fork_epoch = None;
+
+        // Act
+        let skip = should_skip_for_gloas::<MainnetEthSpec>(&spec, Slot::new(100_000));
+
+        // Assert
+        assert!(
+            !skip,
+            "registrations must continue when Gloas is unscheduled"
+        );
+    }
 }


### PR DESCRIPTION
## Problem, Evidence, and Context (Required)

- Under Gloas, SIP-94 §4 removes the pre-fork relay-builder registration mechanism along with blinded blocks, so `RegistrationService`'s periodic `post_validator_register_validator` calls no longer feed block production; they are wasted RPC and operator-log noise.
- The pinned LH BN still accepts the call (no Gloas gate in its handler), which is exactly why the skip belongs on the Anchor side.
- Closes #1065. SIP: ssvlabs/SIPs#94. Replacement flow: #1062, #1063, #1064. Receive-side twin: #1115.

## Change Overview (Required)

- Adds a Gloas gate at the top of the registration spawning loop: once `fork_name_at_slot(slot).gloas_enabled()`, the loop logs at debug, sleeps to the next epoch, and re-evaluates. No BN call, no signing.
- The gate decision is a pure `should_skip_for_gloas` helper so it is unit-testable without a runtime, mirroring `is_scheduled_for_slot` in the same file.
- Intentionally unchanged: the service is not deleted and its startup is not gated; pre-Gloas behavior is identical apart from the pure check. Inbound `ValidatorRegistration` partial-sig rejection is out of scope (#1115).

## Risks, Trade-offs, and Mitigations (Required)

- Sleep-and-recheck was chosen over terminating the task: a `break` would rest on a single wall-clock reading, so a transient forward clock step (bad NTP) on a pre-Gloas network would permanently stop registrations until restart. The sleeping loop self-heals next epoch and matches how the sibling fork-aware services (proposer preferences, payload attestation, metadata) gate.
- Cost of keeping the task alive is one timer wakeup and one debug line per epoch.

## Validation (Required)

- Two runtime-free unit tests on the helper: the exact inclusive fork boundary (last pre-fork slot still registers, first fork-epoch slot skips) and the unscheduled-fork case.
- `cargo test -p anchor_validator_store`: 58 passed. Workspace fmt and clippy clean.

## Rollback (Required for behavior or runtime changes; optional otherwise)

- Revert the single commit; no config, data, or wire impact.

## Blockers / Dependencies (Optional)

N/A. Independent of #1062-#1064; all required LH symbols are already in the current pin.
