### PR TITLE
fix: tolerate unknown proposer duties without spawning QBFT

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6307,6 +6307,7 @@ dependencies = [
  "bls",
  "dashmap",
  "database",
+ "duties_tracker",
  "ethereum_ssz",
  "fork",
  "futures",

--- a/anchor/client/src/lib.rs
+++ b/anchor/client/src/lib.rs
@@ -562,7 +562,6 @@ impl Client {
                     network_tx: network_tx.clone(),
                     private_key: key.clone(),
                     operator_id: operator_id.clone(),
-                    validator: Some(message_validator.clone()),
                     is_synced: is_synced.clone(),
                     subnet_service: subnet_service.clone(),
                 },

--- a/anchor/common/ssv_types/src/msgid.rs
+++ b/anchor/common/ssv_types/src/msgid.rs
@@ -98,6 +98,21 @@ impl Role {
         self.max_round().is_some()
     }
 
+    /// Returns true if this role's duty is bound to a single validator's proposal slot, so the
+    /// proposer-duty assignment for that slot decides whether a message can have a duty at all.
+    pub fn is_proposer_scoped(self) -> bool {
+        match self {
+            Role::Proposer | Role::ProposerPreferences | Role::EnvelopeProposer => true,
+            Role::Committee
+            | Role::Aggregator
+            | Role::SyncCommittee
+            | Role::ValidatorRegistration
+            | Role::VoluntaryExit
+            | Role::PTCAttester
+            | Role::AggregatorCommittee => false,
+        }
+    }
+
     /// monotonicSlotRole reports whether a role's signer advances through slots one at a time, so a
     /// message for a slot below the signer's max is stale and must be rejected. False for
     /// committee roles (state is slot-keyed across many validators) and for proposer

--- a/anchor/duties_tracker/src/duties_tracker.rs
+++ b/anchor/duties_tracker/src/duties_tracker.rs
@@ -10,7 +10,7 @@ use task_executor::TaskExecutor;
 use thiserror::Error;
 use tokio::{sync::watch, time::sleep};
 use tracing::{debug, error, trace, warn};
-use types::{ChainSpec, Epoch, Slot};
+use types::{ChainSpec, Slot};
 
 use crate::{
     Duties, DutiesProvider, DutyAssignment, MembershipKey,
@@ -317,25 +317,6 @@ impl<T: SlotClock + 'static> DutiesProvider for DutiesTracker<T> {
             .is_validator_in_sync_committee(committee_period, validator_index.into())
     }
 
-    fn is_epoch_known_for_proposers(&self, epoch: Epoch) -> bool {
-        self.duties.proposers.read().contains_key(&epoch)
-    }
-
-    fn is_validator_proposer_at_slot(&self, slot: Slot, validator_index: ValidatorIndex) -> bool {
-        let epoch = slot.epoch(self.slots_per_epoch);
-        let validator_index: u64 = validator_index.into();
-        self.duties
-            .proposers
-            .read()
-            .get(&epoch)
-            .map(|proposers| {
-                proposers.iter().any(|proposer_data| {
-                    proposer_data.slot == slot && proposer_data.validator_index == validator_index
-                })
-            })
-            .unwrap_or_default()
-    }
-
     fn get_voluntary_exit_duty_count(&self, slot: Slot, pubkey: &PublicKeyBytes) -> u64 {
         self.voluntary_exit_tracker.get_duty_count(slot, pubkey)
     }
@@ -469,7 +450,7 @@ mod tests {
     // ==================== proposer_assignment_at_slot ====================
 
     #[test]
-    fn test_proposer_assignment_at_slot_returns_some_true_for_assigned_pubkey() {
+    fn test_proposer_assignment_at_slot_returns_assigned_for_assigned_pubkey() {
         // Assigned pubkey AT its slot in a fetched epoch -> Assigned.
         let tracker = tracker_with_empty_network_state();
         let epoch = Epoch::new(0);
@@ -485,8 +466,7 @@ mod tests {
     }
 
     #[test]
-    fn test_proposer_assignment_at_slot_returns_some_false_for_unassigned_pubkey_in_fetched_epoch()
-    {
+    fn test_proposer_assignment_returns_not_assigned_for_unassigned_pubkey() {
         // Different (unassigned) pubkey, same fetched epoch and slot -> NotAssigned.
         let tracker = tracker_with_empty_network_state();
         let epoch = Epoch::new(0);
@@ -503,7 +483,7 @@ mod tests {
     }
 
     #[test]
-    fn test_proposer_assignment_at_slot_returns_some_false_for_assigned_pubkey_at_different_slot() {
+    fn test_proposer_assignment_at_slot_returns_not_assigned_at_different_slot() {
         // The assignment is bound to the exact slot: the assigned pubkey queried at a DIFFERENT
         // slot within the SAME fetched epoch must return NotAssigned (not Assigned). This is the
         // slot-bind case that guards against matching on pubkey alone.
@@ -526,7 +506,7 @@ mod tests {
     }
 
     #[test]
-    fn test_proposer_assignment_at_slot_returns_none_for_unfetched_epoch() {
+    fn test_proposer_assignment_at_slot_returns_unknown_for_unfetched_epoch() {
         // A slot whose epoch has not been fetched -> Unknown, regardless of pubkey.
         let tracker = tracker_with_empty_network_state();
         let fetched_epoch = Epoch::new(0);

--- a/anchor/duties_tracker/src/lib.rs
+++ b/anchor/duties_tracker/src/lib.rs
@@ -88,8 +88,11 @@ type ProposerMap = HashMap<Epoch, Vec<ProposerData>>;
 
 #[derive(Debug)]
 pub struct Duties {
-    /// Maps an epoch to all *local* proposers in this epoch. Notably, this does not contain
-    /// proposals for any validators which are not registered locally.
+    /// Maps an epoch to the network-wide proposer duties returned by the beacon node.
+    ///
+    /// Entries are not filtered by Anchor's local validator registry. This coverage is required
+    /// for a missing pubkey and slot pair to be authoritative once the response is validated as
+    /// complete.
     pub proposers: RwLock<ProposerMap>,
     /// Map from validator index to sync committee duties.
     pub sync_duties: SyncCommitteePerPeriod,
@@ -127,10 +130,6 @@ pub trait DutiesProvider: Sync + Send + 'static {
         committee_period: u64,
         validator_index: ValidatorIndex,
     ) -> bool;
-
-    fn is_epoch_known_for_proposers(&self, epoch: Epoch) -> bool;
-
-    fn is_validator_proposer_at_slot(&self, slot: Slot, validator_index: ValidatorIndex) -> bool;
 
     fn get_voluntary_exit_duty_count(&self, slot: Slot, pubkey: &PublicKeyBytes) -> u64;
 

--- a/anchor/message_receiver/src/lib.rs
+++ b/anchor/message_receiver/src/lib.rs
@@ -4,7 +4,7 @@ use libp2p::{
     PeerId,
     gossipsub::{Message, MessageId},
 };
-pub use message_validator::TopicContext;
+pub use message_validator::ParsedTopic;
 use thiserror::Error;
 
 pub use crate::{NetworkMessageReceiver, manager::*};
@@ -15,7 +15,7 @@ pub trait MessageReceiver {
         propagation_source: PeerId,
         message_id: MessageId,
         message: Message,
-        topic_context: TopicContext,
+        parsed_topic: ParsedTopic,
     ) -> Result<(), Error>;
 }
 

--- a/anchor/message_receiver/src/manager.rs
+++ b/anchor/message_receiver/src/manager.rs
@@ -6,8 +6,7 @@ use libp2p::{
     gossipsub::{Message, MessageAcceptance, MessageId},
 };
 use message_validator::{
-    DutiesProvider, TopicContext, ValidatedMessage, ValidatedSSVMessage, ValidationResult,
-    Validator,
+    DutiesProvider, ParsedTopic, ValidatedMessage, ValidatedSSVMessage, ValidationResult, Validator,
 };
 use operator_doppelganger::OperatorDoppelgangerService;
 use qbft_manager::QbftManager;
@@ -72,7 +71,7 @@ impl<E: types::EthSpec, S: SlotClock + 'static, D: DutiesProvider> MessageReceiv
         propagation_source: PeerId,
         message_id: MessageId,
         message: Message,
-        topic_context: TopicContext,
+        parsed_topic: ParsedTopic,
     ) -> Result<(), crate::Error> {
         let receiver = self.clone();
         self.processor.urgent_consensus.send_blocking(
@@ -80,7 +79,7 @@ impl<E: types::EthSpec, S: SlotClock + 'static, D: DutiesProvider> MessageReceiv
                 let span = debug_span!("message_receiver", msg=%message_id);
                 let _enter = span.enter();
 
-                let result = receiver.validator.validate(&message.data, &topic_context);
+                let result = receiver.validator.validate(&message.data, &parsed_topic);
 
                 let mut action = MessageAcceptance::from(&result);
 
@@ -180,10 +179,19 @@ impl<E: types::EthSpec, S: SlotClock + 'static, D: DutiesProvider> MessageReceiv
 
                 match ssv_message {
                     ValidatedSSVMessage::QbftMessage(qbft_message) => {
-                        if let Err(err) = receiver
-                            .qbft_manager
-                            .receive_data(signed_ssv_message, qbft_message)
-                        {
+                        // Re-query the proposer assignment immediately before dispatch so an
+                        // earlier validation observation cannot authorize later instance
+                        // allocation.
+                        let result = receiver.qbft_manager.receive_network_message(
+                            signed_ssv_message,
+                            qbft_message,
+                            |slot, validator_pubkey| {
+                                receiver
+                                    .validator
+                                    .proposer_assignment_at_slot(slot, validator_pubkey)
+                            },
+                        );
+                        if let Err(err) = result {
                             error!(gossipsub_message_id = ?message_id, ssv_msg_id = ?msg_id, ?err, "Unable to receive QBFT message");
                         }
                     }

--- a/anchor/message_sender/src/network.rs
+++ b/anchor/message_sender/src/network.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use database::OwnOperatorId;
-use message_validator::{DutiesProvider, MessageAcceptance, TopicContext, Validator};
+use message_validator::validate_outbound;
 use openssl::{
     hash::MessageDigest,
     pkey::{PKey, Private},
@@ -15,7 +15,7 @@ use ssv_types::{
 use ssz::Encode;
 use subnet_service::SubnetService;
 use tokio::sync::{mpsc, mpsc::error::TrySendError, watch};
-use tracing::{debug, error, trace, warn};
+use tracing::{error, trace, warn};
 
 use crate::{Error, MessageCallback, MessageSender, SigningError};
 
@@ -23,30 +23,28 @@ const SIGNER_NAME: &str = "message_sign_and_send";
 const SENDER_NAME: &str = "message_send";
 
 /// Configuration for creating a NetworkMessageSender
-pub struct NetworkMessageSenderConfig<S: SlotClock, D: DutiesProvider> {
+pub struct NetworkMessageSenderConfig<S: SlotClock> {
     pub processor: processor::Senders,
     /// Channel to send messages to the network. Tuple of (topic string, message bytes).
     /// Per SIP-43, the topic is determined by the message's slot.
     pub network_tx: mpsc::Sender<(String, Vec<u8>)>,
     pub private_key: Rsa<Private>,
     pub operator_id: OwnOperatorId,
-    pub validator: Option<Arc<Validator<S, D>>>,
     pub is_synced: watch::Receiver<bool>,
     pub subnet_service: Arc<SubnetService<S>>,
 }
 
-pub struct NetworkMessageSender<S: SlotClock, D: DutiesProvider> {
+pub struct NetworkMessageSender<S: SlotClock> {
     processor: processor::Senders,
     /// Channel to send messages to the network. Tuple of (topic string, message bytes).
     network_tx: mpsc::Sender<(String, Vec<u8>)>,
     private_key: PKey<Private>,
     operator_id: OwnOperatorId,
-    validator: Option<Arc<Validator<S, D>>>,
     is_synced: watch::Receiver<bool>,
     subnet_service: Arc<SubnetService<S>>,
 }
 
-impl<S: SlotClock + 'static, D: DutiesProvider> MessageSender for Arc<NetworkMessageSender<S, D>> {
+impl<S: SlotClock + 'static> MessageSender for Arc<NetworkMessageSender<S>> {
     fn sign_and_send(
         &self,
         message: UnsignedSSVMessage,
@@ -118,8 +116,8 @@ impl<S: SlotClock + 'static, D: DutiesProvider> MessageSender for Arc<NetworkMes
     }
 }
 
-impl<S: SlotClock + 'static, D: DutiesProvider> NetworkMessageSender<S, D> {
-    pub fn new(config: NetworkMessageSenderConfig<S, D>) -> Result<Arc<Self>, String> {
+impl<S: SlotClock + 'static> NetworkMessageSender<S> {
+    pub fn new(config: NetworkMessageSenderConfig<S>) -> Result<Arc<Self>, String> {
         let private_key = PKey::from_rsa(config.private_key)
             .map_err(|err| format!("Failed to create PKey from RSA: {err}"))?;
         Ok(Arc::new(Self {
@@ -127,7 +125,6 @@ impl<S: SlotClock + 'static, D: DutiesProvider> NetworkMessageSender<S, D> {
             network_tx: config.network_tx,
             private_key,
             operator_id: config.operator_id,
-            validator: config.validator,
             is_synced: config.is_synced,
             subnet_service: config.subnet_service,
         }))
@@ -136,32 +133,16 @@ impl<S: SlotClock + 'static, D: DutiesProvider> NetworkMessageSender<S, D> {
     fn do_send(&self, message: SignedSSVMessage, committee_id: CommitteeId) {
         let message_bytes = message.as_ssz_bytes();
 
-        // For outgoing messages, we use default TopicContext (no topic validation)
-        // since we're just doing a sanity check on our own message content
-        if let Some(validator) = self.validator.as_ref()
-            && let Err(err) = validator
-                .validate(&message_bytes, &TopicContext::default())
-                .as_result()
-        {
-            // `Reject` is more severe and can be punished by other peers. We should not have
-            // created this message ever, while `Ignore` can be triggered simply because the message
-            // is irrelevant by now.
-            if let MessageAcceptance::Reject = MessageAcceptance::from(err) {
-                warn!(?err, "Validation of outgoing message failed (Reject)");
-                debug!(msg = %message, "Failing message");
-            } else {
-                debug!(?err, "Validation of outgoing message failed (Ignore)");
-            }
-            return;
-        }
-
-        // Extract slot from message for slot-based topic routing (per SIP-43)
-        let message_slot = match message.ssv_message().extract_slot() {
-            Some(slot) => slot,
-            None => {
-                warn!(
+        let message_slot = match validate_outbound(&message_bytes) {
+            Ok(slot) => slot,
+            Err(err) => {
+                error!(
+                    ?err,
                     ?committee_id,
-                    "Cannot extract slot from message for topic routing"
+                    ssv_msg_id = ?message.ssv_message().msg_id(),
+                    msg_type = ?message.ssv_message().msg_type(),
+                    role = ?message.ssv_message().msg_id().role(),
+                    "Stateless validation of outgoing message failed"
                 );
                 return;
             }

--- a/anchor/message_sender/src/network.rs
+++ b/anchor/message_sender/src/network.rs
@@ -134,12 +134,12 @@ impl<S: SlotClock + 'static> NetworkMessageSender<S> {
         let message_slot = match validate_outbound_message(&message) {
             Ok(slot) => slot,
             Err(err) => {
+                let ssv_message = message.ssv_message();
                 error!(
                     ?err,
                     ?committee_id,
-                    ssv_msg_id = ?message.ssv_message().msg_id(),
-                    msg_type = ?message.ssv_message().msg_type(),
-                    role = ?message.ssv_message().msg_id().role(),
+                    ssv_msg_id = ?ssv_message.msg_id(),
+                    msg_type = ?ssv_message.msg_type(),
                     "Stateless validation of outgoing message failed"
                 );
                 return;

--- a/anchor/message_sender/src/network.rs
+++ b/anchor/message_sender/src/network.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use database::OwnOperatorId;
-use message_validator::validate_outbound;
+use message_validator::validate_outbound_message;
 use openssl::{
     hash::MessageDigest,
     pkey::{PKey, Private},
@@ -131,9 +131,7 @@ impl<S: SlotClock + 'static> NetworkMessageSender<S> {
     }
 
     fn do_send(&self, message: SignedSSVMessage, committee_id: CommitteeId) {
-        let message_bytes = message.as_ssz_bytes();
-
-        let message_slot = match validate_outbound(&message_bytes) {
+        let message_slot = match validate_outbound_message(&message) {
             Ok(slot) => slot,
             Err(err) => {
                 error!(
@@ -147,6 +145,7 @@ impl<S: SlotClock + 'static> NetworkMessageSender<S> {
                 return;
             }
         };
+        let message_bytes = message.as_ssz_bytes();
 
         // Use subnet service for slot-based subnet calculation
         let subnet = match self

--- a/anchor/message_validator/src/consensus_message.rs
+++ b/anchor/message_validator/src/consensus_message.rs
@@ -449,14 +449,8 @@ pub(crate) fn validate_qbft_message_by_duty_logic(
     }
 
     let msg_slot = Slot::new(consensus_message.height);
-    let randao_msg = false; // Default to false as in the Go code
 
-    validate_beacon_duty(
-        validation_context,
-        msg_slot,
-        randao_msg,
-        duty_provider.clone(),
-    )?;
+    validate_beacon_duty(validation_context, msg_slot, duty_provider.as_ref())?;
 
     // Rule: current slot(height) must be between duty's starting slot and:
     // - duty's starting slot + 34 (committee and aggregation)
@@ -470,7 +464,7 @@ pub(crate) fn validate_qbft_message_by_duty_logic(
             validation_context,
             msg_slot,
             signer_state,
-            duty_provider.clone(),
+            duty_provider.as_ref(),
         )?;
     }
 
@@ -497,11 +491,12 @@ mod tests {
 
     use super::*;
     use crate::{
-        LATE_MESSAGE_MARGIN, LATE_SLOT_ALLOWANCE, MessageAcceptance, ValidatedSSVMessage,
-        duty_limit,
+        DutyAssignment, LATE_MESSAGE_MARGIN, LATE_SLOT_ALLOWANCE, MessageAcceptance,
+        ValidatedSSVMessage, duty_limit,
         tests::{
-            FOUR_NODE_COMMITTEE, SINGLE_NODE_COMMITTEE, create_committee_info,
-            create_operator_pub_keys, generate_random_rsa_public_keys,
+            FOUR_NODE_COMMITTEE, SINGLE_NODE_COMMITTEE, assert_proposer_assignment_result,
+            create_committee_info, create_operator_pub_keys, generate_random_rsa_public_keys,
+            nonzero_validator_pubkey, validator_message_id,
         },
         validate_ssv_message,
     };
@@ -553,6 +548,67 @@ mod tests {
             DomainType::default(),
             "testing",
         ))
+    }
+
+    fn proposer_consensus_context<'a>(
+        signed_message: &'a SignedSSVMessage,
+        committee_info: &'a CommitteeInfo,
+        operator_pub_keys: &'a HashMap<OperatorId, Rsa<Public>>,
+    ) -> ValidationContext<'a, ManualSlotClock> {
+        let now = SystemTime::now();
+        ValidationContext {
+            signed_ssv_message: signed_message,
+            committee_info,
+            role: Role::Proposer,
+            received_at: now,
+            slots_per_epoch: 32,
+            epochs_per_sync_committee_period: 256,
+            sync_committee_size: 512,
+            slot_clock: ManualSlotClock::new(
+                Slot::new(1),
+                now.duration_since(UNIX_EPOCH).unwrap(),
+                Duration::from_secs(12),
+            ),
+            operator_pub_keys,
+            fork_schedule: generate_fork_schedule(),
+            spec: Arc::new(types::ChainSpec::mainnet()),
+        }
+    }
+
+    fn run_proposer_consensus_with_assignment(
+        assignment: DutyAssignment,
+    ) -> Result<ValidatedSSVMessage, ValidationFailure> {
+        let mut committee_info = create_committee_info(FOUR_NODE_COMMITTEE);
+        committee_info.validator_indices.clear();
+        let (private_key, public_key) = generate_test_key_pair();
+        let operator_pub_keys =
+            create_operator_pub_keys(committee_info.committee_members.clone(), vec![public_key]);
+        let validator_pubkey = nonzero_validator_pubkey(0xBC);
+        let message_id = validator_message_id(Role::Proposer, validator_pubkey);
+        let qbft_message = QbftMessageBuilder::new(Role::Proposer, QbftMessageType::Prepare)
+            .with_identifier(message_id)
+            .build();
+        let signed_message = create_signed_consensus_message(
+            qbft_message,
+            vec![OperatorId(1)],
+            vec![],
+            vec![private_key],
+        );
+        let validation_context =
+            proposer_consensus_context(&signed_message, &committee_info, &operator_pub_keys);
+
+        let duty_provider = Arc::new(MockDutiesProvider::expecting_proposer_query(
+            Slot::new(1),
+            validator_pubkey,
+            assignment,
+        ));
+        let result = validate_consensus_message(
+            validation_context,
+            &mut DutyState::new(64),
+            duty_provider.clone(),
+        );
+        duty_provider.assert_query_count(1);
+        result
     }
 
     // ---------------------------------------------------------------------
@@ -614,6 +670,78 @@ mod tests {
         );
 
         assert_qbft_message_accepted(result, "Expected successful validation");
+    }
+
+    #[test]
+    fn proposer_qbft_uses_pubkey_assignment_without_validator_indices() {
+        for assignment in [
+            DutyAssignment::Assigned,
+            DutyAssignment::Unknown,
+            DutyAssignment::NotAssigned,
+        ] {
+            let result = run_proposer_consensus_with_assignment(assignment);
+            assert_proposer_assignment_result(result, assignment, "proposer QBFT assignment");
+        }
+    }
+
+    #[test]
+    fn unknown_proposer_decided_commit_replay_is_ignored() {
+        let mut committee_info = create_committee_info(FOUR_NODE_COMMITTEE);
+        committee_info.validator_indices.clear();
+
+        let keypairs: Vec<_> = (0..3).map(|_| generate_test_key_pair()).collect();
+        let private_keys = keypairs
+            .iter()
+            .map(|(private_key, _)| private_key.clone())
+            .collect();
+        let public_keys = keypairs
+            .into_iter()
+            .map(|(_, public_key)| public_key)
+            .collect();
+        let operator_pub_keys =
+            create_operator_pub_keys(committee_info.committee_members.clone(), public_keys);
+
+        let validator_pubkey = nonzero_validator_pubkey(0xCD);
+        let message_id = MessageId::new(
+            &DomainType([0, 0, 0, 1]),
+            Role::Proposer,
+            &DutyExecutor::Validator(validator_pubkey),
+        );
+        let qbft_message = QbftMessageBuilder::new(Role::Proposer, QbftMessageType::Commit)
+            .with_identifier(message_id)
+            .build();
+        let signed_message = create_signed_consensus_message(
+            qbft_message,
+            vec![OperatorId(1), OperatorId(2), OperatorId(3)],
+            vec![],
+            private_keys,
+        );
+        let duty_provider = Arc::new(MockDutiesProvider::expecting_proposer_query(
+            Slot::new(1),
+            validator_pubkey,
+            DutyAssignment::Unknown,
+        ));
+        let mut duty_state = DutyState::new(64);
+
+        let first = validate_consensus_message(
+            proposer_consensus_context(&signed_message, &committee_info, &operator_pub_keys),
+            &mut duty_state,
+            duty_provider.clone(),
+        );
+        assert!(
+            first.is_ok(),
+            "first Unknown proposer decided commit should be accepted, got {first:?}"
+        );
+
+        let second = validate_consensus_message(
+            proposer_consensus_context(&signed_message, &committee_info, &operator_pub_keys),
+            &mut duty_state,
+            duty_provider.clone(),
+        );
+        let failure = second.expect_err("identical decided commit replay should fail");
+        assert_eq!(failure, ValidationFailure::DecidedWithSameSigners);
+        assert_eq!(MessageAcceptance::from(&failure), MessageAcceptance::Ignore);
+        duty_provider.assert_query_count(1);
     }
 
     #[test]
@@ -1770,10 +1898,10 @@ mod tests {
 
         // Create a mock DutiesProvider that returns a fixed value for voluntary exits
         let expected_duty_count = 5;
-        let mock_duties_provider = Arc::new(MockDutiesProvider {
+        let mock_duties_provider = MockDutiesProvider {
             voluntary_exit_duty_count: expected_duty_count,
             ..Default::default()
-        });
+        };
 
         let map = create_operator_pub_keys(committee_info.committee_members.clone(), vec![]);
 
@@ -1794,7 +1922,7 @@ mod tests {
 
         let slot = slot_clock.now().unwrap();
 
-        let result = duty_limit(&validation_context, slot, &[], mock_duties_provider);
+        let result = duty_limit(&validation_context, slot, &[], &mock_duties_provider);
 
         assert_eq!(result, Ok(Some(expected_duty_count)));
     }
@@ -1824,10 +1952,10 @@ mod tests {
         .expect("SignedSSVMessage should be created");
 
         let committee_info = create_committee_info(SINGLE_NODE_COMMITTEE);
-        let mock_duties_provider = Arc::new(MockDutiesProvider {
+        let mock_duties_provider = MockDutiesProvider {
             voluntary_exit_duty_count: 0,
             ..Default::default()
-        });
+        };
         let map = create_operator_pub_keys(committee_info.committee_members.clone(), vec![]);
 
         let validation_context = ValidationContext {
@@ -1855,14 +1983,14 @@ mod tests {
             &validation_context,
             slot,
             &one_validator,
-            mock_duties_provider.clone(),
+            &mock_duties_provider,
         );
         assert_eq!(result, Ok(Some(2)));
 
         // The cap does not scale with the slice length (guards against the old
         // cluster-wide `min(slots_per_epoch, V)` formula reappearing).
         let many = vec![ValidatorIndex(0); 100];
-        let result = duty_limit(&validation_context, slot, &many, mock_duties_provider);
+        let result = duty_limit(&validation_context, slot, &many, &mock_duties_provider);
         assert_eq!(result, Ok(Some(2)));
     }
 
@@ -1897,10 +2025,10 @@ mod tests {
         .expect("SignedSSVMessage should be created");
 
         let committee_info = create_committee_info(SINGLE_NODE_COMMITTEE);
-        let mock_duties_provider = Arc::new(MockDutiesProvider {
+        let mock_duties_provider = MockDutiesProvider {
             voluntary_exit_duty_count: 0,
             ..Default::default()
-        });
+        };
         let map = create_operator_pub_keys(committee_info.committee_members.clone(), vec![]);
 
         let validation_context = ValidationContext {
@@ -1925,7 +2053,7 @@ mod tests {
             &validation_context,
             slot,
             &one_validator,
-            mock_duties_provider.clone(),
+            &mock_duties_provider,
         );
 
         // Assert
@@ -1934,7 +2062,7 @@ mod tests {
         // The limit is fixed at `slots_per_epoch` and does not scale with the slice
         // length.
         let many = vec![ValidatorIndex(0); 100];
-        let result = duty_limit(&validation_context, slot, &many, mock_duties_provider);
+        let result = duty_limit(&validation_context, slot, &many, &mock_duties_provider);
         assert_eq!(result, Ok(Some(SLOTS_PER_EPOCH)));
     }
 
@@ -1969,7 +2097,7 @@ mod tests {
         .expect("SignedSSVMessage should be created");
 
         let committee_info = create_committee_info(FOUR_NODE_COMMITTEE);
-        let mock_duties_provider = Arc::new(MockDutiesProvider::default());
+        let mock_duties_provider = MockDutiesProvider::default();
         let map = HashMap::new();
 
         // Create fork schedule with Boole at epoch 0 (active from start).
@@ -2002,7 +2130,7 @@ mod tests {
             &validation_context,
             slot,
             &[ValidatorIndex(0)], // Single validator; irrelevant for EnvelopeProposer
-            mock_duties_provider.clone(),
+            &mock_duties_provider,
         );
 
         // Assert: Duty cap must equal slots_per_epoch and be independent of slice length.
@@ -2014,7 +2142,7 @@ mod tests {
 
         // Verify independence from slice length.
         let many = vec![ValidatorIndex(0); 100];
-        let result = duty_limit(&validation_context, slot, &many, mock_duties_provider);
+        let result = duty_limit(&validation_context, slot, &many, &mock_duties_provider);
         assert_eq!(
             result,
             Ok(Some(SLOTS_PER_EPOCH)),

--- a/anchor/message_validator/src/lib.rs
+++ b/anchor/message_validator/src/lib.rs
@@ -386,16 +386,23 @@ pub struct Validator<S: SlotClock, D: DutiesProvider> {
     spec: Arc<ChainSpec>,
 }
 
+/// Decode and perform stateless structural validation of an outbound message.
+pub fn validate_outbound(message_data: &[u8]) -> Result<Slot, ValidationFailure> {
+    let signed_ssv_message = SignedSSVMessage::from_ssz_bytes(message_data)
+        .map_err(ValidationFailure::UndecodableMessageData)?;
+    validate_outbound_message(&signed_ssv_message)
+}
+
 /// Perform stateless structural validation of an outbound message and return its routing slot.
 ///
 /// This is not an authorization boundary. It deliberately excludes all network, duty, timing,
 /// fork-role, signature-verification, and validation-state checks. Outbound producers must enforce
 /// those invariants before constructing the message. Incoming messages continue through
 /// [`Validator::validate`], which owns gossip validation state.
-pub fn validate_outbound(message_data: &[u8]) -> Result<Slot, ValidationFailure> {
-    let signed_ssv_message = SignedSSVMessage::from_ssz_bytes(message_data)
-        .map_err(ValidationFailure::UndecodableMessageData)?;
-    validate_structure_and_role(&signed_ssv_message)?;
+pub fn validate_outbound_message(
+    signed_ssv_message: &SignedSSVMessage,
+) -> Result<Slot, ValidationFailure> {
+    validate_structure_and_role(signed_ssv_message)?;
     signed_ssv_message
         .ssv_message()
         .extract_slot()

--- a/anchor/message_validator/src/lib.rs
+++ b/anchor/message_validator/src/lib.rs
@@ -9,10 +9,10 @@ use std::{
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
+use bls::PublicKeyBytes;
 use dashmap::{DashMap, mapref::one::RefMut};
 use database::NetworkState;
-pub use duties_tracker::DutiesProvider;
-use duties_tracker::DutyAssignment;
+pub use duties_tracker::{DutiesProvider, DutyAssignment};
 use fork::{Fork, ForkSchedule};
 pub use libp2p::gossipsub::MessageAcceptance;
 use openssl::{
@@ -32,7 +32,7 @@ use ssv_types::{
     partial_sig::PartialSignatureMessages,
 };
 use ssz::{Decode, DecodeError, Encode};
-use subnet_service::topic::ParsedTopic;
+pub use subnet_service::topic::ParsedTopic;
 use task_executor::TaskExecutor;
 use tokio::{sync::watch::Receiver, time::sleep};
 use tracing::{debug, trace};
@@ -326,33 +326,6 @@ impl ValidatedMessage {
     }
 }
 
-/// Context for topic-aware message validation.
-///
-/// This enum makes explicit whether topic validation should be performed:
-/// - `SkipValidation`: Used for tests where topic validation is not needed
-/// - `Validate`: Used for incoming network messages where topic validation is required
-///
-/// For incoming network messages, always use `TopicContext::Validate`. If topic parsing
-/// fails at the network layer, the message should be rejected immediately rather than
-/// passed to the validator with skip context.
-#[derive(Debug, Clone, Default)]
-pub enum TopicContext {
-    /// Skip topic validation entirely.
-    ///
-    /// Used for testing scenarios where topic context is irrelevant.
-    #[default]
-    SkipValidation,
-
-    /// Validate message against the parsed topic.
-    ///
-    /// Used for incoming network messages where we need to verify the message
-    /// is on the correct subnet for its content.
-    Validate {
-        /// The parsed topic information (subnet_id, fork).
-        parsed: ParsedTopic,
-    },
-}
-
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
     #[error("Processor error: {0}")]
@@ -386,19 +359,13 @@ pub struct Validator<S: SlotClock, D: DutiesProvider> {
     spec: Arc<ChainSpec>,
 }
 
-/// Decode and perform stateless structural validation of an outbound message.
-pub fn validate_outbound(message_data: &[u8]) -> Result<Slot, ValidationFailure> {
-    let signed_ssv_message = SignedSSVMessage::from_ssz_bytes(message_data)
-        .map_err(ValidationFailure::UndecodableMessageData)?;
-    validate_outbound_message(&signed_ssv_message)
-}
-
 /// Perform stateless structural validation of an outbound message and return its routing slot.
 ///
 /// This is not an authorization boundary. It deliberately excludes all network, duty, timing,
 /// fork-role, signature-verification, and validation-state checks. Outbound producers must enforce
 /// those invariants before constructing the message. Incoming messages continue through
-/// [`Validator::validate`], which owns gossip validation state.
+/// [`Validator::validate`], which owns gossip validation state. Kept in this crate rather than
+/// `ssv_types` so outbound and inbound validation share [`ValidationFailure`].
 pub fn validate_outbound_message(
     signed_ssv_message: &SignedSSVMessage,
 ) -> Result<Slot, ValidationFailure> {
@@ -454,16 +421,29 @@ impl<S: SlotClock + 'static, D: DutiesProvider> Validator<S, D> {
         validator
     }
 
-    /// Validate a message with topic context for fork-aware validation.
+    /// Return the current proposer assignment from the same duty view used for validation.
     ///
-    /// The `topic_context` provides information about which topic the message was
-    /// received on, enabling validation of whether the message is on the correct
-    /// subnet for its committee based on the topic's fork.
-    pub fn validate(&self, message_data: &[u8], topic_context: &TopicContext) -> ValidationResult {
+    /// Message dispatch uses this immediately before QBFT allocation so it cannot accidentally
+    /// query a different provider from the one owned by this validator.
+    pub fn proposer_assignment_at_slot(
+        &self,
+        slot: Slot,
+        validator_pubkey: &PublicKeyBytes,
+    ) -> DutyAssignment {
+        self.duties_provider
+            .proposer_assignment_at_slot(slot, validator_pubkey)
+    }
+
+    /// Validate a message against the parsed topic it arrived on, for fork-aware validation.
+    ///
+    /// The topic enables validation of whether the message is on the correct subnet for its
+    /// committee based on the topic's fork. If topic parsing fails at the network layer, the
+    /// message should be rejected there rather than passed to the validator.
+    pub fn validate(&self, message_data: &[u8], parsed_topic: &ParsedTopic) -> ValidationResult {
         match SignedSSVMessage::from_ssz_bytes(message_data) {
             Ok(signed_ssv_message) => {
                 trace!(msg = ?signed_ssv_message, "SignedSSVMessage deserialized");
-                match self.validate_decoded_message(&signed_ssv_message, topic_context) {
+                match self.validate_decoded_message(&signed_ssv_message, parsed_topic) {
                     Ok(validated_message) => ValidationResult::Success(validated_message),
                     Err(failure) => {
                         ValidationResult::PostDecodeFailure(failure, signed_ssv_message)
@@ -479,7 +459,7 @@ impl<S: SlotClock + 'static, D: DutiesProvider> Validator<S, D> {
     fn validate_decoded_message(
         &self,
         signed_ssv_message: &SignedSSVMessage,
-        topic_context: &TopicContext,
+        parsed_topic: &ParsedTopic,
     ) -> Result<ValidatedMessage, ValidationFailure> {
         let role = validate_structure_and_role(signed_ssv_message)?;
         let ssv_message = signed_ssv_message.ssv_message();
@@ -508,10 +488,7 @@ impl<S: SlotClock + 'static, D: DutiesProvider> Validator<S, D> {
             | Role::PTCAttester
             | Role::ProposerPreferences
             | Role::EnvelopeProposer => {
-                let validator_pk = match ssv_message.msg_id().duty_executor() {
-                    Some(DutyExecutor::Validator(pk)) => pk,
-                    _ => return Err(ValidationFailure::UnknownValidator),
-                };
+                let validator_pk = validator_pubkey_from_message_id(ssv_message.msg_id())?;
 
                 network_state
                     .get_committee_info_by_validator_pk(&validator_pk)
@@ -522,7 +499,7 @@ impl<S: SlotClock + 'static, D: DutiesProvider> Validator<S, D> {
         // Validate topic - message is on correct subnet and has correct domain for its committee
         let operator_ids: Vec<_> = committee_info.committee_members.iter().copied().collect();
         self.validate_topic_and_domain(
-            topic_context,
+            parsed_topic,
             committee_id,
             &operator_ids,
             ssv_message,
@@ -618,7 +595,7 @@ impl<S: SlotClock + 'static, D: DutiesProvider> Validator<S, D> {
     ///
     /// # Arguments
     ///
-    /// * `topic_context` - The parsed topic information (subnet_id, fork)
+    /// * `parsed` - The parsed topic information (subnet_id, fork)
     /// * `committee_id` - The committee ID from the message
     /// * `operator_ids` - The operator IDs from the committee
     /// * `ssv_message` - The SSV message to validate (for slot extraction)
@@ -634,20 +611,12 @@ impl<S: SlotClock + 'static, D: DutiesProvider> Validator<S, D> {
     /// * `Err(ValidationFailure::UnknownMessageSlot)` if the slot cannot be extracted
     fn validate_topic_and_domain(
         &self,
-        topic_context: &TopicContext,
+        parsed: &ParsedTopic,
         committee_id: Option<ssv_types::CommitteeId>,
         operator_ids: &[OperatorId],
         ssv_message: &ssv_types::message::SSVMessage,
         msg_id: &MessageId,
     ) -> Result<(), ValidationFailure> {
-        let parsed = match topic_context {
-            TopicContext::SkipValidation => {
-                trace!("Topic validation skipped");
-                return Ok(());
-            }
-            TopicContext::Validate { parsed } => parsed,
-        };
-
         // Extract slot from message for slot-based validation
         let message_slot = ssv_message
             .extract_slot()
@@ -826,66 +795,29 @@ fn verify_message_signatures(
     Ok(())
 }
 
-/// Validates if a validator is assigned to a specific duty
+fn validator_pubkey_from_message_id(
+    message_id: &MessageId,
+) -> Result<PublicKeyBytes, ValidationFailure> {
+    match message_id.duty_executor() {
+        Some(DutyExecutor::Validator(pubkey)) => Ok(pubkey),
+        _ => Err(ValidationFailure::UnknownValidator),
+    }
+}
+
+/// Validates if a validator is assigned to a specific duty.
 pub(crate) fn validate_beacon_duty(
     validation_context: &ValidationContext<impl SlotClock>,
     slot: Slot,
-    randao_msg: bool,
-    duty_provider: Arc<impl DutiesProvider>,
+    duty_provider: &impl DutiesProvider,
 ) -> Result<(), ValidationFailure> {
     let role = validation_context.role;
-    let epoch = slot.epoch(validation_context.slots_per_epoch);
-    // Rule: For a proposal duty message, check if the validator is assigned to it
-    if role == Role::Proposer {
-        // Tolerate missing duties for RANDAO signatures during the first slot of an epoch,
-        // while duties are still being fetched from the Beacon node.
-
-        let is_first_slot_of_epoch = epoch.start_slot(validation_context.slots_per_epoch) == slot;
-
-        if randao_msg
-            && is_first_slot_of_epoch
-            && validation_context
-                .slot_clock
-                .now()
-                .ok_or(ValidationFailure::UnexpectedFailure {
-                    msg: "Failed to get current time".to_string(),
-                })?
-                <= slot
-            && !duty_provider.is_epoch_known_for_proposers(epoch)
-        {
-            return Ok(());
-        }
-
-        // Non-committee roles always have one validator index
-        let validator_index = validation_context
-            .committee_info
-            .validator_indices
-            .first()
-            .copied()
-            .ok_or(ValidationFailure::UnexpectedFailure {
-                msg: "Unexpected error when getting first validator index".to_string(),
-            })?;
-
-        if !duty_provider.is_validator_proposer_at_slot(slot, validator_index) {
-            return Err(ValidationFailure::NoDuty);
-        }
-    }
-
-    // Rule: For a proposer-preferences or envelope-proposer message, the validator must be the
-    // assigned proposer at the slot. Checked only once the slot-epoch's proposer duties are known
-    // locally, so a not-yet-fetched epoch is tolerated. No RANDAO tolerance: neither
-    // ProposerPreferences nor EnvelopeProposer carry a RANDAO signature.
-    if matches!(role, Role::ProposerPreferences | Role::EnvelopeProposer) {
-        let validator_pubkey = match validation_context
-            .signed_ssv_message
-            .ssv_message()
-            .msg_id()
-            .duty_executor()
-        {
-            Some(DutyExecutor::Validator(public_key)) => public_key,
-            _ => return Err(ValidationFailure::UnknownValidator),
-        };
-
+    // Only an authoritative negative view proves that a proposer-scoped message has no duty.
+    // Unknown QBFT allocation is gated again at dispatch. Accepted partial signatures retain the
+    // signature collector's existing resource bounds and cleanup behavior.
+    if role.is_proposer_scoped() {
+        let validator_pubkey = validator_pubkey_from_message_id(
+            validation_context.signed_ssv_message.ssv_message().msg_id(),
+        )?;
         if duty_provider.proposer_assignment_at_slot(slot, &validator_pubkey)
             == DutyAssignment::NotAssigned
         {
@@ -895,6 +827,7 @@ pub(crate) fn validate_beacon_duty(
 
     // Rule: For a sync committee duty message, check if the validator is assigned
     if role == Role::SyncCommittee {
+        let epoch = slot.epoch(validation_context.slots_per_epoch);
         let period =
             sync_committee_period(epoch, validation_context.epochs_per_sync_committee_period)?;
         let validator_index = validation_context
@@ -1092,7 +1025,7 @@ pub(crate) fn validate_duty_count(
     validation_context: &ValidationContext<impl SlotClock>,
     slot: Slot,
     signer_state: &mut OperatorState,
-    duty_provider: Arc<impl DutiesProvider>,
+    duty_provider: &impl DutiesProvider,
 ) -> Result<(), ValidationFailure> {
     if let Some(limit) = duty_limit(
         validation_context,
@@ -1130,20 +1063,13 @@ fn duty_limit(
     validation_context: &ValidationContext<impl SlotClock>,
     slot: Slot,
     validator_indices: &[ValidatorIndex],
-    duty_provider: Arc<impl DutiesProvider>,
+    duty_provider: &impl DutiesProvider,
 ) -> Result<Option<u64>, ValidationFailure> {
     match validation_context.role {
         Role::VoluntaryExit => {
-            // Extract the validator public key from the message ID
-            let pubkey = match validation_context
-                .signed_ssv_message
-                .ssv_message()
-                .msg_id()
-                .duty_executor()
-            {
-                Some(DutyExecutor::Validator(pubkey)) => pubkey,
-                _ => return Err(ValidationFailure::UnknownValidator),
-            };
+            let pubkey = validator_pubkey_from_message_id(
+                validation_context.signed_ssv_message.ssv_message().msg_id(),
+            )?;
             // Get the current voluntary exit duty count for this validator
             Ok(Some(
                 duty_provider.get_voluntary_exit_duty_count(slot, &pubkey),
@@ -1235,7 +1161,13 @@ pub(crate) fn hash_data(full_data: &[u8]) -> [u8; 32] {
 
 #[cfg(test)]
 mod tests {
-    use std::{collections::HashMap, sync::Arc};
+    use std::{
+        collections::HashMap,
+        sync::{
+            Arc,
+            atomic::{AtomicUsize, Ordering},
+        },
+    };
 
     use bls::{Hash256, PublicKeyBytes, Signature};
     use duties_tracker::{DutiesProvider, DutyAssignment};
@@ -1255,9 +1187,9 @@ mod tests {
         partial_sig::{PartialSignatureKind, PartialSignatureMessage, PartialSignatureMessages},
     };
     use ssz::Encode;
-    use types::{Epoch, Slot};
+    use types::Slot;
 
-    use crate::{MessageAcceptance, ValidationFailure, hash_data, validate_outbound};
+    use crate::{MessageAcceptance, ValidationFailure, hash_data, validate_outbound_message};
 
     // Constants for committee sizes in tests to improve readability.
     pub(crate) const SINGLE_NODE_COMMITTEE: usize = 1;
@@ -1293,7 +1225,7 @@ mod tests {
         );
 
         assert_eq!(
-            validate_outbound(&signed_consensus_message.as_ssz_bytes()),
+            validate_outbound_message(&signed_consensus_message),
             Ok(Slot::new(42))
         );
 
@@ -1315,18 +1247,13 @@ mod tests {
         );
 
         assert_eq!(
-            validate_outbound(&signed_partial_signature_message.as_ssz_bytes()),
+            validate_outbound_message(&signed_partial_signature_message),
             Ok(Slot::new(43))
         );
     }
 
     #[test]
-    fn validate_outbound_rejects_malformed_outer_and_nested_messages() {
-        assert!(matches!(
-            validate_outbound(&[]),
-            Err(ValidationFailure::UndecodableMessageData(_))
-        ));
-
+    fn validate_outbound_rejects_malformed_nested_messages() {
         for (msg_type, role) in [
             (MsgType::SSVConsensusMsgType, Role::Committee),
             (MsgType::SSVPartialSignatureMsgType, Role::Proposer),
@@ -1334,7 +1261,7 @@ mod tests {
             let signed_message =
                 signed_test_message(msg_type, create_message_id_for_test(role), vec![0x01]);
             assert_eq!(
-                validate_outbound(&signed_message.as_ssz_bytes()),
+                validate_outbound_message(&signed_message),
                 Err(ValidationFailure::UnknownMessageSlot)
             );
         }
@@ -1351,7 +1278,7 @@ mod tests {
             .expect("aggregation permits duplicate signers for validation tests");
 
         assert_eq!(
-            validate_outbound(&signed_message.as_ssz_bytes()),
+            validate_outbound_message(&signed_message),
             Err(ValidationFailure::DuplicatedSigner)
         );
     }
@@ -1362,16 +1289,13 @@ mod tests {
         invalid_message_id[4] = u8::MAX;
         let invalid_message_id = MessageId::from(invalid_message_id);
         let qbft_message = QbftMessageBuilder::new(Role::Committee, QbftMessageType::Proposal)
-            .with_identifier(invalid_message_id.clone())
+            .with_identifier(invalid_message_id)
             .build();
-        let signed_message = signed_test_message(
-            MsgType::SSVConsensusMsgType,
-            invalid_message_id,
-            qbft_message.as_ssz_bytes(),
-        );
+        let signed_message =
+            create_signed_consensus_message(qbft_message, vec![OperatorId(1)], vec![], vec![]);
 
         assert_eq!(
-            validate_outbound(&signed_message.as_ssz_bytes()),
+            validate_outbound_message(&signed_message),
             Err(ValidationFailure::InvalidRole)
         );
     }
@@ -1620,15 +1544,7 @@ mod tests {
 
     pub struct MockDutiesProvider {
         pub(crate) voluntary_exit_duty_count: u64,
-        /// Value returned by `is_epoch_known_for_proposers`. Defaults to `true`
-        /// so existing tests keep the historical "epoch always known" behavior.
-        pub(crate) epoch_known_for_proposers: bool,
-        /// Value returned by `is_validator_proposer_at_slot`. Defaults to `true`
-        /// so existing tests keep the historical "validator is always proposer"
-        /// behavior.
-        pub(crate) validator_is_proposer: bool,
-        /// Value returned by `proposer_assignment_at_slot`, the pubkey-keyed
-        /// lookup used by the `ProposerPreferences` / `EnvelopeProposer` arm.
+        /// Value returned by the pubkey-keyed proposer assignment lookup.
         /// `DutyAssignment::Assigned` = assigned proposer at the slot,
         /// `DutyAssignment::NotAssigned` = a fetched epoch proves the pubkey is
         /// not the proposer at the slot, `DutyAssignment::Unknown` = the slot's
@@ -1636,19 +1552,43 @@ mod tests {
         /// so pre-existing tests keep the "assigned proposer" behavior; new tests
         /// set it explicitly to drive the three cases.
         pub(crate) proposer_assignment: DutyAssignment,
+        /// When set, every proposer-assignment query must match this (slot, pubkey) pair.
+        pub(crate) expected_proposer_query: Option<(Slot, PublicKeyBytes)>,
+        pub(crate) proposer_query_count: AtomicUsize,
     }
 
-    // Manual `Default` (not derived) so the proposer flags default to their
-    // "assigned" values, preserving the behavior all pre-existing tests relied on
-    // before these fields were added. New tests set them explicitly to drive the
-    // proposer-assignment arm.
+    impl MockDutiesProvider {
+        /// A provider that returns `proposer_assignment` while asserting each query matches
+        /// the expected (slot, pubkey) pair; verify call counts with [`Self::assert_query_count`].
+        pub(crate) fn expecting_proposer_query(
+            expected_slot: Slot,
+            expected_validator_pubkey: PublicKeyBytes,
+            proposer_assignment: DutyAssignment,
+        ) -> Self {
+            Self {
+                proposer_assignment,
+                expected_proposer_query: Some((expected_slot, expected_validator_pubkey)),
+                ..Default::default()
+            }
+        }
+
+        pub(crate) fn assert_query_count(&self, expected: usize) {
+            assert_eq!(
+                self.proposer_query_count.load(Ordering::Relaxed),
+                expected,
+                "unexpected proposer assignment query count"
+            );
+        }
+    }
+
+    // Default to an assigned proposer so existing tests retain their historical behavior.
     impl Default for MockDutiesProvider {
         fn default() -> Self {
             Self {
                 voluntary_exit_duty_count: 0,
-                epoch_known_for_proposers: true,
-                validator_is_proposer: true,
                 proposer_assignment: DutyAssignment::Assigned,
+                expected_proposer_query: None,
+                proposer_query_count: AtomicUsize::new(0),
             }
         }
     }
@@ -1662,29 +1602,70 @@ mod tests {
             true
         }
 
-        fn is_epoch_known_for_proposers(&self, _epoch: Epoch) -> bool {
-            self.epoch_known_for_proposers
-        }
-
-        fn is_validator_proposer_at_slot(
-            &self,
-            _slot: Slot,
-            _validator_index: ValidatorIndex,
-        ) -> bool {
-            self.validator_is_proposer
-        }
-
         fn get_voluntary_exit_duty_count(&self, _slot: Slot, _pubkey: &PublicKeyBytes) -> u64 {
             self.voluntary_exit_duty_count
         }
 
         fn proposer_assignment_at_slot(
             &self,
-            _slot: Slot,
-            _validator_pubkey: &PublicKeyBytes,
+            slot: Slot,
+            validator_pubkey: &PublicKeyBytes,
         ) -> DutyAssignment {
+            if let Some((expected_slot, expected_validator_pubkey)) = &self.expected_proposer_query
+            {
+                assert_eq!(slot, *expected_slot, "unexpected proposer duty slot");
+                assert_eq!(
+                    validator_pubkey, expected_validator_pubkey,
+                    "unexpected proposer duty validator pubkey"
+                );
+            }
+            self.proposer_query_count.fetch_add(1, Ordering::Relaxed);
             self.proposer_assignment
         }
+    }
+
+    /// Assert the outcome of a proposer-scoped validation driven by `assignment`:
+    /// `Assigned` and `Unknown` are accepted, `NotAssigned` fails with `NoDuty`.
+    pub(crate) fn assert_proposer_assignment_result(
+        result: Result<crate::ValidatedSSVMessage, ValidationFailure>,
+        assignment: DutyAssignment,
+        context: &str,
+    ) {
+        match assignment {
+            DutyAssignment::Assigned | DutyAssignment::Unknown => {
+                assert!(
+                    result.is_ok(),
+                    "{context}: expected acceptance, got {result:?}"
+                );
+            }
+            DutyAssignment::NotAssigned => assert_validation_error(
+                result,
+                |failure| matches!(failure, ValidationFailure::NoDuty),
+                context,
+            ),
+        }
+    }
+
+    pub(crate) fn nonzero_validator_pubkey(byte: u8) -> PublicKeyBytes {
+        assert_ne!(byte, 0, "test validator pubkey byte must be nonzero");
+        let validator_pubkey = PublicKeyBytes::deserialize(&[byte; bls::PUBLIC_KEY_BYTES_LEN])
+            .expect("48-byte input is a valid PublicKeyBytes");
+        assert_ne!(
+            validator_pubkey,
+            PublicKeyBytes::empty(),
+            "test validator pubkey must be nonzero"
+        );
+        validator_pubkey
+    }
+
+    /// Build the standard test `MessageId` for a validator-executor role, using the same
+    /// domain as [`create_message_id_for_test`].
+    pub(crate) fn validator_message_id(role: Role, validator_pubkey: PublicKeyBytes) -> MessageId {
+        MessageId::new(
+            &DomainType([0, 0, 0, 1]),
+            role,
+            &DutyExecutor::Validator(validator_pubkey),
+        )
     }
 
     // ---------------------------------------------------------------------

--- a/anchor/message_validator/src/lib.rs
+++ b/anchor/message_validator/src/lib.rs
@@ -329,7 +329,7 @@ impl ValidatedMessage {
 /// Context for topic-aware message validation.
 ///
 /// This enum makes explicit whether topic validation should be performed:
-/// - `SkipValidation`: Used for outgoing messages and tests where topic validation is not needed
+/// - `SkipValidation`: Used for tests where topic validation is not needed
 /// - `Validate`: Used for incoming network messages where topic validation is required
 ///
 /// For incoming network messages, always use `TopicContext::Validate`. If topic parsing
@@ -339,9 +339,7 @@ impl ValidatedMessage {
 pub enum TopicContext {
     /// Skip topic validation entirely.
     ///
-    /// Used for:
-    /// - Outgoing message self-validation (we calculate our own routing)
-    /// - Testing scenarios where topic context is irrelevant
+    /// Used for testing scenarios where topic context is irrelevant.
     #[default]
     SkipValidation,
 
@@ -386,6 +384,35 @@ pub struct Validator<S: SlotClock, D: DutiesProvider> {
     subnet_service: Arc<subnet_service::SubnetService<S>>,
     fork_schedule: Arc<ForkSchedule>,
     spec: Arc<ChainSpec>,
+}
+
+/// Perform stateless structural validation of an outbound message and return its routing slot.
+///
+/// This is not an authorization boundary. It deliberately excludes all network, duty, timing,
+/// fork-role, signature-verification, and validation-state checks. Outbound producers must enforce
+/// those invariants before constructing the message. Incoming messages continue through
+/// [`Validator::validate`], which owns gossip validation state.
+pub fn validate_outbound(message_data: &[u8]) -> Result<Slot, ValidationFailure> {
+    let signed_ssv_message = SignedSSVMessage::from_ssz_bytes(message_data)
+        .map_err(ValidationFailure::UndecodableMessageData)?;
+    validate_structure_and_role(&signed_ssv_message)?;
+    signed_ssv_message
+        .ssv_message()
+        .extract_slot()
+        .ok_or(ValidationFailure::UnknownMessageSlot)
+}
+
+fn validate_structure_and_role(
+    signed_ssv_message: &SignedSSVMessage,
+) -> Result<Role, ValidationFailure> {
+    signed_ssv_message
+        .validate()
+        .map_err(ValidationFailure::from)?;
+    signed_ssv_message
+        .ssv_message()
+        .msg_id()
+        .role()
+        .ok_or(ValidationFailure::InvalidRole)
 }
 
 impl<S: SlotClock + 'static, D: DutiesProvider> Validator<S, D> {
@@ -447,17 +474,8 @@ impl<S: SlotClock + 'static, D: DutiesProvider> Validator<S, D> {
         signed_ssv_message: &SignedSSVMessage,
         topic_context: &TopicContext,
     ) -> Result<ValidatedMessage, ValidationFailure> {
-        // Structural validation: signer/signature invariants, RSA size, etc.
-        signed_ssv_message
-            .validate()
-            .map_err(ValidationFailure::from)?;
-
-        // Get the role from message ID
+        let role = validate_structure_and_role(signed_ssv_message)?;
         let ssv_message = signed_ssv_message.ssv_message();
-        let role = ssv_message
-            .msg_id()
-            .role()
-            .ok_or(ValidationFailure::InvalidRole)?;
 
         // Get committee ID for topic validation
         let committee_id = match ssv_message.msg_id().duty_executor() {
@@ -1212,7 +1230,7 @@ pub(crate) fn hash_data(full_data: &[u8]) -> [u8; 32] {
 mod tests {
     use std::{collections::HashMap, sync::Arc};
 
-    use bls::{Hash256, PublicKeyBytes};
+    use bls::{Hash256, PublicKeyBytes, Signature};
     use duties_tracker::{DutiesProvider, DutyAssignment};
     use openssl::{
         hash::MessageDigest,
@@ -1227,15 +1245,129 @@ mod tests {
         domain_type::DomainType,
         message::{MsgType, SSVMessage, SignedSSVMessage},
         msgid::{DutyExecutor, MessageId, Role},
+        partial_sig::{PartialSignatureKind, PartialSignatureMessage, PartialSignatureMessages},
     };
     use ssz::Encode;
     use types::{Epoch, Slot};
 
-    use crate::{MessageAcceptance, ValidationFailure, hash_data};
+    use crate::{MessageAcceptance, ValidationFailure, hash_data, validate_outbound};
 
     // Constants for committee sizes in tests to improve readability.
     pub(crate) const SINGLE_NODE_COMMITTEE: usize = 1;
     pub(crate) const FOUR_NODE_COMMITTEE: usize = 4;
+
+    fn signed_test_message(
+        msg_type: MsgType,
+        message_id: MessageId,
+        data: Vec<u8>,
+    ) -> SignedSSVMessage {
+        let ssv_message = SSVMessage::new(msg_type, message_id, data)
+            .expect("test SSVMessage should be structurally valid");
+        SignedSSVMessage::new(
+            vec![[0xAA; RSA_SIGNATURE_SIZE]],
+            vec![OperatorId(1)],
+            ssv_message,
+            vec![],
+        )
+        .expect("test SignedSSVMessage should be structurally valid")
+    }
+
+    #[test]
+    fn validate_outbound_returns_nested_message_slots() {
+        let consensus_message_id = create_message_id_for_test(Role::Committee);
+        let mut qbft_message = QbftMessageBuilder::new(Role::Committee, QbftMessageType::Proposal)
+            .with_identifier(consensus_message_id.clone())
+            .build();
+        qbft_message.height = 42;
+        let signed_consensus_message = signed_test_message(
+            MsgType::SSVConsensusMsgType,
+            consensus_message_id,
+            qbft_message.as_ssz_bytes(),
+        );
+
+        assert_eq!(
+            validate_outbound(&signed_consensus_message.as_ssz_bytes()),
+            Ok(Slot::new(42))
+        );
+
+        let partial_signature_messages = PartialSignatureMessages {
+            kind: PartialSignatureKind::RandaoPartialSig,
+            slot: Slot::new(43),
+            messages: VariableList::new(vec![PartialSignatureMessage {
+                partial_signature: Signature::empty(),
+                signing_root: Hash256::ZERO,
+                signer: OperatorId(1),
+                validator_index: ValidatorIndex(0),
+            }])
+            .expect("one partial signature should fit"),
+        };
+        let signed_partial_signature_message = signed_test_message(
+            MsgType::SSVPartialSignatureMsgType,
+            create_message_id_for_test(Role::Proposer),
+            partial_signature_messages.as_ssz_bytes(),
+        );
+
+        assert_eq!(
+            validate_outbound(&signed_partial_signature_message.as_ssz_bytes()),
+            Ok(Slot::new(43))
+        );
+    }
+
+    #[test]
+    fn validate_outbound_rejects_malformed_outer_and_nested_messages() {
+        assert!(matches!(
+            validate_outbound(&[]),
+            Err(ValidationFailure::UndecodableMessageData(_))
+        ));
+
+        for (msg_type, role) in [
+            (MsgType::SSVConsensusMsgType, Role::Committee),
+            (MsgType::SSVPartialSignatureMsgType, Role::Proposer),
+        ] {
+            let signed_message =
+                signed_test_message(msg_type, create_message_id_for_test(role), vec![0x01]);
+            assert_eq!(
+                validate_outbound(&signed_message.as_ssz_bytes()),
+                Err(ValidationFailure::UnknownMessageSlot)
+            );
+        }
+    }
+
+    #[test]
+    fn validate_outbound_rejects_duplicate_signers() {
+        let qbft_message =
+            QbftMessageBuilder::new(Role::Committee, QbftMessageType::Proposal).build();
+        let mut signed_message =
+            create_signed_consensus_message(qbft_message, vec![OperatorId(1)], vec![], vec![]);
+        signed_message
+            .aggregate([signed_message.clone()])
+            .expect("aggregation permits duplicate signers for validation tests");
+
+        assert_eq!(
+            validate_outbound(&signed_message.as_ssz_bytes()),
+            Err(ValidationFailure::DuplicatedSigner)
+        );
+    }
+
+    #[test]
+    fn validate_outbound_rejects_invalid_role() {
+        let mut invalid_message_id = [0u8; 56];
+        invalid_message_id[4] = u8::MAX;
+        let invalid_message_id = MessageId::from(invalid_message_id);
+        let qbft_message = QbftMessageBuilder::new(Role::Committee, QbftMessageType::Proposal)
+            .with_identifier(invalid_message_id.clone())
+            .build();
+        let signed_message = signed_test_message(
+            MsgType::SSVConsensusMsgType,
+            invalid_message_id,
+            qbft_message.as_ssz_bytes(),
+        );
+
+        assert_eq!(
+            validate_outbound(&signed_message.as_ssz_bytes()),
+            Err(ValidationFailure::InvalidRole)
+        );
+    }
 
     /// Test that an `ExcessiveDutyCount` maps to `Ignore`.
     /// Duty-limit breach is a rate condition. An honest relayer can forward a message that

--- a/anchor/message_validator/src/partial_signature.rs
+++ b/anchor/message_validator/src/partial_signature.rs
@@ -203,13 +203,7 @@ fn validate_partial_sig_messages_by_duty_logic(
         }
     }
 
-    let is_randao_msg = partial_signature_messages.kind == PartialSignatureKind::RandaoPartialSig;
-    validate_beacon_duty(
-        validation_context,
-        message_slot,
-        is_randao_msg,
-        duty_provider.clone(),
-    )?;
+    validate_beacon_duty(validation_context, message_slot, duty_provider.as_ref())?;
 
     // Check if we've seen messages for this slot already
     if let Some(signer_state) = operator_state.get_signer_state(&message_slot) {
@@ -234,7 +228,7 @@ fn validate_partial_sig_messages_by_duty_logic(
         validation_context,
         message_slot,
         operator_state,
-        duty_provider.clone(),
+        duty_provider.as_ref(),
     )?;
 
     // Process role-specific message count constraints
@@ -357,18 +351,20 @@ mod tests {
         OperatorId, RSA_SIGNATURE_SIZE, ValidatorIndex, VariableList,
         domain_type::DomainType,
         message::{MsgType, SSVMessage, SignedSSVMessage},
+        msgid::MessageId,
         partial_sig::PartialSignatureMessage,
     };
     use ssz::Encode;
-    use types::{EthSpec, MainnetEthSpec, Slot};
+    use types::{ChainSpec, EthSpec, MainnetEthSpec, Slot};
 
     use super::*;
     use crate::{
         MessageAcceptance,
         tests::{
-            FOUR_NODE_COMMITTEE, MockDutiesProvider, assert_validation_error,
-            create_committee_info, create_message_id_for_test, create_operator_pub_keys,
-            generate_random_rsa_public_keys, spec_with_gloas,
+            FOUR_NODE_COMMITTEE, MockDutiesProvider, assert_proposer_assignment_result,
+            assert_validation_error, create_committee_info, create_message_id_for_test,
+            create_operator_pub_keys, generate_random_rsa_public_keys, nonzero_validator_pubkey,
+            spec_with_gloas, validator_message_id,
         },
     };
 
@@ -379,6 +375,8 @@ mod tests {
         pub different_message_signer: Option<OperatorId>,
         pub empty_messages: bool,
         pub validator_index: Option<ValidatorIndex>,
+        pub slot: Option<Slot>,
+        pub message_id: Option<MessageId>,
     }
 
     // Helper to create a partial signature message for testing
@@ -404,11 +402,13 @@ mod tests {
 
         let partial_sig_messages = PartialSignatureMessages {
             kind,
-            slot: Slot::new(0),
+            slot: options.slot.unwrap_or_default(),
             messages: VariableList::new(messages).unwrap(),
         };
 
-        let msg_id = create_message_id_for_test(role);
+        let msg_id = options
+            .message_id
+            .unwrap_or_else(|| create_message_id_for_test(role));
         let ssv_msg_data = partial_sig_messages.as_ssz_bytes();
         let ssv_msg = SSVMessage::new(MsgType::SSVPartialSignatureMsgType, msg_id, ssv_msg_data)
             .expect("SSVMessage should be created");
@@ -2074,27 +2074,16 @@ mod tests {
         operator_pub_keys: &'a HashMap<OperatorId, Rsa<Public>>,
         current_slot: Slot,
     ) -> ValidationContext<'a, ManualSlotClock> {
-        let now = SystemTime::now();
-        let slot_clock = ManualSlotClock::new(
-            current_slot,
-            now.duration_since(UNIX_EPOCH).unwrap(),
-            Duration::from_secs(12),
-        );
-
-        ValidationContext {
-            signed_ssv_message: signed_msg,
+        create_role_context(
+            signed_msg,
             committee_info,
-            role: Role::EnvelopeProposer,
-            received_at: now,
-            slots_per_epoch: SLOTS_PER_EPOCH_TEST,
-            epochs_per_sync_committee_period: 256,
-            sync_committee_size: 512,
-            slot_clock,
             operator_pub_keys,
-            fork_schedule: generate_fork_schedule(Fork::Boole),
+            current_slot,
+            Role::EnvelopeProposer,
+            Fork::Boole,
             // EnvelopeProposer only exists post-Gloas; activate from epoch 0.
-            spec: spec_with_gloas(Some(0)),
-        }
+            spec_with_gloas(Some(0)),
+        )
     }
 
     /// `EnvelopeProposer` only accepts the `PostConsensus` kind (the Gloas fork gate is
@@ -2337,6 +2326,39 @@ mod tests {
         SignedSSVMessage::new(vec![signature], vec![signer_id], ssv_msg, vec![]).unwrap()
     }
 
+    /// Builds a `ValidationContext` for `role` with the standard test knobs and a 12-second
+    /// `ManualSlotClock` reading `current_slot` now.
+    fn create_role_context<'a>(
+        signed_msg: &'a SignedSSVMessage,
+        committee_info: &'a crate::CommitteeInfo,
+        operator_pub_keys: &'a HashMap<OperatorId, Rsa<Public>>,
+        current_slot: Slot,
+        role: Role,
+        fork: Fork,
+        spec: Arc<ChainSpec>,
+    ) -> ValidationContext<'a, ManualSlotClock> {
+        let now = SystemTime::now();
+        let slot_clock = ManualSlotClock::new(
+            current_slot,
+            now.duration_since(UNIX_EPOCH).unwrap(),
+            Duration::from_secs(12),
+        );
+
+        ValidationContext {
+            signed_ssv_message: signed_msg,
+            committee_info,
+            role,
+            received_at: now,
+            slots_per_epoch: SLOTS_PER_EPOCH_TEST,
+            epochs_per_sync_committee_period: 256,
+            sync_committee_size: 512,
+            slot_clock,
+            operator_pub_keys,
+            fork_schedule: generate_fork_schedule(fork),
+            spec,
+        }
+    }
+
     /// Builds a ProposerPreferences validation context whose wall clock currently reads
     /// `current_slot`, with `received_at` pinned to the start of that slot. When the packet's
     /// envelope `proposal_slot` equals `current_slot` the message is exactly on time; when
@@ -2349,27 +2371,16 @@ mod tests {
         operator_pub_keys: &'a HashMap<OperatorId, Rsa<Public>>,
         current_slot: Slot,
     ) -> ValidationContext<'a, ManualSlotClock> {
-        let now = SystemTime::now();
-        let slot_clock = ManualSlotClock::new(
-            current_slot,
-            now.duration_since(UNIX_EPOCH).unwrap(),
-            Duration::from_secs(12),
-        );
-
-        ValidationContext {
-            signed_ssv_message: signed_msg,
+        create_role_context(
+            signed_msg,
             committee_info,
-            role: Role::ProposerPreferences,
-            received_at: now,
-            slots_per_epoch: SLOTS_PER_EPOCH_TEST,
-            epochs_per_sync_committee_period: 256,
-            sync_committee_size: 512,
-            slot_clock,
             operator_pub_keys,
-            fork_schedule: generate_fork_schedule(Fork::Boole),
+            current_slot,
+            Role::ProposerPreferences,
+            Fork::Boole,
             // ProposerPreferences only exists post-Gloas; activate from epoch 0.
-            spec: spec_with_gloas(Some(0)),
-        }
+            spec_with_gloas(Some(0)),
+        )
     }
 
     /// Slot duration used by the ProposerPreferences timing helpers/tests.
@@ -3286,107 +3297,95 @@ mod tests {
         );
     }
 
-    // ==================== ProposerPreferences proposer-assignment arm ====================
-    //
-    // `validate_beacon_duty` gained a `Role::ProposerPreferences` arm keyed on the envelope
-    // `proposal_slot`. It rejects with `NoDuty` (Ignore) only when the slot's epoch is known
-    // AND the validator is NOT the assigned proposer; an unknown epoch is tolerated (accepted),
-    // and no RANDAO tolerance applies. These three cases drive the mock's
-    // `is_epoch_known_for_proposers` / `is_validator_proposer_at_slot`.
-
-    /// Runs the full ProposerPreferences pipeline with a mock configured for the given
-    /// proposer-assignment knobs, returning the validation result.
-    fn run_proposer_preferences_with_duties(
-        epoch_known_for_proposers: bool,
-        validator_is_proposer: bool,
+    fn run_proposer_partial_signature_with_assignment(
+        kind: PartialSignatureKind,
+        slot: Slot,
+        proposer_assignment: DutyAssignment,
     ) -> Result<ValidatedSSVMessage, ValidationFailure> {
-        let committee_info = create_committee_info(FOUR_NODE_COMMITTEE);
-        let (private_key, public_key) = generate_test_key_pair();
-        let map =
-            create_operator_pub_keys(committee_info.committee_members.clone(), vec![public_key]);
-        let signed_msg = create_signed_proposer_preferences_message(
-            OperatorId(1),
-            &private_key,
-            Slot::new(1),
-            Hash256::from([0x33; 32]),
-        );
-        let validation_context =
-            create_proposer_preferences_context(&signed_msg, &committee_info, &map, Slot::new(1));
+        let (mut committee_info, private_key, operator_pub_keys) =
+            four_node_committee_and_keypair();
+        committee_info.validator_indices.clear();
 
-        validate_partial_signature_message(
+        let validator_pubkey = nonzero_validator_pubkey(0xAB);
+        let message_id = validator_message_id(Role::Proposer, validator_pubkey);
+        let (_, signed_message) = create_test_partial_signature(
+            Role::Proposer,
+            kind,
+            OperatorId(1),
+            PartialSigTestOptions {
+                slot: Some(slot),
+                message_id: Some(message_id),
+                ..Default::default()
+            },
+            Some(private_key),
+        );
+
+        let validation_context = create_role_context(
+            &signed_message,
+            &committee_info,
+            &operator_pub_keys,
+            slot,
+            Role::Proposer,
+            Fork::Alan,
+            spec_with_gloas(None),
+        );
+
+        let duty_provider = Arc::new(MockDutiesProvider::expecting_proposer_query(
+            slot,
+            validator_pubkey,
+            proposer_assignment,
+        ));
+        let result = validate_partial_signature_message(
             validation_context,
             &mut DutyState::new(64),
-            Arc::new(MockDutiesProvider {
-                // Map the two legacy knobs onto the pubkey-keyed lookup the arm now uses:
-                // an unfetched epoch is `None` (tolerated), a fetched epoch reports
-                // `Some(is the validator the assigned proposer)`.
-                proposer_assignment: proposer_assignment_from_knobs(
-                    epoch_known_for_proposers,
-                    validator_is_proposer,
-                ),
-                ..Default::default()
-            }),
-        )
+            duty_provider.clone(),
+        );
+        duty_provider.assert_query_count(1);
+        result
     }
 
-    /// Maps the legacy `is_epoch_known_for_proposers` / `is_validator_proposer_at_slot`
-    /// knobs onto the `proposer_assignment_at_slot` return the arm now consumes:
-    /// unknown epoch -> `Unknown` (tolerated), known epoch -> `Assigned` / `NotAssigned`.
-    fn proposer_assignment_from_knobs(epoch_known: bool, is_proposer: bool) -> DutyAssignment {
-        match (epoch_known, is_proposer) {
-            (false, _) => DutyAssignment::Unknown,
-            (true, true) => DutyAssignment::Assigned,
-            (true, false) => DutyAssignment::NotAssigned,
+    #[test]
+    fn proposer_partial_signatures_use_pubkey_assignment_without_validator_indices() {
+        for kind in [
+            PartialSignatureKind::RandaoPartialSig,
+            PartialSignatureKind::PostConsensus,
+        ] {
+            for assignment in [
+                DutyAssignment::Assigned,
+                DutyAssignment::Unknown,
+                DutyAssignment::NotAssigned,
+            ] {
+                let result =
+                    run_proposer_partial_signature_with_assignment(kind, Slot::new(1), assignment);
+                assert_proposer_assignment_result(
+                    result,
+                    assignment,
+                    &format!("proposer {kind:?} assignment"),
+                );
+            }
         }
     }
 
     #[test]
-    fn test_proposer_preferences_assigned_proposer_accepted() {
-        // Known epoch + validator IS the assigned proposer → accepted.
-        let result = run_proposer_preferences_with_duties(true, true);
-        assert!(
-            result.is_ok(),
-            "Expected assigned proposer to be accepted, got: {result:?}"
-        );
+    fn proposer_randao_unknown_policy_is_independent_of_epoch_boundary() {
+        for slot in [Slot::new(0), Slot::new(1)] {
+            let result = run_proposer_partial_signature_with_assignment(
+                PartialSignatureKind::RandaoPartialSig,
+                slot,
+                DutyAssignment::Unknown,
+            );
+            assert!(
+                result.is_ok(),
+                "Unknown proposer RANDAO should be accepted at slot {slot}, got {result:?}"
+            );
+        }
     }
 
-    #[test]
-    fn test_proposer_preferences_known_epoch_not_assigned_no_duty() {
-        // Known epoch + validator is NOT the assigned proposer → `NoDuty` (maps to Ignore).
-        let result = run_proposer_preferences_with_duties(true, false);
-        assert_validation_error(
-            result,
-            |failure| matches!(failure, ValidationFailure::NoDuty),
-            "NoDuty (known epoch, validator not the assigned proposer)",
-        );
-        // Pin the Ignore mapping so a future reclassification of NoDuty is caught here.
-        // `MessageAcceptance` does not implement `PartialEq`, so match on the variant.
-        assert!(
-            matches!(
-                MessageAcceptance::from(&ValidationFailure::NoDuty),
-                MessageAcceptance::Ignore
-            ),
-            "NoDuty must map to Ignore"
-        );
-    }
+    // ==================== ProposerPreferences proposer-assignment arm ====================
 
-    #[test]
-    fn test_proposer_preferences_unknown_epoch_tolerated() {
-        // Unknown epoch → the assignment check is skipped and the message is accepted
-        // (tolerated while proposer duties for that epoch are not yet fetched). The
-        // not-assigned flag is irrelevant here because the `&&` short-circuits on the
-        // unknown epoch.
-        let result = run_proposer_preferences_with_duties(false, false);
-        assert!(
-            result.is_ok(),
-            "Expected unknown-epoch ProposerPreferences to be tolerated (accepted), got: {result:?}"
-        );
-    }
-
-    /// Runs the full ProposerPreferences pipeline, driving `proposer_assignment_at_slot`
-    /// DIRECTLY with `proposer_assignment` (rather than via the legacy knob mapping) and
-    /// allowing the caller to supply the `committee_info`. This pins the pubkey-keyed arm
-    /// introduced in #1142, which no longer consults `committee_info.validator_indices`.
+    /// Runs the full ProposerPreferences pipeline with the supplied assignment and committee info.
+    /// This pins the pubkey-keyed arm introduced in #1142, which no longer consults
+    /// `committee_info.validator_indices`.
     fn run_proposer_preferences_with_assignment(
         committee_info: crate::CommitteeInfo,
         proposer_assignment: DutyAssignment,
@@ -3440,11 +3439,9 @@ mod tests {
         );
     }
 
-    /// Runs the full `EnvelopeProposer` (role 9) partial-signature pipeline, driving
-    /// `proposer_assignment_at_slot` DIRECTLY with `proposer_assignment` and allowing the caller
-    /// to supply the `committee_info`. Mirrors `run_proposer_preferences_with_assignment` for the
-    /// shared `Role::ProposerPreferences | Role::EnvelopeProposer` arm, which is keyed on the
-    /// message-id validator PUBKEY and does not consult `committee_info.validator_indices`.
+    /// Runs the full `EnvelopeProposer` partial-signature pipeline with the supplied assignment and
+    /// committee info. Mirrors `run_proposer_preferences_with_assignment` for the shared
+    /// pubkey-keyed proposer-duty check.
     fn run_envelope_proposer_with_assignment(
         committee_info: crate::CommitteeInfo,
         proposer_assignment: DutyAssignment,
@@ -3499,7 +3496,7 @@ mod tests {
     }
 
     #[test]
-    fn test_proposer_preferences_assignment_some_true_accepted() {
+    fn test_proposer_preferences_assigned_is_accepted() {
         // #1142: `proposer_assignment_at_slot` == `Assigned` (assigned proposer) -> accepted.
         // Arrange
         let committee_info = create_committee_info(FOUR_NODE_COMMITTEE);
@@ -3514,7 +3511,7 @@ mod tests {
     }
 
     #[test]
-    fn test_proposer_preferences_assignment_some_false_no_duty_maps_to_ignore() {
+    fn test_proposer_preferences_not_assigned_returns_no_duty() {
         // #1142: `proposer_assignment_at_slot` == `NotAssigned` (fetched epoch proves the pubkey
         // is NOT the proposer at this slot) -> `NoDuty`, which must map to `Ignore`.
         // Arrange
@@ -3538,7 +3535,7 @@ mod tests {
     }
 
     #[test]
-    fn test_proposer_preferences_assignment_none_tolerated() {
+    fn test_proposer_preferences_unknown_is_accepted() {
         // #1142: `proposer_assignment_at_slot` == `Unknown` (slot's epoch not fetched / unknown) ->
         // tolerated (accepted). Only `NotAssigned` rejects.
         // Arrange
@@ -3551,53 +3548,6 @@ mod tests {
             result.is_ok(),
             "Expected `Unknown` (unfetched epoch) assignment to be tolerated (accepted), got: \
              {result:?}"
-        );
-    }
-
-    #[test]
-    fn test_proposer_role_still_uses_index_path_not_pubkey_assignment() {
-        // Regression pin for #1142: the INDEX-based `Role::Proposer` arm of `validate_beacon_duty`
-        // is unchanged. It must decide purely on `is_validator_proposer_at_slot` (the index-keyed
-        // lookup), independent of the new pubkey-keyed `proposer_assignment_at_slot`. We prove the
-        // separation by driving the two lookups to OPPOSITE verdicts:
-        //   - `proposer_assignment = DutyAssignment::Assigned` (the pubkey arm would ACCEPT), yet
-        //   - `validator_is_proposer = false`  (the index arm must REJECT with `NoDuty`).
-        // The Proposer path must reject, showing it never consulted the pubkey assignment.
-        let committee_info = create_committee_info(FOUR_NODE_COMMITTEE);
-        let (_, signed_msg) = create_test_partial_signature(
-            Role::Proposer,
-            PartialSignatureKind::PostConsensus,
-            OperatorId(1),
-            PartialSigTestOptions::default(),
-            None,
-        );
-        let binding = generate_random_rsa_public_keys(signed_msg.operator_ids().len());
-        let map = create_operator_pub_keys(committee_info.committee_members.clone(), binding);
-        let validation_context = create_test_validation_context(
-            &signed_msg,
-            &committee_info,
-            Role::Proposer,
-            &map,
-            generate_fork_schedule(Fork::Alan),
-        );
-
-        // Act: `randao_msg = false` so the Proposer arm goes straight to the index check.
-        let result = validate_beacon_duty(
-            &validation_context,
-            Slot::new(0),
-            false,
-            Arc::new(MockDutiesProvider {
-                validator_is_proposer: false,
-                proposer_assignment: DutyAssignment::Assigned,
-                ..Default::default()
-            }),
-        );
-
-        // Assert: rejected by the index arm; the pubkey `Assigned` did not rescue it.
-        assert_validation_error(
-            result,
-            |failure| matches!(failure, ValidationFailure::NoDuty),
-            "NoDuty (Role::Proposer index path unchanged, ignores pubkey assignment)",
         );
     }
 
@@ -3815,17 +3765,9 @@ mod tests {
 
     // ==================== EnvelopeProposer proposer-assignment arm ====================
     //
-    // `validate_beacon_duty`'s `Role::ProposerPreferences | Role::EnvelopeProposer` arm (keyed on
-    // the message's `slot`) rejects with `NoDuty` only when the slot's epoch is known AND the
-    // validator is NOT the assigned proposer; an unknown epoch is tolerated and no RANDAO
-    // tolerance applies.
-
-    /// Runs the `EnvelopeProposer` proposer-assignment arm of `validate_beacon_duty` with the
-    /// mock's two knobs, returning the result for the caller to assert on. `randao_msg` is always
-    /// false for `EnvelopeProposer` (no RANDAO tolerance applies).
+    // The assignment check rejects only `NotAssigned`. `Assigned` and `Unknown` continue.
     fn run_envelope_beacon_duty(
-        epoch_known: bool,
-        is_proposer: bool,
+        proposer_assignment: DutyAssignment,
     ) -> Result<(), ValidationFailure> {
         let (committee_info, private_key, map) = four_node_committee_and_keypair();
         let signed_msg = create_signed_envelope_proposer_message(
@@ -3840,39 +3782,35 @@ mod tests {
         validate_beacon_duty(
             &validation_context,
             Slot::new(0),
-            false,
-            Arc::new(MockDutiesProvider {
-                proposer_assignment: proposer_assignment_from_knobs(epoch_known, is_proposer),
+            &MockDutiesProvider {
+                proposer_assignment,
                 ..Default::default()
-            }),
+            },
         )
     }
 
     #[test]
-    fn envelope_proposer_tolerates_unknown_proposer_epoch() {
-        // Before the epoch's proposer duties are fetched, tolerate (Ok), not drop as NoDuty.
-        let result = run_envelope_beacon_duty(false, false);
+    fn envelope_proposer_unknown_is_accepted() {
+        let result = run_envelope_beacon_duty(DutyAssignment::Unknown);
         assert!(
             result.is_ok(),
-            "unknown proposer epoch must be tolerated for EnvelopeProposer, got: {result:?}"
+            "Unknown assignment must be accepted for EnvelopeProposer, got: {result:?}"
         );
     }
 
     #[test]
-    fn envelope_proposer_known_epoch_non_proposer_is_no_duty() {
-        // Known epoch, not the assigned proposer -> reject with NoDuty.
-        let result = run_envelope_beacon_duty(true, false);
+    fn envelope_proposer_not_assigned_returns_no_duty() {
+        let result = run_envelope_beacon_duty(DutyAssignment::NotAssigned);
         assert_validation_error(
             result,
             |failure| matches!(failure, ValidationFailure::NoDuty),
-            "NoDuty (known epoch, validator not the assigned proposer)",
+            "NoDuty (NotAssigned proposer assignment)",
         );
     }
 
     #[test]
-    fn envelope_proposer_known_epoch_proposer_ok() {
-        // Known epoch and the assigned proposer -> accept.
-        let result = run_envelope_beacon_duty(true, true);
+    fn envelope_proposer_assigned_is_accepted() {
+        let result = run_envelope_beacon_duty(DutyAssignment::Assigned);
         assert!(
             result.is_ok(),
             "Expected assigned proposer to be accepted for EnvelopeProposer, got: {result:?}"

--- a/anchor/network/src/network.rs
+++ b/anchor/network/src/network.rs
@@ -22,7 +22,7 @@ use libp2p::{
     swarm::{SwarmEvent, dial_opts::DialOpts},
     upnp::Event,
 };
-use message_receiver::{MessageReceiver, Outcome, TopicContext};
+use message_receiver::{MessageReceiver, Outcome};
 use prometheus_client::registry::Registry;
 use subnet_service::{SUBNET_COUNT, SubnetId, TopicEvent, topic};
 use task_executor::TaskExecutor;
@@ -319,23 +319,20 @@ impl<R: MessageReceiver> Network<R> {
             "Received SignedSSVMessage"
         );
 
-        // Build topic context for fork-aware validation.
+        // Parse the topic for fork-aware validation.
         // If we can't parse the topic, reject immediately - we only
         // subscribe to topics we create, so parsing should always succeed.
-        let topic_context = match topic::parse_topic(&message.topic) {
-            Some(parsed) => TopicContext::Validate { parsed },
-            None => {
-                warn!(
-                    topic = ?message.topic,
-                    "Received message on unparseable topic - this is a bug"
-                );
-                return;
-            }
+        let Some(parsed_topic) = topic::parse_topic(&message.topic) else {
+            warn!(
+                topic = ?message.topic,
+                "Received message on unparseable topic - this is a bug"
+            );
+            return;
         };
 
         if let Err(err) =
             self.message_receiver
-                .receive(propagation_source, message_id, message, topic_context)
+                .receive(propagation_source, message_id, message, parsed_topic)
         {
             error!(?err, "Unable to pass message to message receiver");
         }

--- a/anchor/qbft_manager/Cargo.toml
+++ b/anchor/qbft_manager/Cargo.toml
@@ -8,6 +8,7 @@ edition = { workspace = true }
 bls = { workspace = true }
 dashmap = { workspace = true }
 database = { workspace = true }
+duties_tracker = { workspace = true }
 ethereum_ssz = { workspace = true }
 fork = { workspace = true }
 message_sender = { workspace = true }

--- a/anchor/qbft_manager/src/lib.rs
+++ b/anchor/qbft_manager/src/lib.rs
@@ -3,6 +3,7 @@ use std::{fmt::Debug, future::Future, hash::Hash, num::NonZeroU64, sync::Arc};
 use bls::PublicKeyBytes;
 use dashmap::DashMap;
 use database::OwnOperatorId;
+use duties_tracker::DutyAssignment;
 use fork::{Fork, ForkSchedule};
 use message_sender::MessageSender;
 use processor::{Error::Queue, Senders, work::DropOnFinish};
@@ -119,6 +120,36 @@ pub enum QbftMessageKind<D: QbftData> {
     // deserialization we determine the message is for the qbft instance and decode it into a
     // wrapped qbft message consisting of the signed message and the qbft message
     NetworkMessage(WrappedQbftMessage),
+}
+
+/// Result of dispatching a network message to a QBFT instance.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum QbftDispatchOutcome {
+    /// The processor accepted work that will try to send the message to the instance.
+    ///
+    /// The instance sender may close before that work runs, so this does not guarantee delivery
+    /// to the per-instance channel.
+    ProcessorEnqueued,
+    /// The duty view was unknown and no matching instance already existed.
+    DroppedMissingInstance,
+    /// The current duty view authoritatively excludes this validator and slot.
+    DroppedNotAssigned,
+}
+
+#[derive(Debug, Clone, Copy)]
+enum InstanceAccess {
+    GetOrSpawn,
+    ExistingOnly,
+}
+
+impl InstanceAccess {
+    fn for_proposer_assignment(assignment: DutyAssignment) -> Option<Self> {
+        match assignment {
+            DutyAssignment::Assigned => Some(Self::GetOrSpawn),
+            DutyAssignment::Unknown => Some(Self::ExistingOnly),
+            DutyAssignment::NotAssigned => None,
+        }
+    }
 }
 
 /// Represents the initialization data required to start a new QBFT instance.
@@ -284,29 +315,56 @@ impl<E: EthSpec, S: SlotClock + Clone + 'static> QbftManager<E, S> {
         Ok(result_receiver.await?)
     }
 
-    /// Send a new network message to the instance
-    pub fn receive_data(
+    /// Dispatch a network message using the latest proposer-duty view.
+    ///
+    /// Proposer and fork-active envelope-proposer messages query the supplied assignment source
+    /// exactly once. Assigned messages may create an instance, Unknown messages require an
+    /// existing instance, and NotAssigned messages are dropped before map access. Other QBFT roles
+    /// retain their existing receive-or-spawn behavior and do not query proposer duties.
+    pub fn receive_network_message(
         &self,
         full_message: SignedSSVMessage,
         qbft_message: ssv_types::consensus::QbftMessage,
-    ) -> Result<(), QbftError> {
+        proposer_assignment_at_slot: impl FnOnce(Slot, &PublicKeyBytes) -> DutyAssignment,
+    ) -> Result<QbftDispatchOutcome, QbftError> {
         let msg_id = full_message.ssv_message().msg_id();
         let instance_height = (qbft_message.height as usize).into();
+        let slot = Slot::new(qbft_message.height);
 
         match msg_id.duty_executor() {
             Some(DutyExecutor::Validator(validator)) => {
-                let duty = match msg_id.role() {
-                    Some(Role::Proposer) => ValidatorDutyKind::Proposal,
-                    Some(Role::Aggregator) => ValidatorDutyKind::Aggregator,
-                    Some(Role::SyncCommittee) => ValidatorDutyKind::SyncCommitteeAggregator,
+                let (duty, instance_access) = match msg_id.role() {
+                    Some(Role::Proposer) => {
+                        let Some(instance_access) =
+                            InstanceAccess::for_proposer_assignment(
+                                proposer_assignment_at_slot(slot, &validator),
+                            )
+                        else {
+                            return Ok(QbftDispatchOutcome::DroppedNotAssigned);
+                        };
+                        (ValidatorDutyKind::Proposal, instance_access)
+                    }
+                    Some(Role::Aggregator) => {
+                        (ValidatorDutyKind::Aggregator, InstanceAccess::GetOrSpawn)
+                    }
+                    Some(Role::SyncCommittee) => (
+                        ValidatorDutyKind::SyncCommitteeAggregator,
+                        InstanceAccess::GetOrSpawn,
+                    ),
                     Some(Role::EnvelopeProposer) => {
-                        let slot = types::Slot::new(qbft_message.height);
                         // Defense in depth behind `validate_role_for_fork`: envelope QBFT
                         // exists only post-Gloas.
                         if !self.gloas_enabled_at_slot(slot) {
                             warn!(%slot, "Ignoring EnvelopeProposer message before Gloas fork");
                             return Err(QbftError::RoleNotActive);
                         }
+                        let Some(instance_access) =
+                            InstanceAccess::for_proposer_assignment(
+                                proposer_assignment_at_slot(slot, &validator),
+                            )
+                        else {
+                            return Ok(QbftDispatchOutcome::DroppedNotAssigned);
+                        };
                         let id = EnvelopeProposerInstanceId {
                             validator,
                             instance_height,
@@ -317,6 +375,7 @@ impl<E: EthSpec, S: SlotClock + Clone + 'static> QbftManager<E, S> {
                                 signed_message: full_message,
                                 qbft_message,
                             },
+                            instance_access,
                         );
                     }
                     // Committee roles use DutyExecutor::Committee, not Validator
@@ -341,12 +400,12 @@ impl<E: EthSpec, S: SlotClock + Clone + 'static> QbftManager<E, S> {
                         signed_message: full_message,
                         qbft_message,
                     },
+                    instance_access,
                 )
             }
             Some(DutyExecutor::Committee(committee)) => {
                 match msg_id.role() {
                     Some(Role::Committee) => {
-                        let slot = types::Slot::new(qbft_message.height);
                         let id = CommitteeInstanceId {
                             committee,
                             instance_height,
@@ -358,14 +417,21 @@ impl<E: EthSpec, S: SlotClock + Clone + 'static> QbftManager<E, S> {
 
                         // Gate the Gloas beacon-vote shape on Ethereum's Gloas (ePBS) fork using Ethereum consensus spec.
                         if self.gloas_enabled_at_slot(slot) {
-                            self.pass_to_instance::<GloasBeaconVote>(id, wrapped)
+                            self.pass_to_instance::<GloasBeaconVote>(
+                                id,
+                                wrapped,
+                                InstanceAccess::GetOrSpawn,
+                            )
                         } else {
-                            self.pass_to_instance::<BeaconVote>(id, wrapped)
+                            self.pass_to_instance::<BeaconVote>(
+                                id,
+                                wrapped,
+                                InstanceAccess::GetOrSpawn,
+                            )
                         }
                     }
                     Some(Role::AggregatorCommittee) => {
                         // Route to aggregator committee instances with fork gating
-                        let slot = types::Slot::new(qbft_message.height);
                         let epoch = slot.epoch(E::slots_per_epoch());
 
                         // Fork gating: Reject before Boole
@@ -384,6 +450,7 @@ impl<E: EthSpec, S: SlotClock + Clone + 'static> QbftManager<E, S> {
                                 signed_message: full_message,
                                 qbft_message,
                             },
+                            InstanceAccess::GetOrSpawn,
                         )
                     }
                     // Validator roles should use DutyExecutor::Validator, not
@@ -412,8 +479,18 @@ impl<E: EthSpec, S: SlotClock + Clone + 'static> QbftManager<E, S> {
         &self,
         id: D::Id,
         data: WrappedQbftMessage,
-    ) -> Result<(), QbftError> {
-        let sender = D::get_or_spawn_instance(self, id);
+        instance_access: InstanceAccess,
+    ) -> Result<QbftDispatchOutcome, QbftError> {
+        let sender = match instance_access {
+            InstanceAccess::GetOrSpawn => D::get_or_spawn_instance(self, id),
+            InstanceAccess::ExistingOnly => {
+                let Some(sender) = D::get_map(self).get(&id).map(|entry| entry.value().clone())
+                else {
+                    return Ok(QbftDispatchOutcome::DroppedMissingInstance);
+                };
+                sender
+            }
+        };
         self.processor.urgent_consensus.send_immediate(
             move |drop_on_finish: DropOnFinish| {
                 let _ = sender.send(QbftMessage {
@@ -423,7 +500,7 @@ impl<E: EthSpec, S: SlotClock + Clone + 'static> QbftManager<E, S> {
             },
             QBFT_MESSAGE_NAME,
         )?;
-        Ok(())
+        Ok(QbftDispatchOutcome::ProcessorEnqueued)
     }
 
     // Long running cleaner that will remove instances that are no longer relevant
@@ -496,8 +573,8 @@ pub trait QbftDecidable<E: EthSpec>: QbftData<Hash = Hash256> + Send + Sync + 's
         match map.entry(id) {
             dashmap::Entry::Occupied(entry) => entry.get().clone(),
             dashmap::Entry::Vacant(entry) => {
-                // There is not an instance running yet, store the sender and spawn a new instance
-                // with the receiver
+                // There is no instance entry yet. Store the sender, then attempt to schedule the
+                // instance receiver.
                 let (tx, rx) = mpsc::unbounded_channel();
                 let span = debug_span!("qbft_instance", instance_id = ?entry.key());
                 let tx = entry.insert(tx);

--- a/anchor/qbft_manager/src/tests.rs
+++ b/anchor/qbft_manager/src/tests.rs
@@ -5,6 +5,7 @@ use std::{
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
+use duties_tracker::DutyAssignment;
 use fork::{Fork, ForkSchedule};
 use message_sender::testing::MockMessageSender;
 use processor::Senders;
@@ -37,13 +38,73 @@ use super::{
     CommitteeInstanceId, Completed, QbftDecidable, QbftError, QbftInitialization, QbftManager,
     QbftMessageKind, TimeoutMode, WrappedQbftMessage,
 };
-use crate::instance::qbft_instance;
+use crate::{InstanceAccess, instance::qbft_instance};
 
 mod aggregator_tests;
 mod envelope_dispatch_tests;
 mod gloas_dispatch_tests;
+mod receive_mode_tests;
 mod setup;
 mod timeout_tests;
+
+/// Build a distinct, non-zero test validator pubkey from a fill byte.
+///
+/// A zero byte is rejected: an all-zero key equals `PublicKeyBytes::empty()`, which makes
+/// wrong-key and executor round-trip assertions vacuous.
+fn validator_pubkey(byte: u8) -> bls::PublicKeyBytes {
+    assert_ne!(byte, 0, "test pubkeys must be non-zero");
+    bls::PublicKeyBytes::deserialize(&[byte; bls::PUBLIC_KEY_BYTES_LEN])
+        .expect("48-byte input is a valid PublicKeyBytes")
+}
+
+fn assigned_proposer_duty(_: Slot, _: &bls::PublicKeyBytes) -> DutyAssignment {
+    DutyAssignment::Assigned
+}
+
+fn unexpected_proposer_duty_lookup(_: Slot, _: &bls::PublicKeyBytes) -> DutyAssignment {
+    panic!("this role must not query proposer duties")
+}
+
+/// Build a signed consensus (`SignedSSVMessage`, `QbftMessage`) pair for `role` and `executor`
+/// at the given slot height, signed by `OperatorId(1)` with a dummy RSA signature.
+fn build_signed_consensus_pair(
+    role: Role,
+    executor: &DutyExecutor,
+    message_type: QbftMessageType,
+    height: u64,
+) -> (SignedSSVMessage, QbftMessage) {
+    use ssv_types::{
+        RSA_SIGNATURE_SIZE,
+        message::{MsgType, SSVMessage},
+    };
+    use ssz::Encode;
+
+    let msg_id = MessageId::new(&DomainType([0; 4]), role, executor);
+    let qbft_message = QbftMessage {
+        qbft_message_type: message_type,
+        height,
+        round: 1,
+        identifier: (&msg_id).into(),
+        root: Hash256::ZERO,
+        data_round: 1,
+        round_change_justification: ssv_types::VariableList::empty(),
+        prepare_justification: ssv_types::VariableList::empty(),
+    };
+    let ssv_msg = SSVMessage::new(
+        MsgType::SSVConsensusMsgType,
+        msg_id,
+        qbft_message.as_ssz_bytes(),
+    )
+    .expect("SSVMessage creation should succeed");
+    let signed_msg = SignedSSVMessage::new(
+        vec![[0xAA; RSA_SIGNATURE_SIZE]],
+        vec![OperatorId(1)],
+        ssv_msg,
+        vec![],
+    )
+    .expect("SignedSSVMessage creation should succeed");
+    (signed_msg, qbft_message)
+}
 
 /// The time we wait at most for consensus results until the test times out. Note that this is not
 /// real time, but simulated time, if the test is started with `start_paused = true`
@@ -594,7 +655,11 @@ where
             }
 
             for message in &messages {
-                let _ = manager.pass_to_instance::<D>(data_id.clone(), message.clone());
+                let _ = manager.pass_to_instance::<D>(
+                    data_id.clone(),
+                    message.clone(),
+                    InstanceAccess::GetOrSpawn,
+                );
             }
         }
     }
@@ -886,15 +951,6 @@ mod manager_tests {
     /// Verifies the fork gating allows messages through when Boole is active.
     #[tokio::test]
     async fn test_aggregator_committee_accepted_after_boole() {
-        use fork::{Fork, ForkSchedule};
-        use message_sender::testing::MockMessageSender;
-        use ssv_types::{
-            RSA_SIGNATURE_SIZE,
-            consensus::{QbftMessage, QbftMessageType},
-            message::{MsgType, SSVMessage, SignedSSVMessage},
-        };
-        use ssz::Encode;
-
         let setup = setup_test(1);
 
         // Create fork schedule with Boole active at epoch 0
@@ -918,48 +974,20 @@ mod manager_tests {
         )
         .expect("Manager creation should succeed");
 
-        // Create an AggregatorCommittee message
-        let msg_id = MessageId::new(
-            &DomainType([0; 4]),
+        // Create an AggregatorCommittee message. Any slot works: Boole is active from epoch 0.
+        let (signed_msg, qbft_message) = build_signed_consensus_pair(
             Role::AggregatorCommittee,
             &DutyExecutor::Committee(CommitteeId([0; 32])),
+            QbftMessageType::Proposal,
+            100,
         );
 
-        let qbft_message = QbftMessage {
-            qbft_message_type: QbftMessageType::Proposal,
-            height: 100, // Any slot, Boole is active from epoch 0
-            round: 1,
-            identifier: (&msg_id).into(),
-            root: Hash256::from([0u8; 32]),
-            data_round: 1,
-            round_change_justification: ssv_types::VariableList::empty(),
-            prepare_justification: ssv_types::VariableList::empty(),
-        };
-
-        let ssv_msg = SSVMessage::new(
-            MsgType::SSVConsensusMsgType,
-            msg_id,
-            qbft_message.as_ssz_bytes(),
-        )
-        .expect("SSVMessage creation should succeed");
-
-        let signed_msg = SignedSSVMessage::new(
-            vec![[0xAA; RSA_SIGNATURE_SIZE]],
-            vec![OperatorId(1)],
-            ssv_msg,
-            vec![],
-        )
-        .expect("SignedSSVMessage creation should succeed");
-
-        // Call receive_data - should NOT return RoleNotActive
-        let result = manager.receive_data(signed_msg, qbft_message);
-
-        // It might return Ok or some other error (e.g., no instance running),
-        // but critically it should NOT be RoleNotActive
-        assert!(
-            !matches!(result, Err(QbftError::RoleNotActive)),
-            "Should not return RoleNotActive after Boole fork, got: {:?}",
-            result
+        let result = manager.receive_network_message(
+            signed_msg,
+            qbft_message,
+            unexpected_proposer_duty_lookup,
         );
+
+        result.expect("AggregatorCommittee should dispatch after Boole");
     }
 }

--- a/anchor/qbft_manager/src/tests/aggregator_tests.rs
+++ b/anchor/qbft_manager/src/tests/aggregator_tests.rs
@@ -4,15 +4,6 @@ use super::{setup::setup_test, *};
 /// This is a critical security test - the role should not be processed until Boole is active.
 #[tokio::test]
 async fn test_aggregator_committee_rejected_before_boole() {
-    use fork::ForkSchedule;
-    use message_sender::testing::MockMessageSender;
-    use ssv_types::{
-        RSA_SIGNATURE_SIZE,
-        consensus::{QbftMessage, QbftMessageType},
-        message::{MsgType, SSVMessage, SignedSSVMessage},
-    };
-    use ssz::Encode;
-
     let setup = setup_test(1);
 
     // Create QbftManager with default fork schedule (no Boole)
@@ -34,41 +25,16 @@ async fn test_aggregator_committee_rejected_before_boole() {
     )
     .expect("Manager creation should succeed");
 
-    // Create an AggregatorCommittee message
-    let msg_id = MessageId::new(
-        &DomainType([0; 4]),
+    // Create an AggregatorCommittee message at slot 100, well before any Boole epoch.
+    let (signed_msg, qbft_message) = build_signed_consensus_pair(
         Role::AggregatorCommittee,
         &DutyExecutor::Committee(CommitteeId([0; 32])),
+        QbftMessageType::Proposal,
+        100,
     );
 
-    let qbft_message = QbftMessage {
-        qbft_message_type: QbftMessageType::Proposal,
-        height: 100, // Slot 100, well before any Boole epoch
-        round: 1,
-        identifier: (&msg_id).into(),
-        root: Hash256::from([0u8; 32]),
-        data_round: 1,
-        round_change_justification: ssv_types::VariableList::empty(),
-        prepare_justification: ssv_types::VariableList::empty(),
-    };
-
-    let ssv_msg = SSVMessage::new(
-        MsgType::SSVConsensusMsgType,
-        msg_id,
-        qbft_message.as_ssz_bytes(),
-    )
-    .expect("SSVMessage creation should succeed");
-
-    let signed_msg = SignedSSVMessage::new(
-        vec![[0xAA; RSA_SIGNATURE_SIZE]],
-        vec![OperatorId(1)],
-        ssv_msg,
-        vec![],
-    )
-    .expect("SignedSSVMessage creation should succeed");
-
-    // Call receive_data - should return RoleNotActive
-    let result = manager.receive_data(signed_msg, qbft_message);
+    let result =
+        manager.receive_network_message(signed_msg, qbft_message, unexpected_proposer_duty_lookup);
 
     assert!(
         matches!(result, Err(QbftError::RoleNotActive)),

--- a/anchor/qbft_manager/src/tests/envelope_dispatch_tests.rs
+++ b/anchor/qbft_manager/src/tests/envelope_dispatch_tests.rs
@@ -1,20 +1,18 @@
 //! `Role::EnvelopeProposer` dispatch tests for the Ethereum Gloas (ePBS) fork.
 //!
-//! These exercise the Gloas-gated routing inside `QbftManager::receive_data`:
+//! These exercise the Gloas-gated routing inside `QbftManager::receive_network_message`:
 //! before Gloas an `EnvelopeProposer` message is rejected with `RoleNotActive`;
 //! at or after Gloas it spawns an `EnvelopeConsensusData` instance keyed by
 //! `EnvelopeProposerInstanceId`, leaving the `ProposerConsensusData` map
 //! untouched. As in `gloas_dispatch_tests`, `DashMap` entries are inserted
 //! synchronously inside `get_or_spawn_instance`, so map sizes are deterministic
-//! immediately after `receive_data` returns.
+//! immediately after `receive_network_message` returns.
 
-use bls::{PUBLIC_KEY_BYTES_LEN, PublicKeyBytes};
+use bls::PublicKeyBytes;
 use ssv_types::{
-    RSA_SIGNATURE_SIZE,
     consensus::{EnvelopeConsensusData, ProposerConsensusData, QbftMessage, QbftMessageType},
-    message::{MsgType, SSVMessage, SignedSSVMessage},
+    message::SignedSSVMessage,
 };
-use ssz::Encode;
 
 use super::{
     gloas_dispatch_tests::{TEST_SLOT_HEIGHT, build_manager, spec_with_gloas},
@@ -30,35 +28,12 @@ fn build_envelope_message(
     slot_height: u64,
     executor: &DutyExecutor,
 ) -> (SignedSSVMessage, QbftMessage) {
-    let msg_id = MessageId::new(&DomainType([0; 4]), Role::EnvelopeProposer, executor);
-
-    let qbft_message = QbftMessage {
-        qbft_message_type: QbftMessageType::Proposal,
-        height: slot_height,
-        round: 1,
-        identifier: (&msg_id).into(),
-        root: Hash256::from([0u8; 32]),
-        data_round: 1,
-        round_change_justification: ssv_types::VariableList::empty(),
-        prepare_justification: ssv_types::VariableList::empty(),
-    };
-
-    let ssv_msg = SSVMessage::new(
-        MsgType::SSVConsensusMsgType,
-        msg_id,
-        qbft_message.as_ssz_bytes(),
+    build_signed_consensus_pair(
+        Role::EnvelopeProposer,
+        executor,
+        QbftMessageType::Proposal,
+        slot_height,
     )
-    .expect("SSVMessage creation should succeed");
-
-    let signed_msg = SignedSSVMessage::new(
-        vec![[0xAA; RSA_SIGNATURE_SIZE]],
-        vec![OperatorId(1)],
-        ssv_msg,
-        vec![],
-    )
-    .expect("SignedSSVMessage creation should succeed");
-
-    (signed_msg, qbft_message)
 }
 
 /// Before Gloas (here: never scheduled), an `EnvelopeProposer` message must be rejected with
@@ -72,7 +47,7 @@ fn build_envelope_message(
 /// the identical 56-byte `MessageId` regardless of the executor passed in.
 ///
 /// `MessageId::duty_executor` then selects the executor purely from the role, and role 9 is
-/// hard-wired to the `Validator` arm (bytes 8..56). So `receive_data` always enters the
+/// hard-wired to the `Validator` arm (bytes 8..56). The network receive path always enters the
 /// `Some(DutyExecutor::Validator(_))` branch and hits the `Some(Role::EnvelopeProposer)` arm,
 /// which checks `gloas_enabled_at_slot` and returns `QbftError::RoleNotActive` when Gloas is
 /// inactive. A committee-executor `EnvelopeProposer` is therefore unconstructable, and the
@@ -109,7 +84,11 @@ async fn envelope_proposer_rejected_before_gloas() {
         DutyExecutor::Committee(CommitteeId([0; 32])),
     ] {
         let (signed_msg, qbft_message) = build_envelope_message(TEST_SLOT_HEIGHT, &executor);
-        let result = manager.receive_data(signed_msg, qbft_message);
+        let result = manager.receive_network_message(
+            signed_msg,
+            qbft_message,
+            unexpected_proposer_duty_lookup,
+        );
         assert!(
             matches!(result, Err(QbftError::RoleNotActive)),
             "`EnvelopeProposer` always decodes as `Validator` and must be `RoleNotActive` pre-Gloas, got: {result:?}"
@@ -141,12 +120,12 @@ async fn envelope_proposer_routes_to_envelope_map_at_gloas() {
     );
 
     // Act
-    let result = manager.receive_data(signed_msg, qbft_message);
+    let result = manager.receive_network_message(signed_msg, qbft_message, assigned_proposer_duty);
 
     // Assert
     assert!(
         result.is_ok(),
-        "receive_data should succeed at Gloas, got: {result:?}"
+        "network receive should succeed at Gloas, got: {result:?}"
     );
     assert_eq!(
         manager.envelope_consensus_data_instances.len(),
@@ -176,7 +155,8 @@ async fn envelope_proposer_routes_at_gloas_activation_boundary() {
     // Act + Assert: the last pre-Gloas slot is rejected and inserts nothing.
     let last_pre_gloas = GLOAS_ACTIVATION_EPOCH * SLOTS_PER_EPOCH - 1;
     let (signed_msg, qbft_message) = build_envelope_message(last_pre_gloas, &validator_executor);
-    let result = manager.receive_data(signed_msg, qbft_message);
+    let result =
+        manager.receive_network_message(signed_msg, qbft_message, unexpected_proposer_duty_lookup);
     assert!(
         matches!(result, Err(QbftError::RoleNotActive)),
         "the last pre-Gloas slot must be rejected with `RoleNotActive`, got: {result:?}"
@@ -190,7 +170,7 @@ async fn envelope_proposer_routes_at_gloas_activation_boundary() {
     // Act + Assert: the first Gloas slot routes and spawns an instance.
     let first_gloas = GLOAS_ACTIVATION_EPOCH * SLOTS_PER_EPOCH;
     let (signed_msg, qbft_message) = build_envelope_message(first_gloas, &validator_executor);
-    let result = manager.receive_data(signed_msg, qbft_message);
+    let result = manager.receive_network_message(signed_msg, qbft_message, assigned_proposer_duty);
     assert!(
         result.is_ok(),
         "the first Gloas slot must route successfully, got: {result:?}"
@@ -211,8 +191,7 @@ async fn envelope_proposer_routes_at_gloas_activation_boundary() {
 fn envelope_proposer_message_id_is_validator_scoped() {
     // Arrange
     let domain = DomainType([0; 4]);
-    let validator_pubkey = PublicKeyBytes::deserialize(&[0xAB; PUBLIC_KEY_BYTES_LEN])
-        .expect("48-byte input is a valid PublicKeyBytes");
+    let validator_pubkey = super::validator_pubkey(0xAB);
     let instance_height: InstanceHeight = (TEST_SLOT_HEIGHT as usize).into();
     let envelope_id = EnvelopeProposerInstanceId {
         validator: validator_pubkey,

--- a/anchor/qbft_manager/src/tests/gloas_dispatch_tests.rs
+++ b/anchor/qbft_manager/src/tests/gloas_dispatch_tests.rs
@@ -1,20 +1,18 @@
 //! `Role::Committee` dispatch tests for the Ethereum Gloas (ePBS) fork.
 //!
-//! These exercise the fork-gated routing inside `QbftManager::receive_data`: at
+//! These exercise the fork-gated routing inside `QbftManager::receive_network_message`: at
 //! or after the Ethereum Gloas fork (read from the `ChainSpec`) a committee
 //! message must spawn a `GloasBeaconVote` instance, before Gloas a `BeaconVote`
 //! instance. The `DashMap` entry is inserted synchronously inside
 //! `get_or_spawn_instance` before the processor task is even dispatched, so map
-//! sizes are deterministic immediately after `receive_data` returns.
+//! sizes are deterministic immediately after `receive_network_message` returns.
 
 use fork::ForkSchedule;
 use message_sender::testing::MockMessageSender;
 use ssv_types::{
-    RSA_SIGNATURE_SIZE,
     consensus::{QbftMessage, QbftMessageType},
-    message::{MsgType, SSVMessage, SignedSSVMessage},
+    message::SignedSSVMessage,
 };
-use ssz::Encode;
 use types::{ChainSpec, Epoch};
 
 use super::{setup::setup_test, *};
@@ -64,39 +62,12 @@ pub(super) fn build_manager(
 /// given slot height. The shape mirrors the aggregator dispatch test so the
 /// two tests stay aligned.
 fn build_committee_message(slot_height: u64) -> (SignedSSVMessage, QbftMessage) {
-    let msg_id = MessageId::new(
-        &DomainType([0; 4]),
+    build_signed_consensus_pair(
         Role::Committee,
         &DutyExecutor::Committee(CommitteeId([0; 32])),
-    );
-
-    let qbft_message = QbftMessage {
-        qbft_message_type: QbftMessageType::Proposal,
-        height: slot_height,
-        round: 1,
-        identifier: (&msg_id).into(),
-        root: Hash256::from([0u8; 32]),
-        data_round: 1,
-        round_change_justification: ssv_types::VariableList::empty(),
-        prepare_justification: ssv_types::VariableList::empty(),
-    };
-
-    let ssv_msg = SSVMessage::new(
-        MsgType::SSVConsensusMsgType,
-        msg_id,
-        qbft_message.as_ssz_bytes(),
+        QbftMessageType::Proposal,
+        slot_height,
     )
-    .expect("SSVMessage creation should succeed");
-
-    let signed_msg = SignedSSVMessage::new(
-        vec![[0xAA; RSA_SIGNATURE_SIZE]],
-        vec![OperatorId(1)],
-        ssv_msg,
-        vec![],
-    )
-    .expect("SignedSSVMessage creation should succeed");
-
-    (signed_msg, qbft_message)
 }
 
 /// With the Ethereum Gloas fork active from genesis, a `Role::Committee` message
@@ -110,13 +81,13 @@ async fn test_committee_message_routes_to_gloas_at_fork() {
     let (signed_msg, qbft_message) = build_committee_message(TEST_SLOT_HEIGHT);
 
     // Act
-    let result = manager.receive_data(signed_msg, qbft_message);
+    let result =
+        manager.receive_network_message(signed_msg, qbft_message, unexpected_proposer_duty_lookup);
 
     // Assert
     assert!(
         result.is_ok(),
-        "receive_data should succeed at Gloas, got: {:?}",
-        result
+        "network receive should succeed at Gloas, got: {result:?}"
     );
     assert_eq!(
         manager.gloas_beacon_vote_instances.len(),
@@ -141,13 +112,13 @@ async fn test_committee_message_routes_to_beacon_pre_gloas() {
     let (signed_msg, qbft_message) = build_committee_message(TEST_SLOT_HEIGHT);
 
     // Act
-    let result = manager.receive_data(signed_msg, qbft_message);
+    let result =
+        manager.receive_network_message(signed_msg, qbft_message, unexpected_proposer_duty_lookup);
 
     // Assert
     assert!(
         result.is_ok(),
-        "receive_data should succeed pre-Gloas, got: {:?}",
-        result
+        "network receive should succeed pre-Gloas, got: {result:?}"
     );
     assert_eq!(
         manager.beacon_vote_instances.len(),
@@ -175,14 +146,16 @@ async fn test_committee_message_routes_at_gloas_activation_boundary() {
     let last_pre_gloas = GLOAS_ACTIVATION_EPOCH * SLOTS_PER_EPOCH - 1;
     let (signed, qbft) = build_committee_message(last_pre_gloas);
     manager
-        .receive_data(signed, qbft)
+        .receive_network_message(signed, qbft, unexpected_proposer_duty_lookup)
         .expect("pre-Gloas dispatch");
     assert_eq!(manager.beacon_vote_instances.len(), 1);
     assert_eq!(manager.gloas_beacon_vote_instances.len(), 0);
 
     let first_gloas = GLOAS_ACTIVATION_EPOCH * SLOTS_PER_EPOCH;
     let (signed, qbft) = build_committee_message(first_gloas);
-    manager.receive_data(signed, qbft).expect("Gloas dispatch");
+    manager
+        .receive_network_message(signed, qbft, unexpected_proposer_duty_lookup)
+        .expect("Gloas dispatch");
     assert_eq!(manager.gloas_beacon_vote_instances.len(), 1);
     // BeaconVote map still holds the pre-Gloas instance.
     assert_eq!(manager.beacon_vote_instances.len(), 1);

--- a/anchor/qbft_manager/src/tests/receive_mode_tests.rs
+++ b/anchor/qbft_manager/src/tests/receive_mode_tests.rs
@@ -1,0 +1,366 @@
+use std::cell::Cell;
+
+use bls::PublicKeyBytes;
+use ssv_types::consensus::{EnvelopeConsensusData, ProposerConsensusData, QbftData};
+use ssz::Encode;
+use tokio::time::timeout;
+
+use super::{
+    gloas_dispatch_tests::{TEST_SLOT_HEIGHT, build_manager, spec_with_gloas},
+    setup::setup_test,
+    *,
+};
+use crate::{
+    EnvelopeProposerInstanceId, ProposerInstanceId, QbftDispatchOutcome, ValidatorDutyKind,
+};
+
+fn build_validator_message(
+    role: Role,
+    message_type: QbftMessageType,
+    height: u64,
+    validator: PublicKeyBytes,
+) -> (SignedSSVMessage, QbftMessage) {
+    build_signed_consensus_pair(
+        role,
+        &DutyExecutor::Validator(validator),
+        message_type,
+        height,
+    )
+}
+
+fn proposer_instance_id(validator: PublicKeyBytes, height: u64) -> ProposerInstanceId {
+    ProposerInstanceId {
+        validator,
+        duty: ValidatorDutyKind::Proposal,
+        instance_height: (height as usize).into(),
+    }
+}
+
+fn envelope_instance_id(validator: PublicKeyBytes, height: u64) -> EnvelopeProposerInstanceId {
+    EnvelopeProposerInstanceId {
+        validator,
+        instance_height: (height as usize).into(),
+    }
+}
+
+fn assert_exact_network_message<D: QbftData>(
+    actual: crate::QbftMessage<D>,
+    expected_signed: &SignedSSVMessage,
+    expected_qbft: &QbftMessage,
+) {
+    let crate::QbftMessage {
+        kind,
+        drop_on_finish,
+    } = actual;
+    assert!(
+        drop_on_finish.is_some(),
+        "processor permit should travel with the instance message"
+    );
+    let QbftMessageKind::NetworkMessage(wrapped) = kind else {
+        panic!("expected a network message");
+    };
+    assert_eq!(&wrapped.signed_message, expected_signed);
+    assert_eq!(
+        wrapped.qbft_message.as_ssz_bytes(),
+        expected_qbft.as_ssz_bytes()
+    );
+}
+
+fn assert_instance_presence(
+    manager: &QbftManager<types::MainnetEthSpec, ManualSlotClock>,
+    role: Role,
+    validator: PublicKeyBytes,
+    height: u64,
+    expected: bool,
+) {
+    let present = match role {
+        Role::Proposer => manager
+            .proposer_consensus_data_instances
+            .contains_key(&proposer_instance_id(validator, height)),
+        Role::EnvelopeProposer => manager
+            .envelope_consensus_data_instances
+            .contains_key(&envelope_instance_id(validator, height)),
+        _ => panic!("unexpected role in proposer dispatch test: {role:?}"),
+    };
+    assert_eq!(present, expected, "unexpected {role:?} instance state");
+}
+
+async fn assert_unknown_dispatch_is_exact_keyed<D>(
+    manager: &QbftManager<types::MainnetEthSpec, ManualSlotClock>,
+    role: Role,
+    height: u64,
+    validator: PublicKeyBytes,
+    other_validator: PublicKeyBytes,
+    instance_id: D::Id,
+    other_instance_id: D::Id,
+) where
+    D: QbftDecidable<types::MainnetEthSpec>,
+{
+    let (tx, mut rx) = mpsc::unbounded_channel();
+    D::get_map(manager).insert(instance_id, tx);
+
+    let (wrong_signed, wrong_qbft) =
+        build_validator_message(role, QbftMessageType::Proposal, height, other_validator);
+    let outcome = manager
+        .receive_network_message(wrong_signed, wrong_qbft, |slot, validator| {
+            assert_eq!(slot, Slot::new(height));
+            assert_eq!(validator, &other_validator);
+            DutyAssignment::Unknown
+        })
+        .expect("wrong-key lookup should not fail");
+    assert_eq!(outcome, QbftDispatchOutcome::DroppedMissingInstance);
+    assert!(
+        timeout(Duration::from_millis(50), rx.recv()).await.is_err(),
+        "another validator pubkey must not reach the seeded {role:?} instance"
+    );
+    assert!(!D::get_map(manager).contains_key(&other_instance_id));
+
+    let (correct_signed, correct_qbft) =
+        build_validator_message(role, QbftMessageType::Proposal, height, validator);
+    let expected_signed = correct_signed.clone();
+    let expected_qbft = correct_qbft.clone();
+    let outcome = manager
+        .receive_network_message(correct_signed, correct_qbft, |slot, pubkey| {
+            assert_eq!(slot, Slot::new(height));
+            assert_eq!(pubkey, &validator);
+            DutyAssignment::Unknown
+        })
+        .expect("present instance should dispatch");
+    assert_eq!(outcome, QbftDispatchOutcome::ProcessorEnqueued);
+    let actual = timeout(Duration::from_secs(1), rx.recv())
+        .await
+        .expect("processor should dispatch promptly")
+        .expect("seeded receiver should remain open");
+    assert_exact_network_message::<D>(actual, &expected_signed, &expected_qbft);
+}
+
+async fn assert_not_assigned_drops_existing<D>(
+    manager: &QbftManager<types::MainnetEthSpec, ManualSlotClock>,
+    role: Role,
+    height: u64,
+    validator: PublicKeyBytes,
+    instance_id: D::Id,
+) where
+    D: QbftDecidable<types::MainnetEthSpec>,
+    D::Id: Clone,
+{
+    let (tx, mut rx) = mpsc::unbounded_channel();
+    D::get_map(manager).insert(instance_id.clone(), tx);
+    let (signed_message, qbft_message) =
+        build_validator_message(role, QbftMessageType::Proposal, height, validator);
+    let query_count = Cell::new(0);
+
+    let outcome = manager
+        .receive_network_message(signed_message, qbft_message, |slot, pubkey| {
+            assert_eq!(slot, Slot::new(height));
+            assert_eq!(pubkey, &validator);
+            query_count.set(query_count.get() + 1);
+            DutyAssignment::NotAssigned
+        })
+        .expect("NotAssigned should be an ordinary drop");
+
+    assert_eq!(outcome, QbftDispatchOutcome::DroppedNotAssigned);
+    assert_eq!(query_count.get(), 1);
+    assert!(
+        timeout(Duration::from_millis(50), rx.recv()).await.is_err(),
+        "NotAssigned {role:?} traffic must not reach an existing instance"
+    );
+    assert!(D::get_map(manager).contains_key(&instance_id));
+}
+
+#[tokio::test]
+async fn proposer_dispatch_uses_the_latest_assignment() {
+    let setup = setup_test(1);
+    let manager = build_manager(&setup, spec_with_gloas(Some(0)));
+    // Message-validator tests cover the first observation. Keep it in this table to enumerate all
+    // accepted validation-to-dispatch transitions while exercising the fresh manager lookup.
+    let transitions = [
+        (DutyAssignment::Assigned, DutyAssignment::Assigned),
+        (DutyAssignment::Assigned, DutyAssignment::Unknown),
+        (DutyAssignment::Assigned, DutyAssignment::NotAssigned),
+        (DutyAssignment::Unknown, DutyAssignment::Assigned),
+        (DutyAssignment::Unknown, DutyAssignment::Unknown),
+        (DutyAssignment::Unknown, DutyAssignment::NotAssigned),
+    ];
+
+    for (role_offset, role) in [Role::Proposer, Role::EnvelopeProposer]
+        .into_iter()
+        .enumerate()
+    {
+        for (transition_offset, (validation_assignment, dispatch_assignment)) in
+            transitions.into_iter().enumerate()
+        {
+            let height =
+                TEST_SLOT_HEIGHT + (role_offset * transitions.len() + transition_offset) as u64;
+            let validator = validator_pubkey(
+                0x10 + (role_offset * transitions.len() + transition_offset) as u8,
+            );
+            let (signed_message, qbft_message) =
+                build_validator_message(role, QbftMessageType::Proposal, height, validator);
+            let expected_slot = Slot::new(height);
+            assert!(matches!(
+                validation_assignment,
+                DutyAssignment::Assigned | DutyAssignment::Unknown
+            ));
+            let query_count = Cell::new(0);
+
+            let outcome = manager
+                .receive_network_message(signed_message, qbft_message, |slot, pubkey| {
+                    assert_eq!(slot, expected_slot, "unexpected proposer duty slot");
+                    assert_eq!(pubkey, &validator, "unexpected proposer duty pubkey");
+                    query_count.set(query_count.get() + 1);
+                    dispatch_assignment
+                })
+                .expect("proposer dispatch should not fail");
+
+            let expected_outcome = match dispatch_assignment {
+                DutyAssignment::Assigned => QbftDispatchOutcome::ProcessorEnqueued,
+                DutyAssignment::Unknown => QbftDispatchOutcome::DroppedMissingInstance,
+                DutyAssignment::NotAssigned => QbftDispatchOutcome::DroppedNotAssigned,
+            };
+            assert_eq!(
+                outcome, expected_outcome,
+                "{role:?}: {validation_assignment:?} -> {dispatch_assignment:?}"
+            );
+            assert_eq!(query_count.get(), 1);
+            assert_instance_presence(
+                &manager,
+                role,
+                validator,
+                height,
+                dispatch_assignment == DutyAssignment::Assigned,
+            );
+        }
+    }
+}
+
+#[tokio::test]
+async fn unknown_dispatch_routes_only_to_exact_validator_instances() {
+    let setup = setup_test(1);
+    let manager = build_manager(&setup, spec_with_gloas(Some(0)));
+
+    let proposer_height = TEST_SLOT_HEIGHT;
+    let proposer_validator = validator_pubkey(0x51);
+    let other_proposer_validator = validator_pubkey(0x52);
+    assert_unknown_dispatch_is_exact_keyed::<ProposerConsensusData>(
+        &manager,
+        Role::Proposer,
+        proposer_height,
+        proposer_validator,
+        other_proposer_validator,
+        proposer_instance_id(proposer_validator, proposer_height),
+        proposer_instance_id(other_proposer_validator, proposer_height),
+    )
+    .await;
+
+    let envelope_height = TEST_SLOT_HEIGHT + 1;
+    let envelope_validator = validator_pubkey(0x61);
+    let other_envelope_validator = validator_pubkey(0x62);
+    assert_unknown_dispatch_is_exact_keyed::<EnvelopeConsensusData>(
+        &manager,
+        Role::EnvelopeProposer,
+        envelope_height,
+        envelope_validator,
+        other_envelope_validator,
+        envelope_instance_id(envelope_validator, envelope_height),
+        envelope_instance_id(other_envelope_validator, envelope_height),
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn not_assigned_drops_even_when_an_instance_exists() {
+    let setup = setup_test(1);
+    let manager = build_manager(&setup, spec_with_gloas(Some(0)));
+
+    let proposer_height = TEST_SLOT_HEIGHT;
+    let proposer_validator = validator_pubkey(0x71);
+    assert_not_assigned_drops_existing::<ProposerConsensusData>(
+        &manager,
+        Role::Proposer,
+        proposer_height,
+        proposer_validator,
+        proposer_instance_id(proposer_validator, proposer_height),
+    )
+    .await;
+
+    let envelope_height = TEST_SLOT_HEIGHT + 1;
+    let envelope_validator = validator_pubkey(0x72);
+    assert_not_assigned_drops_existing::<EnvelopeConsensusData>(
+        &manager,
+        Role::EnvelopeProposer,
+        envelope_height,
+        envelope_validator,
+        envelope_instance_id(envelope_validator, envelope_height),
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn assigned_proposer_and_other_validator_roles_spawn() {
+    let setup = setup_test(1);
+    let manager = build_manager(&setup, spec_with_gloas(Some(0)));
+
+    for (offset, (role, duty, proposer_assignment)) in [
+        (
+            Role::Proposer,
+            ValidatorDutyKind::Proposal,
+            assigned_proposer_duty as fn(Slot, &PublicKeyBytes) -> DutyAssignment,
+        ),
+        (
+            Role::Aggregator,
+            ValidatorDutyKind::Aggregator,
+            unexpected_proposer_duty_lookup as fn(Slot, &PublicKeyBytes) -> DutyAssignment,
+        ),
+        (
+            Role::SyncCommittee,
+            ValidatorDutyKind::SyncCommitteeAggregator,
+            unexpected_proposer_duty_lookup as fn(Slot, &PublicKeyBytes) -> DutyAssignment,
+        ),
+    ]
+    .into_iter()
+    .enumerate()
+    {
+        let height = TEST_SLOT_HEIGHT + offset as u64;
+        let validator = validator_pubkey(0x80 + offset as u8);
+        let (signed_message, qbft_message) =
+            build_validator_message(role, QbftMessageType::Prepare, height, validator);
+        let outcome = manager
+            .receive_network_message(signed_message, qbft_message, proposer_assignment)
+            .expect("network message should dispatch");
+        assert_eq!(outcome, QbftDispatchOutcome::ProcessorEnqueued);
+        assert!(
+            manager
+                .proposer_consensus_data_instances
+                .contains_key(&ProposerInstanceId {
+                    validator,
+                    duty,
+                    instance_height: (height as usize).into(),
+                })
+        );
+    }
+}
+
+#[tokio::test]
+async fn pre_gloas_envelope_rejection_precedes_duty_lookup() {
+    let setup = setup_test(1);
+    let manager = build_manager(&setup, spec_with_gloas(None));
+    let (signed_message, qbft_message) = build_validator_message(
+        Role::EnvelopeProposer,
+        QbftMessageType::Proposal,
+        TEST_SLOT_HEIGHT,
+        validator_pubkey(0x90),
+    );
+    let query_count = Cell::new(0);
+
+    let result = manager.receive_network_message(signed_message, qbft_message, |_, _| {
+        query_count.set(query_count.get() + 1);
+        DutyAssignment::Assigned
+    });
+    assert!(
+        matches!(result, Err(QbftError::RoleNotActive)),
+        "pre-Gloas EnvelopeProposer should return RoleNotActive, got {result:?}"
+    );
+    assert_eq!(query_count.get(), 0);
+    assert!(manager.envelope_consensus_data_instances.is_empty());
+}


### PR DESCRIPTION
## Problem, Evidence, and Context (Required)

An absent proposer-duty schedule is not evidence that a validator has no duty. The current proposer path can therefore reject honest inbound messages when local duty data or validator indices are missing. Simply accepting those messages is also unsafe if network input can allocate an unverified QBFT instance.

Closes #1190.

## Change Overview (Required)

- Validate proposer duties by message-ID pubkey with the existing `Assigned`, `Unknown`, and `NotAssigned` contract.
- Continue validation for `Assigned` and `Unknown`; return `NoDuty` only for authoritative `NotAssigned`.
- Recompute the assignment inside `QbftManager::receive_network_message`: `Assigned` may create an instance, `Unknown` can use only an existing instance, and `NotAssigned` drops before map access.
- Keep allocation behavior unchanged for non-proposer QBFT roles.
- Remove the legacy validator-index and first-slot RANDAO exception paths.

No wire, topic, fork-schedule, database, or configuration change is included.

## Risks, Trade-offs, and Mitigations (Required)

- An `Unknown` message with no existing instance is accepted by gossip validation but dropped locally without buffering. Replay and count state has already been consumed, so the same message is not deferred for later delivery.
- `EnvelopeProposer` has no local QBFT initializer today, so its `Unknown` path is normally drop-only.
- The dispatch-time lookup is point-in-time rather than transactional with map insertion.

The manager owns the gate at the typed-map routing boundary. `ExistingOnly` performs one lookup without falling through to allocation, and tests cover both proposer roles, all verdict transitions, exact-key isolation, fork gating, and unchanged controls.

## Validation (Required)

- `cargo test -p duties_tracker -p message_validator -p qbft_manager -p message_receiver --no-fail-fast`
- `cargo check -p client`
- `make cargo-fmt-check`
- `make lint`
- `make test`

## Rollback (Required for behavior or runtime changes; optional otherwise)

Revert this PR. It has no persistent-data, configuration, or wire-format migration.

## Blockers / Dependencies (Optional)

Keep as draft until:

- #1193 merges. This branch is stacked on its stateless outbound-validation changes and should drop those duplicate commits after merge.
- #1183 lands. It establishes complete proposer schedules before missing assignments become authoritative `NotAssigned` evidence.
