### PR TITLE
ci: opt in to fork PR checkout in claude-pr-review

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -80,6 +80,9 @@ jobs:
               with:
                   token: ${{ steps.app-token.outputs.token }}
                   ref: ${{ github.event.pull_request.head.sha }}
+                  # Fork PR checkout is gated on the is_member check above,
+                  # so only org members' code ever reaches this step.
+                  allow-unsafe-pr-checkout: true
 
             - name: Configure AWS Credentials (OIDC)
               if: steps.check.outputs.is_member == 'true'


### PR DESCRIPTION
## Problem, Evidence, and Context (Required)

- The `claude-pr-review` job fails at the checkout step for every fork PR. A recent `actions/checkout@v6` release added a guard that refuses to fetch fork PR code in `pull_request_target` workflows unless the step opts in via `allow-unsafe-pr-checkout: true`.
- Since virtually all PRs come from forks, automated review is currently broken repo-wide. Example failure: https://github.com/sigp/anchor/actions/runs/29801402538/job/88543041685 (PR #1151).
- Guard rationale: https://gh.io/securely-using-pull_request_target

## Change Overview (Required)

- Adds `allow-unsafe-pr-checkout: true` to the checkout step in `claude-pr-review.yml`, restoring pre-v6 behavior.
- This PR targets `stable` because `pull_request_target` loads the workflow from the default branch regardless of the PR's base (same as #830, #844, #845, #1130). The copy on `unstable` is currently byte-identical and reconciles at the next backmerge.
- `claude-mentions.yml` is untouched: its checkout has no PR `ref`, so the guard does not fire there.

## Risks, Trade-offs, and Mitigations (Required)

- The guard exists to prevent "pwn requests" (executing an untrusted fork's code with repo secrets). Here the checkout step is gated on the org-membership check (`is_member`, derived from server-computed `author_association`), so only sigp members' fork code ever reaches it. Members already have push access, so this does not extend trust.
- A code comment on the step documents why the opt-in is safe.

## Validation (Required)

- The error message names this exact opt-in as the remedy.
- This PR's own `claude-pr-review` run will still fail (it executes the not-yet-merged copy from `stable`); after merge, fork PRs can be re-checked via the `claude-recheck` label.

## Rollback (Required for behavior or runtime changes; optional otherwise)

- Revert the commit; no config, data, or operational impact.