### PR TITLE
Support next-domain ENR discovery after Boole

### DIFF
--- a/anchor/network/src/discovery.rs
+++ b/anchor/network/src/discovery.rs
@@ -85,6 +85,22 @@ struct QueryResult {
     result: Result<Vec<Enr>, discv5::QueryError>,
 }
 
+fn enr_matches_current_domain(enr: &Enr, current_domain: DomainType) -> bool {
+    let Some(Ok(domain_type)) = enr.get_decodable::<[u8; 4]>("domaintype") else {
+        trace!(?enr, "Rejecting ENR with missing domaintype");
+        return false;
+    };
+
+    // Some clients keep the main domain static across a fork and advertise the active
+    // post-fork domain as their next domain. The exact NodeInfo check remains authoritative
+    // for newly dialed peers and disconnects domain mismatches.
+    domain_type == current_domain.0
+        || matches!(
+            enr.get_decodable::<[u8; 4]>("next_domaintype"),
+            Some(Ok(next_domain_type)) if next_domain_type == current_domain.0
+        )
+}
+
 #[derive(Debug, Clone)]
 pub struct DiscoveredPeers {
     pub peers: Vec<Enr>,
@@ -467,12 +483,8 @@ impl Discovery {
         let lifecycle_rx = self.lifecycle_rx.clone();
 
         let domain_type_predicate = move |enr: &Enr| {
-            if let Some(Ok(domain_type)) = enr.get_decodable::<[u8; 4]>("domaintype") {
-                lifecycle_rx.borrow().current_fork_config().domain_type.0 == domain_type
-            } else {
-                trace!(?enr, "Rejecting ENR with missing domaintype");
-                false
-            }
+            let current_domain = lifecycle_rx.borrow().current_fork_config().domain_type;
+            enr_matches_current_domain(enr, current_domain)
         };
 
         // General predicate
@@ -768,5 +780,80 @@ pub fn subnet_predicate(subnets: Vec<SubnetId>) -> impl Fn(&Enr) -> bool + Send 
             );
         }
         predicate
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const DOMAIN_A: DomainType = DomainType([0, 0, 0, 1]);
+    const DOMAIN_B: DomainType = DomainType([0, 0, 0, 2]);
+    const DOMAIN_C: DomainType = DomainType([0, 0, 0, 3]);
+    const MALFORMED_DOMAIN: [u8; 3] = [0, 0, 2];
+
+    fn test_enr(main_domain: Option<&[u8]>, next_domain: Option<&[u8]>) -> Enr {
+        let key = CombinedKey::generate_secp256k1();
+        let mut builder = Enr::builder();
+
+        if let Some(domain) = main_domain {
+            builder.add_value("domaintype", &Bytes::copy_from_slice(domain));
+        }
+        if let Some(domain) = next_domain {
+            builder.add_value("next_domaintype", &Bytes::copy_from_slice(domain));
+        }
+
+        builder.build(&key).expect("test ENR should build")
+    }
+
+    #[test]
+    fn test_enr_matches_current_domain_accepts_go_ssv_next_domain() {
+        let enr = test_enr(Some(&DOMAIN_A.0), Some(&DOMAIN_B.0));
+
+        assert!(enr_matches_current_domain(&enr, DOMAIN_B));
+    }
+
+    #[test]
+    fn test_enr_matches_current_domain_accepts_current_main_without_valid_next() {
+        let cases = [
+            (None, "missing next domain"),
+            (Some(DOMAIN_C.0.as_slice()), "non-matching next domain"),
+            (Some(MALFORMED_DOMAIN.as_slice()), "malformed next domain"),
+        ];
+
+        for (next_domain, description) in cases {
+            let enr = test_enr(Some(&DOMAIN_B.0), next_domain);
+
+            assert!(enr_matches_current_domain(&enr, DOMAIN_B), "{description}");
+        }
+    }
+
+    #[test]
+    fn test_enr_matches_current_domain_rejects_invalid_or_nonmatching_fields() {
+        let cases = [
+            (Some(DOMAIN_A.0.as_slice()), None, "missing next domain"),
+            (
+                Some(DOMAIN_A.0.as_slice()),
+                Some(DOMAIN_C.0.as_slice()),
+                "non-matching domains",
+            ),
+            (
+                Some(DOMAIN_A.0.as_slice()),
+                Some(MALFORMED_DOMAIN.as_slice()),
+                "malformed next domain",
+            ),
+            (None, Some(DOMAIN_B.0.as_slice()), "missing main domain"),
+            (
+                Some(MALFORMED_DOMAIN.as_slice()),
+                Some(DOMAIN_B.0.as_slice()),
+                "malformed main domain",
+            ),
+        ];
+
+        for (main_domain, next_domain, description) in cases {
+            let enr = test_enr(main_domain, next_domain);
+
+            assert!(!enr_matches_current_domain(&enr, DOMAIN_B), "{description}");
+        }
     }
 }


### PR DESCRIPTION
## Problem, Evidence, and Context (Required)

- Closes #1185.
- After Boole, go-ssv PR 2941 advertises Alan in `domaintype` and Boole in `next_domaintype`, while Anchor only accepts a main domain matching its current Boole domain. Normal discv5 selection therefore cannot replenish fresh cross-client edges.
- Existing and directly dialed connections remain compatible, which explains the successful warm fork transition.
- A Hoodi-stage Anchor restart after Boole recovered all three Anchor peers but zero go-ssv peers. The three nodes that had not restarted retained 3 to 5 go-ssv peers. Full code references and runtime evidence are in #1185.
- Related: [go-ssv PR 2941](https://github.com/ssvlabs/ssv/pull/2941), [go-ssv issue 2952](https://github.com/ssvlabs/ssv/issues/2952), and [Spesi PR 527](https://github.com/sigp/spesi/pull/527).

## Change Overview (Required)

- Require a structurally valid main `domaintype`, as before.
- Accept an ENR when either its main domain or valid optional `next_domaintype` equals Anchor's current domain.
- Apply the rule through the existing shared predicate used by general and subnet discovery.
- Add regression coverage for matching, absent, unrelated, and malformed main and next fields.
- This does not change Anchor's ENR publication, fork lifecycle, peer manager, or exact NodeInfo handshake.

## Risks, Trade-offs, and Mitigations (Required)

- The broader candidate rule can produce extra dial attempts toward peers with a stale or misleading next domain.
- ENR domain fields are self-asserted, so a peer could already claim the current domain in its main field. This does not add a new authorization capability.
- A valid main domain remains mandatory, and the exact current-domain NodeInfo handshake disconnects mismatched newly dialed peers.

## Validation (Required)

- `cargo test -p network --lib`, 56 passed.
- `cargo test -p network --lib handshake::tests::mismatched_networks_handshake_failed -- --exact`.
- `cargo test -p network --lib handshake::tests::watch_lifecycle_updates_propagate_to_handshakes -- --exact`.
- `cargo clippy -p network --tests -- -D warnings -D clippy::allow_attributes`.
- `cargo fmt --all -- --check`.
- `git diff --check upstream/unstable...HEAD`.
- A live postfork restart canary with this build remains the final operational confirmation.

## Rollback (Required for behavior or runtime changes; optional otherwise)

Revert this commit. There are no schema, configuration, persistent-data, or ENR-publication changes.

## Blockers / Dependencies (Optional)

None for merge. A Hoodi-stage canary is recommended before release deployment.
