### PR TITLE
fix(ssv_types): cap Role::Proposer QBFT rounds at 2

### DIFF
--- a/anchor/common/ssv_types/src/msgid.rs
+++ b/anchor/common/ssv_types/src/msgid.rs
@@ -76,11 +76,12 @@ impl Role {
     }
 
     pub fn max_round(self) -> Option<u64> {
-        // as per https://github.com/ssvlabs/ssv/blob/6382d4b52ea5e0efd9378a5a00ef481f39d6234f/message/validation/consensus_validation.go#L370
+        // Caps both the incoming consensus-message round gate and the local QBFT
+        // instance round limit. ePBS (Gloas) caps specified https://github.com/ssvlabs/SIPs/pull/94.
         match self {
             Role::Committee | Role::Aggregator | Role::AggregatorCommittee => Some(12),
-            Role::Proposer | Role::SyncCommittee => Some(6),
-            Role::EnvelopeProposer => Some(2),
+            Role::Proposer | Role::EnvelopeProposer => Some(2),
+            Role::SyncCommittee => Some(6),
             // These roles don't use QBFT consensus
             Role::ValidatorRegistration
             | Role::VoluntaryExit
@@ -517,6 +518,21 @@ mod tests {
             msg_id.duty_executor(),
             Some(DutyExecutor::Validator(pk)),
             "EnvelopeProposer resolves to a validator-scoped duty executor"
+        );
+    }
+
+    /// Pins the proposer QBFT and sync-committee round caps.
+    #[test]
+    fn proposer_and_sync_committee_max_rounds_are_pinned() {
+        assert_eq!(
+            Role::Proposer.max_round(),
+            Some(2),
+            "`Role::Proposer` must cap QBFT at round 2"
+        );
+        assert_eq!(
+            Role::SyncCommittee.max_round(),
+            Some(6),
+            "`Role::SyncCommittee` must maintain its round 6 cap"
         );
     }
 }

--- a/anchor/common/ssv_types/src/msgid.rs
+++ b/anchor/common/ssv_types/src/msgid.rs
@@ -77,7 +77,8 @@ impl Role {
 
     pub fn max_round(self) -> Option<u64> {
         // Caps both the incoming consensus-message round gate and the local QBFT
-        // instance round limit. ePBS (Gloas) caps specified https://github.com/ssvlabs/SIPs/pull/94.
+        // instance round limit. Values mirror go-ssv's maxRound:
+        // https://github.com/ssvlabs/ssv/blob/d2352a3dba3e7b309ef090b7a23f4cac1d9002d1/message/validation/consensus_validation.go#L434-L443
         match self {
             Role::Committee | Role::Aggregator | Role::AggregatorCommittee => Some(12),
             Role::Proposer | Role::EnvelopeProposer => Some(2),

--- a/anchor/message_validator/src/consensus_message.rs
+++ b/anchor/message_validator/src/consensus_message.rs
@@ -933,6 +933,61 @@ mod tests {
         );
     }
 
+    /// A proposer consensus message above the round 2 cap is rejected.
+    #[test]
+    fn test_proposer_consensus_message_round_three_too_high() {
+        // Create proposer QBFT message with round 3 (exceeds round 2 cap).
+        let committee_info = create_committee_info(SINGLE_NODE_COMMITTEE);
+        let qbft_message = QbftMessageBuilder::new(Role::Proposer, QbftMessageType::Prepare)
+            .with_round(3)
+            .build();
+        let signed_msg = create_signed_consensus_message(
+            qbft_message.clone(),
+            vec![OperatorId(1)],
+            vec![],
+            vec![],
+        );
+        let map = create_operator_pub_keys(committee_info.committee_members.clone(), vec![]);
+
+        // Validate consensus message.
+        let result =
+            validate_consensus_message_semantics(&signed_msg, &qbft_message, &committee_info, &map);
+
+        // Should reject with RoundTooHigh error.
+        assert_validation_error(
+            result,
+            |failure| matches!(failure, ValidationFailure::RoundTooHigh),
+            "RoundTooHigh",
+        );
+    }
+
+    /// A proposer consensus message at the round 2 cap is still accepted.
+    #[test]
+    fn test_proposer_consensus_message_round_two_accepted() {
+        // Create a proposer QBFT message with round 2 (at the cap boundary).
+        let committee_info = create_committee_info(SINGLE_NODE_COMMITTEE);
+        let qbft_message = QbftMessageBuilder::new(Role::Proposer, QbftMessageType::Prepare)
+            .with_round(2)
+            .build();
+        let signed_msg = create_signed_consensus_message(
+            qbft_message.clone(),
+            vec![OperatorId(1)],
+            vec![],
+            vec![],
+        );
+        let map = create_operator_pub_keys(committee_info.committee_members.clone(), vec![]);
+
+        // Validate consensus message.
+        let result =
+            validate_consensus_message_semantics(&signed_msg, &qbft_message, &committee_info, &map);
+
+        // Expect successful validation (round 2 is the maximum allowed).
+        assert!(
+            result.is_ok(),
+            "Proposer consensus message at round 2 cap should validate successfully, got: {result:?}"
+        );
+    }
+
     #[test]
     fn test_consensus_message_mismatched_identifier() {
         let committee_info = create_committee_info(SINGLE_NODE_COMMITTEE);


### PR DESCRIPTION
## Problem, Evidence, and Context

- `Role::Proposer` capped QBFT at round 6, so Anchor accepted proposer consensus messages at rounds 3-6 that go-ssv drops as `ErrRoundTooHigh`.
- go-ssv `epbs-gloas` `message/validation/consensus_validation.go` `maxRound` returns 2 for the proposer-class roles, 6 for sync-committee contribution, 12 for the committee and aggregator roles.
- A proposer that has not decided by round 2 has already missed its in-slot broadcast deadline, so rounds 3-6 only widen the accepted-message surface. go-ssv's round timer documents the same reasoning: the 2s quick timeout is deliberately not retimed for Gloas, making the proposer effectively round-1-must-succeed.
- Closes #1119

## Change Overview

- `Role::Proposer` now shares the round 2 cap with `Role::EnvelopeProposer`, mirroring how go-ssv groups the two proposer-class roles.
- `Role::SyncCommittee` keeps its round 6 cap in its own match arm.
- Updated `max_round` comment citing SSV SIP-94 (reference now cannot go stale).
- Unchanged: `Role::EnvelopeProposer`, committee and aggregator, the non-QBFT roles, round-timer durations, and timeout-mode selection.

## Risks, Trade-offs, and Mitigations

- Proposer consensus messages at rounds 3-6 are now ignored instead of accepted, and a local proposer instance times out one round-change earlier. Both are the intended go-ssv parity.
- Anchor uses one value for the gossip gate and the local instance limit, while `ssv` keeps its local cut-off role-independent at 12. However, rounds above the validation cap cannot reach quorum because peers drop them, so stopping the local instance there forfeits no reachable consensus.
- Blast radius is one constant. No signature, wire-format, or control-flow change.

## Validation

- New unit test pins the proposer cap at 2 and the sync-committee cap at 6, so a future re-merge of the arms fails loudly.
- New message-validation tests assert a proposer message at round 3 is rejected with `RoundTooHigh` and one at round 2 is still accepted, covering both sides of the boundary.
- `cargo test -p ssv_types -p message_validator`: 220 passed, 0 failed.
- `make cargo-fmt-check` and `make lint`: clean.

## Rollback

- Revert the commit. The match arms return to a shared round 6 cap for `Role::Proposer` and `Role::SyncCommittee`. No config, data, or migration impact.
