### PR TITLE
feat(message_validator): reject ValidatorRegistration after Gloas

### DIFF
--- a/anchor/message_validator/src/consensus_message.rs
+++ b/anchor/message_validator/src/consensus_message.rs
@@ -1400,7 +1400,7 @@ mod tests {
         ValidationFailure::{EarlySlotMessage, LateSlotMessage},
         tests::{
             MockDutiesProvider, QbftMessageBuilder, create_message_id_for_test,
-            create_signed_consensus_message,
+            create_signed_consensus_message, spec_with_gloas,
         },
     };
 
@@ -1801,12 +1801,15 @@ mod tests {
         assert_eq!(result, Ok(Some(2)));
     }
 
-    /// Helper function for testing role validation against fork schedules.
-    ///
-    /// Tests whether a consensus message for a given role is properly accepted or rejected
-    /// based on the fork schedule. Used to verify that deprecated roles (Aggregator and
-    /// SyncCommittee) are rejected after the Boole fork but accepted before it.
-    fn test_role_fork_validation(role: Role, is_after_boole: bool, should_be_rejected: bool) {
+    /// Builds a signed consensus message for `role` and runs it through the full
+    /// `validate_ssv_message` path (including `validate_role_for_fork`) with the
+    /// given fork schedule and chain spec, returning the result for the caller
+    /// to assert on.
+    fn run_role_fork_validation(
+        role: Role,
+        fork_schedule: Arc<ForkSchedule>,
+        spec: Arc<types::ChainSpec>,
+    ) -> Result<ValidatedSSVMessage, ValidationFailure> {
         // Arrange: Set up test data and validation context
         let committee_info = create_committee_info(FOUR_NODE_COMMITTEE);
         let (private_key, public_key) = generate_test_key_pair();
@@ -1815,7 +1818,7 @@ mod tests {
 
         let qbft_message = QbftMessageBuilder::new(role, QbftMessageType::Prepare).build();
         let signed_msg = create_signed_consensus_message(
-            qbft_message.clone(),
+            qbft_message,
             vec![OperatorId(1)],
             vec![],
             vec![private_key],
@@ -1831,16 +1834,6 @@ mod tests {
         slot_clock.advance_slot();
         slot_clock.advance_time(slot_duration);
 
-        let fork_schedule = if is_after_boole {
-            Arc::new(ForkSchedule::new(
-                Fork::Boole,
-                DomainType::default(),
-                "testing",
-            ))
-        } else {
-            generate_fork_schedule()
-        };
-
         let validation_context = ValidationContext {
             signed_ssv_message: &signed_msg,
             committee_info: &committee_info,
@@ -1852,17 +1845,37 @@ mod tests {
             slot_clock,
             operator_pub_keys: &map,
             fork_schedule,
-            spec: Arc::new(types::ChainSpec::mainnet()),
+            spec,
         };
 
         // Act: Validate the message
-        let result = validate_ssv_message(
+        validate_ssv_message(
             validation_context,
             &mut DutyState::new(64),
             Arc::new(MockDutiesProvider {
                 voluntary_exit_duty_count: 0,
             }),
-        );
+        )
+    }
+
+    /// Helper function for testing role validation against fork schedules.
+    ///
+    /// Tests whether a consensus message for a given role is properly accepted or rejected
+    /// based on the fork schedule. Used to verify that deprecated roles (Aggregator and
+    /// SyncCommittee) are rejected after the Boole fork but accepted before it.
+    fn test_role_fork_validation(role: Role, is_after_boole: bool, should_be_rejected: bool) {
+        let fork_schedule = if is_after_boole {
+            Arc::new(ForkSchedule::new(
+                Fork::Boole,
+                DomainType::default(),
+                "testing",
+            ))
+        } else {
+            generate_fork_schedule()
+        };
+
+        let result =
+            run_role_fork_validation(role, fork_schedule, Arc::new(types::ChainSpec::mainnet()));
 
         // Assert: Verify the expected outcome
         if should_be_rejected {
@@ -1906,5 +1919,33 @@ mod tests {
     #[test]
     fn test_sync_committee_consensus_message_rejected_after_boole() {
         test_role_fork_validation(Role::SyncCommittee, true, true);
+    }
+
+    #[test]
+    fn test_validator_registration_consensus_message_rejected_after_gloas() {
+        // A ValidatorRegistration consensus message with Gloas active at epoch 0
+        // (the builder's height of 1 is a slot in epoch 0). The Ethereum fork
+        // gate runs before the structural non-QBFT-role check, so the
+        // deprecated-role rejection surfaces instead of UnexpectedConsensusMessage.
+        let result = run_role_fork_validation(
+            Role::ValidatorRegistration,
+            generate_fork_schedule(),
+            spec_with_gloas(Some(0)),
+        );
+
+        assert_validation_error(
+            result,
+            |failure| {
+                matches!(
+                    failure,
+                    ValidationFailure::RoleNotActiveAfterEthFork {
+                        role: Role::ValidatorRegistration,
+                        deprecated_since_fork: types::ForkName::Gloas,
+                        ..
+                    }
+                )
+            },
+            "RoleNotActiveAfterEthFork (ValidatorRegistration consensus message post-Gloas)",
+        );
     }
 }

--- a/anchor/message_validator/src/lib.rs
+++ b/anchor/message_validator/src/lib.rs
@@ -228,6 +228,12 @@ pub enum ValidationFailure {
         current_fork: ForkName,
         minimum_fork: ForkName,
     },
+    /// A role deprecated at an Ethereum hard fork was seen at/after that fork activated.
+    RoleNotActiveAfterEthFork {
+        role: Role,
+        current_fork: ForkName,
+        deprecated_since_fork: ForkName,
+    },
 }
 
 impl From<&ValidationFailure> for MessageAcceptance {
@@ -846,6 +852,7 @@ pub(crate) fn validate_beacon_duty(
 /// - AggregatorCommittee before Boole fork (not yet active)
 /// - Aggregator and SyncCommittee after Boole fork (deprecated)
 /// - PTCAttester before the Ethereum Gloas (ePBS) fork (not yet active)
+/// - ValidatorRegistration at/after the Ethereum Gloas (ePBS) fork (deprecated by SIP-94)
 pub(crate) fn validate_role_for_fork(
     slot: Slot,
     validation_context: &ValidationContext<impl SlotClock>,
@@ -880,6 +887,22 @@ pub(crate) fn validate_role_for_fork(
                 role,
                 current_fork,
                 minimum_fork: ForkName::Gloas,
+            });
+        }
+    }
+
+    // Reject ValidatorRegistration at/after the Ethereum Gloas (ePBS) fork; SIP-94
+    // deprecates the duty (proposer preferences replace relay registrations). Gated
+    // on the message's duty slot, not wall clock, so registrations for pre-fork
+    // slots remain valid through their TTL window. Wire values are retained for
+    // pre-Gloas decode per SIP-94.
+    if role == Role::ValidatorRegistration {
+        let current_fork = validation_context.spec.fork_name_at_epoch(epoch);
+        if current_fork.gloas_enabled() {
+            return Err(ValidationFailure::RoleNotActiveAfterEthFork {
+                role,
+                current_fork,
+                deprecated_since_fork: ForkName::Gloas,
             });
         }
     }
@@ -1109,7 +1132,7 @@ pub(crate) fn hash_data(full_data: &[u8]) -> [u8; 32] {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashMap;
+    use std::{collections::HashMap, sync::Arc};
 
     use bls::{Hash256, PublicKeyBytes};
     use duties_tracker::DutiesProvider;
@@ -1325,6 +1348,16 @@ mod tests {
         public_keys: Vec<Rsa<Public>>,
     ) -> HashMap<OperatorId, Rsa<Public>> {
         committee_members.into_iter().zip(public_keys).collect()
+    }
+
+    /// Build a `ChainSpec` whose Ethereum Gloas (ePBS) fork activates at
+    /// `gloas_fork_epoch` (`None` = "Gloas never happens"). Used by role gates
+    /// keyed to the Ethereum fork, e.g. PTCAttester activation and
+    /// ValidatorRegistration deprecation.
+    pub(crate) fn spec_with_gloas(gloas_fork_epoch: Option<u64>) -> Arc<types::ChainSpec> {
+        let mut spec = types::ChainSpec::mainnet();
+        spec.gloas_fork_epoch = gloas_fork_epoch.map(types::Epoch::new);
+        Arc::new(spec)
     }
 
     // Assert helpers for common validation patterns

--- a/anchor/message_validator/src/partial_signature.rs
+++ b/anchor/message_validator/src/partial_signature.rs
@@ -1400,6 +1400,7 @@ mod tests {
                 matches!(
                     failure,
                     ValidationFailure::RoleNotActiveAfterEthFork {
+                        role: Role::ValidatorRegistration,
                         deprecated_since_fork: types::ForkName::Gloas,
                         ..
                     }

--- a/anchor/message_validator/src/partial_signature.rs
+++ b/anchor/message_validator/src/partial_signature.rs
@@ -359,6 +359,7 @@ mod tests {
     use crate::tests::{
         FOUR_NODE_COMMITTEE, MockDutiesProvider, assert_validation_error, create_committee_info,
         create_message_id_for_test, create_operator_pub_keys, generate_random_rsa_public_keys,
+        spec_with_gloas,
     };
 
     // Options for creating test partial signature messages
@@ -487,15 +488,6 @@ mod tests {
 
     fn generate_fork_schedule(fork: Fork) -> Arc<ForkSchedule> {
         Arc::new(ForkSchedule::new(fork, DomainType::default(), "testing"))
-    }
-
-    /// Build a `ChainSpec` whose Ethereum Gloas (ePBS) fork activates at
-    /// `gloas_fork_epoch` (`None` = "Gloas never happens"). Used to gate
-    /// post-Gloas roles such as `PTCAttester`.
-    fn spec_with_gloas(gloas_fork_epoch: Option<u64>) -> Arc<types::ChainSpec> {
-        let mut spec = types::ChainSpec::mainnet();
-        spec.gloas_fork_epoch = gloas_fork_epoch.map(types::Epoch::new);
-        Arc::new(spec)
     }
 
     #[test]
@@ -1366,6 +1358,58 @@ mod tests {
     }
 
     #[test]
+    fn test_validator_registration_rejected_after_gloas() {
+        // Setup
+        let committee_info = create_committee_info(FOUR_NODE_COMMITTEE);
+        let (private_key, public_key) = generate_test_key_pair();
+        let map =
+            create_operator_pub_keys(committee_info.committee_members.clone(), vec![public_key]);
+        let signed_msg = create_signed_partial_sig_message(
+            Role::ValidatorRegistration,
+            PartialSignatureKind::ValidatorRegistration,
+            OperatorId(1),
+            &private_key,
+        );
+
+        let fork_schedule = ForkSchedule::new(Fork::Alan, DomainType::default(), "testing");
+        let mut validation_context = create_ttl_validation_context(
+            &signed_msg,
+            &committee_info,
+            Role::ValidatorRegistration,
+            &map,
+            TTL_SLOTS,
+            Arc::new(fork_schedule),
+        );
+        // ValidatorRegistration is deprecated at Gloas; the role gate reads the Ethereum
+        // fork from the spec. The message slot (1) is in epoch 0, where Gloas is active.
+        validation_context.spec = spec_with_gloas(Some(0));
+
+        // Execute
+        let result = validate_partial_signature_message(
+            validation_context,
+            &mut DutyState::new(64),
+            Arc::new(MockDutiesProvider {
+                voluntary_exit_duty_count: 0,
+            }),
+        );
+
+        // Assert
+        assert_validation_error(
+            result,
+            |failure| {
+                matches!(
+                    failure,
+                    ValidationFailure::RoleNotActiveAfterEthFork {
+                        deprecated_since_fork: types::ForkName::Gloas,
+                        ..
+                    }
+                )
+            },
+            "RoleNotActiveAfterEthFork (ValidatorRegistration post-Gloas)",
+        );
+    }
+
+    #[test]
     fn test_voluntary_exit_within_ttl_accepted() {
         // Setup
         let committee_info = create_committee_info(FOUR_NODE_COMMITTEE);
@@ -1779,6 +1823,62 @@ mod tests {
             },
             "RoleNotActiveBeforeEthFork (PTCAttester pre-Gloas)",
         );
+    }
+
+    #[test]
+    fn test_validator_registration_rejected_at_gloas_boundary() {
+        use crate::validate_role_for_fork;
+
+        let committee_info = create_committee_info(FOUR_NODE_COMMITTEE);
+        let (private_key, public_key) = generate_test_key_pair();
+        let map =
+            create_operator_pub_keys(committee_info.committee_members.clone(), vec![public_key]);
+        let signed_msg = create_signed_partial_sig_message(
+            Role::ValidatorRegistration,
+            PartialSignatureKind::ValidatorRegistration,
+            OperatorId(1),
+            &private_key,
+        );
+
+        let fork_schedule = generate_fork_schedule(Fork::Boole);
+        let mut validation_context = create_test_validation_context_with_fork(
+            &signed_msg,
+            &committee_info,
+            Role::ValidatorRegistration,
+            &map,
+            Some(fork_schedule),
+        );
+        // The role gate reads the Ethereum fork from the spec; Gloas activates at epoch 2.
+        validation_context.spec = spec_with_gloas(Some(2));
+
+        // Slot 63 is the last slot of epoch 1 (32 slots per epoch): still pre-Gloas,
+        // so registrations remain valid.
+        let result = validate_role_for_fork(Slot::new(63), &validation_context);
+        assert!(result.is_ok(), "Expected ok but got: {result:?}");
+
+        // Slot 64 is the first slot of epoch 2: Gloas is active, the deprecated
+        // duty is rejected.
+        let result = validate_role_for_fork(Slot::new(64), &validation_context);
+        assert_validation_error(
+            result,
+            |failure| {
+                matches!(
+                    failure,
+                    ValidationFailure::RoleNotActiveAfterEthFork {
+                        role: Role::ValidatorRegistration,
+                        deprecated_since_fork: types::ForkName::Gloas,
+                        ..
+                    }
+                )
+            },
+            "RoleNotActiveAfterEthFork (ValidatorRegistration post-Gloas)",
+        );
+
+        // Pins the mainnet no-op: with Gloas unscheduled, the deprecation gate
+        // never fires regardless of slot.
+        validation_context.spec = spec_with_gloas(None);
+        let result = validate_role_for_fork(Slot::new(100_000), &validation_context);
+        assert!(result.is_ok(), "Expected ok but got: {result:?}");
     }
 
     #[test]


### PR DESCRIPTION
## Problem, Evidence, and Context (Required)

- SIP-94 §5 deprecates the SSV `ValidatorRegistration` duty at the Gloas fork: proposer preferences replace relay registrations, and the relay path is gone with blinded blocks. The emit side shipped in #1137; this is the receive-side half: reject inbound VR partial-signature messages whose envelope slot is at/after Gloas.
- Defense-in-depth: honest upgraded operators emit nothing post-Gloas, so a Gloas-slot VR message is a buggy, stale, or non-upgraded sender. Downstream components (`signature_collector`, `message_receiver` dispatch) are role-blind, making `validate_role_for_fork` the single load-bearing inbound control.
- Closes #1115. SIP: ssvlabs/SIPs#94. Emit-side twin: #1065 (#1137).

## Change Overview (Required)

- New `ValidationFailure::RoleNotActiveAfterEthFork` variant, filling the one empty cell in the existing 2x2 gate matrix (not-yet-active/deprecated x SSV `Fork`/Ethereum `ForkName`), and a fourth branch in `validate_role_for_fork` mirroring the PTCAttester gate with inverted polarity.
- Where to focus review:
  1. `lib.rs`, the new branch in `validate_role_for_fork`: the only production logic. The gate keys on the message envelope slot's epoch (not wall clock), so the first slot of `GLOAS_FORK_EPOCH` rejects and every earlier slot accepts; registrations for pre-fork slots stay valid through their TTL window even when arriving post-fork.
  2. `consensus_message.rs`: the shared arrange/act of the Boole fork tests was factored into `run_role_fork_validation` so the new VR test could reuse it. Confirm the 4 existing Boole tests still assert exactly what they did.
  3. `partial_signature.rs`: additive tests; `spec_with_gloas` moved to the shared `crate::tests` module.
- Intentionally unchanged: wire values (`Role` byte `[4,0,0,0]`, `PartialSignatureKind::ValidatorRegistration = 4`) are retained for pre-Gloas decode per SIP-94 §5, and the acceptance mapping is untouched (the new variant falls through to REJECT like its three siblings).

## Risks, Trade-offs, and Mitigations (Required)

- No behavior change until a network schedules Gloas (`gloas_fork_epoch = None` everywhere today); pinned by a dedicated assertion.
- REJECT rather than IGNORE: a post-Gloas-slot VR is categorically invalid per the SIP, matching the Boole deprecation of Aggregator/SyncCommittee; the peer-score penalty only hits peers still running the deprecated duty schedule.
- Post-Gloas, a VR message on the consensus path now surfaces `RoleNotActiveAfterEthFork` instead of the structural `UnexpectedConsensusMessage` (the fork gate runs first); both map to REJECT.

## Validation (Required)

- Unit test at the exact fork boundary (last pre-fork slot accepts, first fork-epoch slot rejects, Gloas-unscheduled is a no-op) plus end-to-end REJECT tests through both entry paths (partial-sig and consensus).
- `cargo test -p message_validator`: 66 passed. Workspace fmt, clippy, and `cargo check` clean.

## Rollback (Required for behavior or runtime changes; optional otherwise)

- Revert the single commit; no config, data, or wire impact.

## Blockers / Dependencies (Optional)

N/A. Independent of #1062-#1064.
