### PR TITLE
fix: harden signature reconstruction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7322,6 +7322,7 @@ dependencies = [
  "ethereum_ssz",
  "fork",
  "message_sender",
+ "metrics",
  "processor",
  "rand 0.9.2",
  "slot_clock",

--- a/anchor/client/src/lib.rs
+++ b/anchor/client/src/lib.rs
@@ -575,6 +575,7 @@ impl Client {
         let signature_collector = SignatureCollectorManager::new(
             processor_senders.clone(),
             operator_id.clone(),
+            database.clone(),
             fork_schedule.clone(),
             E::slots_per_epoch(),
             message_sender.clone(),

--- a/anchor/signature_collector/Cargo.toml
+++ b/anchor/signature_collector/Cargo.toml
@@ -12,6 +12,7 @@ database = { workspace = true }
 ethereum_ssz = { workspace = true }
 fork = { workspace = true }
 message_sender = { workspace = true }
+metrics = { workspace = true }
 processor = { workspace = true }
 slot_clock = { workspace = true }
 ssv_types = { workspace = true }
@@ -21,4 +22,5 @@ tracing = { workspace = true }
 types = { workspace = true }
 
 [dev-dependencies]
+database = { workspace = true, features = ["test-utils"] }
 rand = { workspace = true }

--- a/anchor/signature_collector/src/lib.rs
+++ b/anchor/signature_collector/src/lib.rs
@@ -61,8 +61,12 @@ enum CreateMessageError {
     SSVMessage(#[from] SSVMessageError),
 }
 
-/// A handle to message the instance collecting a single specific signature
+/// A handle to message an instance collecting one specific signature.
+///
+/// The map entry also owns the corresponding collector task's lifetime.
 struct SignatureCollector {
+    /// Declared before `sender` so cancellation is visible before channel closure wakes the task.
+    _lifetime_guard: oneshot::Sender<()>,
     sender: UnboundedSender<CollectorMessage>,
     for_slot: Slot,
 }
@@ -136,7 +140,8 @@ impl<S: SlotClock + Clone + 'static> SignatureCollectorManager<S> {
     }
 
     /// Sign a message and wait until the signature has been reconstructed.
-    /// Will timeout if the instance is cleaned up, see [`SIGNATURE_COLLECTOR_RETAIN_SLOTS`].
+    /// Returns [`CollectionError::QueueClosedError`] if the instance is cleaned up before
+    /// reconstruction, see [`SIGNATURE_COLLECTOR_RETAIN_SLOTS`].
     /// Check the fields of the parameter structs for more info.
     /// The rough idea behind the separation is that `metadata` will be the same across all calls if
     /// we sign for all validators in a committee, while `validator_signing_data` varies for each.
@@ -393,6 +398,7 @@ impl<S: SlotClock + Clone + 'static> SignatureCollectorManager<S> {
             Entry::Vacant(entry) => {
                 // this channel is effectively limited by the processor permit amount
                 let (tx, rx) = mpsc::unbounded_channel();
+                let (lifetime_guard, lifetime_end) = oneshot::channel();
                 let span = debug_span!(
                     "signature_collector",
                     ?slot,
@@ -400,13 +406,19 @@ impl<S: SlotClock + Clone + 'static> SignatureCollectorManager<S> {
                     ?signing_root
                 );
                 entry.insert(SignatureCollector {
+                    _lifetime_guard: lifetime_guard,
                     sender: tx.clone(),
                     for_slot: slot,
                 });
                 let _ = self.processor.permitless.send_async(
                     Box::pin(
-                        signature_collector(rx, signing_root, self.share_pubkey_loader.clone())
-                            .instrument(span),
+                        signature_collector(
+                            rx,
+                            signing_root,
+                            self.share_pubkey_loader.clone(),
+                            lifetime_end,
+                        )
+                        .instrument(span),
                     ),
                     COLLECTOR_NAME,
                 );
@@ -583,11 +595,26 @@ impl<S: SlotClock + Clone + 'static> SignatureCollecting for Arc<SignatureCollec
 
 /// The actual signature collector task, waiting for messages.
 ///
+/// Removing its manager map entry cancels this future and closes pending notifiers.
+async fn signature_collector<G: Send + 'static>(
+    rx: mpsc::UnboundedReceiver<CollectorMessage<G>>,
+    signing_root: Hash256,
+    share_pubkey_loader: SharePubkeyLoader,
+    lifetime_end: oneshot::Receiver<()>,
+) {
+    tokio::select! {
+        // Do not process queued messages after the map entry has already been removed.
+        biased;
+        _ = lifetime_end => {}
+        _ = signature_collector_loop(rx, signing_root, share_pubkey_loader) => {}
+    }
+}
+
 /// The recv loop is the only place that matches on [`CollectorMessageKind`];
 /// it dispatches each transport message to a typed method on
 /// [`SignatureCollectorState`] so the state machine never sees the channel
 /// shape (or the size-balancing `Box<Signature>` it carries).
-async fn signature_collector<G: Send + 'static>(
+async fn signature_collector_loop<G: Send + 'static>(
     mut rx: mpsc::UnboundedReceiver<CollectorMessage<G>>,
     signing_root: Hash256,
     share_pubkey_loader: SharePubkeyLoader,

--- a/anchor/signature_collector/src/lib.rs
+++ b/anchor/signature_collector/src/lib.rs
@@ -1,3 +1,5 @@
+mod metrics;
+
 use std::{
     collections::{HashMap, hash_map},
     future::Future,
@@ -7,10 +9,10 @@ use std::{
     sync::Arc,
 };
 
-use bls::{PublicKeyBytes, SecretKey, Signature};
+use bls::{PublicKey, PublicKeyBytes, SecretKey, Signature};
 use bls_lagrange::KeyId;
 use dashmap::{DashMap, Entry};
-use database::OwnOperatorId;
+use database::{NetworkDatabase, OwnOperatorId};
 use fork::ForkSchedule;
 use message_sender::MessageSender;
 use processor::{Error, Error::Queue, Senders, work::DropOnFinish};
@@ -31,11 +33,12 @@ use ssz::Encode;
 use thiserror::Error;
 use tokio::{
     sync::{
-        mpsc,
+        Semaphore, mpsc,
         mpsc::{UnboundedSender, error::TrySendError},
         oneshot,
         oneshot::error::RecvError,
     },
+    task,
     time::sleep,
 };
 use tracing::{Instrument, debug_span, error, trace, warn};
@@ -77,6 +80,8 @@ pub struct SignatureCollectorManager<S: SlotClock> {
     processor: Senders,
     /// The local operator we act for.
     operator_id: OwnOperatorId,
+    /// Loads share public keys after a reconstruction failure.
+    share_pubkey_loader: SharePubkeyLoader,
     /// The fork schedule for looking up the slot-based domain type.
     fork_schedule: Arc<ForkSchedule>,
     /// The slot clock for determining the current epoch.
@@ -98,6 +103,7 @@ impl<S: SlotClock + Clone + 'static> SignatureCollectorManager<S> {
     pub fn new(
         processor: Senders,
         operator_id: OwnOperatorId,
+        database: Arc<NetworkDatabase>,
         fork_schedule: Arc<ForkSchedule>,
         slots_per_epoch: u64,
         message_sender: Arc<dyn MessageSender>,
@@ -106,6 +112,7 @@ impl<S: SlotClock + Clone + 'static> SignatureCollectorManager<S> {
         let manager = Arc::new(Self {
             processor,
             operator_id,
+            share_pubkey_loader: SharePubkeyLoader::new(database),
             fork_schedule,
             slot_clock: slot_clock.clone(),
             slots_per_epoch,
@@ -155,6 +162,7 @@ impl<S: SlotClock + Clone + 'static> SignatureCollectorManager<S> {
 
         // first, register notifier with preexisting or newly spawned instance
         let cloned_metadata = metadata.clone();
+        let validator_pubkey = validator_signing_data.validator_pubkey;
         let manager = self.clone();
         self.processor.permitless.send_immediate(
             move |drop_on_finish| {
@@ -167,6 +175,7 @@ impl<S: SlotClock + Clone + 'static> SignatureCollectorManager<S> {
                     kind: CollectorMessageKind::RegisterNotifier {
                         notify: result_tx,
                         threshold: cloned_metadata.threshold,
+                        validator_pubkey,
                     },
                     _drop_on_finish: drop_on_finish,
                 });
@@ -352,17 +361,17 @@ impl<S: SlotClock + Clone + 'static> SignatureCollectorManager<S> {
             move |drop_on_finish| {
                 let sender =
                     manager.get_or_spawn(message.signing_root, message.validator_index, slot);
-                if let Err(err) = sender.send(CollectorMessage {
-                    kind: CollectorMessageKind::PartialSignature {
-                        operator_id: message.signer,
-                        signature: Box::new(message.partial_signature),
-                    },
-                    _drop_on_finish: drop_on_finish,
-                }) {
-                    error!(
-                        ?err,
-                        "failed to send partial signature to collector instance"
-                    );
+                if sender
+                    .send(CollectorMessage {
+                        kind: CollectorMessageKind::PartialSignature {
+                            operator_id: message.signer,
+                            signature: Box::new(message.partial_signature),
+                        },
+                        _drop_on_finish: drop_on_finish,
+                    })
+                    .is_err()
+                {
+                    error!("Failed to send partial signature to collector instance");
                 }
             },
             COLLECTOR_MESSAGE_NAME,
@@ -395,7 +404,10 @@ impl<S: SlotClock + Clone + 'static> SignatureCollectorManager<S> {
                     for_slot: slot,
                 });
                 let _ = self.processor.permitless.send_async(
-                    Box::pin(signature_collector(rx).instrument(span)),
+                    Box::pin(
+                        signature_collector(rx, signing_root, self.share_pubkey_loader.clone())
+                            .instrument(span),
+                    ),
                     COLLECTOR_NAME,
                 );
                 trace!(
@@ -482,12 +494,13 @@ pub enum SignatureRequester {
 pub struct ValidatorSigningData {
     pub root: Hash256,
     pub index: ValidatorIndex,
+    pub validator_pubkey: PublicKeyBytes,
     pub share: Option<SecretKey>,
 }
 
-struct CollectorMessage {
+struct CollectorMessage<G = DropOnFinish> {
     kind: CollectorMessageKind,
-    _drop_on_finish: DropOnFinish,
+    _drop_on_finish: G,
 }
 
 #[derive(Debug)]
@@ -496,6 +509,7 @@ enum CollectorMessageKind {
     RegisterNotifier {
         notify: oneshot::Sender<Arc<Signature>>,
         threshold: u64,
+        validator_pubkey: PublicKeyBytes,
     },
     /// A new partial signature is available - either because it arrived from the network, or
     /// because we created it
@@ -573,71 +587,258 @@ impl<S: SlotClock + Clone + 'static> SignatureCollecting for Arc<SignatureCollec
 /// it dispatches each transport message to a typed method on
 /// [`SignatureCollectorState`] so the state machine never sees the channel
 /// shape (or the size-balancing `Box<Signature>` it carries).
-async fn signature_collector(mut rx: mpsc::UnboundedReceiver<CollectorMessage>) {
-    let mut state = SignatureCollectorState::default();
+async fn signature_collector<G: Send + 'static>(
+    mut rx: mpsc::UnboundedReceiver<CollectorMessage<G>>,
+    signing_root: Hash256,
+    share_pubkey_loader: SharePubkeyLoader,
+) {
+    let mut state = SignatureCollectorState::new(signing_root);
+
     while let Some(message) = rx.recv().await {
-        trace!(msg=?message.kind, "Signature collector received message");
-        let outcome = match message.kind {
-            CollectorMessageKind::RegisterNotifier { notify, threshold } => {
-                state.register_request(notify, threshold)
+        match message.kind {
+            CollectorMessageKind::RegisterNotifier {
+                notify,
+                threshold,
+                validator_pubkey,
+            } => {
+                if state
+                    .register_request(notify, threshold, validator_pubkey)
+                    .is_break()
+                {
+                    return;
+                }
             }
             CollectorMessageKind::PartialSignature {
                 operator_id,
                 signature,
-            } => state.add_partial_signature(operator_id, *signature),
-        };
-        if outcome.is_break() {
-            return;
+            } => {
+                state.add_partial_signature(operator_id, *signature);
+            }
+        }
+
+        match state.try_reconstruct() {
+            Ok(None) => {}
+            Ok(Some(signature)) => state.complete_reconstruction(signature),
+            Err(failure) => {
+                if handle_reconstruction_fallback(&mut state, failure, &share_pubkey_loader)
+                    .await
+                    .is_break()
+                {
+                    return;
+                }
+            }
         }
     }
 }
 
+async fn handle_reconstruction_fallback(
+    state: &mut SignatureCollectorState,
+    failure: ReconstructionFailure,
+    share_pubkey_loader: &SharePubkeyLoader,
+) -> ControlFlow<()> {
+    metrics::inc_counter(&metrics::RECONSTRUCTION_FALLBACKS_TOTAL);
+
+    let Some(registration) = state.registration.as_ref() else {
+        error!("Reconstruction fallback requested before registration");
+        return ControlFlow::Break(());
+    };
+    let validator_pubkey = registration.validator_pubkey;
+    let threshold = registration.threshold;
+    let (failure_kind, combination_error) = match &failure {
+        ReconstructionFailure::Combination(err) => ("combination", Some(err)),
+        ReconstructionFailure::MasterVerification => ("master_verification", None),
+    };
+
+    warn!(
+        failure_kind,
+        ?combination_error,
+        share_count = state.signature_share.len(),
+        threshold,
+        "Reconstructed signature failed, verifying buffered shares"
+    );
+
+    let Some(share_pubkeys) = share_pubkey_loader.fetch(validator_pubkey).await else {
+        return ControlFlow::Break(());
+    };
+
+    let invalid_operator_ids = state.remove_invalid_shares(&share_pubkeys);
+    let remaining_count = state.signature_share.len();
+    warn!(
+        ?invalid_operator_ids,
+        invalid_count = invalid_operator_ids.len(),
+        remaining_count,
+        threshold,
+        "Verified buffered shares after reconstruction failure"
+    );
+
+    if invalid_operator_ids.is_empty() {
+        error!(
+            remaining_count,
+            threshold, "Reconstruction failed although every buffered share verified"
+        );
+        return ControlFlow::Break(());
+    }
+
+    if (remaining_count as u64) < threshold {
+        return ControlFlow::Continue(());
+    }
+
+    match state.try_reconstruct() {
+        Ok(Some(signature)) => {
+            state.complete_reconstruction(signature);
+            ControlFlow::Continue(())
+        }
+        Ok(None) => {
+            error!(
+                remaining_count,
+                threshold, "Immediate reconstruction retry did not complete"
+            );
+            ControlFlow::Break(())
+        }
+        Err(failure) => {
+            error!(
+                ?failure,
+                remaining_count, threshold, "Immediate reconstruction retry failed"
+            );
+            ControlFlow::Break(())
+        }
+    }
+}
+
+/// Loads all share public keys of a validator from the database, serializing
+/// lookups before they enter Tokio's blocking pool.
+#[derive(Clone)]
+struct SharePubkeyLoader {
+    database: Arc<NetworkDatabase>,
+    semaphore: Arc<Semaphore>,
+}
+
+impl SharePubkeyLoader {
+    fn new(database: Arc<NetworkDatabase>) -> Self {
+        Self {
+            database,
+            semaphore: Arc::new(Semaphore::new(1)),
+        }
+    }
+
+    async fn fetch(
+        &self,
+        validator_pubkey: PublicKeyBytes,
+    ) -> Option<HashMap<OperatorId, PublicKeyBytes>> {
+        let Ok(permit) = Arc::clone(&self.semaphore).acquire_owned().await else {
+            error!("Signature reconstruction fallback semaphore closed");
+            return None;
+        };
+
+        let database = Arc::clone(&self.database);
+        match task::spawn_blocking(move || {
+            let _permit = permit;
+            database.get_share_pubkeys_for_validator(&validator_pubkey)
+        })
+        .await
+        {
+            Ok(Ok(share_pubkeys)) if share_pubkeys.is_empty() => {
+                error!("Validator share public-key lookup returned no keys");
+                None
+            }
+            Ok(Ok(share_pubkeys)) => Some(share_pubkeys),
+            Ok(Err(err)) => {
+                error!(%err, "Failed to load validator share public keys");
+                None
+            }
+            Err(err) => {
+                error!(%err, "Validator share public-key lookup task failed");
+                None
+            }
+        }
+    }
+}
+
+#[derive(Debug)]
+enum ReconstructionFailure {
+    Combination(CollectionError),
+    MasterVerification,
+}
+
+struct CollectorRegistration {
+    threshold: u64,
+    validator_pubkey: PublicKeyBytes,
+    decompressed_validator_pubkey: PublicKey,
+}
+
 /// Invariant: once `full_signature` is `Some`, both `signature_share` and
-/// `notifiers` are empty (drained by `try_reconstruct`).
-#[derive(Default)]
+/// `notifiers` are empty (drained by `complete_reconstruction`).
 struct SignatureCollectorState {
+    signing_root: Hash256,
     notifiers: Vec<oneshot::Sender<Arc<Signature>>>,
     signature_share: HashMap<OperatorId, Signature>,
     full_signature: Option<Arc<Signature>>,
-    threshold: Option<u64>,
+    registration: Option<CollectorRegistration>,
 }
 
 impl SignatureCollectorState {
+    fn new(signing_root: Hash256) -> Self {
+        Self {
+            signing_root,
+            notifiers: vec![],
+            signature_share: HashMap::new(),
+            full_signature: None,
+            registration: None,
+        }
+    }
+
     /// Register a task waiting for the reconstructed signature.
     ///
-    /// If reconstruction has already completed, the cached signature is
-    /// delivered immediately. Otherwise the notifier is queued and the
-    /// threshold is recorded; conflicting thresholds from concurrent
-    /// requests cause the collector to `Break` (the recv loop drops the
-    /// state, surfacing `RecvError` to every waiter).
+    /// The first registration fixes the threshold and validator master public
+    /// key. Later registrations must match both. A matching caller receives a
+    /// cached verified signature immediately, or is queued until reconstruction
+    /// completes.
     ///
-    /// Returns `Break` when the collector should exit (conflicting
-    /// thresholds, unrecoverable reconstruction failure).
+    /// Returns `Break` if the master public key is malformed or a later
+    /// registration conflicts. The recv loop then drops the state, closing all
+    /// queued notifiers.
     fn register_request(
         &mut self,
         notify: oneshot::Sender<Arc<Signature>>,
         new_threshold: u64,
+        validator_pubkey: PublicKeyBytes,
     ) -> ControlFlow<()> {
+        if let Some(registration) = &self.registration {
+            if new_threshold != registration.threshold
+                || validator_pubkey != registration.validator_pubkey
+            {
+                error!(
+                    new_threshold,
+                    old_threshold = registration.threshold,
+                    validator_pubkey_matches = validator_pubkey == registration.validator_pubkey,
+                    "Conflicting registration passed to signature collector"
+                );
+                return ControlFlow::Break(());
+            }
+        } else {
+            let decompressed_validator_pubkey = match validator_pubkey.decompress() {
+                Ok(public_key) => public_key,
+                Err(err) => {
+                    error!(?err, "Failed to decompress validator public key");
+                    return ControlFlow::Break(());
+                }
+            };
+            self.registration = Some(CollectorRegistration {
+                threshold: new_threshold,
+                validator_pubkey,
+                decompressed_validator_pubkey,
+            });
+        }
+
         if let Some(full_signature) = &self.full_signature {
-            if let Err(err) = notify.send(Arc::clone(full_signature)) {
-                warn!(?err, "Failed to send recovered signature");
+            if notify.send(Arc::clone(full_signature)).is_err() {
+                warn!("Failed to send recovered signature");
             }
             return ControlFlow::Continue(());
         }
+
         self.notifiers.push(notify);
-        if let Some(old_threshold) = self.threshold
-            && new_threshold != old_threshold
-        {
-            // Different tasks expect different thresholds. We can not know which is
-            // correct, so we exit this instance.
-            error!(
-                new_threshold,
-                old_threshold, "Conflicting thresholds passed!"
-            );
-            return ControlFlow::Break(());
-        }
-        self.threshold = Some(new_threshold);
-        self.try_reconstruct()
+        ControlFlow::Continue(())
     }
 
     /// Ingest a partial signature from one operator.
@@ -645,16 +846,9 @@ impl SignatureCollectorState {
     /// Late shares arriving after reconstruction are silently dropped.
     /// Conflicting shares from the same operator are logged but not fatal,
     /// since the source of the discrepancy is not knowable here.
-    ///
-    /// Returns `Break` when the collector should exit (unrecoverable
-    /// reconstruction failure).
-    fn add_partial_signature(
-        &mut self,
-        operator_id: OperatorId,
-        signature: Signature,
-    ) -> ControlFlow<()> {
+    fn add_partial_signature(&mut self, operator_id: OperatorId, signature: Signature) {
         if self.full_signature.is_some() {
-            return ControlFlow::Continue(());
+            return;
         }
 
         match self.signature_share.entry(operator_id) {
@@ -672,44 +866,73 @@ impl SignatureCollectorState {
                 }
             }
         }
-
-        self.try_reconstruct()
     }
 
-    fn try_reconstruct(&mut self) -> ControlFlow<()> {
-        let Some(threshold) = self.threshold else {
-            return ControlFlow::Continue(());
+    fn try_reconstruct(&self) -> Result<Option<Signature>, ReconstructionFailure> {
+        if self.full_signature.is_some() {
+            return Ok(None);
+        }
+        let Some(registration) = &self.registration else {
+            return Ok(None);
         };
-        if (self.signature_share.len() as u64) < threshold {
-            return ControlFlow::Continue(());
+        if (self.signature_share.len() as u64) < registration.threshold {
+            return Ok(None);
         }
 
-        let signature = match combine_signatures(mem::take(&mut self.signature_share)) {
-            Ok(signature) => Arc::new(signature),
-            Err(err) => {
-                error!(?err, "Failed to recover signature");
-                return ControlFlow::Break(());
-            }
-        };
+        let signature = combine_signatures(&self.signature_share)
+            .map_err(ReconstructionFailure::Combination)?;
 
-        trace!(?signature, "Successfully recovered signature");
+        if !signature.verify(
+            &registration.decompressed_validator_pubkey,
+            self.signing_root,
+        ) {
+            return Err(ReconstructionFailure::MasterVerification);
+        }
+
+        Ok(Some(signature))
+    }
+
+    fn complete_reconstruction(&mut self, signature: Signature) {
+        trace!("Successfully recovered and verified signature");
+        let signature = Arc::new(signature);
+        self.signature_share.clear();
 
         for notifier in mem::take(&mut self.notifiers) {
             if notifier.send(Arc::clone(&signature)).is_err() {
-                warn!("Callback dropped - signature is no longer relevant");
+                warn!("Callback dropped, signature is no longer relevant");
             }
         }
         self.full_signature = Some(signature);
-        ControlFlow::Continue(())
+    }
+
+    fn remove_invalid_shares(
+        &mut self,
+        share_pubkeys: &HashMap<OperatorId, PublicKeyBytes>,
+    ) -> Vec<OperatorId> {
+        let mut invalid_operator_ids = vec![];
+        self.signature_share.retain(|operator_id, signature| {
+            let is_valid = share_pubkeys
+                .get(operator_id)
+                .and_then(|public_key| public_key.decompress().ok())
+                .is_some_and(|public_key| signature.verify(&public_key, self.signing_root));
+            if !is_valid {
+                invalid_operator_ids.push(*operator_id);
+            }
+            is_valid
+        });
+        invalid_operator_ids.sort_unstable();
+        invalid_operator_ids
     }
 }
 
 fn combine_signatures(
-    shares: HashMap<OperatorId, Signature>,
+    shares: &HashMap<OperatorId, Signature>,
 ) -> Result<Signature, CollectionError> {
     let (ids, signatures): (Vec<_>, Vec<_>) = shares
-        .into_iter()
-        .map(|(k, s)| KeyId::try_from(*k).map(|k| (k, s)))
+        .iter()
+        .map(|(operator_id, signature)| {
+            KeyId::try_from(**operator_id).map(|key_id| (key_id, signature.clone()))
+        })
         .collect::<Result<_, _>>()?;
 
     Ok(bls_lagrange::combine_signatures(&signatures, &ids)?)

--- a/anchor/signature_collector/src/metrics.rs
+++ b/anchor/signature_collector/src/metrics.rs
@@ -1,0 +1,10 @@
+use std::sync::LazyLock;
+
+pub use metrics::*;
+
+pub static RECONSTRUCTION_FALLBACKS_TOTAL: LazyLock<Result<IntCounter>> = LazyLock::new(|| {
+    try_create_int_counter(
+        "anchor_signature_collector_reconstruction_fallbacks_total",
+        "Failed reconstruction attempts that entered per-share verification",
+    )
+});

--- a/anchor/signature_collector/src/tests.rs
+++ b/anchor/signature_collector/src/tests.rs
@@ -446,10 +446,12 @@ async fn collector_loop_database_failure_closes_notifier_without_caching() {
     corrupt_database(&database, "DROP TABLE shares");
 
     let (tx, rx) = mpsc::unbounded_channel::<CollectorMessage<()>>();
+    let (_lifetime_guard, lifetime_end) = oneshot::channel();
     let collector = tokio::spawn(signature_collector(
         rx,
         SIGNING_ROOT,
         SharePubkeyLoader::new(database),
+        lifetime_end,
     ));
     let send = |kind| {
         tx.send(CollectorMessage {
@@ -488,4 +490,145 @@ async fn collector_loop_database_failure_closes_notifier_without_caching() {
         .expect("collector task should terminate promptly")
         .expect("collector task should not panic");
     assert_eq!(fallback_count(), count_before + 1);
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn guard_dropped_before_first_poll_exits_without_processing() {
+    let _metric_guard = METRIC_TEST_LOCK.lock().await;
+    let count_before = fallback_count();
+    let keys = split_random_master();
+    let validator_pubkey = keys.master.public_key().compress();
+    let loader = SharePubkeyLoader::new(database_with_share_keys(&keys, validator_pubkey));
+    let (tx, rx) = mpsc::unbounded_channel::<CollectorMessage<()>>();
+    let send = |kind| {
+        tx.send(CollectorMessage {
+            kind,
+            _drop_on_finish: (),
+        })
+        .expect("collector message should queue");
+    };
+
+    let (notify, result_rx) = oneshot::channel();
+    send(CollectorMessageKind::RegisterNotifier {
+        notify,
+        threshold: THRESHOLD,
+        validator_pubkey,
+    });
+    for (operator_id, secret_key) in &keys.shares[..THRESHOLD as usize] {
+        send(CollectorMessageKind::PartialSignature {
+            operator_id: *operator_id,
+            signature: Box::new(secret_key.sign(SIGNING_ROOT)),
+        });
+    }
+
+    let (lifetime_guard, lifetime_end) = oneshot::channel();
+    drop(lifetime_guard);
+    let collector = tokio::spawn(signature_collector(rx, SIGNING_ROOT, loader, lifetime_end));
+
+    let result = tokio::time::timeout(Duration::from_secs(5), result_rx)
+        .await
+        .expect("collector should close the notifier promptly");
+    assert!(
+        result.is_err(),
+        "an expired collector must not process an already-queued quorum"
+    );
+    tokio::time::timeout(Duration::from_secs(5), collector)
+        .await
+        .expect("expired collector task should terminate promptly")
+        .expect("expired collector task should not panic");
+    assert_eq!(fallback_count(), count_before);
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn collector_map_removal_cancels_fallback_wait() {
+    let _metric_guard = METRIC_TEST_LOCK.lock().await;
+    let count_before = fallback_count();
+    let keys = split_random_master();
+    let validator_pubkey = keys.master.public_key().compress();
+    let loader = SharePubkeyLoader::new(database_with_share_keys(&keys, validator_pubkey));
+    let held_permit = Arc::clone(&loader.semaphore)
+        .acquire_owned()
+        .await
+        .expect("fallback semaphore should be open");
+
+    let (lifetime_guard, lifetime_end) = oneshot::channel();
+    let map = DashMap::new();
+    let key = (SIGNING_ROOT, ValidatorIndex(1));
+    let (entry_tx, _entry_rx) = mpsc::unbounded_channel::<CollectorMessage>();
+    map.insert(
+        key,
+        SignatureCollector {
+            _lifetime_guard: lifetime_guard,
+            sender: entry_tx,
+            for_slot: Slot::new(0),
+        },
+    );
+
+    let (tx, rx) = mpsc::unbounded_channel::<CollectorMessage<()>>();
+    let collector = tokio::spawn(signature_collector(
+        rx,
+        SIGNING_ROOT,
+        loader.clone(),
+        lifetime_end,
+    ));
+    let send = |kind| {
+        tx.send(CollectorMessage {
+            kind,
+            _drop_on_finish: (),
+        })
+        .expect("collector should accept messages while running");
+    };
+
+    let (notify, mut result_rx) = oneshot::channel();
+    send(CollectorMessageKind::RegisterNotifier {
+        notify,
+        threshold: THRESHOLD,
+        validator_pubkey,
+    });
+    for (operator_id, secret_key) in &keys.shares[..(THRESHOLD - 1) as usize] {
+        send(CollectorMessageKind::PartialSignature {
+            operator_id: *operator_id,
+            signature: Box::new(secret_key.sign(SIGNING_ROOT)),
+        });
+    }
+    send(CollectorMessageKind::PartialSignature {
+        operator_id: keys.shares[(THRESHOLD - 1) as usize].0,
+        signature: Box::new(keys.shares[(THRESHOLD - 1) as usize].1.sign(WRONG_ROOT)),
+    });
+
+    tokio::time::timeout(Duration::from_secs(5), async {
+        while fallback_count() == count_before {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("collector should enter reconstruction fallback");
+    assert_eq!(fallback_count(), count_before + 1);
+    assert!(!collector.is_finished());
+    assert!(matches!(
+        result_rx.try_recv(),
+        Err(oneshot::error::TryRecvError::Empty)
+    ));
+    assert_eq!(loader.semaphore.available_permits(), 0);
+
+    drop(map.remove(&key).expect("collector map entry should exist"));
+
+    let result = tokio::time::timeout(Duration::from_secs(5), result_rx)
+        .await
+        .expect("collector should close the notifier after map removal");
+    assert!(
+        result.is_err(),
+        "collector cancellation must not return a signature"
+    );
+    tokio::time::timeout(Duration::from_secs(5), collector)
+        .await
+        .expect("collector task should terminate after map removal")
+        .expect("collector task should not panic");
+    assert_eq!(loader.semaphore.available_permits(), 0);
+
+    drop(held_permit);
+    let _permit = loader
+        .semaphore
+        .try_acquire()
+        .expect("cancelled fallback should not retain a semaphore permit");
 }

--- a/anchor/signature_collector/src/tests.rs
+++ b/anchor/signature_collector/src/tests.rs
@@ -1,197 +1,491 @@
-use bls::{SecretKey, Signature};
+use std::{
+    collections::HashMap,
+    sync::{Arc, LazyLock},
+    time::Duration,
+};
+
+use bls::{INFINITY_PUBLIC_KEY, PublicKeyBytes, SecretKey, Signature};
 use bls_lagrange::{KeyId, split_with_rng};
+use database::{
+    NetworkDatabase, PendingStateUpdates,
+    test_utils::{TEST_NETWORK, commit_and_publish, generators},
+};
 use rand::{prelude::*, rngs::StdRng};
-use tokio::sync::oneshot;
+use ssv_types::{ENCRYPTED_KEY_LENGTH, Share, ValidatorIndex, ValidatorMetadata};
+use tokio::sync::{Mutex, oneshot};
+use types::Graffiti;
 
 use super::*;
 
 const TEST_RNG_SEED: u64 = 0xDEAD_BEEF_CAFE_0001;
-const TOTAL_SHARES: u64 = 4;
+const TOTAL_SHARES: u64 = 5;
 const THRESHOLD: u64 = 3;
 const SIGNING_ROOT: Hash256 = Hash256::repeat_byte(0xAB);
+const WRONG_ROOT: Hash256 = Hash256::repeat_byte(0xCD);
 
-fn split_random_master() -> Vec<(OperatorId, SecretKey)> {
+static METRIC_TEST_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
+
+struct TestKeys {
+    master: SecretKey,
+    shares: Vec<(OperatorId, SecretKey)>,
+}
+
+fn split_random_master() -> TestKeys {
     let rng = &mut StdRng::seed_from_u64(TEST_RNG_SEED);
     let master = SecretKey::random();
-
-    split_with_rng(
+    let shares = split_with_rng(
         &master,
         THRESHOLD,
-        (1..=TOTAL_SHARES).map(|x| KeyId::try_from(x).unwrap()),
+        (1..=TOTAL_SHARES).map(|id| KeyId::try_from(id).expect("non-zero key id")),
         rng,
     )
     .expect("split should succeed")
     .into_iter()
-    .map(|(kid, sk)| (OperatorId(u64::from(kid)), sk))
-    .collect()
+    .map(|(key_id, secret_key)| (OperatorId(u64::from(key_id)), secret_key))
+    .collect();
+    TestKeys { master, shares }
 }
 
 fn register_notifier(
     state: &mut SignatureCollectorState,
-    threshold: u64,
+    validator_pubkey: PublicKeyBytes,
 ) -> oneshot::Receiver<Arc<Signature>> {
-    let (notify, rx) = oneshot::channel();
-    let outcome = state.register_request(notify, threshold);
+    let (notify, receiver) = oneshot::channel();
     assert!(
-        outcome.is_continue(),
-        "register_notifier should not break the collector"
+        state
+            .register_request(notify, THRESHOLD, validator_pubkey)
+            .is_continue()
     );
-    rx
+    receiver
 }
 
-fn feed_partial_sig(
+fn add_valid_share(
     state: &mut SignatureCollectorState,
     operator_id: OperatorId,
-    signature: Signature,
+    secret_key: &SecretKey,
 ) {
-    let outcome = state.add_partial_signature(operator_id, signature);
-    assert!(
-        outcome.is_continue(),
-        "feed_partial_sig should not break the collector"
-    );
+    state.add_partial_signature(operator_id, secret_key.sign(SIGNING_ROOT));
 }
 
-fn expect_signature(rx: &mut oneshot::Receiver<Arc<Signature>>, context: &str) {
-    rx.try_recv().expect(context);
+fn complete_ready_reconstruction(state: &mut SignatureCollectorState) {
+    let signature = match state.try_reconstruct() {
+        Ok(Some(signature)) => signature,
+        Ok(None) => panic!("expected enough shares to reconstruct"),
+        Err(_) => panic!("expected reconstructed signature to verify"),
+    };
+    state.complete_reconstruction(signature);
 }
 
-/// Once `THRESHOLD` valid partial signatures have been fed in, the state
-/// reconstructs the master signature and delivers it to a registered notifier.
-#[test]
-fn state_processes_full_quorum_and_notifies() {
-    let shares = split_random_master();
-    let mut state = SignatureCollectorState::default();
+#[track_caller]
+fn expect_master_verification_failure(state: &SignatureCollectorState) -> ReconstructionFailure {
+    match state.try_reconstruct() {
+        Err(failure @ ReconstructionFailure::MasterVerification) => failure,
+        outcome => panic!("expected master signature verification to fail, got {outcome:?}"),
+    }
+}
 
-    let mut result_rx = register_notifier(&mut state, THRESHOLD);
+#[track_caller]
+fn expect_combination_failure(state: &SignatureCollectorState) -> ReconstructionFailure {
+    match state.try_reconstruct() {
+        Err(failure @ ReconstructionFailure::Combination(_)) => failure,
+        outcome => panic!("expected signature combination to fail, got {outcome:?}"),
+    }
+}
 
-    for (op_id, sk) in &shares[..THRESHOLD as usize] {
-        feed_partial_sig(&mut state, *op_id, sk.sign(SIGNING_ROOT));
+async fn enter_fallback(
+    state: &mut SignatureCollectorState,
+    failure: ReconstructionFailure,
+    database: Arc<NetworkDatabase>,
+) -> ControlFlow<()> {
+    handle_reconstruction_fallback(state, failure, &SharePubkeyLoader::new(database)).await
+}
+
+fn expect_signature(receiver: &mut oneshot::Receiver<Arc<Signature>>, expected: &Signature) {
+    let signature = receiver
+        .try_recv()
+        .expect("notifier should receive a verified signature");
+    assert_eq!(signature.as_ref(), expected);
+}
+
+fn fallback_count() -> u64 {
+    metrics::RECONSTRUCTION_FALLBACKS_TOTAL
+        .as_ref()
+        .expect("fallback metric should register")
+        .get()
+}
+
+fn corrupt_database(database: &NetworkDatabase, sql: &str) {
+    database
+        .connection()
+        .expect("connection should open")
+        .execute(sql, [])
+        .expect("corruption statement should execute");
+}
+
+fn database_with_share_keys(
+    keys: &TestKeys,
+    validator_pubkey: PublicKeyBytes,
+) -> Arc<NetworkDatabase> {
+    let operators = keys
+        .shares
+        .iter()
+        .map(|(operator_id, _)| generators::operator::with_id(operator_id.0))
+        .collect::<Vec<_>>();
+    let database = NetworkDatabase::new_in_memory(&operators[0].rsa_pubkey, TEST_NETWORK)
+        .expect("in-memory database should open");
+    let cluster = generators::cluster::with_operators(&operators);
+    let validator = ValidatorMetadata {
+        public_key: validator_pubkey,
+        cluster_id: cluster.cluster_id,
+        index: Some(ValidatorIndex(1)),
+        graffiti: Graffiti::default(),
+    };
+    let shares = keys
+        .shares
+        .iter()
+        .map(|(operator_id, secret_key)| Share {
+            validator_pubkey,
+            operator_id: *operator_id,
+            cluster_id: cluster.cluster_id,
+            share_pubkey: secret_key.public_key().compress(),
+            encrypted_private_key: [0; ENCRYPTED_KEY_LENGTH],
+        })
+        .collect::<Vec<_>>();
+
+    {
+        let mut connection = database.connection().expect("connection should open");
+        let transaction = connection.transaction().expect("transaction should start");
+        let mut pending = PendingStateUpdates::default();
+        for operator in &operators {
+            database
+                .insert_operator_tx(operator, &transaction, &mut pending)
+                .expect("operator should be inserted");
+        }
+        database
+            .insert_validator_tx(cluster, &validator, shares, &transaction, &mut pending)
+            .expect("validator should be inserted");
+        commit_and_publish(&database, transaction, pending);
     }
 
-    expect_signature(
-        &mut result_rx,
-        "Notifier should receive the reconstructed signature",
-    );
+    Arc::new(database)
 }
 
-/// Two `RegisterNotifier` messages disagree on the threshold; the state must
-/// `Break`. In production, the recv loop drops the state on `Break`, which
-/// drops every queued notifier and surfaces `RecvError` to the callers. The
-/// test models that lifetime explicitly via `drop(state)`.
-#[test]
-fn state_breaks_on_conflicting_thresholds() {
-    let mut state = SignatureCollectorState::default();
-    let _first_rx = register_notifier(&mut state, THRESHOLD);
+#[tokio::test]
+async fn clean_quorum_is_verified_cached_and_does_not_enter_fallback() {
+    let _metric_guard = METRIC_TEST_LOCK.lock().await;
+    let count_before = fallback_count();
+    let keys = split_random_master();
+    let validator_pubkey = keys.master.public_key().compress();
+    let expected = keys.master.sign(SIGNING_ROOT);
+    let mut state = SignatureCollectorState::new(SIGNING_ROOT);
 
-    let (second_notify, mut second_rx) = oneshot::channel();
-    let outcome = state.register_request(second_notify, THRESHOLD + 1);
+    let mut first = register_notifier(&mut state, validator_pubkey);
+    let mut second = register_notifier(&mut state, validator_pubkey);
+    for (operator_id, secret_key) in &keys.shares[..(THRESHOLD - 1) as usize] {
+        add_valid_share(&mut state, *operator_id, secret_key);
+    }
+    assert!(matches!(state.try_reconstruct(), Ok(None)));
+    add_valid_share(
+        &mut state,
+        keys.shares[(THRESHOLD - 1) as usize].0,
+        &keys.shares[(THRESHOLD - 1) as usize].1,
+    );
+    complete_ready_reconstruction(&mut state);
+    expect_signature(&mut first, &expected);
+    expect_signature(&mut second, &expected);
+
+    let mut late = register_notifier(&mut state, validator_pubkey);
+    expect_signature(&mut late, &expected);
+    add_valid_share(
+        &mut state,
+        keys.shares[THRESHOLD as usize].0,
+        &keys.shares[THRESHOLD as usize].1,
+    );
+
+    assert!(state.signature_share.is_empty());
+    assert_eq!(fallback_count(), count_before);
+}
+
+#[tokio::test]
+async fn wrong_root_share_is_pruned_then_a_fourth_honest_share_completes() {
+    let _metric_guard = METRIC_TEST_LOCK.lock().await;
+    let count_before = fallback_count();
+    let keys = split_random_master();
+    let validator_pubkey = keys.master.public_key().compress();
+    let database = database_with_share_keys(&keys, validator_pubkey);
+    let mut state = SignatureCollectorState::new(SIGNING_ROOT);
+    let mut receiver = register_notifier(&mut state, validator_pubkey);
+
+    add_valid_share(&mut state, keys.shares[0].0, &keys.shares[0].1);
+    add_valid_share(&mut state, keys.shares[1].0, &keys.shares[1].1);
+    state.add_partial_signature(keys.shares[2].0, keys.shares[2].1.sign(WRONG_ROOT));
+    let failure = expect_master_verification_failure(&state);
 
     assert!(
-        outcome.is_break(),
-        "State should Break when a second notifier disagrees on threshold"
+        enter_fallback(&mut state, failure, database)
+            .await
+            .is_continue()
     );
+    assert_eq!(state.signature_share.len(), 2);
+    assert!(!state.signature_share.contains_key(&keys.shares[2].0));
 
-    drop(state);
+    add_valid_share(&mut state, keys.shares[3].0, &keys.shares[3].1);
+    complete_ready_reconstruction(&mut state);
+    expect_signature(&mut receiver, &keys.master.sign(SIGNING_ROOT));
+    assert_eq!(fallback_count(), count_before + 1);
+}
+
+#[tokio::test]
+async fn empty_share_is_pruned_and_same_operator_can_replace_it() {
+    let _metric_guard = METRIC_TEST_LOCK.lock().await;
+    let count_before = fallback_count();
+    let keys = split_random_master();
+    let validator_pubkey = keys.master.public_key().compress();
+    let database = database_with_share_keys(&keys, validator_pubkey);
+    let mut state = SignatureCollectorState::new(SIGNING_ROOT);
+    let mut receiver = register_notifier(&mut state, validator_pubkey);
+
+    add_valid_share(&mut state, keys.shares[0].0, &keys.shares[0].1);
+    add_valid_share(&mut state, keys.shares[1].0, &keys.shares[1].1);
+    let invalid_operator = keys.shares[2].0;
+    state.add_partial_signature(invalid_operator, Signature::empty());
+    let failure = expect_combination_failure(&state);
 
     assert!(
-        matches!(
-            second_rx.try_recv(),
-            Err(oneshot::error::TryRecvError::Closed)
-        ),
-        "Conflicting notifier sender should be dropped, surfacing RecvError"
+        enter_fallback(&mut state, failure, database)
+            .await
+            .is_continue()
+    );
+    assert!(!state.signature_share.contains_key(&invalid_operator));
+
+    add_valid_share(&mut state, invalid_operator, &keys.shares[2].1);
+    complete_ready_reconstruction(&mut state);
+    expect_signature(&mut receiver, &keys.master.sign(SIGNING_ROOT));
+    assert_eq!(fallback_count(), count_before + 1);
+}
+
+#[tokio::test]
+async fn buffered_bad_shares_are_pruned_and_honest_quorum_retries_immediately() {
+    let _metric_guard = METRIC_TEST_LOCK.lock().await;
+    let count_before = fallback_count();
+    let keys = split_random_master();
+    let validator_pubkey = keys.master.public_key().compress();
+    let database = database_with_share_keys(&keys, validator_pubkey);
+    let mut state = SignatureCollectorState::new(SIGNING_ROOT);
+
+    for (operator_id, secret_key) in &keys.shares[..THRESHOLD as usize] {
+        add_valid_share(&mut state, *operator_id, secret_key);
+    }
+    state.add_partial_signature(keys.shares[3].0, keys.shares[3].1.sign(WRONG_ROOT));
+    state.add_partial_signature(keys.shares[4].0, Signature::empty());
+
+    let (notify, mut receiver) = oneshot::channel();
+    assert!(
+        state
+            .register_request(notify, THRESHOLD, validator_pubkey)
+            .is_continue()
+    );
+    let failure = expect_combination_failure(&state);
+    assert!(
+        enter_fallback(&mut state, failure, database)
+            .await
+            .is_continue()
+    );
+
+    expect_signature(&mut receiver, &keys.master.sign(SIGNING_ROOT));
+    assert!(state.signature_share.is_empty());
+    assert_eq!(fallback_count(), count_before + 1);
+}
+
+#[test]
+fn missing_and_undecompressible_share_keys_remove_only_affected_shares() {
+    let keys = split_random_master();
+    let mut state = SignatureCollectorState::new(SIGNING_ROOT);
+    for (operator_id, secret_key) in &keys.shares[..THRESHOLD as usize] {
+        add_valid_share(&mut state, *operator_id, secret_key);
+    }
+    let undecompressible = PublicKeyBytes::deserialize(&INFINITY_PUBLIC_KEY)
+        .expect("infinity public key should have the correct length");
+    let share_pubkeys = HashMap::from([
+        (keys.shares[0].0, keys.shares[0].1.public_key().compress()),
+        (keys.shares[2].0, undecompressible),
+    ]);
+
+    assert_eq!(
+        state.remove_invalid_shares(&share_pubkeys),
+        vec![keys.shares[1].0, keys.shares[2].0]
+    );
+    assert_eq!(
+        state.signature_share.keys().copied().collect::<Vec<_>>(),
+        vec![keys.shares[0].0]
     );
 }
 
-/// A notifier that registers after reconstruction has already completed should
-/// receive the cached signature immediately rather than waiting on a fresh
-/// quorum.
-#[test]
-fn state_delivers_cached_signature_to_late_registrant() {
-    let shares = split_random_master();
-    let mut state = SignatureCollectorState::default();
+#[tokio::test]
+async fn individually_valid_shares_with_wrong_master_key_are_fatal() {
+    let _metric_guard = METRIC_TEST_LOCK.lock().await;
+    let count_before = fallback_count();
+    let keys = split_random_master();
+    let other_keys = split_random_master();
+    let wrong_validator_pubkey = other_keys.master.public_key().compress();
+    let database = database_with_share_keys(&keys, wrong_validator_pubkey);
+    let mut state = SignatureCollectorState::new(SIGNING_ROOT);
+    let _receiver = register_notifier(&mut state, wrong_validator_pubkey);
 
-    // Reach quorum on the first registrant.
-    let mut first_rx = register_notifier(&mut state, THRESHOLD);
-    for (op_id, sk) in &shares[..THRESHOLD as usize] {
-        feed_partial_sig(&mut state, *op_id, sk.sign(SIGNING_ROOT));
-    }
-    expect_signature(
-        &mut first_rx,
-        "First registrant should receive the reconstructed signature",
-    );
-
-    // Late registrant arrives after `full_signature` is set.
-    let mut late_rx = register_notifier(&mut state, THRESHOLD);
-    expect_signature(
-        &mut late_rx,
-        "Late registrant should receive the cached signature immediately",
-    );
-}
-
-/// Multiple notifiers registered before quorum should all be notified on a
-/// single reconstruction (the `Vec<oneshot::Sender>` fan-out).
-#[test]
-fn state_notifies_all_registrants_on_reconstruction() {
-    let shares = split_random_master();
-    let mut state = SignatureCollectorState::default();
-
-    let mut rx_a = register_notifier(&mut state, THRESHOLD);
-    let mut rx_b = register_notifier(&mut state, THRESHOLD);
-    let mut rx_c = register_notifier(&mut state, THRESHOLD);
-
-    for (op_id, sk) in &shares[..THRESHOLD as usize] {
-        feed_partial_sig(&mut state, *op_id, sk.sign(SIGNING_ROOT));
-    }
-
-    expect_signature(&mut rx_a, "registrant a should be notified");
-    expect_signature(&mut rx_b, "registrant b should be notified");
-    expect_signature(&mut rx_c, "registrant c should be notified");
-}
-
-/// Partial signatures that arrive before any `RegisterNotifier` is buffered.
-/// Reconstruction triggers when a notifier and the threshold arrives.
-#[test]
-fn state_buffers_shares_arriving_before_first_notifier_register() {
-    let shares = split_random_master();
-    let mut state = SignatureCollectorState::default();
-
-    for (op_id, sk) in &shares[..THRESHOLD as usize] {
-        feed_partial_sig(&mut state, *op_id, sk.sign(SIGNING_ROOT));
-    }
+    add_valid_share(&mut state, keys.shares[0].0, &keys.shares[0].1);
+    add_valid_share(&mut state, keys.shares[1].0, &keys.shares[1].1);
+    state.add_partial_signature(keys.shares[2].0, keys.shares[2].1.sign(SIGNING_ROOT));
+    let failure = expect_master_verification_failure(&state);
 
     assert!(
-        state.full_signature.is_none(),
-        "State should not reconstruct without a threshold"
+        enter_fallback(&mut state, failure, database)
+            .await
+            .is_break()
+    );
+    assert!(state.full_signature.is_none());
+    assert_eq!(fallback_count(), count_before + 1);
+}
+
+#[test]
+fn malformed_and_conflicting_registrations_exit_before_notifying() {
+    let keys = split_random_master();
+    let validator_pubkey = keys.master.public_key().compress();
+    let malformed = PublicKeyBytes::deserialize(&INFINITY_PUBLIC_KEY)
+        .expect("infinity public key should have the correct length");
+
+    let mut malformed_state = SignatureCollectorState::new(SIGNING_ROOT);
+    let (notify, _) = oneshot::channel();
+    assert!(
+        malformed_state
+            .register_request(notify, THRESHOLD, malformed)
+            .is_break()
     );
 
-    let mut result_rx = register_notifier(&mut state, THRESHOLD);
-    expect_signature(
-        &mut result_rx,
-        "Notifier should receive the signature reconstructed from buffered shares",
+    let mut threshold_state = SignatureCollectorState::new(SIGNING_ROOT);
+    let _receiver = register_notifier(&mut threshold_state, validator_pubkey);
+    let (notify, _) = oneshot::channel();
+    assert!(
+        threshold_state
+            .register_request(notify, THRESHOLD + 1, validator_pubkey)
+            .is_break()
+    );
+
+    let mut cached_state = SignatureCollectorState::new(SIGNING_ROOT);
+    let mut receiver = register_notifier(&mut cached_state, validator_pubkey);
+    for (operator_id, secret_key) in &keys.shares[..THRESHOLD as usize] {
+        add_valid_share(&mut cached_state, *operator_id, secret_key);
+    }
+    complete_ready_reconstruction(&mut cached_state);
+    expect_signature(&mut receiver, &keys.master.sign(SIGNING_ROOT));
+    let (notify, _) = oneshot::channel();
+    let conflicting_pubkey = split_random_master().master.public_key().compress();
+    assert!(
+        cached_state
+            .register_request(notify, THRESHOLD, conflicting_pubkey)
+            .is_break()
     );
 }
 
-/// Partial signatures that arrive after reconstruction are silently dropped:
-/// no panic, no Break, no re-buffering of the late share. This is the common
-/// case in production: slow operators' shares routinely arrive after a fast
-/// majority has already reconstructed the signature.
-#[test]
-fn state_drops_partial_signatures_after_reconstruction() {
-    let shares = split_random_master();
-    let mut state = SignatureCollectorState::default();
+#[tokio::test]
+async fn empty_malformed_and_failed_database_lookups_are_fatal() {
+    let _metric_guard = METRIC_TEST_LOCK.lock().await;
+    let keys = split_random_master();
+    let validator_pubkey = keys.master.public_key().compress();
 
-    let mut rx = register_notifier(&mut state, THRESHOLD);
-    for (op_id, sk) in &shares[..THRESHOLD as usize] {
-        feed_partial_sig(&mut state, *op_id, sk.sign(SIGNING_ROOT));
-    }
-    expect_signature(&mut rx, "first registrant should be notified");
-
-    let (late_op, late_sk) = &shares[THRESHOLD as usize];
-    feed_partial_sig(&mut state, *late_op, late_sk.sign(SIGNING_ROOT));
-
-    assert!(state.full_signature.is_some(), "cached signature persists");
-    assert!(
-        state.signature_share.is_empty(),
-        "post-reconstruction shares are not buffered"
+    let empty_database = Arc::new(
+        NetworkDatabase::new_in_memory(&generators::pubkey::random_rsa(), TEST_NETWORK)
+            .expect("empty database should open"),
     );
+    let mut empty_state = SignatureCollectorState::new(SIGNING_ROOT);
+    let mut empty_receiver = register_notifier(&mut empty_state, validator_pubkey);
+    add_valid_share(&mut empty_state, keys.shares[0].0, &keys.shares[0].1);
+    add_valid_share(&mut empty_state, keys.shares[1].0, &keys.shares[1].1);
+    empty_state.add_partial_signature(keys.shares[2].0, keys.shares[2].1.sign(WRONG_ROOT));
+    let failure = expect_master_verification_failure(&empty_state);
+    assert!(
+        enter_fallback(&mut empty_state, failure, empty_database)
+            .await
+            .is_break()
+    );
+    assert!(empty_state.full_signature.is_none());
+    drop(empty_state);
+    assert!(matches!(
+        empty_receiver.try_recv(),
+        Err(oneshot::error::TryRecvError::Closed)
+    ));
+
+    let malformed_database = database_with_share_keys(&keys, validator_pubkey);
+    corrupt_database(
+        &malformed_database,
+        "UPDATE shares SET share_pubkey = 'not-a-public-key'",
+    );
+    assert!(
+        SharePubkeyLoader::new(malformed_database)
+            .fetch(validator_pubkey)
+            .await
+            .is_none()
+    );
+
+    let failed_database = database_with_share_keys(&keys, validator_pubkey);
+    corrupt_database(&failed_database, "DROP TABLE shares");
+    assert!(
+        SharePubkeyLoader::new(failed_database)
+            .fetch(validator_pubkey)
+            .await
+            .is_none()
+    );
+}
+
+#[tokio::test]
+async fn collector_loop_database_failure_closes_notifier_without_caching() {
+    let _metric_guard = METRIC_TEST_LOCK.lock().await;
+    let count_before = fallback_count();
+    let keys = split_random_master();
+    let validator_pubkey = keys.master.public_key().compress();
+    let database = database_with_share_keys(&keys, validator_pubkey);
+    corrupt_database(&database, "DROP TABLE shares");
+
+    let (tx, rx) = mpsc::unbounded_channel::<CollectorMessage<()>>();
+    let collector = tokio::spawn(signature_collector(
+        rx,
+        SIGNING_ROOT,
+        SharePubkeyLoader::new(database),
+    ));
+    let send = |kind| {
+        tx.send(CollectorMessage {
+            kind,
+            _drop_on_finish: (),
+        })
+        .expect("collector should accept messages while running");
+    };
+
+    let (notify, result_rx) = oneshot::channel();
+    send(CollectorMessageKind::RegisterNotifier {
+        notify,
+        threshold: THRESHOLD,
+        validator_pubkey,
+    });
+    for (operator_id, secret_key) in &keys.shares[..(THRESHOLD - 1) as usize] {
+        send(CollectorMessageKind::PartialSignature {
+            operator_id: *operator_id,
+            signature: Box::new(secret_key.sign(SIGNING_ROOT)),
+        });
+    }
+    send(CollectorMessageKind::PartialSignature {
+        operator_id: keys.shares[(THRESHOLD - 1) as usize].0,
+        signature: Box::new(keys.shares[(THRESHOLD - 1) as usize].1.sign(WRONG_ROOT)),
+    });
+
+    let result = tokio::time::timeout(Duration::from_secs(5), result_rx)
+        .await
+        .expect("collector should close the notifier promptly");
+    assert!(
+        result.is_err(),
+        "database fallback failure must close the notifier without returning a signature"
+    );
+    tokio::time::timeout(Duration::from_secs(5), collector)
+        .await
+        .expect("collector task should terminate promptly")
+        .expect("collector task should not panic");
+    assert_eq!(fallback_count(), count_before + 1);
 }

--- a/anchor/validator_store/src/lib.rs
+++ b/anchor/validator_store/src/lib.rs
@@ -508,6 +508,7 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> AnchorValidator
         let signing_data = ValidatorSigningData {
             root: signing_root,
             index: validator.index.ok_or(SpecificError::MissingIndex)?,
+            validator_pubkey: validator.public_key,
             share: decrypted_key_share,
         };
 

--- a/anchor/validator_store/src/testing/committee_attestation.rs
+++ b/anchor/validator_store/src/testing/committee_attestation.rs
@@ -36,6 +36,13 @@ async fn sign_attestations_produces_one_stream_item_per_committee() {
         committee_a.cluster.committee_id(),
         committee_b.cluster.committee_id(),
     );
+    let mut expected_validator_pubkeys = committee_a
+        .validators
+        .iter()
+        .chain(&committee_b.validators)
+        .map(|validator| validator.public_key)
+        .collect::<Vec<_>>();
+    expected_validator_pubkeys.sort_by_key(ToString::to_string);
     let harness = ValidatorStoreTestHarness::new(vec![committee_a, committee_b], our_operator_id);
     harness.seed_voting_context();
     let attestations = vec![
@@ -74,6 +81,15 @@ async fn sign_attestations_produces_one_stream_item_per_committee() {
         captured.len(),
         expected_total,
         "expected {expected_total} sign_and_collect calls"
+    );
+    let mut captured_validator_pubkeys = captured
+        .iter()
+        .map(|call| call.validator_pubkey)
+        .collect::<Vec<_>>();
+    captured_validator_pubkeys.sort_by_key(ToString::to_string);
+    assert_eq!(
+        captured_validator_pubkeys, expected_validator_pubkeys,
+        "signature collection should receive each validator master public key"
     );
     let batch_sizes: Vec<_> = captured
         .iter()

--- a/anchor/validator_store/src/testing/common.rs
+++ b/anchor/validator_store/src/testing/common.rs
@@ -66,6 +66,7 @@ pub(super) type CapturedCalls = Arc<Mutex<Vec<CapturedSignatureCall>>>;
 
 pub(super) struct CapturedSignatureCall {
     pub(super) requester: SignatureRequester,
+    pub(super) validator_pubkey: PublicKeyBytes,
 }
 
 /// Mock that captures calls and returns a canned infinity signature.
@@ -78,11 +79,12 @@ impl SignatureCollecting for MockSignatureCollector {
         &self,
         _metadata: SignatureMetadata,
         requester: SignatureRequester,
-        _signing_data: ValidatorSigningData,
+        signing_data: ValidatorSigningData,
     ) -> Pin<Box<dyn Future<Output = Result<Arc<Signature>, CollectionError>> + Send + '_>> {
-        self.captured
-            .lock()
-            .push(CapturedSignatureCall { requester });
+        self.captured.lock().push(CapturedSignatureCall {
+            requester,
+            validator_pubkey: signing_data.validator_pubkey,
+        });
         let sig = Signature::infinity().expect("infinity signature");
         Box::pin(async move { Ok(Arc::new(sig)) })
     }


### PR DESCRIPTION
## Problem, Evidence, and Context

- Signature collection should only complete after the reconstructed signature matches the validator public key.
- Failed reconstruction attempts should remain recoverable when a valid quorum remains or later arrives.
- Closes #933.

## Change Overview

- Verify each reconstructed signature before caching it or notifying callers.
- After a reconstruction failure, load the validator share public keys through a bounded blocking path, remove shares that fail individual verification, and either retry once or wait for later shares.
- Keep the healthy path reconstruct-first, with no database lookup or per-share verification.
- Leave duplicate handling, wire formats, database schema, and notifier errors unchanged.

## Risks, Trade-offs, and Mitigations

- The fallback adds database and BLS work only after reconstruction fails. A manager-wide permit bounds concurrent blocking lookups.
- Inconsistent key data and lookup failures fail closed without caching or notifying.
- Focused tests cover verified completion, recovery after invalid shares, fatal inconsistencies, caching, and late callers.

## Validation

- `cargo test -p signature_collector -p anchor_validator_store --release --locked`
- `make cargo-fmt-check`
- `make lint`
- `git diff --check`

## Rollback

- Revert the commit. There are no schema, configuration, or data migrations.