### PR TITLE
chore: bump lighthouse pin to v8.2.1

### DIFF
--- a/.github/custom/local-testnet/params.yaml
+++ b/.github/custom/local-testnet/params.yaml
@@ -3,7 +3,9 @@ network:
   - el_type: geth
     el_image: ethereum/client-go:v1.16.8
     cl_type: lighthouse
-    cl_image: sigp/lighthouse:v8.0.1
+    # Must be >= v8.2.0: the lighthouse VC code Anchor builds on now requests proposer duties
+    # from /eth/v2/validator/duties/proposer, which older beacon nodes reject with a 400.
+    cl_image: sigp/lighthouse:v8.2.1
     validator_count: 32
     count: 2
     supernode: true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -44,18 +44,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ahash"
-version = "0.8.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
-dependencies = [
- "cfg-if",
- "once_cell",
- "version_check",
- "zerocopy",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -437,7 +425,7 @@ dependencies = [
  "either",
  "futures",
  "futures-utils-wasm",
- "lru 0.16.3",
+ "lru",
  "parking_lot",
  "pin-project",
  "reqwest",
@@ -556,7 +544,7 @@ dependencies = [
  "alloy-rlp",
  "alloy-serde",
  "alloy-sol-types",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "serde",
  "serde_json",
  "serde_with",
@@ -709,7 +697,7 @@ checksum = "aa501ad58dd20acddbfebc65b52e60f05ebf97c52fa40d1b35e91f5e2da0ad0e"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "reqwest",
  "serde_json",
  "tower",
@@ -802,7 +790,7 @@ dependencies = [
  "fork",
  "futures",
  "hex",
- "lru 0.16.3",
+ "lru",
  "metrics",
  "openssl",
  "parking_lot",
@@ -1402,7 +1390,7 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 [[package]]
 name = "beacon_node_fallback"
 version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?rev=4b3a9d3#4b3a9d3d10a6181a1a1588880de133457eb90816"
+source = "git+https://github.com/sigp/lighthouse?rev=b263df5#b263df596671a2bd42bf1034e1cdc8188ba8a9b0"
 dependencies = [
  "bls",
  "clap",
@@ -1502,7 +1490,7 @@ dependencies = [
 [[package]]
 name = "bls"
 version = "0.2.0"
-source = "git+https://github.com/sigp/lighthouse?rev=4b3a9d3#4b3a9d3d10a6181a1a1588880de133457eb90816"
+source = "git+https://github.com/sigp/lighthouse?rev=b263df5#b263df596671a2bd42bf1034e1cdc8188ba8a9b0"
 dependencies = [
  "alloy-primitives 1.5.7",
  "blst",
@@ -2453,9 +2441,9 @@ dependencies = [
 
 [[package]]
 name = "discv5"
-version = "0.10.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f170f4f6ed0e1df52bf43b403899f0081917ecf1500bfe312505cc3b515a8899"
+checksum = "470ad731fddfc5b184e8bd2e3e24ddc6c7b006212af2b3989fd37a3de1217b4b"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -2466,18 +2454,17 @@ dependencies = [
  "enr",
  "fnv",
  "futures",
- "hashlink 0.9.1",
+ "hashlink",
  "hex",
  "hkdf",
  "lazy_static",
  "libp2p-identity",
- "lru 0.12.5",
  "more-asserts",
  "multiaddr",
  "parking_lot",
  "rand 0.8.5",
  "smallvec",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "tokio",
  "tracing",
  "uint 0.10.0",
@@ -2617,7 +2604,7 @@ dependencies = [
 [[package]]
 name = "eip_3076"
 version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?rev=4b3a9d3#4b3a9d3d10a6181a1a1588880de133457eb90816"
+source = "git+https://github.com/sigp/lighthouse?rev=b263df5#b263df596671a2bd42bf1034e1cdc8188ba8a9b0"
 dependencies = [
  "bls",
  "ethereum_serde_utils 0.8.0",
@@ -2841,7 +2828,7 @@ dependencies = [
 [[package]]
 name = "eth2"
 version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?rev=4b3a9d3#4b3a9d3d10a6181a1a1588880de133457eb90816"
+source = "git+https://github.com/sigp/lighthouse?rev=b263df5#b263df596671a2bd42bf1034e1cdc8188ba8a9b0"
 dependencies = [
  "bls",
  "context_deserialize",
@@ -2870,7 +2857,7 @@ dependencies = [
 [[package]]
 name = "eth2_config"
 version = "0.2.0"
-source = "git+https://github.com/sigp/lighthouse?rev=4b3a9d3#4b3a9d3d10a6181a1a1588880de133457eb90816"
+source = "git+https://github.com/sigp/lighthouse?rev=b263df5#b263df596671a2bd42bf1034e1cdc8188ba8a9b0"
 dependencies = [
  "paste",
  "types",
@@ -2879,20 +2866,20 @@ dependencies = [
 [[package]]
 name = "eth2_interop_keypairs"
 version = "0.2.0"
-source = "git+https://github.com/sigp/lighthouse?rev=4b3a9d3#4b3a9d3d10a6181a1a1588880de133457eb90816"
+source = "git+https://github.com/sigp/lighthouse?rev=b263df5#b263df596671a2bd42bf1034e1cdc8188ba8a9b0"
 dependencies = [
  "bls",
  "ethereum_hashing 0.8.0",
  "hex",
  "num-bigint",
  "serde",
- "serde_yaml",
+ "yaml_serde",
 ]
 
 [[package]]
 name = "eth2_key_derivation"
 version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?rev=4b3a9d3#4b3a9d3d10a6181a1a1588880de133457eb90816"
+source = "git+https://github.com/sigp/lighthouse?rev=b263df5#b263df596671a2bd42bf1034e1cdc8188ba8a9b0"
 dependencies = [
  "bls",
  "num-bigint-dig",
@@ -2904,7 +2891,7 @@ dependencies = [
 [[package]]
 name = "eth2_keystore"
 version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?rev=4b3a9d3#4b3a9d3d10a6181a1a1588880de133457eb90816"
+source = "git+https://github.com/sigp/lighthouse?rev=b263df5#b263df596671a2bd42bf1034e1cdc8188ba8a9b0"
 dependencies = [
  "aes",
  "bls",
@@ -2928,7 +2915,7 @@ dependencies = [
 [[package]]
 name = "eth2_network_config"
 version = "0.2.0"
-source = "git+https://github.com/sigp/lighthouse?rev=4b3a9d3#4b3a9d3d10a6181a1a1588880de133457eb90816"
+source = "git+https://github.com/sigp/lighthouse?rev=b263df5#b263df596671a2bd42bf1034e1cdc8188ba8a9b0"
 dependencies = [
  "bytes",
  "discv5",
@@ -2938,11 +2925,11 @@ dependencies = [
  "pretty_reqwest_error",
  "reqwest",
  "sensitive_url",
- "serde_yaml",
  "sha2",
  "tracing",
  "types",
  "url",
+ "yaml_serde",
  "zip",
 ]
 
@@ -2996,9 +2983,9 @@ dependencies = [
 
 [[package]]
 name = "ethereum_ssz"
-version = "0.10.1"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2128a84f7a3850d54ee343334e3392cca61f9f6aa9441eec481b9394b43c238b"
+checksum = "e462875ad8693755ea8913d6e905715c76ea4836e2254e18c9cf0f7a8f8c2a13"
 dependencies = [
  "alloy-primitives 1.5.7",
  "context_deserialize",
@@ -3152,7 +3139,7 @@ dependencies = [
 [[package]]
 name = "filesystem"
 version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?rev=4b3a9d3#4b3a9d3d10a6181a1a1588880de133457eb90816"
+source = "git+https://github.com/sigp/lighthouse?rev=b263df5#b263df596671a2bd42bf1034e1cdc8188ba8a9b0"
 dependencies = [
  "winapi",
  "windows-acl",
@@ -3179,7 +3166,7 @@ dependencies = [
 [[package]]
 name = "fixed_bytes"
 version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?rev=4b3a9d3#4b3a9d3d10a6181a1a1588880de133457eb90816"
+source = "git+https://github.com/sigp/lighthouse?rev=b263df5#b263df596671a2bd42bf1034e1cdc8188ba8a9b0"
 dependencies = [
  "alloy-primitives 1.5.7",
  "safe_arith",
@@ -3516,7 +3503,7 @@ dependencies = [
 [[package]]
 name = "graffiti_file"
 version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?rev=4b3a9d3#4b3a9d3d10a6181a1a1588880de133457eb90816"
+source = "git+https://github.com/sigp/lighthouse?rev=b263df5#b263df596671a2bd42bf1034e1cdc8188ba8a9b0"
 dependencies = [
  "bls",
  "serde",
@@ -3567,9 +3554,6 @@ name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
-dependencies = [
- "ahash",
-]
 
 [[package]]
 name = "hashbrown"
@@ -3577,8 +3561,6 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "allocator-api2",
- "equivalent",
  "foldhash 0.1.5",
  "serde",
 ]
@@ -3598,15 +3580,6 @@ dependencies = [
 
 [[package]]
 name = "hashlink"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
-dependencies = [
- "hashbrown 0.14.5",
-]
-
-[[package]]
-name = "hashlink"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea0b22561a9c04a7cb1a302c013e0259cd3b4bb619f145b32f72b8b4bcbed230"
@@ -3617,7 +3590,7 @@ dependencies = [
 [[package]]
 name = "health_metrics"
 version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?rev=4b3a9d3#4b3a9d3d10a6181a1a1588880de133457eb90816"
+source = "git+https://github.com/sigp/lighthouse?rev=b263df5#b263df596671a2bd42bf1034e1cdc8188ba8a9b0"
 dependencies = [
  "eth2",
  "metrics",
@@ -4163,7 +4136,7 @@ dependencies = [
 [[package]]
 name = "int_to_bytes"
 version = "0.2.0"
-source = "git+https://github.com/sigp/lighthouse?rev=4b3a9d3#4b3a9d3d10a6181a1a1588880de133457eb90816"
+source = "git+https://github.com/sigp/lighthouse?rev=b263df5#b263df596671a2bd42bf1034e1cdc8188ba8a9b0"
 dependencies = [
  "bytes",
 ]
@@ -4377,7 +4350,7 @@ dependencies = [
 [[package]]
 name = "kzg"
 version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?rev=4b3a9d3#4b3a9d3d10a6181a1a1588880de133457eb90816"
+source = "git+https://github.com/sigp/lighthouse?rev=b263df5#b263df596671a2bd42bf1034e1cdc8188ba8a9b0"
 dependencies = [
  "educe",
  "ethereum_hashing 0.8.0",
@@ -4526,7 +4499,7 @@ dependencies = [
  "futures",
  "futures-timer",
  "getrandom 0.2.17",
- "hashlink 0.11.0",
+ "hashlink",
  "hex_fmt",
  "libp2p-core",
  "libp2p-identity",
@@ -4643,7 +4616,7 @@ name = "libp2p-peer-store"
 version = "0.1.0"
 source = "git+https://github.com/sigp/rust-libp2p.git?rev=c774d4e71357d7cd2f792c4767d616d2dd369ee3#c774d4e71357d7cd2f792c4767d616d2dd369ee3"
 dependencies = [
- "hashlink 0.11.0",
+ "hashlink",
  "libp2p-core",
  "libp2p-swarm",
 ]
@@ -4725,7 +4698,7 @@ dependencies = [
  "futures",
  "futures-timer",
  "getrandom 0.2.17",
- "hashlink 0.11.0",
+ "hashlink",
  "libp2p-core",
  "libp2p-identity",
  "libp2p-swarm-derive",
@@ -4845,6 +4818,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "libyaml-rs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e126dda6f34391ab7b444f9922055facc83c07a910da3eb16f1e4d9c45dc777"
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4891,7 +4870,7 @@ dependencies = [
 [[package]]
 name = "logging"
 version = "0.2.0"
-source = "git+https://github.com/sigp/lighthouse?rev=4b3a9d3#4b3a9d3d10a6181a1a1588880de133457eb90816"
+source = "git+https://github.com/sigp/lighthouse?rev=b263df5#b263df596671a2bd42bf1034e1cdc8188ba8a9b0"
 dependencies = [
  "chrono",
  "logroller",
@@ -4921,15 +4900,6 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.12.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
-dependencies = [
- "hashbrown 0.15.5",
-]
-
-[[package]]
-name = "lru"
 version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1dc47f592c06f33f8e3aea9591776ec7c9f9e4124778ff8a3c3b87159f7e593"
@@ -4946,7 +4916,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 [[package]]
 name = "lru_cache"
 version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?rev=4b3a9d3#4b3a9d3d10a6181a1a1588880de133457eb90816"
+source = "git+https://github.com/sigp/lighthouse?rev=b263df5#b263df596671a2bd42bf1034e1cdc8188ba8a9b0"
 dependencies = [
  "fnv",
 ]
@@ -5027,7 +4997,7 @@ dependencies = [
 [[package]]
 name = "merkle_proof"
 version = "0.2.0"
-source = "git+https://github.com/sigp/lighthouse?rev=4b3a9d3#4b3a9d3d10a6181a1a1588880de133457eb90816"
+source = "git+https://github.com/sigp/lighthouse?rev=b263df5#b263df596671a2bd42bf1034e1cdc8188ba8a9b0"
 dependencies = [
  "alloy-primitives 1.5.7",
  "ethereum_hashing 0.8.0",
@@ -5125,7 +5095,7 @@ dependencies = [
 [[package]]
 name = "metrics"
 version = "0.2.0"
-source = "git+https://github.com/sigp/lighthouse?rev=4b3a9d3#4b3a9d3d10a6181a1a1588880de133457eb90816"
+source = "git+https://github.com/sigp/lighthouse?rev=b263df5#b263df596671a2bd42bf1034e1cdc8188ba8a9b0"
 dependencies = [
  "prometheus",
 ]
@@ -5372,7 +5342,7 @@ dependencies = [
 [[package]]
 name = "network_utils"
 version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?rev=4b3a9d3#4b3a9d3d10a6181a1a1588880de133457eb90816"
+source = "git+https://github.com/sigp/lighthouse?rev=b263df5#b263df596671a2bd42bf1034e1cdc8188ba8a9b0"
 dependencies = [
  "discv5",
  "libp2p-identity",
@@ -5949,7 +5919,7 @@ dependencies = [
 [[package]]
 name = "pretty_reqwest_error"
 version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?rev=4b3a9d3#4b3a9d3d10a6181a1a1588880de133457eb90816"
+source = "git+https://github.com/sigp/lighthouse?rev=b263df5#b263df596671a2bd42bf1034e1cdc8188ba8a9b0"
 dependencies = [
  "reqwest",
  "sensitive_url",
@@ -6136,7 +6106,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -6145,16 +6115,18 @@ dependencies = [
 [[package]]
 name = "proto_array"
 version = "0.2.0"
-source = "git+https://github.com/sigp/lighthouse?rev=4b3a9d3#4b3a9d3d10a6181a1a1588880de133457eb90816"
+source = "git+https://github.com/sigp/lighthouse?rev=b263df5#b263df596671a2bd42bf1034e1cdc8188ba8a9b0"
 dependencies = [
  "ethereum_ssz",
  "ethereum_ssz_derive",
  "fixed_bytes",
  "safe_arith",
  "serde",
- "serde_yaml",
+ "smallvec",
  "superstruct",
+ "typenum",
  "types",
+ "yaml_serde",
 ]
 
 [[package]]
@@ -6786,7 +6758,7 @@ dependencies = [
  "bitflags 2.11.0",
  "fallible-iterator",
  "fallible-streaming-iterator",
- "hashlink 0.11.0",
+ "hashlink",
  "libsqlite3-sys",
  "smallvec",
  "sqlite-wasm-rs",
@@ -7397,7 +7369,7 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 [[package]]
 name = "slashing_protection"
 version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?rev=4b3a9d3#4b3a9d3d10a6181a1a1588880de133457eb90816"
+source = "git+https://github.com/sigp/lighthouse?rev=b263df5#b263df596671a2bd42bf1034e1cdc8188ba8a9b0"
 dependencies = [
  "bls",
  "eip_3076",
@@ -7417,7 +7389,7 @@ dependencies = [
 [[package]]
 name = "slot_clock"
 version = "0.2.0"
-source = "git+https://github.com/sigp/lighthouse?rev=4b3a9d3#4b3a9d3d10a6181a1a1588880de133457eb90816"
+source = "git+https://github.com/sigp/lighthouse?rev=b263df5#b263df596671a2bd42bf1034e1cdc8188ba8a9b0"
 dependencies = [
  "metrics",
  "parking_lot",
@@ -7563,9 +7535,9 @@ dependencies = [
 
 [[package]]
 name = "ssz_types"
-version = "0.14.0"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fc20a89bab2dabeee65e9c9eb96892dc222c23254b401e1319b85efd852fa31"
+checksum = "d625e4de8e0057eefe7e0b1510ba1dd7adf10cd375fad6cc7fcceac7c39623c9"
 dependencies = [
  "context_deserialize",
  "educe",
@@ -7665,7 +7637,7 @@ dependencies = [
 [[package]]
 name = "swap_or_not_shuffle"
 version = "0.2.0"
-source = "git+https://github.com/sigp/lighthouse?rev=4b3a9d3#4b3a9d3d10a6181a1a1588880de133457eb90816"
+source = "git+https://github.com/sigp/lighthouse?rev=b263df5#b263df596671a2bd42bf1034e1cdc8188ba8a9b0"
 dependencies = [
  "alloy-primitives 1.5.7",
  "ethereum_hashing 0.8.0",
@@ -7768,7 +7740,7 @@ checksum = "c63f48baada5c52e65a29eef93ab4f8982681b67f9e8d29c7b05abcfec2b9ffe"
 [[package]]
 name = "task_executor"
 version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?rev=4b3a9d3#4b3a9d3d10a6181a1a1588880de133457eb90816"
+source = "git+https://github.com/sigp/lighthouse?rev=b263df5#b263df596671a2bd42bf1034e1cdc8188ba8a9b0"
 dependencies = [
  "async-channel 1.9.0",
  "futures",
@@ -7807,15 +7779,6 @@ name = "termtree"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
-
-[[package]]
-name = "test_random_derive"
-version = "0.2.0"
-source = "git+https://github.com/sigp/lighthouse?rev=4b3a9d3#4b3a9d3d10a6181a1a1588880de133457eb90816"
-dependencies = [
- "quote",
- "syn 2.0.117",
-]
 
 [[package]]
 name = "thiserror"
@@ -8311,7 +8274,7 @@ checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 [[package]]
 name = "types"
 version = "0.2.1"
-source = "git+https://github.com/sigp/lighthouse?rev=4b3a9d3#4b3a9d3d10a6181a1a1588880de133457eb90816"
+source = "git+https://github.com/sigp/lighthouse?rev=b263df5#b263df596671a2bd42bf1034e1cdc8188ba8a9b0"
 dependencies = [
  "alloy-primitives 1.5.7",
  "alloy-rlp",
@@ -8334,6 +8297,7 @@ dependencies = [
  "metastruct",
  "milhouse",
  "parking_lot",
+ "paste",
  "rand 0.9.2",
  "rand_xorshift 0.4.0",
  "rayon",
@@ -8343,17 +8307,16 @@ dependencies = [
  "safe_arith",
  "serde",
  "serde_json",
- "serde_yaml",
  "smallvec",
  "ssz_types",
  "superstruct",
  "swap_or_not_shuffle",
  "tempfile",
- "test_random_derive",
  "tracing",
  "tree_hash",
  "tree_hash_derive",
  "typenum",
+ "yaml_serde",
 ]
 
 [[package]]
@@ -8500,7 +8463,7 @@ dependencies = [
 [[package]]
 name = "validator_metrics"
 version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?rev=4b3a9d3#4b3a9d3d10a6181a1a1588880de133457eb90816"
+source = "git+https://github.com/sigp/lighthouse?rev=b263df5#b263df596671a2bd42bf1034e1cdc8188ba8a9b0"
 dependencies = [
  "metrics",
 ]
@@ -8508,7 +8471,7 @@ dependencies = [
 [[package]]
 name = "validator_services"
 version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?rev=4b3a9d3#4b3a9d3d10a6181a1a1588880de133457eb90816"
+source = "git+https://github.com/sigp/lighthouse?rev=b263df5#b263df596671a2bd42bf1034e1cdc8188ba8a9b0"
 dependencies = [
  "beacon_node_fallback",
  "bls",
@@ -8533,7 +8496,7 @@ dependencies = [
 [[package]]
 name = "validator_store"
 version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?rev=4b3a9d3#4b3a9d3d10a6181a1a1588880de133457eb90816"
+source = "git+https://github.com/sigp/lighthouse?rev=b263df5#b263df596671a2bd42bf1034e1cdc8188ba8a9b0"
 dependencies = [
  "bls",
  "eth2",
@@ -9302,7 +9265,7 @@ dependencies = [
 [[package]]
 name = "workspace_members"
 version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?rev=4b3a9d3#4b3a9d3d10a6181a1a1588880de133457eb90816"
+source = "git+https://github.com/sigp/lighthouse?rev=b263df5#b263df596671a2bd42bf1034e1cdc8188ba8a9b0"
 dependencies = [
  "cargo_metadata",
  "quote",
@@ -9384,6 +9347,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7d8a75eaf6557bb84a65ace8609883db44a29951042ada9b393151532e41fcb"
 dependencies = [
  "xml-rs",
+]
+
+[[package]]
+name = "yaml_serde"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c7c1b1a6a7c8a6b2741a6c21a4f8918e51899b111cfa08d1288202656e3975"
+dependencies = [
+ "indexmap 2.13.0",
+ "itoa",
+ "libyaml-rs",
+ "ryu",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,7 +73,7 @@ ssv_types = { path = "anchor/common/ssv_types" }
 subnet_service = { path = "anchor/subnet_service" }
 version = { path = "anchor/common/version" }
 
-# Lighthouse latest from unstable (4b3a9d3)
+# Lighthouse v8.2.1 release (b263df5)
 beacon_node_fallback = { git = "https://github.com/sigp/lighthouse", rev = "b263df5" }
 bls = { git = "https://github.com/sigp/lighthouse", rev = "b263df5" }
 eth2 = { git = "https://github.com/sigp/lighthouse", rev = "b263df5" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,22 +74,22 @@ subnet_service = { path = "anchor/subnet_service" }
 version = { path = "anchor/common/version" }
 
 # Lighthouse latest from unstable (4b3a9d3)
-beacon_node_fallback = { git = "https://github.com/sigp/lighthouse", rev = "4b3a9d3" }
-bls = { git = "https://github.com/sigp/lighthouse", rev = "4b3a9d3" }
-eth2 = { git = "https://github.com/sigp/lighthouse", rev = "4b3a9d3" }
-eth2_keystore = { git = "https://github.com/sigp/lighthouse", rev = "4b3a9d3" }
-eth2_network_config = { git = "https://github.com/sigp/lighthouse", rev = "4b3a9d3" }
-health_metrics = { git = "https://github.com/sigp/lighthouse", rev = "4b3a9d3" }
-metrics = { git = "https://github.com/sigp/lighthouse", rev = "4b3a9d3" }
-network_utils = { git = "https://github.com/sigp/lighthouse", rev = "4b3a9d3" }
-slashing_protection = { git = "https://github.com/sigp/lighthouse", rev = "4b3a9d3" }
-slot_clock = { git = "https://github.com/sigp/lighthouse", rev = "4b3a9d3" }
-task_executor = { git = "https://github.com/sigp/lighthouse", rev = "4b3a9d3" }
-types = { git = "https://github.com/sigp/lighthouse", rev = "4b3a9d3" }
-validator_metrics = { git = "https://github.com/sigp/lighthouse", rev = "4b3a9d3" }
-validator_services = { git = "https://github.com/sigp/lighthouse", rev = "4b3a9d3" }
-validator_store = { git = "https://github.com/sigp/lighthouse", rev = "4b3a9d3" }
-workspace_members = { git = "https://github.com/sigp/lighthouse", rev = "4b3a9d3" }
+beacon_node_fallback = { git = "https://github.com/sigp/lighthouse", rev = "b263df5" }
+bls = { git = "https://github.com/sigp/lighthouse", rev = "b263df5" }
+eth2 = { git = "https://github.com/sigp/lighthouse", rev = "b263df5" }
+eth2_keystore = { git = "https://github.com/sigp/lighthouse", rev = "b263df5" }
+eth2_network_config = { git = "https://github.com/sigp/lighthouse", rev = "b263df5" }
+health_metrics = { git = "https://github.com/sigp/lighthouse", rev = "b263df5" }
+metrics = { git = "https://github.com/sigp/lighthouse", rev = "b263df5" }
+network_utils = { git = "https://github.com/sigp/lighthouse", rev = "b263df5" }
+slashing_protection = { git = "https://github.com/sigp/lighthouse", rev = "b263df5" }
+slot_clock = { git = "https://github.com/sigp/lighthouse", rev = "b263df5" }
+task_executor = { git = "https://github.com/sigp/lighthouse", rev = "b263df5" }
+types = { git = "https://github.com/sigp/lighthouse", rev = "b263df5" }
+validator_metrics = { git = "https://github.com/sigp/lighthouse", rev = "b263df5" }
+validator_services = { git = "https://github.com/sigp/lighthouse", rev = "b263df5" }
+validator_store = { git = "https://github.com/sigp/lighthouse", rev = "b263df5" }
+workspace_members = { git = "https://github.com/sigp/lighthouse", rev = "b263df5" }
 
 alloy = { version = "1.2.1", features = [
     "sol-types",
@@ -110,7 +110,7 @@ clap = { version = "4.5.15", features = ["derive", "wrap_help"] }
 dashmap = "6.1.0"
 derive_more = { version = "2.0.1", features = ["full"] }
 dirs = "6.0.0"
-discv5 = { version = "0.10", features = ["libp2p"] }
+discv5 = { version = "0.11", features = ["libp2p"] }
 enr = "0.13.0"
 ethereum_hashing = "0.7.0"
 ethereum_ssz = "0.10.0"

--- a/anchor/client/src/lib.rs
+++ b/anchor/client/src/lib.rs
@@ -77,6 +77,8 @@ const HTTP_PROPOSAL_TIMEOUT_QUOTIENT: u32 = 2;
 const HTTP_PROPOSER_DUTIES_TIMEOUT_QUOTIENT: u32 = 4;
 const HTTP_SYNC_COMMITTEE_CONTRIBUTION_TIMEOUT_QUOTIENT: u32 = 4;
 const HTTP_SYNC_DUTIES_TIMEOUT_QUOTIENT: u32 = 4;
+const HTTP_PTC_DUTIES_TIMEOUT_QUOTIENT: u32 = 4;
+const HTTP_PAYLOAD_ATTESTATION_TIMEOUT_QUOTIENT: u32 = 4;
 const HTTP_GET_BEACON_BLOCK_SSZ_TIMEOUT_QUOTIENT: u32 = 4;
 const HTTP_GET_DEBUG_BEACON_STATE_QUOTIENT: u32 = 4;
 const HTTP_GET_DEPOSIT_SNAPSHOT_QUOTIENT: u32 = 4;
@@ -211,7 +213,7 @@ impl Client {
         let beacon_node_setup = |x: (usize, &SensitiveUrl)| {
             let i = x.0;
             let url = x.1;
-            let slot_duration = Duration::from_secs(spec.seconds_per_slot);
+            let slot_duration = spec.get_slot_duration();
 
             let mut beacon_node_http_client_builder = ClientBuilder::new();
 
@@ -245,6 +247,8 @@ impl Client {
                         / HTTP_SYNC_COMMITTEE_CONTRIBUTION_TIMEOUT_QUOTIENT,
                     sync_duties: slot_duration / HTTP_SYNC_DUTIES_TIMEOUT_QUOTIENT,
                     sync_aggregators: slot_duration / HTTP_SYNC_DUTIES_TIMEOUT_QUOTIENT,
+                    ptc_duties: slot_duration / HTTP_PTC_DUTIES_TIMEOUT_QUOTIENT,
+                    payload_attestation: slot_duration / HTTP_PAYLOAD_ATTESTATION_TIMEOUT_QUOTIENT,
                     get_beacon_blocks_ssz: slot_duration
                         / HTTP_GET_BEACON_BLOCK_SSZ_TIMEOUT_QUOTIENT,
                     get_debug_beacon_states: slot_duration / HTTP_GET_DEBUG_BEACON_STATE_QUOTIENT,
@@ -334,7 +338,7 @@ impl Client {
         let slot_clock = SystemTimeSlotClock::new(
             spec.genesis_slot,
             Duration::from_secs(genesis_time),
-            Duration::from_secs(spec.seconds_per_slot),
+            spec.get_slot_duration(),
         );
 
         beacon_nodes.set_slot_clock(slot_clock.clone());
@@ -444,7 +448,7 @@ impl Client {
             fork_schedule.clone(),
             slot_clock.clone(),
             E::slots_per_epoch(),
-            spec.seconds_per_slot,
+            spec.get_slot_duration().as_secs(),
             executor.clone(),
         )?;
 
@@ -516,7 +520,7 @@ impl Client {
                 operator_id.clone(),
                 startup_slot,
                 E::slots_per_epoch(),
-                Duration::from_secs(spec.seconds_per_slot),
+                spec.get_slot_duration(),
             )))
         } else {
             None

--- a/anchor/client/src/notifier.rs
+++ b/anchor/client/src/notifier.rs
@@ -5,10 +5,7 @@ use database::NetworkState;
 use operator_doppelganger::OperatorDoppelgangerService;
 use slot_clock::SlotClock;
 use task_executor::TaskExecutor;
-use tokio::{
-    sync::watch,
-    time::{Duration, sleep},
-};
+use tokio::{sync::watch, time::sleep};
 use tracing::{error, info};
 use types::{ChainSpec, EthSpec};
 
@@ -82,7 +79,7 @@ pub fn spawn_notifier<E: EthSpec, T: SlotClock + 'static>(
     executor: TaskExecutor,
     spec: &ChainSpec,
 ) {
-    let slot_duration = Duration::from_secs(spec.seconds_per_slot);
+    let slot_duration = spec.get_slot_duration();
 
     let interval_fut = async move {
         loop {

--- a/anchor/common/fork/src/monitor.rs
+++ b/anchor/common/fork/src/monitor.rs
@@ -302,7 +302,7 @@ mod tests {
 
     /// Get seconds per slot from minimal spec.
     fn seconds_per_slot() -> u64 {
-        ChainSpec::minimal().seconds_per_slot
+        ChainSpec::minimal().get_slot_duration().as_secs()
     }
 
     fn make_schedule_with_boole(boole_epoch: u64) -> Arc<ForkSchedule> {

--- a/anchor/database/src/tests/utils.rs
+++ b/anchor/database/src/tests/utils.rs
@@ -9,10 +9,7 @@ use ssv_types::{
     ValidatorIndex, ValidatorMetadata,
 };
 use tempfile::TempDir;
-use types::{
-    Address, Graffiti,
-    test_utils::{SeedableRng, XorShiftRng},
-};
+use types::{Address, Graffiti};
 
 use crate::{NetworkDatabase, PendingStateUpdates, multi_index::UniqueIndex};
 
@@ -20,7 +17,6 @@ use crate::{NetworkDatabase, PendingStateUpdates, multi_index::UniqueIndex};
 /// 4 operators allows for QBFT quorum (3) with 1 fault tolerance (f=1, n=3f+1=4)
 pub const DEFAULT_NUM_OPERATORS: u64 = 4;
 const RSA_KEY_SIZE: u32 = 2048;
-const DEFAULT_SEED: [u8; 16] = [42; 16];
 /// Test network name for database isolation
 pub const TEST_NETWORK: &str = "test";
 
@@ -302,8 +298,7 @@ pub mod generators {
     }
 
     pub mod pubkey {
-        use bls::PublicKeyBytes;
-        use types::test_utils::TestRandom;
+        use bls::{Keypair, PublicKeyBytes};
 
         use super::*;
 
@@ -316,10 +311,9 @@ pub mod generators {
                 .expect("Failed to process RSA key")
         }
 
-        // Generate a random public key for validators
+        // Generate a fresh public key for validators.
         pub fn random() -> PublicKeyBytes {
-            let rng = &mut XorShiftRng::from_seed(DEFAULT_SEED);
-            PublicKeyBytes::random_for_test(rng)
+            PublicKeyBytes::from(Keypair::random().pk)
         }
     }
 

--- a/anchor/network/src/behaviour.rs
+++ b/anchor/network/src/behaviour.rs
@@ -120,8 +120,7 @@ impl AnchorBehaviour {
         };
 
         let slots_per_epoch = E::slots_per_epoch();
-        let seconds_per_slot = spec.seconds_per_slot;
-        let duplicate_cache_time = Duration::from_secs(slots_per_epoch * seconds_per_slot); // 6.4 min TODO make this configurable
+        let duplicate_cache_time = spec.get_slot_duration() * slots_per_epoch as u32; // 6.4 min TODO make this configurable
 
         let gossipsub_config = gossipsub::ConfigBuilder::default()
             .duplicate_cache_time(duplicate_cache_time) // This is equivalent to seen_msg_ttl used in PeerScoreParams in go ssv
@@ -161,7 +160,7 @@ impl AnchorBehaviour {
         // Add peer scoring if not disabled
         if !network_config.disable_gossipsub_peer_scoring {
             let slots_per_epoch = E::slots_per_epoch();
-            let slot_duration = Duration::from_secs(spec.seconds_per_slot);
+            let slot_duration = spec.get_slot_duration();
             let one_epoch_duration = slot_duration * slots_per_epoch as u32;
             let score_params = peer_score_params(one_epoch_duration);
             let score_thresholds = peer_score_thresholds();
@@ -186,7 +185,7 @@ impl AnchorBehaviour {
 
         let peer_manager = {
             let slots_per_epoch = E::slots_per_epoch();
-            let slot_duration = Duration::from_secs(spec.seconds_per_slot);
+            let slot_duration = spec.get_slot_duration();
             let one_epoch_duration = slot_duration * slots_per_epoch as u32;
             PeerManager::new(network_config, one_epoch_duration, lifecycle_rx.clone())
         };

--- a/anchor/network/src/scoring/topic_score_config.rs
+++ b/anchor/network/src/scoring/topic_score_config.rs
@@ -113,7 +113,7 @@ impl TopicScoringOptions {
         message_rate: f64,
         chain_spec: &ChainSpec,
     ) -> Self {
-        let slot_duration = Duration::from_secs(chain_spec.seconds_per_slot);
+        let slot_duration = chain_spec.get_slot_duration();
         let one_epoch_duration = E::slots_per_epoch() as u32 * slot_duration;
 
         let network = NetworkConfig {

--- a/anchor/subnet_service/src/message_rate.rs
+++ b/anchor/subnet_service/src/message_rate.rs
@@ -172,7 +172,7 @@ pub fn calculate_message_rate_for_topic<E: EthSpec>(
     }
 
     let slots_per_epoch_f64 = E::slots_per_epoch() as f64;
-    let slot_duration_seconds = chain_spec.seconds_per_slot as f64;
+    let slot_duration_seconds = chain_spec.get_slot_duration().as_secs_f64();
     let sync_committee_size = E::sync_committee_size() as f64;
 
     let mut total_msg_rate = 0.0;

--- a/anchor/validator_store/src/lib.rs
+++ b/anchor/validator_store/src/lib.rs
@@ -65,9 +65,10 @@ use types::{
     AbstractExecPayload, Address, AggregateAndProof, AggregateAndProofBase,
     AggregateAndProofElectra, Attestation, AttestationBase, AttestationElectra, BeaconBlock,
     BeaconBlockRef, BlindedPayload, ChainSpec, ContributionAndProof, Domain, Epoch, EthSpec,
-    ExecutionPayloadEnvelope, ForkName, FullPayload, Graffiti, Hash256, SelectionProof,
-    SignedAggregateAndProof, SignedBeaconBlock, SignedBlindedBeaconBlock,
-    SignedContributionAndProof, SignedExecutionPayloadEnvelope, SignedRoot,
+    ExecutionPayloadEnvelope, ForkName, FullPayload, Graffiti, Hash256, PayloadAttestationData,
+    PayloadAttestationMessage, ProposerPreferences, SelectionProof, SignedAggregateAndProof,
+    SignedBeaconBlock, SignedBlindedBeaconBlock, SignedContributionAndProof,
+    SignedExecutionPayloadEnvelope, SignedProposerPreferences, SignedRoot,
     SignedValidatorRegistrationData, SignedVoluntaryExit, Slot, SlotData,
     SyncAggregatorSelectionData, SyncCommitteeContribution, SyncCommitteeMessage,
     SyncSelectionProof, SyncSubnetId, ValidatorRegistrationData, VoluntaryExit,
@@ -403,10 +404,8 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> AnchorValidator
 
         let timer = metrics::start_timer_vec(&metrics::CONSENSUS_TIMES, &[metric_label]);
         let timeout_mode = TimeoutMode::SlotTime {
-            instance_start_time: self.get_instant_in_slot(
-                slot,
-                Duration::from_secs(self.spec.seconds_per_slot) * 2 / 3,
-            )?,
+            instance_start_time: self
+                .get_instant_in_slot(slot, self.spec.get_slot_duration() * 2 / 3)?,
         };
 
         let completed = self
@@ -938,7 +937,7 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> AnchorValidator
             let timeout_mode = TimeoutMode::SlotTime {
                 instance_start_time: self.get_instant_in_slot(
                     message.aggregate().data().slot,
-                    Duration::from_secs(self.spec.seconds_per_slot) * 2 / 3,
+                    self.spec.get_slot_duration() * 2 / 3,
                 )?,
             };
 
@@ -1088,10 +1087,8 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> AnchorValidator
                 &[metrics::SYNC_CONTRIBUTION_AND_PROOF],
             );
             let timeout_mode = TimeoutMode::SlotTime {
-                instance_start_time: self.get_instant_in_slot(
-                    slot,
-                    Duration::from_secs(self.spec.seconds_per_slot) * 2 / 3,
-                )?,
+                instance_start_time: self
+                    .get_instant_in_slot(slot, self.spec.get_slot_duration() * 2 / 3)?,
             };
 
             let completed = self
@@ -1372,7 +1369,7 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> AnchorValidator
         let timer = metrics::start_timer_vec(&metrics::CONSENSUS_TIMES, &[metrics::BEACON_VOTE]);
         let timeout_mode = TimeoutMode::SlotTime {
             instance_start_time: self
-                .get_instant_in_slot(slot, Duration::from_secs(self.spec.seconds_per_slot) / 3)?,
+                .get_instant_in_slot(slot, self.spec.get_slot_duration() / 3)?,
         };
 
         let completed = self
@@ -1483,7 +1480,7 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> AnchorValidator
         let timer = metrics::start_timer_vec(&metrics::CONSENSUS_TIMES, &[metrics::BEACON_VOTE]);
         let timeout_mode = TimeoutMode::SlotTime {
             instance_start_time: self
-                .get_instant_in_slot(slot, Duration::from_secs(self.spec.seconds_per_slot) / 3)?,
+                .get_instant_in_slot(slot, self.spec.get_slot_duration() / 3)?,
         };
 
         let completed = self
@@ -2626,7 +2623,7 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> ValidatorStore
 
             // Stop at two thirds of the slot. If the selection proof is not ready by then, we
             // will not produce an aggregation anyway.
-            let delay = Duration::from_secs(self.spec.seconds_per_slot) * 2 / 3;
+            let delay = self.spec.get_slot_duration() * 2 / 3;
 
             let signature = if self.fork_schedule.active_fork(epoch) >= Fork::Boole {
                 let committee_id = cluster.committee_id();
@@ -2736,7 +2733,7 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> ValidatorStore
 
             // Stop at two thirds of the slot. If the selection proof is not ready by then, we
             // will not produce an aggregation anyway.
-            let delay = Duration::from_secs(self.spec.seconds_per_slot) * 2 / 3;
+            let delay = self.spec.get_slot_duration() * 2 / 3;
 
             let signature = if self.fork_schedule.active_fork(epoch) >= Fork::Boole {
                 // Under Boole, sync selection proofs use the same committee path as attestation
@@ -3048,6 +3045,22 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> ValidatorStore
         _validator_pubkey: PublicKeyBytes,
         _envelope: ExecutionPayloadEnvelope<E>,
     ) -> Result<SignedExecutionPayloadEnvelope<E>, Error> {
+        Err(Error::SpecificError(SpecificError::Unsupported))
+    }
+
+    async fn sign_payload_attestation(
+        &self,
+        _validator_pubkey: PublicKeyBytes,
+        _data: PayloadAttestationData,
+    ) -> Result<PayloadAttestationMessage, Error> {
+        Err(Error::SpecificError(SpecificError::Unsupported))
+    }
+
+    async fn sign_proposer_preferences(
+        &self,
+        _validator_pubkey: PublicKeyBytes,
+        _preferences: ProposerPreferences,
+    ) -> Result<SignedProposerPreferences, Error> {
         Err(Error::SpecificError(SpecificError::Unsupported))
     }
 }

--- a/anchor/validator_store/src/metadata_service.rs
+++ b/anchor/validator_store/src/metadata_service.rs
@@ -187,7 +187,7 @@ impl<E: EthSpec, T: SlotClock + 'static> MetadataService<E, T> {
         self,
         mut head_monitor_rx: Option<mpsc::Receiver<HeadEvent>>,
     ) -> Result<(), String> {
-        let slot_duration = Duration::from_secs(self.spec.seconds_per_slot);
+        let slot_duration = self.spec.get_slot_duration();
         let duration_to_next_slot = self
             .slot_clock
             .duration_to_next_slot()

--- a/anchor/validator_store/src/registration_service.rs
+++ b/anchor/validator_store/src/registration_service.rs
@@ -19,7 +19,7 @@ use bls::PublicKeyBytes;
 use futures::future::join_all;
 use slot_clock::SlotClock;
 use task_executor::TaskExecutor;
-use tokio::time::{Duration, sleep};
+use tokio::time::sleep;
 use tracing::{debug, error, info, warn};
 use types::{ChainSpec, EthSpec, SignedValidatorRegistrationData, Slot, ValidatorRegistrationData};
 use validator_store::{DoppelgangerStatus, ValidatorStore};
@@ -61,7 +61,7 @@ impl<S: ValidatorStore + 'static, T: SlotClock + 'static> RegistrationService<S,
         info!("Validator registration service started");
 
         let spec = spec.clone();
-        let slot_duration = Duration::from_secs(spec.seconds_per_slot);
+        let slot_duration = spec.get_slot_duration();
 
         let executor = self.inner.executor.clone();
 


### PR DESCRIPTION
## Problem, Evidence, and Context

- The lighthouse pin (`4b3a9d3`, 2026-03-12) is ~4 months old. `v8.2.1` is the latest release and a direct descendant of the current pin.
- Staying current also shrinks the merge surface with the `epbs` branch, which already builds against a newer lighthouse.

## Change Overview

- `Cargo.toml`: lighthouse rev `4b3a9d3` -> `b263df5` (v8.2.1). discv5 `0.10` -> `0.11` to match the version lighthouse now uses, so we compile a single discv5. Lockfile picks up `ssz_types` 0.14.1 / `ethereum_ssz` 0.10.4, required by the new pin.
- `ChainSpec::seconds_per_slot` is private upstream now: all usages moved to the `get_slot_duration()` accessor.
- `ValidatorStore` gained two required Gloas signing methods (`sign_payload_attestation`, `sign_proposer_preferences`): stubbed as `Unsupported`, matching the existing `sign_execution_payload_envelope` stub. Nothing on `unstable` instantiates the lighthouse services that call them.
- `eth2::Timeouts` gained `ptc_duties`/`payload_attestation` fields: added with the quotients lighthouse uses.
- Lighthouse removed its `TestRandom` machinery: the database test helper `pubkey::random()` now generates a fresh keypair instead.

Reading order: `Cargo.toml`, then `validator_store/src/lib.rs` (trait stubs); the rest is mechanical. These resolutions intentionally mirror the `epbs` branch's fixes for the same upstream changes, to keep future `unstable` <-> `epbs` merges clean.

Intentionally unchanged: the libp2p patch section (sigp fork pin) and all timeout/delay values.

## Risks, Trade-offs, and Mitigations

- No behavior change intended; the diff is a dependency bump plus mechanical accessor/field updates. The old `pubkey::random()` test helper drew OS entropy despite its fixed seed, so unique-per-call semantics are preserved.

## Validation

- `cargo check --workspace --all-targets`, `make lint`, `make cargo-fmt-check`: clean.
- Targeted tests on the touched crates: database 46/46, fork 33/33, subnet_service 60/60, network 53/53.

## Rollback

- Revert the commit; no config, data, or operational impact.