### PR TITLE
feat: add validator-scoped QBFT Role::EnvelopeProposer (#1120)

### DIFF
--- a/anchor/common/ssv_types/src/msgid.rs
+++ b/anchor/common/ssv_types/src/msgid.rs
@@ -23,6 +23,7 @@ pub enum Role {
     AggregatorCommittee,
     PTCAttester,
     ProposerPreferences,
+    EnvelopeProposer,
 }
 
 impl From<Role> for [u8; 4] {
@@ -37,6 +38,7 @@ impl From<Role> for [u8; 4] {
             Role::AggregatorCommittee => [6, 0, 0, 0],
             Role::PTCAttester => [7, 0, 0, 0],
             Role::ProposerPreferences => [8, 0, 0, 0],
+            Role::EnvelopeProposer => [9, 0, 0, 0],
         }
     }
 }
@@ -55,6 +57,7 @@ impl TryFrom<&[u8]> for Role {
             [6, 0, 0, 0] => Ok(Role::AggregatorCommittee),
             [7, 0, 0, 0] => Ok(Role::PTCAttester),
             [8, 0, 0, 0] => Ok(Role::ProposerPreferences),
+            [9, 0, 0, 0] => Ok(Role::EnvelopeProposer),
             _ => Err(DecodeError::NoMatchingVariant),
         }
     }
@@ -77,6 +80,7 @@ impl Role {
         match self {
             Role::Committee | Role::Aggregator | Role::AggregatorCommittee => Some(12),
             Role::Proposer | Role::SyncCommittee => Some(6),
+            Role::EnvelopeProposer => Some(2),
             // These roles don't use QBFT consensus
             Role::ValidatorRegistration
             | Role::VoluntaryExit
@@ -178,7 +182,8 @@ impl MessageId {
             | Role::ValidatorRegistration
             | Role::VoluntaryExit
             | Role::PTCAttester
-            | Role::ProposerPreferences => PublicKeyBytes::deserialize(&self.0[8..])
+            | Role::ProposerPreferences
+            | Role::EnvelopeProposer => PublicKeyBytes::deserialize(&self.0[8..])
                 .ok()
                 .map(DutyExecutor::Validator),
         }
@@ -416,6 +421,7 @@ mod tests {
             Role::AggregatorCommittee,
             Role::Proposer,
             Role::SyncCommittee,
+            Role::EnvelopeProposer,
         ] {
             assert!(role.is_qbft_role(), "{role:?} runs QBFT");
             assert!(role.max_round().is_some(), "{role:?} must have a max round");
@@ -459,11 +465,58 @@ mod tests {
             Role::ValidatorRegistration,
             Role::VoluntaryExit,
             Role::PTCAttester,
+            Role::EnvelopeProposer,
         ] {
             assert!(
                 role.monotonic_slot_role(),
                 "{role:?} must be a monotonic-slot role"
             );
         }
+    }
+
+    /// Tests that EnvelopeProposer is a validator-scoped QBFT role with
+    /// round cut-off 2.
+    #[test]
+    fn envelope_proposer_is_validator_scoped_qbft_with_round_cutoff_two() {
+        assert!(
+            !Role::EnvelopeProposer.is_committee_role(),
+            "EnvelopeProposer is per-validator, not a committee role"
+        );
+        assert_eq!(
+            Role::EnvelopeProposer.max_round(),
+            Some(2),
+            "Envelope QBFT cut-off round must be 2"
+        );
+        assert!(
+            Role::EnvelopeProposer.is_qbft_role(),
+            "EnvelopeProposer runs QBFT (max_round is Some)"
+        );
+        assert!(
+            Role::EnvelopeProposer.monotonic_slot_role(),
+            "EnvelopeProposer signers advance slot-by-slot; lower slots are stale"
+        );
+
+        // Wire byte 9 for EnvelopeProposer check.
+        let bytes: [u8; 4] = Role::EnvelopeProposer.into();
+        assert_eq!(bytes, [9, 0, 0, 0], "EnvelopeProposer wire byte is 9");
+        assert_eq!(
+            Role::try_from(bytes.as_slice()).unwrap(),
+            Role::EnvelopeProposer,
+            "wire byte 9 decodes back to EnvelopeProposer"
+        );
+
+        // duty_executor resolves to Validator (per-proposer, pubkey-scoped).
+        let domain = DomainType([0, 0, 0, 1]);
+        let pk = PublicKeyBytes::empty();
+        let msg_id = MessageId::new(
+            &domain,
+            Role::EnvelopeProposer,
+            &DutyExecutor::Validator(pk),
+        );
+        assert_eq!(
+            msg_id.duty_executor(),
+            Some(DutyExecutor::Validator(pk)),
+            "EnvelopeProposer resolves to a validator-scoped duty executor"
+        );
     }
 }

--- a/anchor/message_validator/src/consensus_message.rs
+++ b/anchor/message_validator/src/consensus_message.rs
@@ -1882,6 +1882,90 @@ mod tests {
         assert_eq!(result, Ok(Some(SLOTS_PER_EPOCH)));
     }
 
+    #[test]
+    fn test_duty_limit_envelope_proposer() {
+        // EnvelopeProposer is validator-scoped and per-slot. Its duty limit is
+        // `slots_per_epoch` (one envelope per slot across the lookahead window),
+        // independent of the validator-index slice length. Mirror
+        // test_duty_limit_proposer_preferences.
+        const SLOTS_PER_EPOCH: u64 = 32;
+
+        let now = SystemTime::now();
+        let slot_clock = ManualSlotClock::new(
+            Slot::new(100),
+            now.duration_since(UNIX_EPOCH).unwrap(),
+            Duration::from_secs(1),
+        );
+
+        let msg_id = MessageId::new(
+            &DomainType([0, 0, 0, 1]),
+            Role::EnvelopeProposer,
+            &DutyExecutor::Validator(PublicKeyBytes::empty()),
+        );
+        let ssv_msg = SSVMessage::new(MsgType::SSVConsensusMsgType, msg_id, vec![1, 2, 3])
+            .expect("SSVMessage should be created");
+        let signed_msg = SignedSSVMessage::new(
+            vec![[0xAA; RSA_SIGNATURE_SIZE]],
+            vec![OperatorId(1)],
+            ssv_msg,
+            vec![],
+        )
+        .expect("SignedSSVMessage should be created");
+
+        let committee_info = create_committee_info(FOUR_NODE_COMMITTEE);
+        let mock_duties_provider = Arc::new(MockDutiesProvider::default());
+        let map = HashMap::new();
+
+        // Create fork schedule with Boole at epoch 0 (active from start).
+        let mut fork_epochs = BTreeMap::new();
+        fork_epochs.insert(Fork::Alan, (Epoch::new(0), DomainType([0, 0, 0, 42])));
+        fork_epochs.insert(Fork::Boole, (Epoch::new(0), DomainType([0, 0, 0, 43])));
+        let fork_schedule = Arc::new(
+            fork::ForkSchedule::from_fork_configs(fork_epochs, "testing")
+                .expect("test fork schedule creation should succeed"),
+        );
+
+        let validation_context = ValidationContext {
+            signed_ssv_message: &signed_msg,
+            committee_info: &committee_info,
+            role: Role::EnvelopeProposer,
+            received_at: now,
+            slots_per_epoch: SLOTS_PER_EPOCH,
+            epochs_per_sync_committee_period: 256,
+            sync_committee_size: 512,
+            slot_clock: slot_clock.clone(),
+            operator_pub_keys: &map,
+            fork_schedule,
+            spec: Arc::new(types::ChainSpec::mainnet()),
+        };
+
+        let slot = slot_clock.now().unwrap();
+
+        // Act: Call duty_limit directly (private items visible to child-module tests).
+        let result = duty_limit(
+            &validation_context,
+            slot,
+            &[ValidatorIndex(0)], // Single validator; irrelevant for EnvelopeProposer
+            mock_duties_provider.clone(),
+        );
+
+        // Assert: Duty cap must equal slots_per_epoch and be independent of slice length.
+        assert_eq!(
+            result,
+            Ok(Some(SLOTS_PER_EPOCH)),
+            "EnvelopeProposer duty cap must be slots_per_epoch"
+        );
+
+        // Verify independence from slice length.
+        let many = vec![ValidatorIndex(0); 100];
+        let result = duty_limit(&validation_context, slot, &many, mock_duties_provider);
+        assert_eq!(
+            result,
+            Ok(Some(SLOTS_PER_EPOCH)),
+            "duty cap must be independent of validator-index slice length"
+        );
+    }
+
     /// Builds a signed consensus message for `role` and runs it through the full
     /// `validate_ssv_message` path (including `validate_role_for_fork`) with the
     /// given fork schedule and chain spec, returning the result for the caller
@@ -2028,6 +2112,33 @@ mod tests {
                 )
             },
             "RoleNotActiveAfterEthFork (ValidatorRegistration consensus message post-Gloas)",
+        );
+    }
+
+    #[test]
+    fn test_envelope_proposer_consensus_message_rejected_before_gloas() {
+        // `EnvelopeProposer` is a post-Gloas role. With Gloas never activating
+        // (`spec_with_gloas(None)`), the shared `validate_role_for_fork` gate must reject
+        // its consensus message at every slot. The gate is role-agnostic across entry
+        // points, so exercising it once via the consensus path covers the envelope role.
+        let result = run_role_fork_validation(
+            Role::EnvelopeProposer,
+            generate_fork_schedule(),
+            spec_with_gloas(None),
+        );
+
+        assert_validation_error(
+            result,
+            |failure| {
+                matches!(
+                    failure,
+                    ValidationFailure::RoleNotActiveBeforeEthFork {
+                        minimum_fork: types::ForkName::Gloas,
+                        ..
+                    }
+                )
+            },
+            "RoleNotActiveBeforeEthFork (EnvelopeProposer consensus message pre-Gloas)",
         );
     }
 }

--- a/anchor/message_validator/src/consensus_message.rs
+++ b/anchor/message_validator/src/consensus_message.rs
@@ -497,7 +497,8 @@ mod tests {
 
     use super::*;
     use crate::{
-        LATE_MESSAGE_MARGIN, LATE_SLOT_ALLOWANCE, ValidatedSSVMessage, duty_limit,
+        LATE_MESSAGE_MARGIN, LATE_SLOT_ALLOWANCE, MessageAcceptance, ValidatedSSVMessage,
+        duty_limit,
         tests::{
             FOUR_NODE_COMMITTEE, SINGLE_NODE_COMMITTEE, create_committee_info,
             create_operator_pub_keys, generate_random_rsa_public_keys,
@@ -2126,7 +2127,6 @@ mod tests {
             generate_fork_schedule(),
             spec_with_gloas(None),
         );
-
         assert_validation_error(
             result,
             |failure| {
@@ -2139,6 +2139,18 @@ mod tests {
                 )
             },
             "RoleNotActiveBeforeEthFork (EnvelopeProposer consensus message pre-Gloas)",
+        );
+
+        // Ensures that pre-Gloas EnvelopeProposer messages caught at fork-gate are rejected and not
+        // ignored.
+        assert_eq!(
+            MessageAcceptance::from(&ValidationFailure::RoleNotActiveBeforeEthFork {
+                role: Role::EnvelopeProposer,
+                current_fork: types::ForkName::Base,
+                minimum_fork: types::ForkName::Gloas,
+            }),
+            MessageAcceptance::Reject,
+            "fork-gate failure must be Reject",
         );
     }
 }

--- a/anchor/message_validator/src/lib.rs
+++ b/anchor/message_validator/src/lib.rs
@@ -480,7 +480,8 @@ impl<S: SlotClock + 'static, D: DutiesProvider> Validator<S, D> {
             | Role::ValidatorRegistration
             | Role::VoluntaryExit
             | Role::PTCAttester
-            | Role::ProposerPreferences => {
+            | Role::ProposerPreferences
+            | Role::EnvelopeProposer => {
                 let validator_pk = match ssv_message.msg_id().duty_executor() {
                     Some(DutyExecutor::Validator(pk)) => pk,
                     _ => return Err(ValidationFailure::UnknownValidator),
@@ -844,11 +845,11 @@ pub(crate) fn validate_beacon_duty(
         }
     }
 
-    // Rule: For a proposer-preferences message, the validator must be the assigned proposer at the
-    // preference's `proposal_slot` (= `slot` here). Checked only once the slot-epoch's proposer
-    // duties are known locally, so a not-yet-fetched epoch is tolerated. No RANDAO tolerance:
-    // ProposerPreferences carries no RANDAO signature.
-    if role == Role::ProposerPreferences {
+    // Rule: For a proposer-preferences or envelope-proposer message, the validator must be the
+    // assigned proposer at the slot. Checked only once the slot-epoch's proposer duties are known
+    // locally, so a not-yet-fetched epoch is tolerated. No RANDAO tolerance: neither
+    // ProposerPreferences nor EnvelopeProposer carry a RANDAO signature.
+    if matches!(role, Role::ProposerPreferences | Role::EnvelopeProposer) {
         // Non-committee roles always have one validator index
         let validator_index = validation_context
             .committee_info
@@ -895,6 +896,7 @@ pub(crate) fn validate_beacon_duty(
 /// - PTCAttester before the Ethereum Gloas (ePBS) fork (not yet active)
 /// - ValidatorRegistration at/after the Ethereum Gloas (ePBS) fork (deprecated by SIP-94)
 /// - ProposerPreferences before the Ethereum Gloas (ePBS) fork (not yet active)
+/// - EnvelopeProposer before the Ethereum Gloas (ePBS) fork (not yet active)
 pub(crate) fn validate_role_for_fork(
     slot: Slot,
     validation_context: &ValidationContext<impl SlotClock>,
@@ -921,18 +923,6 @@ pub(crate) fn validate_role_for_fork(
         });
     }
 
-    // Reject PTCAttester before the Ethereum Gloas (ePBS) fork, read from the consensus spec.
-    if role == Role::PTCAttester {
-        let current_fork = validation_context.spec.fork_name_at_epoch(epoch);
-        if !current_fork.gloas_enabled() {
-            return Err(ValidationFailure::RoleNotActiveBeforeEthFork {
-                role,
-                current_fork,
-                minimum_fork: ForkName::Gloas,
-            });
-        }
-    }
-
     // Reject ValidatorRegistration at/after the Ethereum Gloas (ePBS) fork; SIP-94
     // deprecates the duty (proposer preferences replace relay registrations). Gated
     // on the message's duty slot, not wall clock, so registrations for pre-fork
@@ -949,9 +939,12 @@ pub(crate) fn validate_role_for_fork(
         }
     }
 
-    // Reject ProposerPreferences before the Ethereum Gloas (ePBS) fork, read from the consensus
-    // spec.
-    if role == Role::ProposerPreferences {
+    // Reject post-Gloas roles (PTCAttester, ProposerPreferences, EnvelopeProposer) before the
+    // Ethereum Gloas (ePBS) fork, read from the consensus spec.
+    if matches!(
+        role,
+        Role::PTCAttester | Role::ProposerPreferences | Role::EnvelopeProposer
+    ) {
         let current_fork = validation_context.spec.fork_name_at_epoch(epoch);
         if !current_fork.gloas_enabled() {
             return Err(ValidationFailure::RoleNotActiveBeforeEthFork {
@@ -1044,7 +1037,9 @@ fn message_lateness(
     validation_context: &ValidationContext<impl SlotClock>,
 ) -> Result<Duration, ValidationFailure> {
     let ttl = match validation_context.role {
-        Role::Proposer | Role::SyncCommittee | Role::PTCAttester => 1 + LATE_SLOT_ALLOWANCE,
+        Role::Proposer | Role::SyncCommittee | Role::PTCAttester | Role::EnvelopeProposer => {
+            1 + LATE_SLOT_ALLOWANCE
+        }
         Role::Committee
         | Role::Aggregator
         | Role::ValidatorRegistration
@@ -1161,7 +1156,11 @@ fn duty_limit(
         }
         // Proposer and SyncCommittee have no duty limit
         Role::Proposer | Role::SyncCommittee => Ok(None),
-        Role::ProposerPreferences => Ok(Some(validation_context.slots_per_epoch)),
+        // Per-proposal-slot roles: max duties capped at SLOTS_PER_EPOCH (one preferences packet /
+        // one self-build envelope per proposal slot). Overflow is IGNORE-classified.
+        Role::ProposerPreferences | Role::EnvelopeProposer => {
+            Ok(Some(validation_context.slots_per_epoch))
+        }
     }
 }
 
@@ -1254,6 +1253,50 @@ mod tests {
             MessageAcceptance::from(&failure),
             MessageAcceptance::Ignore,
             "duty-limit breach (ExcessiveDutyCount) must classify as Ignore, not Reject."
+        );
+    }
+
+    /// Tests that the `MessageAcceptance` classification for EnvelopeProposer adheres to the SSV
+    /// spec.
+    #[test]
+    fn envelope_proposer_relevant_classifications_match_ssv_spec() {
+        // NoDuty and duty-limit overflow are Ignore; fork-gate, kind mismatch,
+        // packet-count overflow are Reject.
+        assert_eq!(
+            MessageAcceptance::from(&ValidationFailure::NoDuty),
+            MessageAcceptance::Ignore,
+            "NoDuty must be Ignore",
+        );
+        assert_eq!(
+            MessageAcceptance::from(&ValidationFailure::ExcessiveDutyCount {
+                got: 33,
+                limit: 32,
+                role: Role::EnvelopeProposer,
+            }),
+            MessageAcceptance::Ignore,
+            "duty-limit overflow must be Ignore",
+        );
+        assert_eq!(
+            MessageAcceptance::from(&ValidationFailure::RoleNotActiveBeforeEthFork {
+                role: Role::EnvelopeProposer,
+                current_fork: types::ForkName::Base,
+                minimum_fork: types::ForkName::Gloas,
+            }),
+            MessageAcceptance::Reject,
+            "fork-gate failure must be Reject",
+        );
+        assert_eq!(
+            MessageAcceptance::from(&ValidationFailure::PartialSignatureTypeRoleMismatch),
+            MessageAcceptance::Reject,
+            "kind mismatch must be Reject",
+        );
+        assert_eq!(
+            MessageAcceptance::from(&ValidationFailure::TooManyPartialSignatureMessages {
+                got: 2,
+                limit: 1
+            }),
+            MessageAcceptance::Reject,
+            "packet-count overflow must be Reject",
         );
     }
 
@@ -1436,7 +1479,8 @@ mod tests {
             | Role::ValidatorRegistration
             | Role::VoluntaryExit
             | Role::PTCAttester
-            | Role::ProposerPreferences => DutyExecutor::Validator(PublicKeyBytes::empty()),
+            | Role::ProposerPreferences
+            | Role::EnvelopeProposer => DutyExecutor::Validator(PublicKeyBytes::empty()),
         };
         MessageId::new(&domain, role, &duty_executor)
     }

--- a/anchor/message_validator/src/lib.rs
+++ b/anchor/message_validator/src/lib.rs
@@ -1256,50 +1256,6 @@ mod tests {
         );
     }
 
-    /// Tests that the `MessageAcceptance` classification for EnvelopeProposer adheres to the SSV
-    /// spec.
-    #[test]
-    fn envelope_proposer_relevant_classifications_match_ssv_spec() {
-        // NoDuty and duty-limit overflow are Ignore; fork-gate, kind mismatch,
-        // packet-count overflow are Reject.
-        assert_eq!(
-            MessageAcceptance::from(&ValidationFailure::NoDuty),
-            MessageAcceptance::Ignore,
-            "NoDuty must be Ignore",
-        );
-        assert_eq!(
-            MessageAcceptance::from(&ValidationFailure::ExcessiveDutyCount {
-                got: 33,
-                limit: 32,
-                role: Role::EnvelopeProposer,
-            }),
-            MessageAcceptance::Ignore,
-            "duty-limit overflow must be Ignore",
-        );
-        assert_eq!(
-            MessageAcceptance::from(&ValidationFailure::RoleNotActiveBeforeEthFork {
-                role: Role::EnvelopeProposer,
-                current_fork: types::ForkName::Base,
-                minimum_fork: types::ForkName::Gloas,
-            }),
-            MessageAcceptance::Reject,
-            "fork-gate failure must be Reject",
-        );
-        assert_eq!(
-            MessageAcceptance::from(&ValidationFailure::PartialSignatureTypeRoleMismatch),
-            MessageAcceptance::Reject,
-            "kind mismatch must be Reject",
-        );
-        assert_eq!(
-            MessageAcceptance::from(&ValidationFailure::TooManyPartialSignatureMessages {
-                got: 2,
-                limit: 1
-            }),
-            MessageAcceptance::Reject,
-            "packet-count overflow must be Reject",
-        );
-    }
-
     // Helper struct for directly creating consensus messages for tests
     pub(crate) struct QbftMessageBuilder {
         msg_type: QbftMessageType,

--- a/anchor/message_validator/src/partial_signature.rs
+++ b/anchor/message_validator/src/partial_signature.rs
@@ -147,6 +147,7 @@ fn partial_signature_type_matches_role(kind: PartialSignatureKind, role: Role) -
         Role::Committee => kind == PartialSignatureKind::PostConsensus,
         Role::PTCAttester => kind == PartialSignatureKind::PTCAttester,
         Role::ProposerPreferences => kind == PartialSignatureKind::ProposerPreferences,
+        Role::EnvelopeProposer => kind == PartialSignatureKind::PostConsensus,
         Role::Aggregator => {
             kind == PartialSignatureKind::PostConsensus
                 || kind == PartialSignatureKind::SelectionProofPartialSig
@@ -324,7 +325,8 @@ fn validate_partial_sig_messages_by_duty_logic(
         | Role::ValidatorRegistration
         | Role::VoluntaryExit
         | Role::PTCAttester
-        | Role::ProposerPreferences => {
+        | Role::ProposerPreferences
+        | Role::EnvelopeProposer => {
             if message_count > 1 {
                 return Err(ValidationFailure::TooManyPartialSignatureMessages {
                     got: message_count,
@@ -2006,6 +2008,171 @@ mod tests {
         ));
     }
 
+    // ==================== EnvelopeProposer partial-signature tests ====================
+    //
+    // `EnvelopeProposer` (wire byte [9,0,0,0]) is the validator-scoped, QBFT self-build role:
+    // binds `PostConsensus`, gated to the Ethereum Gloas (ePBS) fork, caps its packet at one
+    // message, and uses the SHORT `1 + LATE_SLOT_ALLOWANCE` (3-slot) lateness bucket.
+
+    /// `EnvelopeProposer` only accepts the `PostConsensus` kind (the Gloas fork gate is
+    /// covered once in `consensus_message.rs` via the shared `validate_role_for_fork`).
+    #[test]
+    fn envelope_proposer_binds_post_consensus_kind() {
+        assert!(
+            partial_signature_type_matches_role(
+                PartialSignatureKind::PostConsensus,
+                Role::EnvelopeProposer,
+            ),
+            "EnvelopeProposer must accept PostConsensus"
+        );
+        assert!(
+            !partial_signature_type_matches_role(
+                PartialSignatureKind::RandaoPartialSig,
+                Role::EnvelopeProposer,
+            ),
+            "EnvelopeProposer must reject non-PostConsensus kinds"
+        );
+    }
+
+    #[test]
+    fn envelope_proposer_rejects_multiple_messages_per_packet() {
+        // EnvelopeProposer is validator-scoped: exactly one PostConsensus message per packet.
+        // The per-validator `> 1` bound rejects a second message, which also subsumes the
+        // validator-index occurrence cap (two messages for the same index would already trip
+        // `> 1`).
+        let (committee_info, private_key, map) = four_node_committee_and_keypair();
+
+        // ValidatorIndex(123) is in the test committee's validator_indices, so each message
+        // passes the per-validator index check; the second message then trips the `> 1` bound.
+        let messages: Vec<_> = (0..2)
+            .map(|_| PartialSignatureMessage {
+                partial_signature: Signature::empty(),
+                signing_root: Hash256::from([0u8; 32]),
+                signer: OperatorId(1),
+                validator_index: ValidatorIndex(123),
+            })
+            .collect();
+
+        let partial_sig_messages = PartialSignatureMessages {
+            kind: PartialSignatureKind::PostConsensus,
+            slot: Slot::new(1),
+            messages: VariableList::new(messages).unwrap(),
+        };
+
+        let msg_id = create_message_id_for_test(Role::EnvelopeProposer);
+        let ssv_msg = SSVMessage::new(
+            MsgType::SSVPartialSignatureMsgType,
+            msg_id,
+            partial_sig_messages.as_ssz_bytes(),
+        )
+        .unwrap();
+
+        let p_key = PKey::from_rsa(private_key).unwrap();
+        let mut signer = Signer::new(MessageDigest::sha256(), &p_key).unwrap();
+        signer.update(&ssv_msg.as_ssz_bytes()).unwrap();
+        let signature = signer.sign_to_vec().unwrap().try_into().unwrap();
+
+        let signed_msg =
+            SignedSSVMessage::new(vec![signature], vec![OperatorId(1)], ssv_msg, vec![]).unwrap();
+
+        let validation_context =
+            create_envelope_proposer_context(&signed_msg, &committee_info, &map, Slot::new(1));
+
+        let result = validate_partial_signature_message(
+            validation_context,
+            &mut DutyState::new(64),
+            Arc::new(MockDutiesProvider {
+                voluntary_exit_duty_count: 0,
+                ..Default::default()
+            }),
+        );
+
+        assert_validation_error(
+            result,
+            |failure| {
+                matches!(
+                    failure,
+                    ValidationFailure::TooManyPartialSignatureMessages { limit: 1, .. }
+                )
+            },
+            "TooManyPartialSignatureMessages (EnvelopeProposer cap 1 per packet)",
+        );
+    }
+
+    #[test]
+    fn envelope_proposer_within_ttl_accepted() {
+        let (committee_info, private_key, map) = four_node_committee_and_keypair();
+        let signed_msg = create_signed_partial_sig_message(
+            Role::EnvelopeProposer,
+            PartialSignatureKind::PostConsensus,
+            OperatorId(1),
+            &private_key,
+        );
+
+        // `EnvelopeProposer` uses the SHORT slot-bound TTL (`1 + LATE_SLOT_ALLOWANCE` = 3 slots);
+        // two slots late is inside it. `create_ttl_validation_context` sets a pre-Gloas spec, so
+        // override it (the role only exists post-Gloas).
+        let mut validation_context = create_ttl_validation_context(
+            &signed_msg,
+            &committee_info,
+            Role::EnvelopeProposer,
+            &map,
+            LATE_SLOT_ALLOWANCE_TEST,
+            generate_fork_schedule(Fork::Boole),
+        );
+        validation_context.spec = spec_with_gloas(Some(0));
+
+        let result = validate_partial_signature_message(
+            validation_context,
+            &mut DutyState::new(64),
+            Arc::new(MockDutiesProvider {
+                voluntary_exit_duty_count: 0,
+                ..Default::default()
+            }),
+        );
+
+        assert!(result.is_ok(), "Expected ok but got: {result:?}");
+    }
+
+    #[test]
+    fn envelope_proposer_beyond_short_ttl_rejected() {
+        let (committee_info, private_key, map) = four_node_committee_and_keypair();
+        let signed_msg = create_signed_partial_sig_message(
+            Role::EnvelopeProposer,
+            PartialSignatureKind::PostConsensus,
+            OperatorId(1),
+            &private_key,
+        );
+
+        // 20 slots late is still inside the long (committee) TTL of 34 slots; rejecting it pins
+        // `EnvelopeProposer` to the short slot-bound bucket (`1 + LATE_SLOT_ALLOWANCE` = 3 slots).
+        // Override the helper's pre-Gloas spec (the role only exists post-Gloas).
+        let mut validation_context = create_ttl_validation_context(
+            &signed_msg,
+            &committee_info,
+            Role::EnvelopeProposer,
+            &map,
+            COMMITTEE_TTL_BUCKET_SLOTS,
+            generate_fork_schedule(Fork::Boole),
+        );
+        validation_context.spec = spec_with_gloas(Some(0));
+
+        let result = validate_partial_signature_message(
+            validation_context,
+            &mut DutyState::new(64),
+            Arc::new(MockDutiesProvider {
+                voluntary_exit_duty_count: 0,
+                ..Default::default()
+            }),
+        );
+
+        assert_validation_error(
+            result,
+            |failure| matches!(failure, ValidationFailure::LateSlotMessage { .. }),
+            "LateSlotMessage (EnvelopeProposer past short TTL)",
+        );
+    }
+
     // ==================== ProposerPreferences tests ====================
     //
     // ProposerPreferences (wire byte [8,0,0,0]) is validator-scoped and non-QBFT.
@@ -3278,6 +3445,418 @@ mod tests {
                 )
             },
             "RoleNotActiveAfterFork for Aggregator",
+        );
+    }
+
+    // ==================== EnvelopeProposer proposer-assignment arm ====================
+    //
+    // `validate_beacon_duty`'s `Role::ProposerPreferences | Role::EnvelopeProposer` arm (keyed on
+    // the message's `slot`) rejects with `NoDuty` only when the slot's epoch is known AND the
+    // validator is NOT the assigned proposer; an unknown epoch is tolerated and no RANDAO
+    // tolerance applies. The three cases below drive the mock's two proposer knobs.
+
+    /// Standard single-signer four-node fixture (committee info + keypair + pubkey map).
+    fn four_node_committee_and_keypair() -> (
+        crate::CommitteeInfo,
+        Rsa<Private>,
+        HashMap<OperatorId, Rsa<Public>>,
+    ) {
+        let committee_info = create_committee_info(FOUR_NODE_COMMITTEE);
+        let (private_key, public_key) = generate_test_key_pair();
+        let map =
+            create_operator_pub_keys(committee_info.committee_members.clone(), vec![public_key]);
+        (committee_info, private_key, map)
+    }
+
+    /// Helper to create a SignedSSVMessage for EnvelopeProposer testing.
+    fn create_signed_envelope_proposer_message(
+        signer_id: OperatorId,
+        private_key: &Rsa<Private>,
+        slot: Slot,
+        signing_root: Hash256,
+    ) -> SignedSSVMessage {
+        let partial_sig_messages = PartialSignatureMessages {
+            kind: PartialSignatureKind::PostConsensus,
+            slot,
+            messages: VariableList::new(vec![PartialSignatureMessage {
+                partial_signature: Signature::empty(),
+                signing_root,
+                signer: signer_id,
+                // ValidatorIndex(0) is in the test committee's validator_indices.
+                validator_index: ValidatorIndex(0),
+            }])
+            .unwrap(),
+        };
+
+        let msg_id = create_message_id_for_test(Role::EnvelopeProposer);
+        let ssv_msg = SSVMessage::new(
+            MsgType::SSVPartialSignatureMsgType,
+            msg_id,
+            partial_sig_messages.as_ssz_bytes(),
+        )
+        .unwrap();
+
+        let p_key = PKey::from_rsa(private_key.clone()).unwrap();
+        let mut signer = Signer::new(MessageDigest::sha256(), &p_key).unwrap();
+        signer.update(&ssv_msg.as_ssz_bytes()).unwrap();
+        let signature = signer.sign_to_vec().unwrap().try_into().unwrap();
+
+        SignedSSVMessage::new(vec![signature], vec![signer_id], ssv_msg, vec![]).unwrap()
+    }
+
+    /// Helper to create a ValidationContext for EnvelopeProposer testing.
+    fn create_envelope_proposer_context<'a>(
+        signed_msg: &'a SignedSSVMessage,
+        committee_info: &'a crate::CommitteeInfo,
+        operator_pub_keys: &'a HashMap<OperatorId, Rsa<Public>>,
+        current_slot: Slot,
+    ) -> ValidationContext<'a, ManualSlotClock> {
+        let now = SystemTime::now();
+        let slot_clock = ManualSlotClock::new(
+            current_slot,
+            now.duration_since(UNIX_EPOCH).unwrap(),
+            Duration::from_secs(12),
+        );
+
+        ValidationContext {
+            signed_ssv_message: signed_msg,
+            committee_info,
+            role: Role::EnvelopeProposer,
+            received_at: now,
+            slots_per_epoch: SLOTS_PER_EPOCH_TEST,
+            epochs_per_sync_committee_period: 256,
+            sync_committee_size: 512,
+            slot_clock,
+            operator_pub_keys,
+            fork_schedule: generate_fork_schedule(Fork::Boole),
+            // EnvelopeProposer only exists post-Gloas; activate from epoch 0.
+            spec: spec_with_gloas(Some(0)),
+        }
+    }
+
+    /// Runs the `EnvelopeProposer` proposer-assignment arm of `validate_beacon_duty` with the
+    /// mock's two knobs, returning the result for the caller to assert on. `randao_msg` is always
+    /// false for `EnvelopeProposer` (no RANDAO tolerance applies).
+    fn run_envelope_beacon_duty(
+        epoch_known: bool,
+        is_proposer: bool,
+    ) -> Result<(), ValidationFailure> {
+        let (committee_info, private_key, map) = four_node_committee_and_keypair();
+        let signed_msg = create_signed_envelope_proposer_message(
+            OperatorId(1),
+            &private_key,
+            Slot::new(0),
+            Hash256::from([0x33; 32]),
+        );
+        let validation_context =
+            create_envelope_proposer_context(&signed_msg, &committee_info, &map, Slot::new(0));
+
+        validate_beacon_duty(
+            &validation_context,
+            Slot::new(0),
+            false,
+            Arc::new(MockDutiesProvider {
+                epoch_known_for_proposers: epoch_known,
+                validator_is_proposer: is_proposer,
+                ..Default::default()
+            }),
+        )
+    }
+
+    #[test]
+    fn envelope_proposer_tolerates_unknown_proposer_epoch() {
+        // Before the epoch's proposer duties are fetched, tolerate (Ok), not drop as NoDuty.
+        let result = run_envelope_beacon_duty(false, false);
+        assert!(
+            result.is_ok(),
+            "unknown proposer epoch must be tolerated for EnvelopeProposer, got: {result:?}"
+        );
+    }
+
+    #[test]
+    fn envelope_proposer_known_epoch_non_proposer_is_no_duty() {
+        // Known epoch, not the assigned proposer -> reject with NoDuty.
+        let result = run_envelope_beacon_duty(true, false);
+        assert_validation_error(
+            result,
+            |failure| matches!(failure, ValidationFailure::NoDuty),
+            "NoDuty (known epoch, validator not the assigned proposer)",
+        );
+    }
+
+    #[test]
+    fn envelope_proposer_known_epoch_proposer_ok() {
+        // Known epoch and the assigned proposer -> accept.
+        let result = run_envelope_beacon_duty(true, true);
+        assert!(
+            result.is_ok(),
+            "Expected assigned proposer to be accepted for EnvelopeProposer, got: {result:?}"
+        );
+    }
+
+    #[test]
+    fn envelope_proposer_shared_state_accepts_consensus_then_partial_sig() {
+        // Consensus and PostConsensus share one DutyState per MessageId. Validate a consensus
+        // message at slot 1, persist it (the outer `validate_consensus_message` does this via
+        // `update_for_consensus_message`; `validate_qbft_message_by_duty_logic` alone does not),
+        // then validate a same-slot PostConsensus. The guard is strict (`max_slot > message_slot`),
+        // so the `max_slot == message_slot` equality boundary must be tolerated (Ok).
+
+        // Arrange: EnvelopeProposer consensus message at slot 1 (the builder defaults height to 1).
+        let (committee_info, private_key, map) = four_node_committee_and_keypair();
+
+        let qbft_message = crate::tests::QbftMessageBuilder::new(
+            Role::EnvelopeProposer,
+            ssv_types::consensus::QbftMessageType::Prepare,
+        )
+        .build();
+        let consensus_signed_msg = crate::tests::create_signed_consensus_message(
+            qbft_message.clone(),
+            vec![OperatorId(1)],
+            vec![],
+            vec![private_key.clone()],
+        );
+        let consensus_context = create_envelope_proposer_context(
+            &consensus_signed_msg,
+            &committee_info,
+            &map,
+            Slot::new(1),
+        );
+
+        let mut shared_duty_state = crate::duty_state::DutyState::new(64);
+
+        let consensus_result = crate::consensus_message::validate_qbft_message_by_duty_logic(
+            &consensus_context,
+            &qbft_message,
+            &mut shared_duty_state,
+            Arc::new(MockDutiesProvider::default()),
+        );
+        assert!(
+            consensus_result.is_ok(),
+            "EnvelopeProposer consensus at slot 1 must be accepted"
+        );
+
+        // Persist the accepted consensus so `max_slot == 1` before Act 2; without it the state
+        // would stay at `max_slot == 0` and never exercise the equality boundary.
+        shared_duty_state.update_for_consensus_message(
+            &consensus_signed_msg,
+            &qbft_message,
+            SLOTS_PER_EPOCH_TEST,
+        );
+
+        // Act: same-slot PostConsensus partial sig against the now-advanced shared state.
+        let partial_sig_signed_msg = create_signed_envelope_proposer_message(
+            OperatorId(1),
+            &private_key,
+            Slot::new(1),
+            Hash256::from([0x33; 32]),
+        );
+        let partial_sig_context = create_envelope_proposer_context(
+            &partial_sig_signed_msg,
+            &committee_info,
+            &map,
+            Slot::new(1),
+        );
+        let partial_sig_result = validate_partial_signature_message(
+            partial_sig_context,
+            &mut shared_duty_state,
+            Arc::new(MockDutiesProvider::default()),
+        );
+
+        assert!(
+            partial_sig_result.is_ok(),
+            "EnvelopeProposer PostConsensus at slot 1 must be accepted when the shared state's max_slot already equals 1 (equality boundary of the strict monotonic guard)"
+        );
+    }
+
+    /// Seeds `state` with an accepted `EnvelopeProposer` consensus message at `height` for
+    /// `OperatorId(1)`, advancing that signer's max slot.
+    fn seed_state_via_consensus(state: &mut crate::duty_state::DutyState, height: u64) {
+        let mut qbft = crate::tests::QbftMessageBuilder::new(
+            Role::EnvelopeProposer,
+            ssv_types::consensus::QbftMessageType::Prepare,
+        )
+        .build();
+        qbft.height = height;
+        let signed_msg = crate::tests::create_signed_consensus_message(
+            qbft.clone(),
+            vec![OperatorId(1)],
+            vec![],
+            vec![],
+        );
+        state.update_for_consensus_message(&signed_msg, &qbft, SLOTS_PER_EPOCH_TEST);
+    }
+
+    #[test]
+    fn envelope_proposer_consensus_advances_blocks_lower_partial_sig() {
+        // §7 monotonic-slot rule, consensus-advances direction: a consensus message at slot 10
+        // must block a later PostConsensus partial sig at the lower slot 5.
+        let (committee_info, private_key, map) = four_node_committee_and_keypair();
+
+        // Arrange: Seed DutyState at slot 10 via consensus update.
+        let mut duty_state = crate::duty_state::DutyState::new(64);
+        seed_state_via_consensus(&mut duty_state, 10);
+
+        // Arrange: PostConsensus partial sig at slot 5 (lower than 10).
+        let partial_sig_signed_msg = create_signed_envelope_proposer_message(
+            OperatorId(1),
+            &private_key,
+            Slot::new(5),
+            Hash256::from([0x33; 32]),
+        );
+        let validation_context = create_envelope_proposer_context(
+            &partial_sig_signed_msg,
+            &committee_info,
+            &map,
+            Slot::new(10),
+        );
+
+        // Act: Validate PostConsensus partial sig at slot 5 against advanced DutyState.
+        let result = validate_partial_signature_message(
+            validation_context,
+            &mut duty_state,
+            Arc::new(MockDutiesProvider::default()),
+        );
+
+        // Assert: Must be rejected as SlotAlreadyAdvanced.
+        assert_validation_error(
+            result,
+            |failure| {
+                matches!(
+                    failure,
+                    crate::ValidationFailure::SlotAlreadyAdvanced { .. }
+                )
+            },
+            "EnvelopeProposer PostConsensus below advanced consensus slot must be SlotAlreadyAdvanced",
+        );
+    }
+
+    #[test]
+    fn envelope_proposer_partial_sig_advances_blocks_lower_consensus() {
+        // §7 monotonic-slot rule, partial-sig-advances direction: seeding via a PostConsensus
+        // partial sig at slot 10 must block a later consensus message at the lower height 5.
+        // The seeding mechanism (partial sig, not consensus) is the point of this direction.
+        let (committee_info, private_key, map) = four_node_committee_and_keypair();
+
+        // Arrange: Seed DutyState at slot 10 via partial-sig update.
+        let mut duty_state = crate::duty_state::DutyState::new(64);
+        let dummy_partial_sig = create_signed_envelope_proposer_message(
+            OperatorId(1),
+            &private_key,
+            Slot::new(10),
+            Hash256::from([0x99; 32]),
+        );
+        let messages =
+            PartialSignatureMessages::from_ssz_bytes(dummy_partial_sig.ssv_message().data())
+                .expect("dummy envelope message must decode");
+        duty_state
+            .update_for_partial_signature(&messages, &OperatorId(1), SLOTS_PER_EPOCH_TEST)
+            .expect("seeding partial-signature state must succeed");
+
+        // Arrange: Consensus message at height 5 (lower than 10).
+        let mut qbft_message = crate::tests::QbftMessageBuilder::new(
+            Role::EnvelopeProposer,
+            ssv_types::consensus::QbftMessageType::Prepare,
+        )
+        .build();
+        qbft_message.height = 5;
+        let consensus_signed_msg = crate::tests::create_signed_consensus_message(
+            qbft_message.clone(),
+            vec![OperatorId(1)],
+            vec![],
+            vec![private_key.clone()],
+        );
+        let validation_context = create_envelope_proposer_context(
+            &consensus_signed_msg,
+            &committee_info,
+            &map,
+            Slot::new(10),
+        );
+
+        // Act: Validate consensus message at height 5 against advanced DutyState.
+        let result = crate::consensus_message::validate_qbft_message_by_duty_logic(
+            &validation_context,
+            &qbft_message,
+            &mut duty_state,
+            Arc::new(MockDutiesProvider::default()),
+        );
+
+        // Assert: Must be rejected as SlotAlreadyAdvanced.
+        assert_validation_error(
+            result,
+            |failure| {
+                matches!(
+                    failure,
+                    crate::ValidationFailure::SlotAlreadyAdvanced { .. }
+                )
+            },
+            "EnvelopeProposer consensus below advanced PostConsensus slot must be SlotAlreadyAdvanced",
+        );
+    }
+
+    #[test]
+    fn envelope_proposer_repeated_post_consensus_rejected() {
+        // Validate an EnvelopeProposer PostConsensus at slot 5 (accepted; records the
+        // post-consensus count), then validate a second PostConsensus for the same
+        // signer/slot against the same DutyState. The inherited post-consensus seen-message
+        // guard must reject the second as InvalidPartialSignatureTypeCount.
+
+        let (committee_info, private_key, map) = four_node_committee_and_keypair();
+
+        // Arrange: First PostConsensus message at slot 5.
+        let first_signed_msg = create_signed_envelope_proposer_message(
+            OperatorId(1),
+            &private_key,
+            Slot::new(5),
+            Hash256::from([0x33; 32]),
+        );
+        let first_context = create_envelope_proposer_context(
+            &first_signed_msg,
+            &committee_info,
+            &map,
+            Slot::new(5),
+        );
+
+        let mut duty_state = crate::duty_state::DutyState::new(64);
+
+        let first_result = validate_partial_signature_message(
+            first_context,
+            &mut duty_state,
+            Arc::new(MockDutiesProvider::default()),
+        );
+        assert!(
+            first_result.is_ok(),
+            "First EnvelopeProposer PostConsensus must be accepted"
+        );
+
+        // A second PostConsensus for the same signer/slot (only the root differs).
+        let second_signed_msg = create_signed_envelope_proposer_message(
+            OperatorId(1),
+            &private_key,
+            Slot::new(5),
+            Hash256::from([0x44; 32]),
+        );
+        let second_context = create_envelope_proposer_context(
+            &second_signed_msg,
+            &committee_info,
+            &map,
+            Slot::new(5),
+        );
+        let second_result = validate_partial_signature_message(
+            second_context,
+            &mut duty_state,
+            Arc::new(MockDutiesProvider::default()),
+        );
+
+        assert_validation_error(
+            second_result,
+            |failure| {
+                matches!(
+                    failure,
+                    crate::ValidationFailure::InvalidPartialSignatureTypeCount { .. }
+                )
+            },
+            "Repeated EnvelopeProposer PostConsensus for the same signer/slot must be rejected",
         );
     }
 }

--- a/anchor/message_validator/src/partial_signature.rs
+++ b/anchor/message_validator/src/partial_signature.rs
@@ -2014,8 +2014,89 @@ mod tests {
     // binds `PostConsensus`, gated to the Ethereum Gloas (ePBS) fork, caps its packet at one
     // message, and uses the SHORT `1 + LATE_SLOT_ALLOWANCE` (3-slot) lateness bucket.
 
+    /// Standard single-signer four-node fixture (committee info + keypair + pubkey map).
+    fn four_node_committee_and_keypair() -> (
+        crate::CommitteeInfo,
+        Rsa<Private>,
+        HashMap<OperatorId, Rsa<Public>>,
+    ) {
+        let committee_info = create_committee_info(FOUR_NODE_COMMITTEE);
+        let (private_key, public_key) = generate_test_key_pair();
+        let map =
+            create_operator_pub_keys(committee_info.committee_members.clone(), vec![public_key]);
+        (committee_info, private_key, map)
+    }
+
+    /// Helper to create a SignedSSVMessage for EnvelopeProposer testing.
+    fn create_signed_envelope_proposer_message(
+        signer_id: OperatorId,
+        private_key: &Rsa<Private>,
+        slot: Slot,
+        signing_root: Hash256,
+    ) -> SignedSSVMessage {
+        let partial_sig_messages = PartialSignatureMessages {
+            kind: PartialSignatureKind::PostConsensus,
+            slot,
+            messages: VariableList::new(vec![PartialSignatureMessage {
+                partial_signature: Signature::empty(),
+                signing_root,
+                signer: signer_id,
+                // ValidatorIndex(0) is in the test committee's validator_indices.
+                validator_index: ValidatorIndex(0),
+            }])
+            .unwrap(),
+        };
+
+        let msg_id = create_message_id_for_test(Role::EnvelopeProposer);
+        let ssv_msg = SSVMessage::new(
+            MsgType::SSVPartialSignatureMsgType,
+            msg_id,
+            partial_sig_messages.as_ssz_bytes(),
+        )
+        .unwrap();
+
+        let p_key = PKey::from_rsa(private_key.clone()).unwrap();
+        let mut signer = Signer::new(MessageDigest::sha256(), &p_key).unwrap();
+        signer.update(&ssv_msg.as_ssz_bytes()).unwrap();
+        let signature = signer.sign_to_vec().unwrap().try_into().unwrap();
+
+        SignedSSVMessage::new(vec![signature], vec![signer_id], ssv_msg, vec![]).unwrap()
+    }
+
+    /// Helper to create a ValidationContext for EnvelopeProposer testing.
+    fn create_envelope_proposer_context<'a>(
+        signed_msg: &'a SignedSSVMessage,
+        committee_info: &'a crate::CommitteeInfo,
+        operator_pub_keys: &'a HashMap<OperatorId, Rsa<Public>>,
+        current_slot: Slot,
+    ) -> ValidationContext<'a, ManualSlotClock> {
+        let now = SystemTime::now();
+        let slot_clock = ManualSlotClock::new(
+            current_slot,
+            now.duration_since(UNIX_EPOCH).unwrap(),
+            Duration::from_secs(12),
+        );
+
+        ValidationContext {
+            signed_ssv_message: signed_msg,
+            committee_info,
+            role: Role::EnvelopeProposer,
+            received_at: now,
+            slots_per_epoch: SLOTS_PER_EPOCH_TEST,
+            epochs_per_sync_committee_period: 256,
+            sync_committee_size: 512,
+            slot_clock,
+            operator_pub_keys,
+            fork_schedule: generate_fork_schedule(Fork::Boole),
+            // EnvelopeProposer only exists post-Gloas; activate from epoch 0.
+            spec: spec_with_gloas(Some(0)),
+        }
+    }
+
     /// `EnvelopeProposer` only accepts the `PostConsensus` kind (the Gloas fork gate is
     /// covered once in `consensus_message.rs` via the shared `validate_role_for_fork`).
+    /// Asserts that this kind mismatch maps to
+    /// `ValidationFailure::PartialSignatureTypeRoleMismatch` and is rejected (not ignored).
     #[test]
     fn envelope_proposer_binds_post_consensus_kind() {
         assert!(
@@ -2024,6 +2105,11 @@ mod tests {
                 Role::EnvelopeProposer,
             ),
             "EnvelopeProposer must accept PostConsensus"
+        );
+        assert_eq!(
+            MessageAcceptance::from(&ValidationFailure::PartialSignatureTypeRoleMismatch),
+            MessageAcceptance::Reject,
+            "kind mismatch must be Reject",
         );
         assert!(
             !partial_signature_type_matches_role(
@@ -2096,6 +2182,16 @@ mod tests {
                 )
             },
             "TooManyPartialSignatureMessages (EnvelopeProposer cap 1 per packet)",
+        );
+
+        // Check that more than 1 partial signature message in a packet is rejected and not ignored.
+        assert_eq!(
+            MessageAcceptance::from(&ValidationFailure::TooManyPartialSignatureMessages {
+                got: 2,
+                limit: 1
+            }),
+            MessageAcceptance::Reject,
+            "packet-count overflow must be Reject",
         );
     }
 
@@ -2770,6 +2866,37 @@ mod tests {
             result,
             |failure| matches!(failure, ValidationFailure::EarlySlotMessage { .. }),
             "EarlySlotMessage (non-ProposerPreferences role has no future-slot allowance)",
+        );
+    }
+
+    #[test]
+    fn envelope_proposer_future_slot_still_early() {
+        // `EnvelopeProposer` message slot is its PRESENT emission slot (no future-slot allowance).
+        // This case is rejected.
+
+        // Creates `EnvelopeProposer` packet with an envelope slot of 1.
+        let (committee_info, private_key, map) = four_node_committee_and_keypair();
+        let signed_msg = create_signed_envelope_proposer_message(
+            OperatorId(1),
+            &private_key,
+            Slot::new(1),
+            Hash256::from([0x44; 32]),
+        );
+        // Current slot set to 0. Envelope slot 1 = one slot (12s) in the future.
+        let ctx =
+            create_envelope_proposer_context(&signed_msg, &committee_info, &map, Slot::new(0));
+
+        // Validate the message and raise the error.
+        let result = validate_partial_signature_message(
+            ctx,
+            &mut DutyState::new(64),
+            Arc::new(MockDutiesProvider::default()),
+        );
+
+        assert_validation_error(
+            result,
+            |failure| matches!(failure, ValidationFailure::EarlySlotMessage { .. }),
+            "EarlySlotMessage (EnvelopeProposer has no future-slot allowance. One slot ahead is early)",
         );
     }
 
@@ -3453,86 +3580,7 @@ mod tests {
     // `validate_beacon_duty`'s `Role::ProposerPreferences | Role::EnvelopeProposer` arm (keyed on
     // the message's `slot`) rejects with `NoDuty` only when the slot's epoch is known AND the
     // validator is NOT the assigned proposer; an unknown epoch is tolerated and no RANDAO
-    // tolerance applies. The three cases below drive the mock's two proposer knobs.
-
-    /// Standard single-signer four-node fixture (committee info + keypair + pubkey map).
-    fn four_node_committee_and_keypair() -> (
-        crate::CommitteeInfo,
-        Rsa<Private>,
-        HashMap<OperatorId, Rsa<Public>>,
-    ) {
-        let committee_info = create_committee_info(FOUR_NODE_COMMITTEE);
-        let (private_key, public_key) = generate_test_key_pair();
-        let map =
-            create_operator_pub_keys(committee_info.committee_members.clone(), vec![public_key]);
-        (committee_info, private_key, map)
-    }
-
-    /// Helper to create a SignedSSVMessage for EnvelopeProposer testing.
-    fn create_signed_envelope_proposer_message(
-        signer_id: OperatorId,
-        private_key: &Rsa<Private>,
-        slot: Slot,
-        signing_root: Hash256,
-    ) -> SignedSSVMessage {
-        let partial_sig_messages = PartialSignatureMessages {
-            kind: PartialSignatureKind::PostConsensus,
-            slot,
-            messages: VariableList::new(vec![PartialSignatureMessage {
-                partial_signature: Signature::empty(),
-                signing_root,
-                signer: signer_id,
-                // ValidatorIndex(0) is in the test committee's validator_indices.
-                validator_index: ValidatorIndex(0),
-            }])
-            .unwrap(),
-        };
-
-        let msg_id = create_message_id_for_test(Role::EnvelopeProposer);
-        let ssv_msg = SSVMessage::new(
-            MsgType::SSVPartialSignatureMsgType,
-            msg_id,
-            partial_sig_messages.as_ssz_bytes(),
-        )
-        .unwrap();
-
-        let p_key = PKey::from_rsa(private_key.clone()).unwrap();
-        let mut signer = Signer::new(MessageDigest::sha256(), &p_key).unwrap();
-        signer.update(&ssv_msg.as_ssz_bytes()).unwrap();
-        let signature = signer.sign_to_vec().unwrap().try_into().unwrap();
-
-        SignedSSVMessage::new(vec![signature], vec![signer_id], ssv_msg, vec![]).unwrap()
-    }
-
-    /// Helper to create a ValidationContext for EnvelopeProposer testing.
-    fn create_envelope_proposer_context<'a>(
-        signed_msg: &'a SignedSSVMessage,
-        committee_info: &'a crate::CommitteeInfo,
-        operator_pub_keys: &'a HashMap<OperatorId, Rsa<Public>>,
-        current_slot: Slot,
-    ) -> ValidationContext<'a, ManualSlotClock> {
-        let now = SystemTime::now();
-        let slot_clock = ManualSlotClock::new(
-            current_slot,
-            now.duration_since(UNIX_EPOCH).unwrap(),
-            Duration::from_secs(12),
-        );
-
-        ValidationContext {
-            signed_ssv_message: signed_msg,
-            committee_info,
-            role: Role::EnvelopeProposer,
-            received_at: now,
-            slots_per_epoch: SLOTS_PER_EPOCH_TEST,
-            epochs_per_sync_committee_period: 256,
-            sync_committee_size: 512,
-            slot_clock,
-            operator_pub_keys,
-            fork_schedule: generate_fork_schedule(Fork::Boole),
-            // EnvelopeProposer only exists post-Gloas; activate from epoch 0.
-            spec: spec_with_gloas(Some(0)),
-        }
-    }
+    // tolerance applies.
 
     /// Runs the `EnvelopeProposer` proposer-assignment arm of `validate_beacon_duty` with the
     /// mock's two knobs, returning the result for the caller to assert on. `randao_msg` is always

--- a/anchor/qbft_manager/src/lib.rs
+++ b/anchor/qbft_manager/src/lib.rs
@@ -30,7 +30,7 @@ use tokio::{
     },
     time::{Instant, sleep},
 };
-use tracing::{Instrument, debug_span, error, warn};
+use tracing::{Instrument, debug, debug_span, error, warn};
 use types::{ChainSpec, Epoch, EthSpec, Hash256, Slot};
 
 use crate::instance::qbft_instance;
@@ -284,7 +284,7 @@ impl<E: EthSpec, S: SlotClock + Clone + 'static> QbftManager<E, S> {
                     Some(Role::SyncCommittee) => ValidatorDutyKind::SyncCommitteeAggregator,
                     Some(Role::EnvelopeProposer) => {
                         // TODO: wire EnvelopeProposer instance routing (#1122)
-                        warn!(?msg_id, "EnvelopeProposer routing not yet wired");
+                        debug!(?msg_id, "EnvelopeProposer routing not yet wired");
                         return Err(QbftError::RoleNotActive);
                     }
                     // Committee roles use DutyExecutor::Committee, not Validator

--- a/anchor/qbft_manager/src/lib.rs
+++ b/anchor/qbft_manager/src/lib.rs
@@ -282,6 +282,11 @@ impl<E: EthSpec, S: SlotClock + Clone + 'static> QbftManager<E, S> {
                     Some(Role::Proposer) => ValidatorDutyKind::Proposal,
                     Some(Role::Aggregator) => ValidatorDutyKind::Aggregator,
                     Some(Role::SyncCommittee) => ValidatorDutyKind::SyncCommitteeAggregator,
+                    Some(Role::EnvelopeProposer) => {
+                        // TODO: wire EnvelopeProposer instance routing (#1122)
+                        warn!(?msg_id, "EnvelopeProposer routing not yet wired");
+                        return Err(QbftError::RoleNotActive);
+                    }
                     // Committee roles use DutyExecutor::Committee, not Validator
                     Some(Role::Committee | Role::AggregatorCommittee)
                     // These roles don't use QBFT consensus
@@ -352,7 +357,12 @@ impl<E: EthSpec, S: SlotClock + Clone + 'static> QbftManager<E, S> {
                     }
                     // Validator roles should use DutyExecutor::Validator, not
                     // Committee
-                    Some(Role::Aggregator | Role::Proposer | Role::SyncCommittee)
+                    Some(
+                        Role::Aggregator
+                        | Role::Proposer
+                        | Role::SyncCommittee
+                        | Role::EnvelopeProposer,
+                    )
                     // These roles don't use QBFT consensus
                     | Some(
                         Role::ValidatorRegistration | Role::VoluntaryExit | Role::PTCAttester | Role::ProposerPreferences,

--- a/anchor/qbft_manager/src/tests.rs
+++ b/anchor/qbft_manager/src/tests.rs
@@ -961,4 +961,172 @@ mod manager_tests {
             result
         );
     }
+
+    #[tokio::test]
+    async fn envelope_proposer_validator_executor_is_transient_role_not_active() {
+        // Validator-executor EnvelopeProposer is a correctly-formed message whose QBFT
+        // routing is not wired yet (PR4/#1122): transient RoleNotActive, NOT InconsistentMessageId.
+        use fork::{Fork, ForkSchedule};
+        use message_sender::testing::MockMessageSender;
+        use ssv_types::{
+            RSA_SIGNATURE_SIZE,
+            consensus::{QbftMessage, QbftMessageType},
+            message::{MsgType, SSVMessage, SignedSSVMessage},
+        };
+        use ssz::Encode;
+
+        let setup = setup_test(1);
+
+        // Create fork schedule with Boole active (latest SSV fork)
+        // EnvelopeProposer requires Ethereum's Gloas (ePBS) fork, which mainnet ChainSpec has
+        let fork_schedule = ForkSchedule::new(Fork::Boole, DomainType::default(), "test");
+
+        let config = processor::Config {
+            max_workers: 4,
+            queue_size: Default::default(),
+        };
+        let senders = processor::spawn(config, setup.executor);
+        let (network_tx, _network_rx) = mpsc::unbounded_channel();
+
+        let manager = QbftManager::<types::MainnetEthSpec, _>::new(
+            senders,
+            OperatorId(1).into(),
+            setup.clock,
+            Arc::new(MockMessageSender::new(network_tx, OperatorId(1))),
+            NonZeroU64::new(32).expect("slots_per_epoch is non-zero"),
+            Arc::new(fork_schedule),
+            Arc::new(types::ChainSpec::mainnet()),
+        )
+        .expect("Manager creation should succeed");
+
+        // Create an EnvelopeProposer message with Validator executor
+        let msg_id = MessageId::new(
+            &DomainType([0; 4]),
+            Role::EnvelopeProposer,
+            &DutyExecutor::Validator(bls::PublicKeyBytes::empty()),
+        );
+
+        let qbft_message = QbftMessage {
+            qbft_message_type: QbftMessageType::Proposal,
+            height: 100, // Any slot in Gloas fork
+            round: 1,
+            identifier: (&msg_id).into(),
+            root: Hash256::from([0u8; 32]),
+            data_round: 1,
+            round_change_justification: ssv_types::VariableList::empty(),
+            prepare_justification: ssv_types::VariableList::empty(),
+        };
+
+        let ssv_msg = SSVMessage::new(
+            MsgType::SSVConsensusMsgType,
+            msg_id,
+            qbft_message.as_ssz_bytes(),
+        )
+        .expect("SSVMessage creation should succeed");
+
+        let signed_msg = SignedSSVMessage::new(
+            vec![[0xAA; RSA_SIGNATURE_SIZE]],
+            vec![OperatorId(1)],
+            ssv_msg,
+            vec![],
+        )
+        .expect("SignedSSVMessage creation should succeed");
+
+        // Act: Call receive_data
+        let result = manager.receive_data(signed_msg, qbft_message);
+
+        // Assert: Must be transient RoleNotActive (routing not wired), NOT InconsistentMessageId
+        assert!(
+            matches!(result, Err(QbftError::RoleNotActive)),
+            "validator-executor EnvelopeProposer must be transient RoleNotActive, got: {result:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn envelope_proposer_committee_executor_decodes_as_validator_executor() {
+        // NOTE: This test documents a MessageId encoding constraint.
+        // Due to MessageId encoding, Role::EnvelopeProposer is always decoded as
+        // DutyExecutor::Validator (bytes 8-55), making Committee-executor EnvelopeProposer
+        // impossible to construct via normal MessageId operations.
+        //
+        // This test verifies the encoding behavior: attempting to create a
+        // Committee-executor EnvelopeProposer in MessageId results in a Validator-executor
+        // being decoded, which then returns RoleNotActive (routing not wired).
+        use fork::{Fork, ForkSchedule};
+        use message_sender::testing::MockMessageSender;
+        use ssv_types::{
+            RSA_SIGNATURE_SIZE,
+            consensus::{QbftMessage, QbftMessageType},
+            message::{MsgType, SSVMessage, SignedSSVMessage},
+        };
+        use ssz::Encode;
+
+        let setup = setup_test(1);
+
+        // Create fork schedule with Boole active (latest SSV fork)
+        let fork_schedule = ForkSchedule::new(Fork::Boole, DomainType::default(), "test");
+
+        let config = processor::Config {
+            max_workers: 4,
+            queue_size: Default::default(),
+        };
+        let senders = processor::spawn(config, setup.executor);
+        let (network_tx, _network_rx) = mpsc::unbounded_channel();
+
+        let manager = QbftManager::<types::MainnetEthSpec, _>::new(
+            senders,
+            OperatorId(1).into(),
+            setup.clock,
+            Arc::new(MockMessageSender::new(network_tx, OperatorId(1))),
+            NonZeroU64::new(32).expect("slots_per_epoch is non-zero"),
+            Arc::new(fork_schedule),
+            Arc::new(types::ChainSpec::mainnet()),
+        )
+        .expect("Manager creation should succeed");
+
+        // Attempt to create EnvelopeProposer with Committee executor.
+        // Due to MessageId encoding (Committee writes bytes 24-55, but EnvelopeProposer
+        // decodes bytes 8-55 as Validator), this will be decoded as Validator executor.
+        let msg_id = MessageId::new(
+            &DomainType([0; 4]),
+            Role::EnvelopeProposer,
+            &DutyExecutor::Committee(CommitteeId([0; 32])),
+        );
+
+        let qbft_message = QbftMessage {
+            qbft_message_type: QbftMessageType::Proposal,
+            height: 100,
+            round: 1,
+            identifier: (&msg_id).into(),
+            root: Hash256::from([0u8; 32]),
+            data_round: 1,
+            round_change_justification: ssv_types::VariableList::empty(),
+            prepare_justification: ssv_types::VariableList::empty(),
+        };
+
+        let ssv_msg = SSVMessage::new(
+            MsgType::SSVConsensusMsgType,
+            msg_id,
+            qbft_message.as_ssz_bytes(),
+        )
+        .expect("SSVMessage creation should succeed");
+
+        let signed_msg = SignedSSVMessage::new(
+            vec![[0xAA; RSA_SIGNATURE_SIZE]],
+            vec![OperatorId(1)],
+            ssv_msg,
+            vec![],
+        )
+        .expect("SignedSSVMessage creation should succeed");
+
+        // Act: Call receive_data
+        let result = manager.receive_data(signed_msg, qbft_message);
+
+        // Assert: Due to encoding, this is decoded as Validator executor,
+        // so we get RoleNotActive (routing not wired), not InconsistentMessageId.
+        assert!(
+            matches!(result, Err(QbftError::RoleNotActive)),
+            "EnvelopeProposer is always decoded as Validator, so expect RoleNotActive, got: {result:?}"
+        );
+    }
 }

--- a/anchor/qbft_manager/src/tests.rs
+++ b/anchor/qbft_manager/src/tests.rs
@@ -963,9 +963,22 @@ mod manager_tests {
     }
 
     #[tokio::test]
-    async fn envelope_proposer_validator_executor_is_transient_role_not_active() {
-        // Validator-executor EnvelopeProposer is a correctly-formed message whose QBFT
-        // routing is not wired yet (PR4/#1122): transient RoleNotActive, NOT InconsistentMessageId.
+    async fn envelope_proposer_any_executor_decodes_as_validator_transient_role_not_active() {
+        // `MessageId::new` starts from a zeroed 56-byte buffer and writes the executor bytes
+        // in place: `DutyExecutor::Validator` fills bytes 8..56, `DutyExecutor::Committee` fills
+        // bytes 24..56. Because `PublicKeyBytes::empty()` and `CommitteeId([0; 32])` are both
+        // all-zero, each executor writes ONLY zeros into an already-zero buffer, so role 9
+        // (`Role::EnvelopeProposer`) encodes to the identical 56-byte `MessageId` regardless of
+        // the executor passed in.
+        //
+        // `MessageId::duty_executor` then selects the executor purely from the role, and role 9
+        // is hard-wired to the `Validator` arm (bytes 8..55). So `receive_data` always enters the
+        // `Some(DutyExecutor::Validator(_))` branch and hits the `Some(Role::EnvelopeProposer)`
+        // arm, which returns `QbftError::RoleNotActive` unconditionally (routing not wired,
+        // TODO #1122). A committee-executor `EnvelopeProposer` is therefore unconstructable, and
+        // the `Role::EnvelopeProposer` listing in the `DutyExecutor::Committee` arm is unreachable
+        // for role 9 — it exists only for match exhaustiveness, so its `InconsistentMessageId` can
+        // never fire here.
         use fork::{Fork, ForkSchedule};
         use message_sender::testing::MockMessageSender;
         use ssv_types::{
@@ -975,12 +988,10 @@ mod manager_tests {
         };
         use ssz::Encode;
 
+        // Arrange: build the manager once. The fork/spec values are irrelevant here — the
+        // `Validator`/`EnvelopeProposer` arm returns before consulting either.
         let setup = setup_test(1);
-
-        // Create fork schedule with Boole active (latest SSV fork)
-        // EnvelopeProposer requires Ethereum's Gloas (ePBS) fork, which mainnet ChainSpec has
         let fork_schedule = ForkSchedule::new(Fork::Boole, DomainType::default(), "test");
-
         let config = processor::Config {
             max_workers: 4,
             queue_size: Default::default(),
@@ -999,134 +1010,66 @@ mod manager_tests {
         )
         .expect("Manager creation should succeed");
 
-        // Create an EnvelopeProposer message with Validator executor
-        let msg_id = MessageId::new(
+        // Constructs an `EnvelopeProposer` message for the given executor, returning the signed
+        // message plus its `QbftMessage`. Avoids duplicating the construction block per executor.
+        let build = |executor: &DutyExecutor| -> (SignedSSVMessage, QbftMessage) {
+            let msg_id = MessageId::new(&DomainType([0; 4]), Role::EnvelopeProposer, executor);
+            let qbft_message = QbftMessage {
+                qbft_message_type: QbftMessageType::Proposal,
+                height: 100,
+                round: 1,
+                identifier: (&msg_id).into(),
+                root: Hash256::from([0u8; 32]),
+                data_round: 1,
+                round_change_justification: ssv_types::VariableList::empty(),
+                prepare_justification: ssv_types::VariableList::empty(),
+            };
+            let ssv_msg = SSVMessage::new(
+                MsgType::SSVConsensusMsgType,
+                msg_id,
+                qbft_message.as_ssz_bytes(),
+            )
+            .expect("SSVMessage creation should succeed");
+            let signed_msg = SignedSSVMessage::new(
+                vec![[0xAA; RSA_SIGNATURE_SIZE]],
+                vec![OperatorId(1)],
+                ssv_msg,
+                vec![],
+            )
+            .expect("SignedSSVMessage creation should succeed");
+            (signed_msg, qbft_message)
+        };
+
+        // Make the byte-identity invariant explicit: both executors encode to the same 56 bytes.
+        let validator_msg_id = MessageId::new(
             &DomainType([0; 4]),
             Role::EnvelopeProposer,
             &DutyExecutor::Validator(bls::PublicKeyBytes::empty()),
         );
-
-        let qbft_message = QbftMessage {
-            qbft_message_type: QbftMessageType::Proposal,
-            height: 100, // Any slot in Gloas fork
-            round: 1,
-            identifier: (&msg_id).into(),
-            root: Hash256::from([0u8; 32]),
-            data_round: 1,
-            round_change_justification: ssv_types::VariableList::empty(),
-            prepare_justification: ssv_types::VariableList::empty(),
-        };
-
-        let ssv_msg = SSVMessage::new(
-            MsgType::SSVConsensusMsgType,
-            msg_id,
-            qbft_message.as_ssz_bytes(),
-        )
-        .expect("SSVMessage creation should succeed");
-
-        let signed_msg = SignedSSVMessage::new(
-            vec![[0xAA; RSA_SIGNATURE_SIZE]],
-            vec![OperatorId(1)],
-            ssv_msg,
-            vec![],
-        )
-        .expect("SignedSSVMessage creation should succeed");
-
-        // Act: Call receive_data
-        let result = manager.receive_data(signed_msg, qbft_message);
-
-        // Assert: Must be transient RoleNotActive (routing not wired), NOT InconsistentMessageId
-        assert!(
-            matches!(result, Err(QbftError::RoleNotActive)),
-            "validator-executor EnvelopeProposer must be transient RoleNotActive, got: {result:?}"
-        );
-    }
-
-    #[tokio::test]
-    async fn envelope_proposer_committee_executor_decodes_as_validator_executor() {
-        // NOTE: This test documents a MessageId encoding constraint.
-        // Due to MessageId encoding, Role::EnvelopeProposer is always decoded as
-        // DutyExecutor::Validator (bytes 8-55), making Committee-executor EnvelopeProposer
-        // impossible to construct via normal MessageId operations.
-        //
-        // This test verifies the encoding behavior: attempting to create a
-        // Committee-executor EnvelopeProposer in MessageId results in a Validator-executor
-        // being decoded, which then returns RoleNotActive (routing not wired).
-        use fork::{Fork, ForkSchedule};
-        use message_sender::testing::MockMessageSender;
-        use ssv_types::{
-            RSA_SIGNATURE_SIZE,
-            consensus::{QbftMessage, QbftMessageType},
-            message::{MsgType, SSVMessage, SignedSSVMessage},
-        };
-        use ssz::Encode;
-
-        let setup = setup_test(1);
-
-        // Create fork schedule with Boole active (latest SSV fork)
-        let fork_schedule = ForkSchedule::new(Fork::Boole, DomainType::default(), "test");
-
-        let config = processor::Config {
-            max_workers: 4,
-            queue_size: Default::default(),
-        };
-        let senders = processor::spawn(config, setup.executor);
-        let (network_tx, _network_rx) = mpsc::unbounded_channel();
-
-        let manager = QbftManager::<types::MainnetEthSpec, _>::new(
-            senders,
-            OperatorId(1).into(),
-            setup.clock,
-            Arc::new(MockMessageSender::new(network_tx, OperatorId(1))),
-            NonZeroU64::new(32).expect("slots_per_epoch is non-zero"),
-            Arc::new(fork_schedule),
-            Arc::new(types::ChainSpec::mainnet()),
-        )
-        .expect("Manager creation should succeed");
-
-        // Attempt to create EnvelopeProposer with Committee executor.
-        // Due to MessageId encoding (Committee writes bytes 24-55, but EnvelopeProposer
-        // decodes bytes 8-55 as Validator), this will be decoded as Validator executor.
-        let msg_id = MessageId::new(
+        let committee_msg_id = MessageId::new(
             &DomainType([0; 4]),
             Role::EnvelopeProposer,
             &DutyExecutor::Committee(CommitteeId([0; 32])),
         );
-
-        let qbft_message = QbftMessage {
-            qbft_message_type: QbftMessageType::Proposal,
-            height: 100,
-            round: 1,
-            identifier: (&msg_id).into(),
-            root: Hash256::from([0u8; 32]),
-            data_round: 1,
-            round_change_justification: ssv_types::VariableList::empty(),
-            prepare_justification: ssv_types::VariableList::empty(),
-        };
-
-        let ssv_msg = SSVMessage::new(
-            MsgType::SSVConsensusMsgType,
-            msg_id,
-            qbft_message.as_ssz_bytes(),
-        )
-        .expect("SSVMessage creation should succeed");
-
-        let signed_msg = SignedSSVMessage::new(
-            vec![[0xAA; RSA_SIGNATURE_SIZE]],
-            vec![OperatorId(1)],
-            ssv_msg,
-            vec![],
-        )
-        .expect("SignedSSVMessage creation should succeed");
-
-        // Act: Call receive_data
-        let result = manager.receive_data(signed_msg, qbft_message);
-
-        // Assert: Due to encoding, this is decoded as Validator executor,
-        // so we get RoleNotActive (routing not wired), not InconsistentMessageId.
-        assert!(
-            matches!(result, Err(QbftError::RoleNotActive)),
-            "EnvelopeProposer is always decoded as Validator, so expect RoleNotActive, got: {result:?}"
+        assert_eq!(
+            validator_msg_id.as_ref(),
+            committee_msg_id.as_ref(),
+            "validator- and committee-executor `EnvelopeProposer` must encode to the same 56 bytes for role 9"
         );
+
+        // Act + Assert: both executor variants route through the same
+        // `Validator`/`EnvelopeProposer` arm and return transient `RoleNotActive` (routing
+        // not wired), never `InconsistentMessageId`.
+        for executor in [
+            DutyExecutor::Validator(bls::PublicKeyBytes::empty()),
+            DutyExecutor::Committee(CommitteeId([0; 32])),
+        ] {
+            let (signed_msg, qbft_message) = build(&executor);
+            let result = manager.receive_data(signed_msg, qbft_message);
+            assert!(
+                matches!(result, Err(QbftError::RoleNotActive)),
+                "`EnvelopeProposer` always decodes as `Validator` and must be transient `RoleNotActive`, got: {result:?}"
+            );
+        }
     }
 }


### PR DESCRIPTION
## Problem, Evidence, and Context (Required)

SIP-94 introduces ePBS self-build envelope signing (§6) as a second, proposer-scoped QBFT duty that runs after the §4 block is published. Anchor has no `Role` for it, so envelope messages cannot be classified, fork-gated, or validated. This PR adds that role and wires the message-validation contract SIP-94 §7 pins for it.

Because `Role` is a plain enum (not `#[non_exhaustive]`), adding a variant breaks every exhaustive match across `ssv_types`, `message_validator`, and `qbft_manager`. This change intentionally bundles those compile-coupled edits so the workspace stays buildable in one step, and leaves QBFT instance routing as a transient reject for the follow-up (#1122).

- Closes #1120
- Spec: SIP-94 §6 (self-build envelope signing) and §7 (message-validation contract)

## Change Overview (Required)

`Role::EnvelopeProposer` (wire byte `[9, 0, 0, 0]`, matching SIP-94 `RoleEnvelopeProposer = 9`) is a validator-scoped, QBFT, monotonic-slot role bound to `PartialSignatureKind::PostConsensus`. It reuses the existing post-consensus machinery rather than adding a new partial-signature kind; the runner role discriminates routing. Validation is gated on the Ethereum Gloas fork.

The production surface is small (~42 lines): the new variant plus the arms every compile-coupled match site needs. The bulk of the diff is tests (~950 lines) that pin each SIP-94 §7 rule against the real validation entry points.

**Issue Criteria Addressed:**

- **Wire round-trip** — `Role::EnvelopeProposer` encodes/decodes as `[9, 0, 0, 0]` via `From<Role>` / `TryFrom<&[u8]>`. *(msgid.rs)*
- **Classification** — `is_committee_role() == false`, `is_qbft_role() == true`, `max_round() == Some(2)` (its own arm — deliberately **not** grouped with `Role::Proposer`'s `Some(6)`, per §7's cut-off of 2). *(msgid.rs)*
- **Duty executor** — `MessageId::duty_executor()` resolves to `DutyExecutor::Validator`. *(msgid.rs)*
- **Partial-signature kind** — only `PostConsensus` is accepted; any other kind is rejected with `PartialSignatureTypeRoleMismatch`. No new kind added. *(partial_signature.rs)*
- **Packet cardinality** — same-packet `message_count > 1` is rejected via the per-validator bound. *(partial_signature.rs / lib.rs)*
- **Replay guard** — a repeated `PostConsensus` packet for the same signer/slot is rejected by the inherited post-consensus seen-message counter. *(message_counts.rs path; no new arm needed)*
- **Monotonic slot (shared state)** — consensus and post-consensus share one role-specific `MessageId` state; after accepting at slot N, a lower-slot envelope message from the same signer returns `SlotAlreadyAdvanced` (→ `Ignore`). Ordinary `Role::Proposer` state stays isolated by its different role byte. *(inherited non-committee checks; no envelope-specific stale branch)*
- **Fork gate** — pre-Gloas messages are rejected with `RoleNotActiveBeforeEthFork { minimum_fork: ForkName::Gloas }`. *(lib.rs `validate_role_for_fork`)*
- **TTL** — short bucket `1 + LATE_SLOT_ALLOWANCE` (3 slots), not the committee bucket. *(lib.rs)*
- **Beacon duty** — `validate_beacon_duty` rejects a known-epoch non-proposer with `NoDuty`, and tolerates a not-yet-fetched proposer epoch (accepts). *(lib.rs)*
- **Duty cap** — `duty_limit(EnvelopeProposer) == Ok(Some(slots_per_epoch))`. *(lib.rs)*
- **Gossip classification** — `NoDuty` and duty-limit overflow → `Ignore`; fork-gate, kind mismatch, packet-count overflow → `Reject`. *(lib.rs classification test)*
- **QBFT routing** — validator-executor `EnvelopeProposer` returns `RoleNotActive` with a `TODO(#1122)` marker (executor is correct, routing not yet wired — deliberately **not** `InconsistentMessageId`); committee-executor path handles it for exhaustiveness. *(qbft_manager/lib.rs)*

**Intentionally unchanged:** no new `PartialSignatureKind`; no envelope-specific stale-slot branch (the role inherits the existing monotonic checks); `Role::Proposer` behaviour and its `max_round() == Some(6)`; QBFT instance routing (deferred to #1122).

## Risks, Trade-offs, and Mitigations (Required)

- **Blast radius:** touches shared `Role` match sites, so a missed arm would be a compile error, not a silent runtime bug — the type system is the safety net here. All new arms are additive.
- **Trade-off:** QBFT routing is a transient `RoleNotActive` reject rather than a working instance. This is deliberate and marked `TODO(#1122)`; envelope QBFT duties are inert until that lands, matching the issue's staged plan.
- **One deviation from the issue's suggested shape:** the committee-executor `EnvelopeProposer` case cannot produce `InconsistentMessageId` as literally worded, because `duty_executor()` always decodes bytes 8–55 as a `Validator` pubkey — a committee-executor `EnvelopeProposer` `MessageId` is unconstructable. The role is instead handled in the committee arm for exhaustiveness, and a test documents this encoding constraint. Called out for reviewer awareness.
- **Mitigation:** every §7 rule has a dedicated test exercising the real validation entry point (not a hand-rolled shortcut), so behaviour is pinned rather than assumed.

## Validation (Required)

- `cargo test -p ssv_types` — 111 passed
- `cargo test -p message_validator` — 100 passed (all new EnvelopeProposer coverage + sibling roles)
- `cargo test -p qbft_manager` — 36 passed
- `cargo fmt --check` — clean; `cargo clippy --tests -- -D warnings` — clean
- Coverage is new tests written for this change, exercising production entry points: role byte round-trip, duty executor, QBFT classification, kind binding, repeated-packet rejection, pre-Gloas fork gate, short TTL bucket, known/unknown proposer-epoch behaviour, duty cap, both monotonic-slot directions through the shared `MessageId` state, and the qbft_manager transient/permanent reject behaviour.

## Rollback (Required for behavior or runtime changes; optional otherwise)

Revert the single commit. The role is fork-gated to Gloas (not yet active) and QBFT routing is a no-op reject, so there is no runtime or data impact on current networks. No config or migration involved.

## Additional Info / Next Steps (Optional)

**Reviewer guide — production vs test.** The diff is ~4% production, ~96% test. Read the production arms first (small, mechanical), then spot-check the tests.

*Production (~42 lines) — read these first:*
- `ssv_types/src/msgid.rs` (+6) — the variant, `[9,0,0,0]` codec, `max_round() = Some(2)`, `Validator` executor.
- `message_validator/src/lib.rs` (+22) — committee lookup, fork gate, short TTL, `duty_limit`, and the `validate_beacon_duty` proposer-assignment arm.
- `qbft_manager/src/lib.rs` (+11) — transient `RoleNotActive` reject + `TODO(#1122)`; exhaustiveness in the committee arm.
- `message_validator/src/partial_signature.rs` (+3 production) — the role added to the `PostConsensus` bind and the per-validator packet bound.

*Tests (~950 lines) — verify the contract:*
- `message_validator/src/partial_signature.rs` (+577) — the §7 partial-signature contract: kind bind, packet cap, short TTL (accept + reject), proposer-assignment (3 cases), monotonic equality boundary + both stale-slot directions, replay rejection. A shared `four_node_committee_and_keypair` fixture removes repeated setup across these.
- `message_validator/src/consensus_message.rs` (+111) — duty-cap and the pre-Gloas fork-gate rejection via the consensus entry point.
- `message_validator/src/lib.rs` (+46) — gossip `MessageAcceptance` classification.
- `qbft_manager/src/tests.rs` (+168) — transient/permanent reject behaviour and the committee-executor encoding constraint noted above.
- `ssv_types/src/msgid.rs` (+48) — role byte round-trip and classification pinning.

The single commit is `feat: add validator-scoped QBFT Role::EnvelopeProposer (#1120)`.
