### PR TITLE
fix: batch pre-Boole post-consensus sync contributions

### DIFF
--- a/anchor/signature_collector/src/lib.rs
+++ b/anchor/signature_collector/src/lib.rs
@@ -80,15 +80,32 @@ struct CommitteePartialSignatureBatch {
     for_slot: Slot,
 }
 
-/// One unique pre-Boole sync selection proof root and its original position multiplicity.
+/// One unique pre-Boole sync committee subnet and signing root pair.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct SyncSelectionProofDescriptor {
-    /// Unique sync committee subnet represented by this entry.
+pub struct SyncCommitteeBatchEntry {
+    /// Sync committee subnet represented by this entry.
     pub subnet_id: SyncSubnetId,
-    /// Ethereum signing root for the subnet's selection proof.
+    /// Ethereum signing root for this partial signature.
     pub signing_root: Hash256,
-    /// Number of original sync committee positions that map to this subnet and root.
-    pub position_count: usize,
+    /// Raw committee-position count for type 3, or repeated identical decided-entry count for
+    /// type 0.
+    pub multiplicity: usize,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+enum SingleValidatorBatchPhase {
+    ContributionProofs,
+    PostConsensus,
+}
+
+impl SingleValidatorBatchPhase {
+    fn from_kind(kind: PartialSignatureKind) -> Option<Self> {
+        match kind {
+            PartialSignatureKind::ContributionProofs => Some(Self::ContributionProofs),
+            PartialSignatureKind::PostConsensus => Some(Self::PostConsensus),
+            _ => None,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -97,11 +114,12 @@ enum SingleValidatorBatchState {
     Admitted,
 }
 
-/// Canonical outgoing pre-Boole sync selection proof batch for one validator and slot.
+/// Canonical outgoing pre-Boole sync committee partial signature batch for one validator, phase,
+/// and slot.
 struct SingleValidatorBatchRecord {
     validator_index: ValidatorIndex,
     committee_id: CommitteeId,
-    descriptor: Vec<SyncSelectionProofDescriptor>,
+    descriptor: Vec<SyncCommitteeBatchEntry>,
     /// The guard may cover only bounded synchronous signing, SSZ construction, and admission-only
     /// `sign_and_send`. Never await or perform a blocking channel send while holding it.
     state: Mutex<SingleValidatorBatchState>,
@@ -129,9 +147,13 @@ pub struct SignatureCollectorManager<S: SlotClock> {
     /// Note that this hash may differ from the actual signing root.
     committee_partial_signature_batches:
         DashMap<(Hash256, CommitteeId), CommitteePartialSignatureBatch>,
-    /// Pre-Boole batches keyed independently from root-specific collectors. Pending and admitted
-    /// records, including records created by detached callback work, are removed by slot cleanup.
-    single_validator_batches: DashMap<(Slot, PublicKeyBytes), Arc<SingleValidatorBatchRecord>>,
+    /// Pre-Boole batches keyed independently by phase and from root-specific collectors. Pending
+    /// and admitted records, including records created by detached callback work, are removed by
+    /// slot cleanup.
+    single_validator_batches:
+        DashMap<(SingleValidatorBatchPhase, Slot, PublicKeyBytes), Arc<SingleValidatorBatchRecord>>,
+    #[cfg(test)]
+    single_validator_batch_before_state_lock: Mutex<Option<Box<dyn FnOnce() + Send>>>,
 }
 
 impl<S: SlotClock + Clone + 'static> SignatureCollectorManager<S> {
@@ -155,6 +177,8 @@ impl<S: SlotClock + Clone + 'static> SignatureCollectorManager<S> {
             signature_collectors: DashMap::new(),
             committee_partial_signature_batches: DashMap::new(),
             single_validator_batches: DashMap::new(),
+            #[cfg(test)]
+            single_validator_batch_before_state_lock: Mutex::new(None),
         });
 
         manager
@@ -239,21 +263,10 @@ impl<S: SlotClock + Clone + 'static> SignatureCollectorManager<S> {
         self.processor.urgent_consensus.send_blocking(
             move || {
                 trace!(root = ?validator_signing_data.root, "Signing...");
-                // If we have no share, we can not actually sign the message, because we are running
-                // in impostor mode.
-                let partial_signature = if let Some(share) = &validator_signing_data.share {
-                    share.sign(validator_signing_data.root)
-                } else {
-                    Signature::empty()
-                };
+                let message = validator_signing_data
+                    .partial_signature_message(validator_signing_data.root, signer);
                 trace!(root = ?validator_signing_data.root, "Signed");
 
-                let message = PartialSignatureMessage {
-                    partial_signature,
-                    signing_root: validator_signing_data.root,
-                    signer,
-                    validator_index: validator_signing_data.index,
-                };
                 let messages_to_inject = match requester {
                     SignatureRequester::SingleValidator { pubkey } => {
                         // we do not have to wait for other partial signatures - send the message
@@ -377,7 +390,7 @@ impl<S: SlotClock + Clone + 'static> SignatureCollectorManager<S> {
         Ok(result_rx.await?)
     }
 
-    /// Builds and attempts the canonical pre-Boole selection-proof batch for one callback.
+    /// Builds and attempts the canonical pre-Boole sync committee batch for one callback.
     ///
     /// Returns the unique real messages this callback should inject after the record lock is
     /// released. An attempted send returns all descriptor roots, an admitted sibling or an
@@ -387,7 +400,7 @@ impl<S: SlotClock + Clone + 'static> SignatureCollectorManager<S> {
         metadata: &SignatureMetadata,
         pubkey: PublicKeyBytes,
         subnet_id: SyncSubnetId,
-        descriptor: Vec<SyncSelectionProofDescriptor>,
+        descriptor: Vec<SyncCommitteeBatchEntry>,
         validator_signing_data: &ValidatorSigningData,
         current_message: PartialSignatureMessage,
     ) -> Vec<PartialSignatureMessage> {
@@ -397,9 +410,32 @@ impl<S: SlotClock + Clone + 'static> SignatureCollectorManager<S> {
             return Vec::new();
         }
 
+        let Some(phase) = SingleValidatorBatchPhase::from_kind(metadata.kind) else {
+            error!(
+                reason = "unsupported_kind",
+                kind = ?metadata.kind,
+                slot = %metadata.slot,
+                callback_subnet = ?subnet_id,
+                "Suppressing single-validator batch publication for unsupported metadata"
+            );
+            return vec![current_message];
+        };
+        if metadata.role != Role::SyncCommittee {
+            error!(
+                reason = "role_mismatch",
+                kind = ?metadata.kind,
+                role = ?metadata.role,
+                slot = %metadata.slot,
+                callback_subnet = ?subnet_id,
+                "Suppressing single-validator batch publication for unsupported metadata"
+            );
+            return vec![current_message];
+        }
+
         if pubkey != validator_signing_data.validator_pubkey {
             error!(
                 reason = "validator_pubkey_mismatch",
+                kind = ?metadata.kind,
                 slot = %metadata.slot,
                 requester_pubkey = ?pubkey,
                 signing_data_pubkey = ?validator_signing_data.validator_pubkey,
@@ -409,12 +445,12 @@ impl<S: SlotClock + Clone + 'static> SignatureCollectorManager<S> {
             return vec![current_message];
         }
         if !descriptor.iter().any(|entry| {
-            entry.subnet_id == subnet_id
-                && entry.signing_root == validator_signing_data.root
+            entry.signing_root == validator_signing_data.root
                 && entry.signing_root == current_message.signing_root
         }) {
             error!(
                 reason = "descriptor_mismatch",
+                kind = ?metadata.kind,
                 slot = %metadata.slot,
                 ?pubkey,
                 callback_subnet = ?subnet_id,
@@ -425,7 +461,10 @@ impl<S: SlotClock + Clone + 'static> SignatureCollectorManager<S> {
             return vec![current_message];
         }
 
-        let record = match self.single_validator_batches.entry((metadata.slot, pubkey)) {
+        let record = match self
+            .single_validator_batches
+            .entry((phase, metadata.slot, pubkey))
+        {
             Entry::Occupied(entry) => Arc::clone(entry.get()),
             Entry::Vacant(entry) => {
                 let record = Arc::new(SingleValidatorBatchRecord {
@@ -442,6 +481,7 @@ impl<S: SlotClock + Clone + 'static> SignatureCollectorManager<S> {
         if record.committee_id != metadata.committee_id {
             error!(
                 reason = "committee_id_mismatch",
+                kind = ?metadata.kind,
                 slot = %metadata.slot,
                 ?pubkey,
                 callback_subnet = ?subnet_id,
@@ -454,6 +494,7 @@ impl<S: SlotClock + Clone + 'static> SignatureCollectorManager<S> {
         if record.validator_index != current_message.validator_index {
             error!(
                 reason = "validator_index_mismatch",
+                kind = ?metadata.kind,
                 slot = %metadata.slot,
                 ?pubkey,
                 callback_subnet = ?subnet_id,
@@ -466,6 +507,7 @@ impl<S: SlotClock + Clone + 'static> SignatureCollectorManager<S> {
         if record.descriptor != descriptor {
             error!(
                 reason = "descriptor_mismatch",
+                kind = ?metadata.kind,
                 slot = %metadata.slot,
                 ?pubkey,
                 callback_subnet = ?subnet_id,
@@ -476,9 +518,14 @@ impl<S: SlotClock + Clone + 'static> SignatureCollectorManager<S> {
             return vec![current_message];
         }
 
+        #[cfg(test)]
+        if let Some(hook) = self.single_validator_batch_before_state_lock.lock().take() {
+            hook();
+        }
         let mut state = record.state.lock();
         if *state == SingleValidatorBatchState::Admitted {
             trace!(
+                kind = ?metadata.kind,
                 slot = %metadata.slot,
                 validator_index = ?record.validator_index,
                 callback_subnet = ?subnet_id,
@@ -488,46 +535,29 @@ impl<S: SlotClock + Clone + 'static> SignatureCollectorManager<S> {
             return vec![current_message];
         }
 
-        let unique_messages = record
+        let signer = current_message.signer;
+        let mut injection_messages = vec![current_message];
+        let expanded_entries = record
             .descriptor
             .iter()
-            .map(|entry| {
-                let partial_signature = if entry.subnet_id == subnet_id {
-                    current_message.partial_signature.clone()
-                } else if let Some(share) = &validator_signing_data.share {
-                    share.sign(entry.signing_root)
-                } else {
-                    Signature::empty()
-                };
-                PartialSignatureMessage {
-                    partial_signature,
-                    signing_root: entry.signing_root,
-                    signer: current_message.signer,
-                    validator_index: current_message.validator_index,
-                }
-            })
-            .collect::<Vec<_>>();
-
-        let mut injection_messages = Vec::with_capacity(unique_messages.len());
-        injection_messages.push(current_message);
-        injection_messages.extend(
-            record
-                .descriptor
-                .iter()
-                .zip(&unique_messages)
-                .filter(|(entry, _)| entry.subnet_id != subnet_id)
-                .map(|(_, message)| message.clone()),
-        );
-
-        let expanded_positions = record
-            .descriptor
-            .iter()
-            .map(|entry| entry.position_count)
+            .map(|entry| entry.multiplicity)
             .sum();
-        let mut expanded_messages = Vec::with_capacity(expanded_positions);
-        for (entry, message) in record.descriptor.iter().zip(&unique_messages) {
-            expanded_messages.extend(std::iter::repeat_n(message.clone(), entry.position_count));
+        let mut expanded_messages = Vec::with_capacity(expanded_entries);
+        for entry in &record.descriptor {
+            let message = if let Some(index) = injection_messages
+                .iter()
+                .position(|message| message.signing_root == entry.signing_root)
+            {
+                injection_messages[index].clone()
+            } else {
+                let message =
+                    validator_signing_data.partial_signature_message(entry.signing_root, signer);
+                injection_messages.push(message.clone());
+                message
+            };
+            expanded_messages.extend(std::iter::repeat_n(message, entry.multiplicity));
         }
+        let unique_root_count = injection_messages.len();
 
         let outgoing = match self.create_message(
             metadata,
@@ -538,12 +568,13 @@ impl<S: SlotClock + Clone + 'static> SignatureCollectorManager<S> {
             Err(err) => {
                 error!(
                     %err,
+                    kind = ?metadata.kind,
                     slot = %metadata.slot,
                     committee_id = ?metadata.committee_id,
                     validator_index = ?record.validator_index,
                     callback_subnet = ?subnet_id,
-                    unique_roots = record.descriptor.len(),
-                    expanded_positions,
+                    unique_roots = unique_root_count,
+                    expanded_entries,
                     "Failed to construct single-validator partial signature batch"
                 );
                 drop(state);
@@ -558,23 +589,25 @@ impl<S: SlotClock + Clone + 'static> SignatureCollectorManager<S> {
             Ok(()) => {
                 *state = SingleValidatorBatchState::Admitted;
                 trace!(
+                    kind = ?metadata.kind,
                     slot = %metadata.slot,
                     validator_index = ?record.validator_index,
                     callback_subnet = ?subnet_id,
-                    unique_roots = record.descriptor.len(),
-                    expanded_positions,
+                    unique_roots = unique_root_count,
+                    expanded_entries,
                     "Admitted single-validator partial signature batch"
                 );
             }
             Err(err) => {
                 error!(
                     ?err,
+                    kind = ?metadata.kind,
                     slot = %metadata.slot,
                     committee_id = ?metadata.committee_id,
                     validator_index = ?record.validator_index,
                     callback_subnet = ?subnet_id,
-                    unique_roots = record.descriptor.len(),
-                    expanded_positions,
+                    unique_roots = unique_root_count,
+                    expanded_entries,
                     batch_state = "pending",
                     "Failed to admit single-validator partial signature batch for sending"
                 );
@@ -714,7 +747,7 @@ impl<S: SlotClock + Clone + 'static> SignatureCollectorManager<S> {
         self.committee_partial_signature_batches
             .retain(|_, batch| batch.for_slot >= cutoff);
         self.single_validator_batches
-            .retain(|(slot, _), _| *slot >= cutoff);
+            .retain(|(_, slot, _), _| *slot >= cutoff);
     }
 
     async fn cleaner(self: Arc<Self>) {
@@ -767,14 +800,15 @@ pub enum SignatureRequester {
         /// The public key of the validator. Used in the created network message.
         pubkey: PublicKeyBytes,
     },
-    /// Pre-Boole sync selection proofs for one validator are sent in one expanded envelope.
+    /// Pre-Boole sync committee partial signatures for one validator are sent in one expanded
+    /// envelope.
     SingleValidatorBatch {
         /// Public key used by the validator-scoped message ID and batch identity.
         pubkey: PublicKeyBytes,
         /// Subnet requested by this callback.
         subnet_id: SyncSubnetId,
-        /// Canonical descriptor for every unique subnet assigned to this validator and slot.
-        descriptor: Vec<SyncSelectionProofDescriptor>,
+        /// Canonical descriptor for every unique subnet and signing root pair in this batch.
+        descriptor: Vec<SyncCommitteeBatchEntry>,
     },
     /// The local operator is signing for multiple validators in one committee round.
     /// We batch those validator partial signatures into a single outgoing committee message instead
@@ -799,6 +833,26 @@ pub struct ValidatorSigningData {
     pub index: ValidatorIndex,
     pub validator_pubkey: PublicKeyBytes,
     pub share: Option<SecretKey>,
+}
+
+impl ValidatorSigningData {
+    fn partial_signature_message(
+        &self,
+        signing_root: Hash256,
+        signer: OperatorId,
+    ) -> PartialSignatureMessage {
+        // Without a share, impostor mode publishes the expected shape with empty signatures.
+        let partial_signature = self
+            .share
+            .as_ref()
+            .map_or_else(Signature::empty, |share| share.sign(signing_root));
+        PartialSignatureMessage {
+            partial_signature,
+            signing_root,
+            signer,
+            validator_index: self.index,
+        }
+    }
 }
 
 struct CollectorMessage<G = DropOnFinish> {

--- a/anchor/signature_collector/src/tests.rs
+++ b/anchor/signature_collector/src/tests.rs
@@ -404,17 +404,29 @@ impl BatchScenario {
     }
 }
 
-fn descriptor(entries: &[(u64, Hash256, usize)]) -> Vec<SyncSelectionProofDescriptor> {
+fn descriptor(entries: &[(u64, Hash256, usize)]) -> Vec<SyncCommitteeBatchEntry> {
     entries
         .iter()
         .map(
-            |(subnet_id, signing_root, position_count)| SyncSelectionProofDescriptor {
+            |(subnet_id, signing_root, multiplicity)| SyncCommitteeBatchEntry {
                 subnet_id: SyncSubnetId::new(*subnet_id),
                 signing_root: *signing_root,
-                position_count: *position_count,
+                multiplicity: *multiplicity,
             },
         )
         .collect()
+}
+
+fn batch_key(
+    metadata: &SignatureMetadata,
+    pubkey: PublicKeyBytes,
+) -> (SingleValidatorBatchPhase, Slot, PublicKeyBytes) {
+    (
+        SingleValidatorBatchPhase::from_kind(metadata.kind)
+            .expect("batch test metadata should use a supported phase"),
+        metadata.slot,
+        pubkey,
+    )
 }
 
 fn process_batch(
@@ -424,13 +436,36 @@ fn process_batch(
     validator_key: &SecretKey,
     validator_index: ValidatorIndex,
     subnet_id: SyncSubnetId,
-    descriptor: Vec<SyncSelectionProofDescriptor>,
+    descriptor: Vec<SyncCommitteeBatchEntry>,
 ) -> Vec<PartialSignatureMessage> {
     let signing_root = descriptor
         .iter()
         .find(|entry| entry.subnet_id == subnet_id)
         .expect("callback subnet should be in its descriptor")
         .signing_root;
+    process_batch_for_root(
+        manager,
+        metadata,
+        pubkey,
+        validator_key,
+        validator_index,
+        subnet_id,
+        signing_root,
+        descriptor,
+    )
+}
+
+#[expect(clippy::too_many_arguments)]
+fn process_batch_for_root(
+    manager: &SignatureCollectorManager<ManualSlotClock>,
+    metadata: &SignatureMetadata,
+    pubkey: PublicKeyBytes,
+    validator_key: &SecretKey,
+    validator_index: ValidatorIndex,
+    subnet_id: SyncSubnetId,
+    signing_root: Hash256,
+    descriptor: Vec<SyncCommitteeBatchEntry>,
+) -> Vec<PartialSignatureMessage> {
     let signing_data = ValidatorSigningData {
         root: signing_root,
         index: validator_index,
@@ -458,7 +493,7 @@ async fn sign_and_collect_batch(
     metadata: SignatureMetadata,
     validator_index: ValidatorIndex,
     subnet_id: SyncSubnetId,
-    descriptor: Vec<SyncSelectionProofDescriptor>,
+    descriptor: Vec<SyncCommitteeBatchEntry>,
 ) -> Arc<Signature> {
     let signing_root = descriptor
         .iter()
@@ -493,6 +528,40 @@ async fn wait_until(mut predicate: impl FnMut() -> bool) {
     })
     .await
     .expect("condition should become true promptly");
+}
+
+async fn drain_batch_processor_work(manager: &SignatureCollectorManager<ManualSlotClock>) {
+    let (urgent_done_tx, urgent_done_rx) = oneshot::channel();
+    manager
+        .processor
+        .urgent_consensus
+        .send_blocking(
+            move || {
+                let _ = urgent_done_tx.send(());
+            },
+            "batch_test_urgent_barrier",
+        )
+        .expect("urgent barrier should enter the processor");
+    tokio::time::timeout(Duration::from_secs(5), urgent_done_rx)
+        .await
+        .expect("urgent barrier should run promptly")
+        .expect("urgent barrier should signal completion");
+
+    let (permitless_done_tx, permitless_done_rx) = oneshot::channel();
+    manager
+        .processor
+        .permitless
+        .send_immediate(
+            move |_drop_on_finish| {
+                let _ = permitless_done_tx.send(());
+            },
+            "batch_test_permitless_barrier",
+        )
+        .expect("permitless barrier should enter the processor");
+    tokio::time::timeout(Duration::from_secs(5), permitless_done_rx)
+        .await
+        .expect("permitless barrier should run promptly")
+        .expect("permitless barrier should signal completion");
 }
 
 async fn register_manager_notifier(
@@ -543,6 +612,7 @@ fn single_validator_batch_envelope_cases() {
             0,
             vec![root_0],
             vec![root_0],
+            PartialSignatureKind::ContributionProofs,
             "one position",
         ),
         (
@@ -550,6 +620,7 @@ fn single_validator_batch_envelope_cases() {
             0,
             vec![root_0, root_0],
             vec![root_0],
+            PartialSignatureKind::ContributionProofs,
             "same-subnet multiplicity",
         ),
         (
@@ -557,17 +628,27 @@ fn single_validator_batch_envelope_cases() {
             1,
             vec![root_0, root_0, root_1],
             vec![root_1, root_0],
+            PartialSignatureKind::ContributionProofs,
             "multiple subnets",
+        ),
+        (
+            descriptor(&[(0, root_0, 2), (1, root_1, 1)]),
+            0,
+            vec![root_0, root_0, root_1],
+            vec![root_0, root_1],
+            PartialSignatureKind::PostConsensus,
+            "post-consensus decided root multiset",
         ),
     ];
 
     for (
         case_index,
-        (descriptor, callback_subnet, expected_wire_roots, expected_injection_roots, label),
+        (descriptor, callback_subnet, expected_wire_roots, expected_injection_roots, kind, label),
     ) in cases.into_iter().enumerate()
     {
         let mut metadata = scenario.metadata.clone();
         metadata.slot += case_index as u64;
+        metadata.kind = kind;
         let unique_messages = process_batch(
             &scenario.manager,
             &metadata,
@@ -601,7 +682,7 @@ fn single_validator_batch_envelope_cases() {
         );
         let messages = PartialSignatureMessages::from_ssz_bytes(unsigned.ssv_message.data())
             .expect("captured batch should decode");
-        assert_eq!(messages.kind, PartialSignatureKind::ContributionProofs);
+        assert_eq!(messages.kind, kind, "{label}");
         assert_eq!(messages.slot, metadata.slot);
         assert_eq!(
             messages
@@ -615,14 +696,175 @@ fn single_validator_batch_envelope_cases() {
         assert!(messages.messages.iter().all(|message| {
             message.signer == TEST_OPERATOR_ID && message.validator_index == ValidatorIndex(42)
         }));
+        for (message, signing_root) in messages.messages.iter().zip(&expected_wire_roots) {
+            assert_eq!(
+                message.partial_signature,
+                scenario.validator_key.sign(*signing_root),
+                "{label}"
+            );
+        }
     }
-    assert_eq!(sender.attempts(), 3);
+    assert_eq!(sender.attempts(), 4);
+}
+
+#[test]
+fn post_consensus_uses_exact_roots_for_same_subnet_callbacks() {
+    let sender = Arc::new(RecordingMessageSender::new(0));
+    let mut scenario = BatchScenario::new(Arc::clone(&sender) as Arc<dyn MessageSender>);
+    scenario.metadata.kind = PartialSignatureKind::PostConsensus;
+    let first_root = Hash256::repeat_byte(0x18);
+    let callback_root = Hash256::repeat_byte(0x19);
+    let descriptor = descriptor(&[(1, first_root, 1), (1, callback_root, 1)]);
+
+    let injections = process_batch_for_root(
+        &scenario.manager,
+        &scenario.metadata,
+        scenario.validator_pubkey,
+        &scenario.validator_key,
+        ValidatorIndex(42),
+        SyncSubnetId::new(1),
+        callback_root,
+        descriptor,
+    );
+
+    assert_eq!(
+        injections
+            .iter()
+            .map(|message| message.signing_root)
+            .collect::<Vec<_>>(),
+        vec![callback_root, first_root]
+    );
+    let sent = sender.messages();
+    assert_eq!(sent.len(), 1);
+    let messages = PartialSignatureMessages::from_ssz_bytes(sent[0].ssv_message.data())
+        .expect("post-consensus batch should decode");
+    assert_eq!(messages.kind, PartialSignatureKind::PostConsensus);
+    assert_eq!(messages.messages.len(), 2);
+    assert_eq!(messages.messages[0].signing_root, first_root);
+    assert_eq!(messages.messages[1].signing_root, callback_root);
+    assert_eq!(
+        messages.messages[0].partial_signature,
+        scenario.validator_key.sign(first_root)
+    );
+    assert_eq!(
+        messages.messages[1].partial_signature,
+        scenario.validator_key.sign(callback_root)
+    );
+}
+
+#[test]
+fn post_consensus_injects_one_message_for_one_root_on_multiple_subnets() {
+    let sender = Arc::new(RecordingMessageSender::new(0));
+    let mut scenario = BatchScenario::new(Arc::clone(&sender) as Arc<dyn MessageSender>);
+    scenario.metadata.kind = PartialSignatureKind::PostConsensus;
+    let signing_root = Hash256::repeat_byte(0x1A);
+
+    let injections = process_batch(
+        &scenario.manager,
+        &scenario.metadata,
+        scenario.validator_pubkey,
+        &scenario.validator_key,
+        ValidatorIndex(42),
+        SyncSubnetId::new(0),
+        descriptor(&[(0, signing_root, 1), (1, signing_root, 1)]),
+    );
+
+    assert_eq!(injections.len(), 1);
+    assert_eq!(injections[0].signing_root, signing_root);
+    let sent = sender.messages();
+    let messages = PartialSignatureMessages::from_ssz_bytes(sent[0].ssv_message.data())
+        .expect("post-consensus batch should decode");
+    assert_eq!(messages.kind, PartialSignatureKind::PostConsensus);
+    assert_eq!(messages.messages.len(), 2);
+    assert!(
+        messages
+            .messages
+            .iter()
+            .all(|message| message.signing_root == signing_root)
+    );
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn first_callback_injects_all_roots_and_admitted_sibling_reinjects() {
+async fn post_consensus_impostor_sends_empty_batch_without_sibling_injection() {
     let sender = Arc::new(RecordingMessageSender::new(0));
-    let scenario = BatchScenario::new(Arc::clone(&sender) as Arc<dyn MessageSender>);
+    let mut scenario =
+        BatchScenario::new_with_max_workers(Arc::clone(&sender) as Arc<dyn MessageSender>, 1);
+    scenario.metadata.kind = PartialSignatureKind::PostConsensus;
+    let validator_index = ValidatorIndex(42);
+    let current_root = Hash256::repeat_byte(0x1B);
+    let sibling_root = Hash256::repeat_byte(0x1C);
+    let collector_key = (current_root, validator_index);
+    let sibling_collector_key = (sibling_root, validator_index);
+    let manager = Arc::clone(&scenario.manager);
+    let metadata = scenario.metadata.clone();
+    let validator_pubkey = scenario.validator_pubkey;
+
+    let task = tokio::spawn(async move {
+        manager
+            .sign_and_collect(
+                metadata,
+                SignatureRequester::SingleValidatorBatch {
+                    pubkey: validator_pubkey,
+                    subnet_id: SyncSubnetId::new(0),
+                    descriptor: descriptor(&[(0, current_root, 1), (1, sibling_root, 1)]),
+                },
+                ValidatorSigningData {
+                    root: current_root,
+                    index: validator_index,
+                    validator_pubkey,
+                    share: None,
+                },
+            )
+            .await
+    });
+
+    wait_until(|| sender.attempts() == 1).await;
+    drain_batch_processor_work(&scenario.manager).await;
+
+    let sent = sender.messages();
+    let messages = PartialSignatureMessages::from_ssz_bytes(sent[0].ssv_message.data())
+        .expect("impostor post-consensus batch should decode");
+    assert_eq!(messages.kind, PartialSignatureKind::PostConsensus);
+    assert_eq!(messages.slot, scenario.metadata.slot);
+    assert_eq!(messages.messages.len(), 2);
+    assert_eq!(
+        messages
+            .messages
+            .iter()
+            .map(|message| message.signing_root)
+            .collect::<Vec<_>>(),
+        vec![current_root, sibling_root]
+    );
+    assert!(
+        messages
+            .messages
+            .iter()
+            .all(|message| message.partial_signature == Signature::empty()
+                && message.signer == TEST_OPERATOR_ID
+                && message.validator_index == validator_index)
+    );
+    assert!(
+        scenario
+            .manager
+            .signature_collectors
+            .contains_key(&collector_key)
+    );
+    assert!(
+        !scenario
+            .manager
+            .signature_collectors
+            .contains_key(&sibling_collector_key),
+        "impostor mode must not inject an empty sibling share"
+    );
+
+    task.abort();
+    let _ = task.await;
+}
+
+async fn run_first_callback_injection_and_reinjection(kind: PartialSignatureKind) {
+    let sender = Arc::new(RecordingMessageSender::new(0));
+    let mut scenario = BatchScenario::new(Arc::clone(&sender) as Arc<dyn MessageSender>);
+    scenario.metadata.kind = kind;
     let validator_index = ValidatorIndex(42);
     let root_0 = Hash256::repeat_byte(0x20);
     let root_1 = Hash256::repeat_byte(0x21);
@@ -686,10 +928,20 @@ async fn first_callback_injects_all_roots_and_admitted_sibling_reinjects() {
     );
 }
 
-#[test]
-fn failed_admission_stays_pending_and_sibling_retries() {
+#[tokio::test(flavor = "multi_thread")]
+async fn first_callback_injects_all_roots_and_admitted_sibling_reinjects() {
+    run_first_callback_injection_and_reinjection(PartialSignatureKind::ContributionProofs).await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn post_consensus_first_callback_injects_all_roots_and_admitted_sibling_reinjects() {
+    run_first_callback_injection_and_reinjection(PartialSignatureKind::PostConsensus).await;
+}
+
+fn run_failed_admission_and_sibling_retry(kind: PartialSignatureKind) {
     let sender = Arc::new(RecordingMessageSender::new(1));
-    let scenario = BatchScenario::new(Arc::clone(&sender) as Arc<dyn MessageSender>);
+    let mut scenario = BatchScenario::new(Arc::clone(&sender) as Arc<dyn MessageSender>);
+    scenario.metadata.kind = kind;
     let root_0 = Hash256::repeat_byte(0x30);
     let root_1 = Hash256::repeat_byte(0x31);
     let descriptor = descriptor(&[(0, root_0, 1), (1, root_1, 1)]);
@@ -709,7 +961,7 @@ fn failed_admission_stays_pending_and_sibling_retries() {
     let record = scenario
         .manager
         .single_validator_batches
-        .get(&(scenario.metadata.slot, scenario.validator_pubkey))
+        .get(&batch_key(&scenario.metadata, scenario.validator_pubkey))
         .expect("pending record should be retained");
     assert_eq!(*record.state.lock(), SingleValidatorBatchState::Pending);
     drop(record);
@@ -724,11 +976,30 @@ fn failed_admission_stays_pending_and_sibling_retries() {
         descriptor.clone(),
     );
     assert_eq!(sender.attempts(), 2);
-    assert_eq!(sender.messages().len(), 1);
+    let sent = sender.messages();
+    assert_eq!(sent.len(), 1);
+    let messages = PartialSignatureMessages::from_ssz_bytes(sent[0].ssv_message.data())
+        .expect("retried single-validator batch should decode");
+    assert_eq!(messages.kind, kind);
+    assert_eq!(messages.slot, scenario.metadata.slot);
+    assert_eq!(messages.messages.len(), 2);
+    assert_eq!(
+        messages
+            .messages
+            .iter()
+            .map(|message| message.signing_root)
+            .collect::<Vec<_>>(),
+        vec![root_0, root_1]
+    );
+    assert!(messages.messages.iter().all(|message| {
+        message.signer == TEST_OPERATOR_ID
+            && message.validator_index == ValidatorIndex(42)
+            && message.partial_signature == scenario.validator_key.sign(message.signing_root)
+    }));
     let record = scenario
         .manager
         .single_validator_batches
-        .get(&(scenario.metadata.slot, scenario.validator_pubkey))
+        .get(&batch_key(&scenario.metadata, scenario.validator_pubkey))
         .expect("admitted record should be retained");
     assert_eq!(*record.state.lock(), SingleValidatorBatchState::Admitted);
     drop(record);
@@ -743,13 +1014,53 @@ fn failed_admission_stays_pending_and_sibling_retries() {
         descriptor,
     );
     assert_eq!(admitted_injections.len(), 1);
+    assert_eq!(admitted_injections[0].signing_root, root_0);
     assert_eq!(sender.attempts(), 2);
 }
 
 #[test]
-fn concurrent_callbacks_produce_one_admitted_send() {
+fn failed_admission_stays_pending_and_sibling_retries() {
+    run_failed_admission_and_sibling_retry(PartialSignatureKind::ContributionProofs);
+}
+
+#[test]
+fn post_consensus_failed_admission_stays_pending_and_sibling_retries() {
+    run_failed_admission_and_sibling_retry(PartialSignatureKind::PostConsensus);
+}
+
+#[test]
+fn post_consensus_construction_failure_retains_pending_for_retry() {
+    let sender = Arc::new(RecordingMessageSender::new(0));
+    let mut scenario = BatchScenario::new(Arc::clone(&sender) as Arc<dyn MessageSender>);
+    scenario.metadata.kind = PartialSignatureKind::PostConsensus;
+    let signing_root = Hash256::repeat_byte(0x38);
+    let oversized_multiplicity = PartialSignatureMessagesLen::USIZE + 1;
+
+    let injections = process_batch(
+        &scenario.manager,
+        &scenario.metadata,
+        scenario.validator_pubkey,
+        &scenario.validator_key,
+        ValidatorIndex(42),
+        SyncSubnetId::new(0),
+        descriptor(&[(0, signing_root, oversized_multiplicity)]),
+    );
+
+    assert_eq!(injections.len(), 1);
+    assert_eq!(injections[0].signing_root, signing_root);
+    assert_eq!(sender.attempts(), 0);
+    let record = scenario
+        .manager
+        .single_validator_batches
+        .get(&batch_key(&scenario.metadata, scenario.validator_pubkey))
+        .expect("construction failure should retain the batch record");
+    assert_eq!(*record.state.lock(), SingleValidatorBatchState::Pending);
+}
+
+fn run_concurrent_callbacks(kind: PartialSignatureKind) {
     let (sender, first_attempt_entered) = BlockingMessageSender::new();
-    let scenario = BatchScenario::new(Arc::clone(&sender) as Arc<dyn MessageSender>);
+    let mut scenario = BatchScenario::new(Arc::clone(&sender) as Arc<dyn MessageSender>);
+    scenario.metadata.kind = kind;
     let descriptor = descriptor(&[
         (0, Hash256::repeat_byte(0x40), 1),
         (1, Hash256::repeat_byte(0x41), 1),
@@ -778,6 +1089,25 @@ fn concurrent_callbacks_produce_one_admitted_send() {
     first_attempt_entered
         .recv_timeout(Duration::from_secs(5))
         .expect("first callback should enter sign_and_send");
+    let record = scenario
+        .manager
+        .single_validator_batches
+        .get(&batch_key(&scenario.metadata, scenario.validator_pubkey))
+        .expect("concurrent batch record should exist");
+    assert!(
+        record.state.try_lock().is_none(),
+        "the first callback should hold admission state while sending"
+    );
+    drop(record);
+    let (second_at_lock_tx, second_at_lock_rx) = std_mpsc::sync_channel(1);
+    *scenario
+        .manager
+        .single_validator_batch_before_state_lock
+        .lock() = Some(Box::new(move || {
+        second_at_lock_tx
+            .send(())
+            .expect("test should observe the sibling at the state lock");
+    }));
 
     let second = std::thread::spawn(move || {
         process_batch(
@@ -790,7 +1120,9 @@ fn concurrent_callbacks_produce_one_admitted_send() {
             descriptor_b,
         )
     });
-    std::thread::sleep(Duration::from_millis(50));
+    second_at_lock_rx
+        .recv_timeout(Duration::from_secs(5))
+        .expect("sibling callback should reach the state lock during admission");
     assert_eq!(sender.attempts(), 1);
     sender.release();
 
@@ -816,10 +1148,20 @@ fn concurrent_callbacks_produce_one_admitted_send() {
     );
 }
 
-#[tokio::test(flavor = "multi_thread")]
-async fn mismatched_callbacks_suppress_publication_but_inject_current_share() {
-    let sender = Arc::new(RecordingMessageSender::new(0));
-    let scenario = BatchScenario::new(Arc::clone(&sender) as Arc<dyn MessageSender>);
+#[test]
+fn concurrent_callbacks_produce_one_admitted_send() {
+    run_concurrent_callbacks(PartialSignatureKind::ContributionProofs);
+}
+
+#[test]
+fn concurrent_post_consensus_callbacks_produce_one_admitted_send() {
+    run_concurrent_callbacks(PartialSignatureKind::PostConsensus);
+}
+
+async fn run_mismatched_callbacks(kind: PartialSignatureKind) {
+    let sender = Arc::new(RecordingMessageSender::new(usize::MAX));
+    let mut scenario = BatchScenario::new(Arc::clone(&sender) as Arc<dyn MessageSender>);
+    scenario.metadata.kind = kind;
     let validator_index = ValidatorIndex(42);
     let root_0 = Hash256::repeat_byte(0x50);
     let root_1 = Hash256::repeat_byte(0x51);
@@ -835,6 +1177,15 @@ async fn mismatched_callbacks_suppress_publication_but_inject_current_share() {
     )
     .await;
     assert_eq!(sender.attempts(), 1);
+    let record_key = batch_key(&scenario.metadata, scenario.validator_pubkey);
+    let record = scenario
+        .manager
+        .single_validator_batches
+        .get(&record_key)
+        .expect("canonical pending record should be retained");
+    assert_eq!(*record.state.lock(), SingleValidatorBatchState::Pending);
+    assert_eq!(record.descriptor, canonical);
+    drop(record);
 
     let mismatched = descriptor(&[(1, root_1, 1)]);
     scenario.seed_remote_shares(root_1, validator_index);
@@ -867,7 +1218,7 @@ async fn mismatched_callbacks_suppress_publication_but_inject_current_share() {
         &scenario.validator_key,
         ValidatorIndex(43),
         SyncSubnetId::new(0),
-        canonical,
+        canonical.clone(),
     );
     let other_pubkey = SecretKey::random().public_key().compress();
     let pubkey_mismatch_injections = scenario.manager.process_single_validator_batch(
@@ -888,10 +1239,81 @@ async fn mismatched_callbacks_suppress_publication_but_inject_current_share() {
             validator_index,
         },
     );
+    let mut unsupported_kind = scenario.metadata.clone();
+    unsupported_kind.kind = PartialSignatureKind::RandaoPartialSig;
+    let unsupported_kind_injections = process_batch(
+        &scenario.manager,
+        &unsupported_kind,
+        scenario.validator_pubkey,
+        &scenario.validator_key,
+        validator_index,
+        SyncSubnetId::new(0),
+        descriptor(&[(0, root_0, 1)]),
+    );
+    let mut wrong_role = scenario.metadata.clone();
+    wrong_role.role = Role::Aggregator;
+    let wrong_role_injections = process_batch(
+        &scenario.manager,
+        &wrong_role,
+        scenario.validator_pubkey,
+        &scenario.validator_key,
+        validator_index,
+        SyncSubnetId::new(0),
+        descriptor(&[(0, root_0, 1)]),
+    );
     assert_eq!(committee_injections.len(), 1);
     assert_eq!(index_injections.len(), 1);
     assert_eq!(pubkey_mismatch_injections.len(), 1);
+    assert_eq!(unsupported_kind_injections.len(), 1);
+    assert_eq!(wrong_role_injections.len(), 1);
     assert_eq!(sender.attempts(), 1);
+    assert_eq!(scenario.manager.single_validator_batches.len(), 1);
+    let record = scenario
+        .manager
+        .single_validator_batches
+        .get(&record_key)
+        .expect("mismatches should preserve the canonical pending record");
+    assert_eq!(*record.state.lock(), SingleValidatorBatchState::Pending);
+    assert_eq!(record.descriptor, canonical);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn mismatched_callbacks_suppress_publication_but_inject_current_share() {
+    run_mismatched_callbacks(PartialSignatureKind::ContributionProofs).await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn mismatched_post_consensus_callbacks_suppress_publication_but_inject_current_share() {
+    run_mismatched_callbacks(PartialSignatureKind::PostConsensus).await;
+}
+
+#[test]
+fn post_consensus_callback_root_must_be_in_the_descriptor() {
+    let sender = Arc::new(RecordingMessageSender::new(0));
+    let mut scenario = BatchScenario::new(Arc::clone(&sender) as Arc<dyn MessageSender>);
+    scenario.metadata.kind = PartialSignatureKind::PostConsensus;
+    let descriptor_root = Hash256::repeat_byte(0x58);
+    let callback_root = Hash256::repeat_byte(0x59);
+
+    let injections = process_batch_for_root(
+        &scenario.manager,
+        &scenario.metadata,
+        scenario.validator_pubkey,
+        &scenario.validator_key,
+        ValidatorIndex(42),
+        SyncSubnetId::new(0),
+        callback_root,
+        descriptor(&[(0, descriptor_root, 1)]),
+    );
+
+    assert_eq!(injections.len(), 1);
+    assert_eq!(injections[0].signing_root, callback_root);
+    assert_eq!(
+        injections[0].partial_signature,
+        scenario.validator_key.sign(callback_root)
+    );
+    assert_eq!(sender.attempts(), 0);
+    assert!(scenario.manager.single_validator_batches.is_empty());
 }
 
 #[test]
@@ -935,6 +1357,122 @@ fn validator_and_slot_batch_records_are_isolated() {
     assert_eq!(sender.attempts(), 3);
     assert_eq!(sender.messages().len(), 3);
     assert_eq!(scenario.manager.single_validator_batches.len(), 3);
+}
+
+#[test]
+fn contribution_proof_and_post_consensus_records_are_isolated() {
+    let sender = Arc::new(RecordingMessageSender::new(0));
+    let scenario = BatchScenario::new(Arc::clone(&sender) as Arc<dyn MessageSender>);
+    let type_three_root = Hash256::repeat_byte(0x68);
+    let type_zero_root = Hash256::repeat_byte(0x69);
+    let mut post_consensus = scenario.metadata.clone();
+    post_consensus.kind = PartialSignatureKind::PostConsensus;
+
+    process_batch(
+        &scenario.manager,
+        &scenario.metadata,
+        scenario.validator_pubkey,
+        &scenario.validator_key,
+        ValidatorIndex(42),
+        SyncSubnetId::new(0),
+        descriptor(&[(0, type_three_root, 1)]),
+    );
+    process_batch(
+        &scenario.manager,
+        &post_consensus,
+        scenario.validator_pubkey,
+        &scenario.validator_key,
+        ValidatorIndex(42),
+        SyncSubnetId::new(0),
+        descriptor(&[(0, type_zero_root, 1)]),
+    );
+
+    assert_eq!(scenario.manager.single_validator_batches.len(), 2);
+    assert!(
+        scenario
+            .manager
+            .single_validator_batches
+            .contains_key(&batch_key(&scenario.metadata, scenario.validator_pubkey))
+    );
+    assert!(
+        scenario
+            .manager
+            .single_validator_batches
+            .contains_key(&batch_key(&post_consensus, scenario.validator_pubkey))
+    );
+    let kinds = sender
+        .messages()
+        .iter()
+        .map(|unsigned| {
+            PartialSignatureMessages::from_ssz_bytes(unsigned.ssv_message.data())
+                .expect("phase-isolated batch should decode")
+                .kind
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(
+        kinds,
+        vec![
+            PartialSignatureKind::ContributionProofs,
+            PartialSignatureKind::PostConsensus
+        ]
+    );
+}
+
+#[test]
+fn cleanup_removes_pending_and_admitted_records_from_both_phases() {
+    let sender = Arc::new(RecordingMessageSender::new(1));
+    let scenario = BatchScenario::new(Arc::clone(&sender) as Arc<dyn MessageSender>);
+    let descriptor = descriptor(&[(0, Hash256::repeat_byte(0x70), 1)]);
+    let mut stale = scenario.metadata.clone();
+    stale.slot = BATCH_TEST_SLOT - 2;
+    let mut stale_post_consensus = stale.clone();
+    stale_post_consensus.kind = PartialSignatureKind::PostConsensus;
+    scenario.manager.slot_clock.set_slot(stale.slot.as_u64());
+
+    process_batch(
+        &scenario.manager,
+        &stale,
+        scenario.validator_pubkey,
+        &scenario.validator_key,
+        ValidatorIndex(42),
+        SyncSubnetId::new(0),
+        descriptor.clone(),
+    );
+    process_batch(
+        &scenario.manager,
+        &stale_post_consensus,
+        scenario.validator_pubkey,
+        &scenario.validator_key,
+        ValidatorIndex(42),
+        SyncSubnetId::new(0),
+        descriptor.clone(),
+    );
+    scenario
+        .manager
+        .slot_clock
+        .set_slot(BATCH_TEST_SLOT.as_u64());
+    process_batch(
+        &scenario.manager,
+        &scenario.metadata,
+        scenario.validator_pubkey,
+        &scenario.validator_key,
+        ValidatorIndex(42),
+        SyncSubnetId::new(0),
+        descriptor,
+    );
+    assert_eq!(scenario.manager.single_validator_batches.len(), 3);
+
+    scenario
+        .manager
+        .remove_stale_entries(BATCH_TEST_SLOT.saturating_sub(SIGNATURE_COLLECTOR_RETAIN_SLOTS));
+
+    assert_eq!(scenario.manager.single_validator_batches.len(), 1);
+    assert!(
+        scenario
+            .manager
+            .single_validator_batches
+            .contains_key(&batch_key(&scenario.metadata, scenario.validator_pubkey))
+    );
 }
 
 #[test]
@@ -990,17 +1528,17 @@ fn cleanup_removes_pending_and_admitted_batch_records() {
         scenario
             .manager
             .single_validator_batches
-            .contains_key(&(BATCH_TEST_SLOT, scenario.validator_pubkey))
+            .contains_key(&batch_key(&scenario.metadata, scenario.validator_pubkey))
     );
 }
 
-#[test]
-fn stale_callback_after_cleanup_does_not_recreate_or_publish_batch() {
+fn run_stale_callback_after_cleanup(kind: PartialSignatureKind) {
     let sender = Arc::new(RecordingMessageSender::new(0));
-    let scenario = BatchScenario::new(Arc::clone(&sender) as Arc<dyn MessageSender>);
+    let mut scenario = BatchScenario::new(Arc::clone(&sender) as Arc<dyn MessageSender>);
+    scenario.metadata.kind = kind;
     let signing_root = Hash256::repeat_byte(0x71);
     let descriptor = descriptor(&[(0, signing_root, 1)]);
-    let batch_key = (scenario.metadata.slot, scenario.validator_pubkey);
+    let batch_key = batch_key(&scenario.metadata, scenario.validator_pubkey);
 
     let initial_injections = process_batch(
         &scenario.manager,
@@ -1082,16 +1620,26 @@ fn stale_callback_after_cleanup_does_not_recreate_or_publish_batch() {
     );
 }
 
-#[tokio::test(flavor = "multi_thread")]
-async fn stale_sign_and_collect_does_not_recreate_cleaned_collectors() {
+#[test]
+fn stale_callback_after_cleanup_does_not_recreate_or_publish_batch() {
+    run_stale_callback_after_cleanup(PartialSignatureKind::ContributionProofs);
+}
+
+#[test]
+fn stale_post_consensus_callback_after_cleanup_does_not_recreate_or_publish_batch() {
+    run_stale_callback_after_cleanup(PartialSignatureKind::PostConsensus);
+}
+
+async fn run_stale_sign_and_collect(kind: PartialSignatureKind) {
     let sender = Arc::new(RecordingMessageSender::new(0));
-    let scenario =
+    let mut scenario =
         BatchScenario::new_with_max_workers(Arc::clone(&sender) as Arc<dyn MessageSender>, 1);
+    scenario.metadata.kind = kind;
     let validator_index = ValidatorIndex(42);
     let signing_root = Hash256::repeat_byte(0x72);
     let descriptor = descriptor(&[(0, signing_root, 1)]);
     let collector_key = (signing_root, validator_index);
-    let batch_key = (scenario.metadata.slot, scenario.validator_pubkey);
+    let batch_key = batch_key(&scenario.metadata, scenario.validator_pubkey);
 
     drop(
         scenario
@@ -1138,39 +1686,7 @@ async fn stale_sign_and_collect_does_not_recreate_cleaned_collectors() {
     .expect("stale notifier should be dropped promptly");
     assert!(matches!(result, Err(CollectionError::QueueClosedError)));
 
-    let (urgent_done_tx, urgent_done_rx) = oneshot::channel();
-    scenario
-        .manager
-        .processor
-        .urgent_consensus
-        .send_blocking(
-            move || {
-                let _ = urgent_done_tx.send(());
-            },
-            "stale_batch_urgent_barrier",
-        )
-        .expect("urgent barrier should enter the processor");
-    tokio::time::timeout(Duration::from_secs(5), urgent_done_rx)
-        .await
-        .expect("urgent barrier should run promptly")
-        .expect("urgent barrier should signal completion");
-
-    let (permitless_done_tx, permitless_done_rx) = oneshot::channel();
-    scenario
-        .manager
-        .processor
-        .permitless
-        .send_immediate(
-            move |_drop_on_finish| {
-                let _ = permitless_done_tx.send(());
-            },
-            "stale_batch_permitless_barrier",
-        )
-        .expect("permitless barrier should enter the processor");
-    tokio::time::timeout(Duration::from_secs(5), permitless_done_rx)
-        .await
-        .expect("permitless barrier should run promptly")
-        .expect("permitless barrier should signal completion");
+    drain_batch_processor_work(&scenario.manager).await;
 
     assert_eq!(sender.attempts(), 0);
     assert!(
@@ -1185,6 +1701,16 @@ async fn stale_sign_and_collect_does_not_recreate_cleaned_collectors() {
             .single_validator_batches
             .contains_key(&batch_key)
     );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn stale_sign_and_collect_does_not_recreate_cleaned_collectors() {
+    run_stale_sign_and_collect(PartialSignatureKind::ContributionProofs).await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn stale_post_consensus_sign_and_collect_does_not_recreate_cleaned_collectors() {
+    run_stale_sign_and_collect(PartialSignatureKind::PostConsensus).await;
 }
 
 #[tokio::test]

--- a/anchor/validator_store/src/lib.rs
+++ b/anchor/validator_store/src/lib.rs
@@ -36,7 +36,7 @@ use qbft_manager::{
 use safe_arith::{ArithError, SafeArith};
 use signature_collector::{
     CollectionError, SignatureCollecting, SignatureMetadata, SignatureRequester,
-    SyncSelectionProofDescriptor, ValidatorSigningData,
+    SyncCommitteeBatchEntry, ValidatorSigningData,
 };
 use slashing_protection::{CheckSlashability, NotSafe, Safe, SlashingDatabase};
 use slot_clock::SlotClock;
@@ -569,7 +569,7 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> AnchorValidator
         slot: Slot,
         callback_subnet: SyncSubnetId,
         position_counts: &HashMap<SyncSubnetId, usize>,
-    ) -> Result<Vec<SyncSelectionProofDescriptor>, SyncSelectionProofAssignmentError> {
+    ) -> Result<Vec<SyncCommitteeBatchEntry>, SyncSelectionProofAssignmentError> {
         if position_counts.is_empty() {
             return Err(SyncSelectionProofAssignmentError::Empty);
         }
@@ -607,10 +607,10 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> AnchorValidator
 
         let mut descriptor = Vec::with_capacity(position_counts.len());
         for (&subnet_id, &position_count) in position_counts {
-            descriptor.push(SyncSelectionProofDescriptor {
+            descriptor.push(SyncCommitteeBatchEntry {
                 subnet_id,
                 signing_root: self.compute_sync_selection_root(slot, subnet_id.into()),
-                position_count,
+                multiplicity: position_count,
             });
         }
 
@@ -1322,31 +1322,32 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> AnchorValidator
             let data = Contributions::<E>::from_ssz_bytes(&data.data_ssz)
                 .map_err(|e| Error::from(SpecificError::InvalidQbftData(e)))?;
 
-            let data = data
-                .into_iter()
-                .map(Contribution::from)
-                .find(|data| data.contribution.subcommittee_index == subcommittee_index)
-                .ok_or(SpecificError::NoDataAgreed)?;
+            let domain_hash = self.get_domain(epoch, Domain::ContributionAndProof);
+            let PreparedSyncContributionBatch {
+                callback_message: message,
+                callback_signing_root: signing_root,
+                descriptor,
+            } = prepare_decided_sync_contributions(
+                data,
+                SyncSubnetId::new(subcommittee_index),
+                aggregator_index,
+                domain_hash,
+            )?;
 
             debug!(
-                slot = %data.contribution.slot,
-                block_root = ?data.contribution.beacon_block_root,
-                subcommittee_index = data.contribution.subcommittee_index,
-                num_set_aggregation_bits = data.contribution.aggregation_bits.num_set_bits(),
+                slot = %message.contribution.slot,
+                block_root = ?message.contribution.beacon_block_root,
+                subcommittee_index = message.contribution.subcommittee_index,
+                num_set_aggregation_bits = message.contribution.aggregation_bits.num_set_bits(),
                 "Decided on Contribution to sign"
             );
 
-            let domain_hash = self.get_domain(epoch, Domain::ContributionAndProof);
-            let message = ContributionAndProof {
-                aggregator_index,
-                contribution: data.contribution,
-                selection_proof: data.selection_proof_sig,
-            };
-            let signing_root = message.signing_root(domain_hash);
+            let collection_mode =
+                sync_committee_collection_mode(SyncSubnetId::new(subcommittee_index), descriptor);
             self.collect_signature(
                 PartialSignatureKind::PostConsensus,
                 Role::SyncCommittee,
-                CollectionMode::SingleValidator,
+                collection_mode,
                 &validator,
                 &cluster,
                 signing_root,
@@ -2260,14 +2261,73 @@ pub struct ContributionAndProofSigningData<E: EthSpec> {
     selection_proof: SyncSelectionProof,
 }
 
+struct PreparedSyncContributionBatch<E: EthSpec> {
+    callback_message: ContributionAndProof<E>,
+    callback_signing_root: Hash256,
+    descriptor: Vec<SyncCommitteeBatchEntry>,
+}
+
+/// Prepares the exact decided sync contribution root multiset for every Lighthouse callback.
+fn prepare_decided_sync_contributions<E: EthSpec>(
+    contributions: Contributions<E>,
+    callback_subnet: SyncSubnetId,
+    aggregator_index: u64,
+    domain_hash: Hash256,
+) -> Result<PreparedSyncContributionBatch<E>, SpecificError> {
+    let mut callback = None;
+    let mut descriptor = Vec::with_capacity(contributions.len());
+
+    for contribution in contributions.into_iter().map(Contribution::from) {
+        let subnet_id = SyncSubnetId::new(contribution.contribution.subcommittee_index);
+        let message = ContributionAndProof {
+            aggregator_index,
+            contribution: contribution.contribution,
+            selection_proof: contribution.selection_proof_sig,
+        };
+        let signing_root = message.signing_root(domain_hash);
+
+        if callback.is_none() && subnet_id == callback_subnet {
+            callback = Some((message, signing_root));
+        }
+        descriptor.push(SyncCommitteeBatchEntry {
+            subnet_id,
+            signing_root,
+            multiplicity: 1,
+        });
+    }
+
+    let (callback_message, callback_signing_root) = callback.ok_or(SpecificError::NoDataAgreed)?;
+
+    descriptor.sort_unstable_by_key(|entry| (u64::from(entry.subnet_id), entry.signing_root));
+
+    let mut collapsed: Vec<SyncCommitteeBatchEntry> = Vec::with_capacity(descriptor.len());
+    for entry in descriptor {
+        match collapsed.last_mut() {
+            Some(previous)
+                if previous.subnet_id == entry.subnet_id
+                    && previous.signing_root == entry.signing_root =>
+            {
+                previous.multiplicity += entry.multiplicity;
+            }
+            _ => collapsed.push(entry),
+        }
+    }
+
+    Ok(PreparedSyncContributionBatch {
+        callback_message,
+        callback_signing_root,
+        descriptor: collapsed,
+    })
+}
+
 #[derive(Clone)]
 enum CollectionMode {
     SingleValidator,
     SingleValidatorBatch {
         /// Subnet requested by the current Lighthouse callback.
         subnet_id: SyncSubnetId,
-        /// Canonical descriptor for every unique subnet assigned to this validator and slot.
-        descriptor: Vec<SyncSelectionProofDescriptor>,
+        /// Canonical descriptor for every unique subnet and signing root pair in this batch.
+        descriptor: Vec<SyncCommitteeBatchEntry>,
     },
     Committee {
         /// The number of validator partial signatures this operator batches locally into the
@@ -2277,6 +2337,25 @@ enum CollectionMode {
         /// message.
         base_hash: Hash256,
     },
+}
+
+fn sync_committee_collection_mode(
+    callback_subnet: SyncSubnetId,
+    descriptor: Vec<SyncCommitteeBatchEntry>,
+) -> CollectionMode {
+    if descriptor
+        .iter()
+        .map(|entry| entry.multiplicity)
+        .sum::<usize>()
+        == 1
+    {
+        CollectionMode::SingleValidator
+    } else {
+        CollectionMode::SingleValidatorBatch {
+            subnet_id: callback_subnet,
+            descriptor,
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -3069,13 +3148,11 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> ValidatorStore
                             },
                         )?;
 
+                    let collection_mode = sync_committee_collection_mode(subnet_id, descriptor);
                     self.collect_signature(
                         PartialSignatureKind::ContributionProofs,
                         Role::SyncCommittee,
-                        CollectionMode::SingleValidatorBatch {
-                            subnet_id,
-                            descriptor,
-                        },
+                        collection_mode,
                         &validator,
                         &cluster,
                         signing_root,

--- a/anchor/validator_store/src/testing/common.rs
+++ b/anchor/validator_store/src/testing/common.rs
@@ -28,7 +28,10 @@ use ssz::Encode;
 use ssz_types::VariableList;
 use task_executor::TaskExecutor;
 use tempfile::TempDir;
-use tokio::{sync::watch, time::Instant};
+use tokio::{
+    sync::{Barrier, watch},
+    time::Instant,
+};
 use types::{
     Attestation, AttestationBase, AttestationData, ChainSpec, Checkpoint, Epoch, EthSpec, Graffiti,
     Hash256, MainnetEthSpec, SelectionProof, Slot, SyncSubnetId,
@@ -42,9 +45,20 @@ pub(super) const SLOT_DURATION_SECS: u64 = 12;
 
 // ==================== Mock consensus decider ====================
 
-/// Mock that instantly returns `Completed::Success(initial)`, echoing back the proposed data.
+/// Mock that either echoes the proposed data or returns one fixed SSZ-decoded value.
 /// Removes the need for `QbftManager` infrastructure and lets the signing pipeline run fully.
-pub(super) struct MockConsensusDecider;
+#[derive(Default)]
+pub(super) struct MockConsensusDecider {
+    fixed_decision: Option<(Vec<u8>, Arc<Barrier>)>,
+}
+
+impl MockConsensusDecider {
+    pub(super) fn fixed_after_barrier<D: Encode>(value: &D, parties: usize) -> Self {
+        Self {
+            fixed_decision: Some((value.as_ssz_bytes(), Arc::new(Barrier::new(parties)))),
+        }
+    }
+}
 
 impl<E: EthSpec> ConsensusDecider<E> for MockConsensusDecider {
     async fn decide_instance<D: QbftDecidable<E>>(
@@ -55,7 +69,14 @@ impl<E: EthSpec> ConsensusDecider<E> for MockConsensusDecider {
         _timeout_mode: TimeoutMode,
         _committee_members: &IndexSet<OperatorId>,
     ) -> Result<Completed<D>, QbftError> {
-        Ok(Completed::Success(initial))
+        let decided = match &self.fixed_decision {
+            Some((bytes, barrier)) => {
+                barrier.wait().await;
+                D::from_ssz_bytes(bytes).expect("fixed test consensus value should decode")
+            }
+            None => initial,
+        };
+        Ok(Completed::Success(decided))
     }
 }
 
@@ -65,6 +86,7 @@ impl<E: EthSpec> ConsensusDecider<E> for MockConsensusDecider {
 pub(super) type CapturedCalls = Arc<Mutex<Vec<CapturedSignatureCall>>>;
 
 pub(super) struct CapturedSignatureCall {
+    pub(super) metadata: SignatureMetadata,
     pub(super) requester: SignatureRequester,
     pub(super) validator_pubkey: PublicKeyBytes,
     pub(super) signing_root: Hash256,
@@ -80,11 +102,12 @@ struct MockSignatureCollector {
 impl SignatureCollecting for MockSignatureCollector {
     fn sign_and_collect(
         &self,
-        _metadata: SignatureMetadata,
+        metadata: SignatureMetadata,
         requester: SignatureRequester,
         signing_data: ValidatorSigningData,
     ) -> Pin<Box<dyn Future<Output = Result<Arc<Signature>, CollectionError>> + Send + '_>> {
         self.captured.lock().push(CapturedSignatureCall {
+            metadata,
             requester,
             validator_pubkey: signing_data.validator_pubkey,
             signing_root: signing_data.root,
@@ -202,6 +225,7 @@ impl ValidatorStoreTestHarness {
             our_operator_id,
             active_fork,
             Duration::ZERO,
+            MockConsensusDecider::default(),
         )
     }
 
@@ -215,6 +239,22 @@ impl ValidatorStoreTestHarness {
             our_operator_id,
             Fork::Boole,
             proposer_delay,
+            MockConsensusDecider::default(),
+        )
+    }
+
+    pub(super) fn new_with_fork_and_consensus(
+        committee_setups: Vec<CommitteeSetup>,
+        our_operator_id: OperatorId,
+        active_fork: Fork,
+        consensus: MockConsensusDecider,
+    ) -> Self {
+        Self::new_with_options(
+            committee_setups,
+            our_operator_id,
+            active_fork,
+            Duration::ZERO,
+            consensus,
         )
     }
 
@@ -223,6 +263,7 @@ impl ValidatorStoreTestHarness {
         our_operator_id: OperatorId,
         active_fork: Fork,
         proposer_delay: Duration,
+        consensus: MockConsensusDecider,
     ) -> Self {
         // Dummy RSA key for database operator identification (not used for decryption)
         let rsa_pubkey = database::test_utils::generators::pubkey::random_rsa();
@@ -312,7 +353,7 @@ impl ValidatorStoreTestHarness {
         let validator_store = AnchorValidatorStore::new(
             database,
             mock_collector,
-            Arc::new(MockConsensusDecider),
+            Arc::new(consensus),
             slashing_protection,
             true, // disable slashing protection for simpler testing
             slot_clock.clone(),

--- a/anchor/validator_store/src/testing/mod.rs
+++ b/anchor/validator_store/src/testing/mod.rs
@@ -3,4 +3,5 @@ mod common;
 mod committee_aggregate;
 mod committee_attestation;
 mod proposer_delay;
+mod sync_contribution;
 mod sync_selection_proof;

--- a/anchor/validator_store/src/testing/sync_contribution.rs
+++ b/anchor/validator_store/src/testing/sync_contribution.rs
@@ -1,0 +1,368 @@
+//! Tests for pre-Boole post-consensus sync contribution preparation and batching.
+
+use std::{collections::HashMap, time::Duration};
+
+use bls::{AggregateSignature, Signature};
+use fork::Fork;
+use futures::StreamExt;
+use signature_collector::{SignatureRequester, SyncCommitteeBatchEntry};
+use ssv_types::{
+    OperatorId, ValidatorIndex,
+    consensus::{
+        BEACON_ROLE_SYNC_COMMITTEE_CONTRIBUTION, Contribution, ContributionWrapper, Contributions,
+        ProposerConsensusData, ValidatorDuty,
+    },
+    partial_sig::PartialSignatureKind,
+};
+use ssz::Encode;
+use ssz_types::VariableList;
+use types::{
+    ContributionAndProof, Domain, EthSpec, ForkName, Hash256, MainnetEthSpec, SignedRoot, Slot,
+    SyncCommitteeContribution, SyncSelectionProof, SyncSubnetId,
+};
+use validator_store::{ContributionToSign, ValidatorStore};
+
+use super::common::*;
+use crate::{
+    AggregationAssignments, CollectionMode, ContributionWaiter, SpecificError,
+    prepare_decided_sync_contributions, sync_committee_collection_mode,
+};
+
+const OUR_OPERATOR_ID: OperatorId = OperatorId(1);
+const AGGREGATOR_INDEX: u64 = 42;
+const DOMAIN_HASH: Hash256 = Hash256::repeat_byte(0xDD);
+
+#[derive(Clone, Copy, Debug)]
+struct ContributionSpec {
+    subnet: u64,
+    block_root_byte: u8,
+}
+
+fn contribution(spec: ContributionSpec) -> Contribution<MainnetEthSpec> {
+    Contribution {
+        selection_proof_sig: Signature::empty(),
+        contribution: SyncCommitteeContribution {
+            slot: Slot::new(TEST_SLOT),
+            beacon_block_root: Hash256::repeat_byte(spec.block_root_byte),
+            subcommittee_index: spec.subnet,
+            aggregation_bits: Default::default(),
+            signature: AggregateSignature::infinity(),
+        },
+    }
+}
+
+fn message(spec: ContributionSpec) -> ContributionAndProof<MainnetEthSpec> {
+    let contribution = contribution(spec);
+    ContributionAndProof {
+        aggregator_index: AGGREGATOR_INDEX,
+        contribution: contribution.contribution,
+        selection_proof: contribution.selection_proof_sig,
+    }
+}
+
+fn decided(specs: &[ContributionSpec]) -> Contributions<MainnetEthSpec> {
+    Contributions::new(
+        specs
+            .iter()
+            .copied()
+            .map(contribution)
+            .map(ContributionWrapper::from)
+            .collect(),
+    )
+    .expect("test contributions should fit the bounded decided value")
+}
+
+fn expected_descriptor(
+    entries: &[(ContributionSpec, usize)],
+    domain_hash: Hash256,
+) -> Vec<SyncCommitteeBatchEntry> {
+    let mut descriptor = entries
+        .iter()
+        .map(|(spec, multiplicity)| SyncCommitteeBatchEntry {
+            subnet_id: SyncSubnetId::new(spec.subnet),
+            signing_root: message(*spec).signing_root(domain_hash),
+            multiplicity: *multiplicity,
+        })
+        .collect::<Vec<_>>();
+    descriptor.sort_unstable_by_key(|entry| (u64::from(entry.subnet_id), entry.signing_root));
+    descriptor
+}
+
+#[test]
+fn decided_contribution_preparation_cases() {
+    struct Case {
+        name: &'static str,
+        decided: Vec<ContributionSpec>,
+        callback_subnet: u64,
+        expected_entries: Vec<(ContributionSpec, usize)>,
+    }
+
+    let a = ContributionSpec {
+        subnet: 0,
+        block_root_byte: 0x10,
+    };
+    let b = ContributionSpec {
+        subnet: 1,
+        block_root_byte: 0x11,
+    };
+    let c = ContributionSpec {
+        subnet: 2,
+        block_root_byte: 0x12,
+    };
+    let d = ContributionSpec {
+        subnet: 3,
+        block_root_byte: 0x13,
+    };
+    let same_subnet_first = ContributionSpec {
+        subnet: 1,
+        block_root_byte: 0x21,
+    };
+    let same_subnet_second = ContributionSpec {
+        subnet: 1,
+        block_root_byte: 0x20,
+    };
+
+    let cases = [
+        Case {
+            name: "one root",
+            decided: vec![a],
+            callback_subnet: 0,
+            expected_entries: vec![(a, 1)],
+        },
+        Case {
+            name: "two roots in reverse subnet order",
+            decided: vec![b, a],
+            callback_subnet: 1,
+            expected_entries: vec![(a, 1), (b, 1)],
+        },
+        Case {
+            name: "four shuffled roots",
+            decided: vec![d, b, a, c],
+            callback_subnet: 2,
+            expected_entries: vec![(a, 1), (b, 1), (c, 1), (d, 1)],
+        },
+        Case {
+            name: "same four roots in another permutation",
+            decided: vec![c, a, d, b],
+            callback_subnet: 2,
+            expected_entries: vec![(a, 1), (b, 1), (c, 1), (d, 1)],
+        },
+        Case {
+            name: "identical entry multiplicity",
+            decided: vec![b, a, b],
+            callback_subnet: 1,
+            expected_entries: vec![(a, 1), (b, 2)],
+        },
+        Case {
+            name: "decided subnet without a local callback",
+            decided: vec![a, d],
+            callback_subnet: 0,
+            expected_entries: vec![(a, 1), (d, 1)],
+        },
+        Case {
+            name: "two distinct roots on one subnet",
+            decided: vec![same_subnet_first, same_subnet_second],
+            callback_subnet: 1,
+            expected_entries: vec![(same_subnet_first, 1), (same_subnet_second, 1)],
+        },
+    ];
+
+    for case in cases {
+        let first_matching = case
+            .decided
+            .iter()
+            .copied()
+            .find(|spec| spec.subnet == case.callback_subnet)
+            .expect("valid case should contain its callback subnet");
+        let prepared = prepare_decided_sync_contributions(
+            decided(&case.decided),
+            SyncSubnetId::new(case.callback_subnet),
+            AGGREGATOR_INDEX,
+            DOMAIN_HASH,
+        )
+        .unwrap_or_else(|error| panic!("{} should prepare: {error:?}", case.name));
+        let expected = expected_descriptor(&case.expected_entries, DOMAIN_HASH);
+
+        assert_eq!(
+            prepared.callback_message,
+            message(first_matching),
+            "{}",
+            case.name
+        );
+        assert_eq!(
+            prepared.callback_signing_root,
+            message(first_matching).signing_root(DOMAIN_HASH),
+            "{}",
+            case.name
+        );
+        assert_eq!(prepared.descriptor, expected, "{}", case.name);
+
+        let total_multiplicity = expected
+            .iter()
+            .map(|entry| entry.multiplicity)
+            .sum::<usize>();
+        match sync_committee_collection_mode(
+            SyncSubnetId::new(case.callback_subnet),
+            prepared.descriptor,
+        ) {
+            CollectionMode::SingleValidator if total_multiplicity == 1 => {}
+            CollectionMode::SingleValidatorBatch {
+                subnet_id,
+                descriptor,
+            } if total_multiplicity > 1 => {
+                assert_eq!(subnet_id, SyncSubnetId::new(case.callback_subnet));
+                assert_eq!(descriptor, expected);
+            }
+            _ => panic!("{} selected the wrong collection mode", case.name),
+        }
+    }
+}
+
+#[test]
+fn decided_contribution_preparation_preserves_no_data_agreed() {
+    let result = prepare_decided_sync_contributions(
+        decided(&[ContributionSpec {
+            subnet: 0,
+            block_root_byte: 0x10,
+        }]),
+        SyncSubnetId::new(1),
+        AGGREGATOR_INDEX,
+        DOMAIN_HASH,
+    );
+
+    assert!(matches!(result, Err(SpecificError::NoDataAgreed)));
+}
+
+fn fixed_consensus_data(
+    validator_pubkey: bls::PublicKeyBytes,
+    validator_index: ValidatorIndex,
+    decided: &Contributions<MainnetEthSpec>,
+) -> ProposerConsensusData {
+    ProposerConsensusData {
+        duty: ValidatorDuty {
+            r#type: BEACON_ROLE_SYNC_COMMITTEE_CONTRIBUTION,
+            pub_key: validator_pubkey,
+            slot: Slot::new(TEST_SLOT),
+            validator_index,
+            committee_index: 0,
+            committee_length: 0,
+            committees_at_slot: 0,
+            validator_committee_index: AGGREGATOR_INDEX,
+            validator_sync_committee_indices: Default::default(),
+        },
+        version: ForkName::Altair.into(),
+        data_ssz: VariableList::new(decided.as_ssz_bytes())
+            .expect("decided contribution bytes should fit proposer consensus data"),
+    }
+}
+
+fn contribution_to_sign(
+    validator_pubkey: bls::PublicKeyBytes,
+    spec: ContributionSpec,
+) -> ContributionToSign<MainnetEthSpec> {
+    let data = contribution(spec);
+    ContributionToSign {
+        aggregator_index: AGGREGATOR_INDEX,
+        aggregator_pubkey: validator_pubkey,
+        contribution: data.contribution,
+        selection_proof: SyncSelectionProof::from(data.selection_proof_sig),
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn pre_boole_callbacks_use_the_complete_fixed_decided_descriptor() {
+    let committee = create_committee_setup(
+        &[OperatorId(1), OperatorId(2), OperatorId(3), OperatorId(4)],
+        1,
+        AGGREGATOR_INDEX as usize,
+    );
+    let validator = committee.validators[0].clone();
+    let callback_a = ContributionSpec {
+        subnet: 0,
+        block_root_byte: 0x31,
+    };
+    let callback_b = ContributionSpec {
+        subnet: 1,
+        block_root_byte: 0x32,
+    };
+    let phantom = ContributionSpec {
+        subnet: 3,
+        block_root_byte: 0x33,
+    };
+    let fixed_decided = decided(&[phantom, callback_b, callback_a]);
+    let validator_index = validator
+        .index
+        .expect("test validator should have an index");
+    let fixed_value = fixed_consensus_data(validator.public_key, validator_index, &fixed_decided);
+    let harness = ValidatorStoreTestHarness::new_with_fork_and_consensus(
+        vec![committee],
+        OUR_OPERATOR_ID,
+        Fork::Alan,
+        MockConsensusDecider::fixed_after_barrier(&fixed_value, 2),
+    );
+    harness
+        .validator_store
+        .update_aggregation_assignments(AggregationAssignments {
+            slot: Slot::new(TEST_SLOT),
+            aggregator_committees: HashMap::new(),
+            multi_sync_aggregators: HashMap::from([(
+                validator.public_key,
+                ContributionWaiter::new(2),
+            )]),
+            consensus_data_by_ssv_committee: HashMap::new(),
+        });
+
+    let stream = harness
+        .validator_store
+        .sign_sync_committee_contributions(vec![
+            contribution_to_sign(validator.public_key, callback_b),
+            contribution_to_sign(validator.public_key, callback_a),
+        ]);
+    let results = tokio::time::timeout(Duration::from_secs(5), stream.collect::<Vec<_>>())
+        .await
+        .expect("concurrent contribution callbacks should complete promptly");
+    let mut signed = results
+        .into_iter()
+        .next()
+        .expect("pre-Boole signing should produce one streamed result")
+        .expect("pre-Boole signing should succeed");
+    signed.sort_by_key(|item| item.message.contribution.subcommittee_index);
+    assert_eq!(signed.len(), 2);
+    assert_eq!(signed[0].message, message(callback_a));
+    assert_eq!(signed[1].message, message(callback_b));
+
+    let epoch = Slot::new(TEST_SLOT).epoch(MainnetEthSpec::slots_per_epoch());
+    let domain_hash = harness
+        .validator_store
+        .get_domain(epoch, Domain::ContributionAndProof);
+    let expected = expected_descriptor(
+        &[(callback_a, 1), (callback_b, 1), (phantom, 1)],
+        domain_hash,
+    );
+    let mut captured = harness.captured_calls.lock();
+    captured.sort_by_key(|call| match &call.requester {
+        SignatureRequester::SingleValidatorBatch { subnet_id, .. } => u64::from(*subnet_id),
+        other => panic!("expected post-consensus batch requester, got {other:?}"),
+    });
+    assert_eq!(captured.len(), 2);
+    for (call, callback) in captured.iter().zip([callback_a, callback_b]) {
+        assert_eq!(call.metadata.kind, PartialSignatureKind::PostConsensus);
+        assert_eq!(call.metadata.role, ssv_types::msgid::Role::SyncCommittee);
+        assert_eq!(call.metadata.slot, Slot::new(TEST_SLOT));
+        assert_eq!(call.validator_pubkey, validator.public_key);
+        let expected_root = message(callback).signing_root(domain_hash);
+        match &call.requester {
+            SignatureRequester::SingleValidatorBatch {
+                pubkey,
+                subnet_id,
+                descriptor,
+            } => {
+                assert_eq!(*pubkey, validator.public_key);
+                assert_eq!(*subnet_id, SyncSubnetId::new(callback.subnet));
+                assert_eq!(descriptor, &expected);
+            }
+            other => panic!("expected post-consensus batch requester, got {other:?}"),
+        }
+        assert_eq!(call.signing_root, expected_root);
+    }
+}

--- a/anchor/validator_store/src/testing/sync_selection_proof.rs
+++ b/anchor/validator_store/src/testing/sync_selection_proof.rs
@@ -1,7 +1,7 @@
 //! Integration tests for sync selection proof descriptor construction.
 
 use fork::Fork;
-use signature_collector::{SignatureRequester, SyncSelectionProofDescriptor};
+use signature_collector::{SignatureRequester, SyncCommitteeBatchEntry};
 use ssv_types::OperatorId;
 use types::{Slot, SyncSubnetId};
 use validator_store::ValidatorStore;
@@ -85,14 +85,18 @@ async fn pre_boole_callbacks_receive_the_same_canonical_descriptor() {
         let expected_descriptor = case
             .expected_counts
             .iter()
-            .map(|(subnet, position_count)| SyncSelectionProofDescriptor {
+            .map(|(subnet, multiplicity)| SyncCommitteeBatchEntry {
                 subnet_id: SyncSubnetId::new(*subnet),
                 signing_root: harness
                     .validator_store
                     .compute_sync_selection_root(Slot::new(TEST_SLOT), *subnet),
-                position_count: *position_count,
+                multiplicity: *multiplicity,
             })
             .collect::<Vec<_>>();
+        let total_multiplicity = expected_descriptor
+            .iter()
+            .map(|entry| entry.multiplicity)
+            .sum::<usize>();
 
         let captured = harness.captured_calls.lock();
         assert_eq!(captured.len(), case.callbacks.len());
@@ -104,18 +108,23 @@ async fn pre_boole_callbacks_receive_the_same_canonical_descriptor() {
                 .expect("callback subnet should be present")
                 .signing_root;
             match &call.requester {
+                SignatureRequester::SingleValidator { pubkey } if total_multiplicity == 1 => {
+                    assert_eq!(*pubkey, validator.public_key);
+                    assert_eq!(call.signing_root, callback_root);
+                    assert_eq!(call.validator_pubkey, validator.public_key);
+                }
                 SignatureRequester::SingleValidatorBatch {
                     pubkey,
                     subnet_id,
                     descriptor,
-                } => {
+                } if total_multiplicity > 1 => {
                     assert_eq!(*pubkey, validator.public_key);
                     assert_eq!(*subnet_id, callback_subnet);
                     assert_eq!(descriptor, &expected_descriptor);
                     assert_eq!(call.signing_root, callback_root);
                     assert_eq!(call.validator_pubkey, validator.public_key);
                 }
-                other => panic!("expected SingleValidatorBatch, got {other:?}"),
+                other => panic!("unexpected signature requester: {other:?}"),
             }
         }
     }
@@ -257,7 +266,7 @@ async fn pre_boole_accepts_exactly_thirteen_positions() {
     assert!(matches!(
         &captured[0].requester,
         SignatureRequester::SingleValidatorBatch { descriptor, .. }
-            if descriptor[0].position_count == 13
+            if descriptor[0].multiplicity == 13
     ));
 }
 


### PR DESCRIPTION
## Problem, Evidence, and Context (Required)

- Before Boole, QBFT can decide multiple sync contributions for one validator, but Anchor publishes each post-consensus callback as a single-root type-0 envelope. go-ssv expects the complete decided root multiset and rejects these envelopes with `wrong expected roots count`.
- A prior mixed-client reproduction recorded 626 type-0 wrong-root-count rejections across 210 multi-root duties.
- #1201 fixed the analogous type-3 producer path and provides the batch reused here.

## Change Overview (Required)

- Prepare a canonical descriptor from the complete decided `Contributions`, sorted by subnet and root with identical entries retained as multiplicity.
- Reuse the eager `Pending`/`Admitted` single-validator batch for post-consensus messages, isolated from type 3 by phase and keyed by exact signing root.
- Keep the single-root path unchanged. Boole, wire types, inbound validation, and Lighthouse APIs are unchanged.
- Review `validator_store` preparation first, then `signature_collector` admission and retry behavior.

## Risks, Trade-offs, and Mitigations (Required)

- The main risk is concurrent sibling callbacks publishing incomplete or duplicate envelopes. Focused tests cover admission, retry, injection, cleanup, stale work, impostor mode, and isolation boundaries.

## Validation (Required)

- 30-minute mixed run with three Anchor nodes and one go-ssv node: 1,035 type-0 duties, including 195 multi-root duties and exact two-, three-, and four-root envelopes; zero root-count, root, signature, descriptor, quorum, restart, or OOM failures; type 3 remained unchanged.
- After #1201 merged, this branch was replayed as one commit on current `unstable`. The only conflicts were in `validator_store` test scaffolding added by #1213, so the harness constructor now takes both a proposer delay and a mock consensus decider. `git range-diff` confirms the production diff is unchanged from the validated candidate.
- On the replayed commit: `git diff --check`, `make cargo-fmt-check`, `make lint`, and release tests covering 56 `validator_store`, 33 `signature_collector`, and 57 `message_validator` cases.

## Rollback (Required for behavior or runtime changes; optional otherwise)

- Revert this commit. There are no config, data, API, or wire-format migrations.
