### PR TITLE
chore: backmerge stable → unstable (v1.3.0 prep)

### DIFF
--- a/.github/prompts/review.md
+++ b/.github/prompts/review.md
@@ -20,5 +20,7 @@ Do NOT comment on:
 
 When you DO find issues:
 - Use inline comments with concrete fix suggestions
+- Post each inline comment as soon as the issue is confirmed; do not save
+  them all up for the end of the review
 - Post a brief summary comment ONLY listing the issues found
 - No preamble, no praise, no filler

--- a/.github/workflows/claude-mentions.yml
+++ b/.github/workflows/claude-mentions.yml
@@ -83,14 +83,14 @@ jobs:
 
             - name: Run Claude Code Action
               if: steps.check.outputs.is_member == 'true'
-              timeout-minutes: 15
+              timeout-minutes: 25
               uses: anthropics/claude-code-action@v1.0.127
               with:
                   github_token: ${{ steps.app-token.outputs.token }}
                   use_bedrock: "true"
                   claude_args: |
-                      --max-turns 50
-                      --model us.anthropic.claude-opus-4-7
+                      --max-turns 80
+                      --model us.anthropic.claude-opus-4-8
                       --allowedTools "Glob,Grep,LS,Read,mcp__github_comment__update_claude_comment,mcp__github_inline_comment__create_inline_comment,mcp__github_ci__get_ci_status,mcp__github_ci__get_workflow_run_details,mcp__github_ci__download_job_log,Bash(git status:*),Bash(git diff:*),Bash(git show:*),Bash(git log:*),Bash(git rev-parse:*),Bash(git merge-base:*),Bash(git grep:*)"
                       --disallowedTools "Edit,MultiEdit,Write,NotebookEdit,Bash(git add:*),Bash(git commit:*),Bash(git rm:*)"
                       --append-system-prompt "${{ steps.review-prompt.outputs.content }}"

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -102,9 +102,20 @@ jobs:
                     echo "PROMPT_EOF"
                   } >> "$GITHUB_OUTPUT"
 
+            # Save the diff to a file the agent can page through with Read.
+            # Reading it via `gh pr diff` wastes agent turns: large diffs
+            # overflow the tool-output limit and the tight tool allowlist
+            # blocks saving the output to a file.
+            - name: Save PR diff
+              if: steps.check.outputs.is_member == 'true'
+              run: |
+                  gh pr diff ${{ github.event.pull_request.number }} --repo ${{ github.repository }} > "${GITHUB_WORKSPACE}/.claude-pr-diff.txt"
+              env:
+                  GH_TOKEN: ${{ github.token }}
+
             - name: Run Claude Code Action
               if: steps.check.outputs.is_member == 'true'
-              timeout-minutes: 15
+              timeout-minutes: 25
               env:
                   ACTIONS_STEP_DEBUG: true
               uses: anthropics/claude-code-action@v1.0.127
@@ -114,6 +125,10 @@ jobs:
                   prompt: |
                       REPO: ${{ github.repository }}
                       PR NUMBER: ${{ github.event.pull_request.number }}
+
+                      The full unified diff of this PR is saved at .claude-pr-diff.txt in
+                      the repository root. Read it with the Read tool (use offset/limit to
+                      page through large diffs) instead of running `gh pr diff`.
 
                       You are an automated silent watchdog reviewer. Your job is to catch
                       real problems — NOT to provide a comprehensive review or commentary.
@@ -125,8 +140,8 @@ jobs:
 
                       ${{ steps.review-prompt.outputs.content }}
                   claude_args: |
-                      --max-turns 50
-                      --model us.anthropic.claude-opus-4-7
+                      --max-turns 80
+                      --model us.anthropic.claude-opus-4-8
                       --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Read,Grep,Bash(git status:*),Bash(git diff:*),Bash(git show:*),Bash(git log:*),Bash(git rev-parse:*),Bash(git merge-base:*),Bash(git grep:*)"
 
             - name: Remove claude-recheck label if present


### PR DESCRIPTION
Backmerge of `stable` into `unstable` ahead of the **v1.3.0** release. Folds in the single commit that landed directly on `stable` since `v1.2.4`:

- #1130 `ci: raise Claude review turn budget and bump to Opus 4.8` — `.github/` only, no runtime change.

This restores `stable` as an ancestor of `unstable` so the upcoming `release-v1.3.0 → stable` fast-forward merge succeeds.

⚠️ **Do not use the merge button.** This is a true 2-parent merge commit; the repo is squash-only, and squashing would drop the merge and defeat the purpose. It will be landed on `unstable` via a direct CLI fast-forward push that preserves the merge commit. **This PR is for CI + visibility only.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_016twd129VqN11gpnTbfN8gu
