### PR TITLE
chore: Release v1.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -765,7 +765,7 @@ dependencies = [
 
 [[package]]
 name = "anchor"
-version = "1.2.4"
+version = "1.3.0"
 dependencies = [
  "assert_cmd",
  "async-channel 1.9.0",
@@ -1813,7 +1813,7 @@ dependencies = [
 
 [[package]]
 name = "client"
-version = "1.2.4"
+version = "1.3.0"
 dependencies = [
  "anchor_validator_store",
  "beacon_node_fallback",
@@ -4333,7 +4333,7 @@ dependencies = [
 
 [[package]]
 name = "keygen"
-version = "1.2.4"
+version = "1.3.0"
 dependencies = [
  "clap",
  "global_config",
@@ -4348,7 +4348,7 @@ dependencies = [
 
 [[package]]
 name = "keysplit"
-version = "1.2.4"
+version = "1.3.0"
 dependencies = [
  "alloy",
  "base64",

--- a/anchor/Cargo.toml
+++ b/anchor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "anchor"
-version = "1.2.4"
+version = "1.3.0"
 edition = { workspace = true }
 authors = ["Sigma Prime <contact@sigmaprime.io>"]
 rust-version = "1.91.0"

--- a/anchor/client/Cargo.toml
+++ b/anchor/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "client"
-version = "1.2.4"
+version = "1.3.0"
 authors = ["Sigma Prime <contact@sigmaprime.io"]
 edition = { workspace = true }
 

--- a/anchor/common/version/src/lib.rs
+++ b/anchor/common/version/src/lib.rs
@@ -17,8 +17,8 @@ pub const VERSION: &str = git_version!(
         // NOTE: using --match instead of --exclude for compatibility with old Git
         "--match=thiswillnevermatchlol"
     ],
-    prefix = "Anchor/v1.2.4-",
-    fallback = "Anchor/v1.2.4"
+    prefix = "Anchor/v1.3.0-",
+    fallback = "Anchor/v1.3.0"
 );
 
 /// Returns the first eight characters of the latest commit hash for this build.

--- a/anchor/keygen/Cargo.toml
+++ b/anchor/keygen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "keygen"
-version = "1.2.4"
+version = "1.3.0"
 edition = { workspace = true }
 authors = ["Sigma Prime <contact@sigmaprime.io>"]
 

--- a/anchor/keysplit/Cargo.toml
+++ b/anchor/keysplit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "keysplit"
-version = "1.2.4"
+version = "1.3.0"
 edition = { workspace = true }
 authors = ["Sigma Prime <contact@sigmaprime.io>"]
 


### PR DESCRIPTION
Version bump to **v1.3.0** (from v1.2.4).

Bumps the workspace crate versions (`anchor`, `client`, `keygen`, `keysplit`) and the `version` crate string, plus the matching `Cargo.lock` entries. No other changes.

Release notes will accompany the tagged GitHub release.
