### PR TITLE
chore: add gossipsub subscription filters

### DIFF
--- a/anchor/client/src/lib.rs
+++ b/anchor/client/src/lib.rs
@@ -611,6 +611,7 @@ impl Client {
             outcome_rx,
             executor.clone(),
             spec.clone(),
+            fork_schedule.clone(),
             lifecycle_rx,
         )
         .await

--- a/anchor/network/src/behaviour.rs
+++ b/anchor/network/src/behaviour.rs
@@ -1,6 +1,6 @@
 use std::{hash::Hasher, time::Duration};
 
-use fork::ForkLifecycle;
+use fork::{ForkLifecycle, ForkSchedule};
 use libp2p::{
     gossipsub::{self, ConfigBuilderError, MessageAuthenticity, ValidationMode},
     identify, ping,
@@ -8,6 +8,7 @@ use libp2p::{
     upnp::tokio::Behaviour as Upnp,
 };
 use prometheus_client::registry::Registry;
+use subnet_service::topic;
 use thiserror::Error;
 use tokio::sync::watch;
 use twox_hash::XxHash64;
@@ -16,7 +17,6 @@ use version::version_with_platform;
 
 use crate::{
     Config,
-    behaviour::BehaviourError::Gossipsub,
     discovery::{Discovery, FIND_NODE_QUERY_CLOSEST_PEERS},
     handshake,
     peer_manager::PeerManager,
@@ -24,6 +24,29 @@ use crate::{
 };
 
 const MAX_TRANSMIT_SIZE_BYTES: usize = 5_000_000;
+
+/// Subscription filter for gossipsub: peers may only subscribe us to topics that are valid on
+/// this network (any subnet of any scheduled fork), bounded by the size of that topic set.
+type SubscriptionFilter =
+    gossipsub::MaxCountSubscriptionFilter<gossipsub::WhitelistSubscriptionFilter>;
+
+/// The gossipsub behaviour type used by Anchor.
+pub type Gossipsub = gossipsub::Behaviour<gossipsub::IdentityTransform, SubscriptionFilter>;
+
+/// Build the subscription filter from the fork schedule.
+///
+/// The whitelist is built with the same topic construction used when subscribing, so it covers
+/// every subnet of every scheduled fork and nothing else. Note the filter also applies to our
+/// own `subscribe` calls.
+fn subscription_filter(fork_schedule: &ForkSchedule) -> SubscriptionFilter {
+    let possible_topics = topic::whitelist_topic_hashes(fork_schedule);
+    gossipsub::MaxCountSubscriptionFilter {
+        // A peer can at most subscribe to every valid topic.
+        max_subscribed_topics: possible_topics.len(),
+        max_subscriptions_per_request: possible_topics.len(),
+        filter: gossipsub::WhitelistSubscriptionFilter(possible_topics),
+    }
+}
 
 /// Gossipsub heartbeat interval in milliseconds (how often messages are propagated)
 pub const GOSSIPSUB_HEARTBEAT_INTERVAL_MILLIS: u64 = 700;
@@ -76,7 +99,7 @@ pub struct AnchorBehaviour {
     /// Used for connection health checks.
     pub ping: ping::Behaviour,
     /// The routing pub-sub mechanism for Anchor.
-    pub gossipsub: gossipsub::Behaviour,
+    pub gossipsub: Gossipsub,
     /// Discv5 Discovery protocol.
     pub discovery: Discovery,
     /// Anchor peer manager, wrapping libp2p behaviours with minimal added logic for peer
@@ -94,6 +117,7 @@ impl AnchorBehaviour {
         network_config: &Config,
         metrics_registry: &mut Registry,
         spec: &ChainSpec,
+        fork_schedule: &ForkSchedule,
         lifecycle_rx: watch::Receiver<ForkLifecycle>,
     ) -> Result<Self, BehaviourError> {
         let identify = {
@@ -132,9 +156,12 @@ impl AnchorBehaviour {
             .validate_messages()
             .build()?;
 
-        let mut gossipsub =
-            gossipsub::Behaviour::new(MessageAuthenticity::RandomAuthor, gossipsub_config)
-                .map_err(|e| Gossipsub(e.to_string()))?;
+        let mut gossipsub = gossipsub::Behaviour::new_with_subscription_filter(
+            MessageAuthenticity::RandomAuthor,
+            gossipsub_config,
+            subscription_filter(fork_schedule),
+        )
+        .map_err(|e| BehaviourError::Gossipsub(e.to_string()))?;
         gossipsub = gossipsub.with_metrics(
             metrics_registry.sub_registry_with_prefix("gossipsub"),
             gossipsub::MetricsConfig::default(),
@@ -151,7 +178,7 @@ impl AnchorBehaviour {
             gossipsub
                 .with_peer_score(score_params, score_thresholds)
                 .map_err(|e| {
-                    Gossipsub(format!(
+                    BehaviourError::Gossipsub(format!(
                         "Failed to activate the peer scoring system with the given parameters: {e}"
                     ))
                 })?;
@@ -327,5 +354,44 @@ mod tests {
 
         // Same data should produce same message ID
         assert_eq!(msg_id_1, msg_id_2);
+    }
+
+    #[test]
+    fn test_subscription_filter_allows_valid_topics_and_rejects_others() {
+        use fork::Fork;
+        use libp2p::gossipsub::TopicSubscriptionFilter;
+        use ssv_types::domain_type::DomainType;
+        use subnet_service::{SUBNET_COUNT, SubnetId, topic::create_topic};
+
+        let network_name = "mainnet";
+        let fork_schedule = ForkSchedule::new(Fork::Boole, DomainType([0, 0, 0, 1]), network_name);
+        let mut filter = subscription_filter(&fork_schedule);
+
+        // Both forks are scheduled, so both bounds cover every valid topic
+        assert_eq!(filter.max_subscribed_topics, 2 * SUBNET_COUNT);
+        assert_eq!(filter.max_subscriptions_per_request, 2 * SUBNET_COUNT);
+
+        // Topics built the way the subscription path builds them must pass the filter,
+        // otherwise our own `subscribe` calls would fail with `SubscriptionError::NotAllowed`.
+        // Exhaustive whitelist coverage lives in the `subnet_service::topic` tests.
+        for fork in Fork::all() {
+            let topic = create_topic(&fork.topic_prefix(network_name), SubnetId::from(0u64));
+            assert!(
+                filter
+                    .filter
+                    .can_subscribe(&gossipsub::IdentTopic::new(topic).hash()),
+                "valid topic must be whitelisted"
+            );
+        }
+
+        // Anything else is rejected
+        for invalid in ["ssv.v2.128", "/ssv/holesky/boole/0", "random-topic"] {
+            assert!(
+                !filter
+                    .filter
+                    .can_subscribe(&gossipsub::IdentTopic::new(invalid).hash()),
+                "invalid topic {invalid} must be rejected"
+            );
+        }
     }
 }

--- a/anchor/network/src/behaviour.rs
+++ b/anchor/network/src/behaviour.rs
@@ -25,27 +25,18 @@ use crate::{
 
 const MAX_TRANSMIT_SIZE_BYTES: usize = 5_000_000;
 
-/// Subscription filter for gossipsub: peers may only subscribe us to topics that are valid on
-/// this network (any subnet of any scheduled fork), bounded by the size of that topic set.
-type SubscriptionFilter =
-    gossipsub::MaxCountSubscriptionFilter<gossipsub::WhitelistSubscriptionFilter>;
-
-/// The gossipsub behaviour type used by Anchor.
-pub type Gossipsub = gossipsub::Behaviour<gossipsub::IdentityTransform, SubscriptionFilter>;
+/// The gossipsub behaviour type used by Anchor. The subscription filter ensures peers may only
+/// subscribe us to topics that are valid on this network (any subnet of any scheduled fork).
+pub type Gossipsub =
+    gossipsub::Behaviour<gossipsub::IdentityTransform, gossipsub::WhitelistSubscriptionFilter>;
 
 /// Build the subscription filter from the fork schedule.
 ///
 /// The whitelist is built with the same topic construction used when subscribing, so it covers
 /// every subnet of every scheduled fork and nothing else. Note the filter also applies to our
 /// own `subscribe` calls.
-fn subscription_filter(fork_schedule: &ForkSchedule) -> SubscriptionFilter {
-    let possible_topics = topic::whitelist_topic_hashes(fork_schedule);
-    gossipsub::MaxCountSubscriptionFilter {
-        // A peer can at most subscribe to every valid topic.
-        max_subscribed_topics: possible_topics.len(),
-        max_subscriptions_per_request: possible_topics.len(),
-        filter: gossipsub::WhitelistSubscriptionFilter(possible_topics),
-    }
+fn subscription_filter(fork_schedule: &ForkSchedule) -> gossipsub::WhitelistSubscriptionFilter {
+    gossipsub::WhitelistSubscriptionFilter(topic::whitelist_topic_hashes(fork_schedule))
 }
 
 /// Gossipsub heartbeat interval in milliseconds (how often messages are propagated)
@@ -361,15 +352,11 @@ mod tests {
         use fork::Fork;
         use libp2p::gossipsub::TopicSubscriptionFilter;
         use ssv_types::domain_type::DomainType;
-        use subnet_service::{SUBNET_COUNT, SubnetId, topic::create_topic};
+        use subnet_service::{SubnetId, topic::create_topic};
 
         let network_name = "mainnet";
         let fork_schedule = ForkSchedule::new(Fork::Boole, DomainType([0, 0, 0, 1]), network_name);
         let mut filter = subscription_filter(&fork_schedule);
-
-        // Both forks are scheduled, so both bounds cover every valid topic
-        assert_eq!(filter.max_subscribed_topics, 2 * SUBNET_COUNT);
-        assert_eq!(filter.max_subscriptions_per_request, 2 * SUBNET_COUNT);
 
         // Topics built the way the subscription path builds them must pass the filter,
         // otherwise our own `subscribe` calls would fail with `SubscriptionError::NotAllowed`.
@@ -377,9 +364,7 @@ mod tests {
         for fork in Fork::all() {
             let topic = create_topic(&fork.topic_prefix(network_name), SubnetId::from(0u64));
             assert!(
-                filter
-                    .filter
-                    .can_subscribe(&gossipsub::IdentTopic::new(topic).hash()),
+                filter.can_subscribe(&gossipsub::IdentTopic::new(topic).hash()),
                 "valid topic must be whitelisted"
             );
         }
@@ -387,9 +372,7 @@ mod tests {
         // Anything else is rejected
         for invalid in ["ssv.v2.128", "/ssv/holesky/boole/0", "random-topic"] {
             assert!(
-                !filter
-                    .filter
-                    .can_subscribe(&gossipsub::IdentTopic::new(invalid).hash()),
+                !filter.can_subscribe(&gossipsub::IdentTopic::new(invalid).hash()),
                 "invalid topic {invalid} must be rejected"
             );
         }

--- a/anchor/network/src/network.rs
+++ b/anchor/network/src/network.rs
@@ -7,7 +7,7 @@ use std::{
     time::Duration,
 };
 
-use fork::ForkLifecycle;
+use fork::{ForkLifecycle, ForkSchedule};
 use futures::StreamExt;
 use libp2p::{
     Multiaddr, PeerId, Swarm, SwarmBuilder, TransportError,
@@ -33,7 +33,7 @@ use types::{ChainSpec, EthSpec};
 
 use crate::{
     Config, Enr,
-    behaviour::{AnchorBehaviour, AnchorBehaviourEvent, BehaviourError},
+    behaviour::{AnchorBehaviour, AnchorBehaviourEvent, BehaviourError, Gossipsub},
     discovery::{DiscoveredPeers, Discovery, DiscoveryError},
     handshake,
     keypair_utils::load_private_key,
@@ -100,6 +100,7 @@ impl<R: MessageReceiver> Network<R> {
         outcome_rx: mpsc::Receiver<Outcome>,
         executor: TaskExecutor,
         spec: Arc<ChainSpec>,
+        fork_schedule: Arc<ForkSchedule>,
         mut lifecycle_rx: watch::Receiver<ForkLifecycle>,
     ) -> Result<Network<R>, Box<NetworkError>> {
         let local_keypair: Keypair = load_private_key(&config.network_dir.key_file());
@@ -117,6 +118,7 @@ impl<R: MessageReceiver> Network<R> {
             config,
             &mut metrics_registry,
             &spec,
+            &fork_schedule,
             lifecycle_rx.clone(),
         )
         .await
@@ -722,7 +724,7 @@ impl<R: MessageReceiver> Network<R> {
         &mut self.swarm.behaviour_mut().peer_manager
     }
 
-    fn gossipsub(&mut self) -> &mut gossipsub::Behaviour {
+    fn gossipsub(&mut self) -> &mut Gossipsub {
         &mut self.swarm.behaviour_mut().gossipsub
     }
 

--- a/anchor/subnet_service/src/topic.rs
+++ b/anchor/subnet_service/src/topic.rs
@@ -5,8 +5,10 @@
 //! - Alan (legacy): `ssv.v2.<subnet_id>`
 //! - Boole and later: `/ssv/<network>/<fork>/<subnet_id>`
 
-use fork::Fork;
-use libp2p::gossipsub::TopicHash;
+use std::collections::HashSet;
+
+use fork::{Fork, ForkSchedule};
+use libp2p::gossipsub::{IdentTopic, TopicHash};
 
 use crate::{SUBNET_COUNT, SubnetId};
 
@@ -15,6 +17,27 @@ use crate::{SUBNET_COUNT, SubnetId};
 /// The prefix should include the trailing separator (e.g., "ssv.v2." or "/ssv/mainnet/boole/").
 pub fn create_topic(prefix: &str, subnet: SubnetId) -> String {
     format!("{}{}", prefix, *subnet)
+}
+
+/// Compute the set of all gossipsub topic hashes that are valid on this network.
+///
+/// Covers every subnet of every fork in the schedule, using the same
+/// [`Fork::topic_prefix`]/[`create_topic`] construction as the subscription path, so the
+/// result exactly matches the topics the node may subscribe to. Used to build the gossipsub
+/// subscription whitelist that stops peers from subscribing us to arbitrary topics.
+pub fn whitelist_topic_hashes(schedule: &ForkSchedule) -> HashSet<TopicHash> {
+    let mut hashes = HashSet::with_capacity(Fork::all().len() * SUBNET_COUNT);
+    for fork in Fork::all() {
+        if schedule.config(*fork).is_none() {
+            continue;
+        }
+        let prefix = fork.topic_prefix(schedule.network_name());
+        for subnet in 0..SUBNET_COUNT as u64 {
+            let topic = create_topic(&prefix, SubnetId::from(subnet));
+            hashes.insert(IdentTopic::new(topic).hash());
+        }
+    }
+    hashes
 }
 
 /// Result of parsing a topic hash.
@@ -109,8 +132,12 @@ pub fn extract_subnet_id(topic_str: &str) -> Option<u64> {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeMap;
+
     use libp2p::gossipsub::IdentTopic;
     use ssv_network_config::ALAN_TOPIC_PREFIX;
+    use ssv_types::domain_type::DomainType;
+    use types::Epoch;
 
     use super::*;
 
@@ -122,6 +149,10 @@ mod tests {
     const TEST_SUBNET_ID: u64 = 42;
     const ALTERNATE_SUBNET_ID: u64 = 100;
     const OUT_OF_RANGE_SUBNET_ID: u64 = 200;
+
+    // Test fork domains
+    const ALAN_DOMAIN: DomainType = DomainType([0, 0, 0, 1]);
+    const BOOLE_DOMAIN: DomainType = DomainType([0, 0, 0, 2]);
 
     /// Constructs the expected Boole topic string for a network and subnet.
     fn expected_boole_topic(network: &str, subnet_id: u64) -> String {
@@ -165,6 +196,70 @@ mod tests {
             topic.as_str(),
             expected_boole_topic(MAINNET, TEST_SUBNET_ID),
             "Boole topic should use network-specific prefix"
+        );
+    }
+
+    // ==================== whitelist_topic_hashes tests ====================
+
+    /// Constructs a schedule with Alan at epoch 0 and Boole at a later epoch.
+    fn two_fork_schedule(network: &str) -> ForkSchedule {
+        let mut configs = BTreeMap::new();
+        configs.insert(Fork::Alan, (Epoch::new(0), ALAN_DOMAIN));
+        configs.insert(Fork::Boole, (Epoch::new(100), BOOLE_DOMAIN));
+        ForkSchedule::from_fork_configs(configs, network).expect("valid test schedule")
+    }
+
+    #[test]
+    fn test_whitelist_topic_hashes_covers_all_subnets_of_all_scheduled_forks() {
+        // Arrange
+        let schedule = two_fork_schedule(MAINNET);
+
+        // Act
+        let hashes = whitelist_topic_hashes(&schedule);
+
+        // Assert
+        assert_eq!(
+            hashes.len(),
+            2 * SUBNET_COUNT,
+            "should contain one topic per subnet per scheduled fork"
+        );
+        for subnet_id in 0..SUBNET_COUNT as u64 {
+            let alan_hash = IdentTopic::new(expected_alan_topic(subnet_id)).hash();
+            let boole_hash = IdentTopic::new(expected_boole_topic(MAINNET, subnet_id)).hash();
+            assert!(
+                hashes.contains(&alan_hash),
+                "should contain Alan topic for subnet {subnet_id}"
+            );
+            assert!(
+                hashes.contains(&boole_hash),
+                "should contain Boole topic for subnet {subnet_id}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_whitelist_topic_hashes_excludes_invalid_topics() {
+        // Arrange
+        let schedule = two_fork_schedule(MAINNET);
+
+        // Act
+        let hashes = whitelist_topic_hashes(&schedule);
+
+        // Assert
+        let out_of_range = IdentTopic::new(expected_alan_topic(OUT_OF_RANGE_SUBNET_ID)).hash();
+        let wrong_network = IdentTopic::new(expected_boole_topic(HOLESKY, TEST_SUBNET_ID)).hash();
+        let foreign = IdentTopic::new("/eth2/12345678/beacon_block/ssz_snappy").hash();
+        assert!(
+            !hashes.contains(&out_of_range),
+            "should not contain out-of-range subnet topics"
+        );
+        assert!(
+            !hashes.contains(&wrong_network),
+            "should not contain topics for other networks"
+        );
+        assert!(
+            !hashes.contains(&foreign),
+            "should not contain topics from other protocols"
         );
     }
 


### PR DESCRIPTION
Configures a whitelist-based subscription filter for gossipsub, following the approach used in Lighthouse. Peers can now only subscribe us to topics that are valid on the network (any subnet of any scheduled fork), with subscription counts bounded by the size of that topic set.