### PR TITLE
chore: backmerge stable → unstable (v1.3.0 release)

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -80,6 +80,9 @@ jobs:
               with:
                   token: ${{ steps.app-token.outputs.token }}
                   ref: ${{ github.event.pull_request.head.sha }}
+                  # Fork PR checkout is gated on the is_member check above,
+                  # so only org members' code ever reaches this step.
+                  allow-unsafe-pr-checkout: true
 
             - name: Configure AWS Credentials (OIDC)
               if: steps.check.outputs.is_member == 'true'


### PR DESCRIPTION
Informational CI gate only. **Do NOT squash-merge** — this is merged via a CLI 2-parent push to unstable to preserve ancestry for the v1.3.0 fast-forward to stable. Brings only #1152 (claude-pr-review checkout fix) into unstable.