### PR TITLE
feat(client): spawn LH ProposerPreferencesService with AnchorValidatorStore backend

### DIFF
--- a/anchor/client/src/lib.rs
+++ b/anchor/client/src/lib.rs
@@ -63,6 +63,7 @@ use validator_services::{
     latency_service::start_latency_service,
     payload_attestation_service::PayloadAttestationService,
     preparation_service::PreparationServiceBuilder,
+    proposer_preferences_service::ProposerPreferencesService,
     sync_committee_service::SyncCommitteeService,
 };
 
@@ -821,7 +822,6 @@ impl Client {
         // mirroring LH's VC (validator_client/src/lib.rs:657). The service also self-gates per
         // slot on `gloas_enabled()`, but gating the start avoids spawning a perpetual idle task
         // on networks where Gloas is not scheduled.
-        // TODO(gloas, #1064): `ProposerPreferences` joins this block once implemented
         if spec.is_gloas_scheduled() {
             PayloadAttestationService::new(
                 duties_service.clone(),
@@ -833,6 +833,17 @@ impl Client {
             )
             .start_update_service()
             .map_err(|e| format!("Unable to start payload attestation service: {e}"))?;
+
+            ProposerPreferencesService::new(
+                duties_service.clone(),
+                validator_store.clone(),
+                slot_clock.clone(),
+                beacon_nodes.clone(),
+                executor.clone(),
+                spec.clone(),
+            )
+            .start_update_service()
+            .map_err(|e| format!("Unable to start proposer preferences service: {e}"))?;
         }
 
         http_api_shared_state.write().database_state = Some(database.watch());


### PR DESCRIPTION
Part of #1064 (ePBS Proposer Preferences duty milestone, SIP-94 §5).

Wires Lighthouse's `ProposerPreferencesService` (with `AnchorValidatorStore` as the backend) into client startup, inside the existing `is_gloas_scheduled()` gate next to `PayloadAttestationService`. Completes the Anchor-side pipeline: LH's service drives `sign_proposer_preferences` (#1063) per validator per epoch, dispatching both `proposal_data` and the signing through Anchor's `ValidatorStore` impl.

No new tests: the client crate has none and no sibling spawned service is tested — the behavior is LH's; Anchor's role is wiring (compile + startup).

Stacked on #1125 (#1063) — those commits drop out of this diff once it merges.

End-to-end SIP-94 §5 behavior additionally needs the upstream LH fix that schedules newly-added `(dependent_root, proposal_slot, validator)` tuples (the current key is `(epoch, dependent_root)` only); tracked in the issue.