### PR TITLE
ci: harden Kurtosis install against API rate limits

### DIFF
--- a/.github/workflows/local-testnet.yml
+++ b/.github/workflows/local-testnet.yml
@@ -47,9 +47,17 @@ jobs:
 
       - name: Install Kurtosis
         run: |
-          KURTOSIS_VERSION=$(curl -s https://api.github.com/repos/kurtosis-tech/kurtosis-cli-release-artifacts/releases/latest | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')
+          set -euo pipefail
+          # Resolve the latest tag from the github.com redirect rather than api.github.com.
+          # The REST API allows 60 unauthenticated requests/hour per IP and the shared runner
+          # egress IPs exhaust it, which silently yielded an empty version and broke the job.
+          KURTOSIS_VERSION=$(curl -fsSLI -o /dev/null -w '%{url_effective}' --retry 3 --retry-all-errors \
+            https://github.com/kurtosis-tech/kurtosis-cli-release-artifacts/releases/latest | sed 's#.*/tag/##')
+          case "${KURTOSIS_VERSION}" in
+            ''|*/*) echo "::error::Could not resolve latest Kurtosis version (got '${KURTOSIS_VERSION}')"; exit 1 ;;
+          esac
           echo "Installing Kurtosis version: ${KURTOSIS_VERSION}"
-          curl -L "https://github.com/kurtosis-tech/kurtosis-cli-release-artifacts/releases/download/${KURTOSIS_VERSION}/kurtosis-cli_${KURTOSIS_VERSION}_linux_amd64.tar.gz" -o kurtosis.tar.gz
+          curl -fL --retry 3 --retry-all-errors "https://github.com/kurtosis-tech/kurtosis-cli-release-artifacts/releases/download/${KURTOSIS_VERSION}/kurtosis-cli_${KURTOSIS_VERSION}_linux_amd64.tar.gz" -o kurtosis.tar.gz
           tar -xzf kurtosis.tar.gz
           sudo mv kurtosis /usr/local/bin/
           sudo chmod +x /usr/local/bin/kurtosis


### PR DESCRIPTION
## Problem, Evidence, and Context

- `run-local-testnet` fails intermittently in `Install Kurtosis`, unrelated to the PR under test. Six occurrences since 2026-06-10: runs `30252125901`, `29434838333`, `29431334751`, `29353107664`, `29017436052`, `27312016351`. That is 5% of the 117 workflow runs in that window and 27% of its failures.
- Every one shows the same signature: `Installing Kurtosis version:` with an empty value, a 9-byte download, then `gzip: stdin: not in gzip format`.
- The version came from an unauthenticated `api.github.com` call, capped at 60 requests/hour per IP. The shared runner egress IPs exhaust it, so the response carries no `tag_name`.
- Nothing stopped the empty value propagating. The step ran without `pipefail`, so `grep` finding nothing still exited 0 through `sed`; `curl` without `-f` then wrote the error page to `kurtosis.tar.gz`. `tar` was the first command to object, which is why the failure reads as a corrupt archive rather than a failed version lookup.
- Most recent case: commit `b7a3f429` on #1173 failed at 09:00 and 09:07, then passed unchanged on re-run. Same tree, opposite results.

## Change Overview

- Resolve the tag from the `github.com` `/releases/latest` redirect instead of `api.github.com`. This is the host the tarball already downloads from, and it is not behind the REST API's unauthenticated quota.
- Add `set -euo pipefail`, an explicit guard rejecting an empty or unparsed version, `-f` on both transfers, and `--retry 3 --retry-all-errors`.
- Unchanged: the step still tracks the latest release rather than pinning, and the rest of the workflow is untouched. No token or added `permissions:` is required, and no new tooling (`gh`, `jq`) is assumed on the warp runner image.

## Risks, Trade-offs, and Mitigations

- Blast radius is one CI step. No production code, and nothing outside this workflow.
- The tag is now parsed from a redirect URL rather than a JSON field. If that redirect shape ever changes, the guard fails the step with a named error instead of passing a bad value downstream.
- The two endpoints were measured directly rather than assumed: `api.github.com` returns `x-ratelimit-limit: 60`, while `github.com/.../releases/latest` returns a `302` carrying the tag in `location` and no `x-ratelimit-*` headers at all. The new path therefore does not consume the REST quota. Retries and fail-fast cover any residual transient failure.

## Validation

- Ran the exact script locally: resolves `1.20.0`, downloads `kurtosis-cli_1.20.0_linux_amd64.tar.gz`, extracts a valid `ELF 64-bit LSB executable, x86-64` binary.
- Confirmed the resolved version matches what `api.github.com` returns and what the last passing CI run installed (`1.20.0`).
- Guard verified against both failure modes: empty string and an unparsed URL both exit 1; `1.20.0` passes.
- Confirmed `-f` now catches a bad asset URL at the download with a real HTTP 404 rather than feeding 9 bytes to `tar`.
- `shellcheck` clean on the extracted script. `actionlint` reports only the two pre-existing `warp-ubuntu-latest-x64-16x` runner-label warnings, which are present on the unmodified base file.
- This workflow runs on `pull_request`, so the updated step executes on this PR itself. On run `30295263760`, `Install Kurtosis` passed with the new code, and the job went on to complete `Start Local Testnet with Assertoor`, which shells out to `kurtosis clean -a` and `kurtosis run` and therefore exercises the installed binary rather than just the download.

## Rollback

- Revert the commit. CI-only, no config, data, or runtime impact.

## Additional Info / Next Steps

- The other failure modes in this workflow (`Start Local Testnet with Assertoor`, `Return Assertoor Test Result`) are separate and not addressed here.
- Note for after merge: GitHub freezes the workflow file at run creation, so re-running an already-failed run will not pick this up. A new run has to be triggered.
