### PR TITLE
ci: deploy docs site on release publish instead of every unstable push

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,17 +1,19 @@
 name: docs
 
 on:
-  push:
-    branches:
-      - unstable
+  release:
+    types: [published]
+  workflow_dispatch:
 
+# All runs deploy to the same S3 bucket with --delete, so they must serialize,
+# and an in-flight sync must never be cancelled halfway through.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  group: docs-deploy
+  cancel-in-progress: false
 
 jobs:
   build-and-upload-to-s3:
-    if: github.repository_owner == 'sigp'
+    if: github.repository_owner == 'sigp' && !github.event.release.prerelease
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -25,17 +25,23 @@ jobs:
           cache: 'npm'
           cache-dependency-path: docs/package-lock.json
 
+      # Step timeouts on the network-bound steps keep a hang from holding the
+      # docs-deploy concurrency group (default job timeout is 6h). Deliberately
+      # no job-level timeout: it could cancel the S3 sync mid-run.
       - name: Install dependencies
         run: npm ci
         working-directory: docs
+        timeout-minutes: 10
 
       - name: Install Playwright browsers
         run: npx playwright install
         working-directory: docs
+        timeout-minutes: 10
 
       - name: Sync version and GitHub stars
         run: npm run sync-version
         working-directory: docs
+        timeout-minutes: 10
 
       - name: Build vocs
         run: npm run build

--- a/docs/README.md
+++ b/docs/README.md
@@ -65,6 +65,14 @@ To preview the built site:
 npm run preview
 ```
 
+## Deployment
+
+The live site ([anchor.sigmaprime.io](https://anchor.sigmaprime.io)) is deployed by the
+`docs` GitHub workflow when a release is published, so the published docs always match the
+latest released binary. Docs merged to `unstable` do not go live until the next release.
+For an out-of-band redeploy (e.g. a docs fix cherry-picked to `stable`), run the workflow
+manually: `gh workflow run docs.yml --ref stable`.
+
 ## Contributing
 
 ### Adding New Pages

--- a/docs/docs/pages/installation.mdx
+++ b/docs/docs/pages/installation.mdx
@@ -35,8 +35,8 @@ wget https://github.com/sigp/anchor/releases/download/<version>/anchor-<version>
 tar -xvf anchor-<version>-<platform>.tar.gz
 
 # Specific version example
-wget https://github.com/sigp/anchor/releases/download/v1.1.0/anchor-v1.1.0-unknown-linux-gnu.tar.gz
-tar -xvf anchor-v1.1.0-unknown-linux-gnu.tar.gz
+wget https://github.com/sigp/anchor/releases/download/v1.1.0/anchor-v1.1.0-x86_64-unknown-linux-gnu.tar.gz
+tar -xvf anchor-v1.1.0-x86_64-unknown-linux-gnu.tar.gz
 sudo mv anchor /usr/local/bin/
 ```
 

--- a/docs/sync-version.js
+++ b/docs/sync-version.js
@@ -87,15 +87,17 @@ async function updateVersionAndStatsInFiles(version, stats) {
   const installationPath = join(__dirname, 'docs/pages/installation.mdx');
   let installationContent = readFileSync(installationPath, 'utf8');
   
-  // Replace download URL versions
+  // Replace download URL versions. The filename version pattern must not have an
+  // optional -suffix group: it would greedily swallow the architecture component
+  // (anchor-v1.1.0-x86_64-... -> anchor-v1.2.0-...).
   installationContent = installationContent.replace(
-    /wget https:\/\/github\.com\/sigp\/anchor\/releases\/download\/v[\d.]+(?:-[\w.]+)?\/anchor-v[\d.]+(?:-[\w.]+)?-/g,
+    /wget https:\/\/github\.com\/sigp\/anchor\/releases\/download\/v[\d.]+(?:-[\w.]+)?\/anchor-v[\d.]+-/g,
     `wget https://github.com/sigp/anchor/releases/download/${vVersion}/anchor-${vVersion}-`
   );
-  
+
   // Replace tar extraction versions
   installationContent = installationContent.replace(
-    /tar -xvf anchor-v[\d.]+(?:-[\w.]+)?-/g,
+    /tar -xvf anchor-v[\d.]+-/g,
     `tar -xvf anchor-${vVersion}-`
   );
   


### PR DESCRIPTION
## Problem, Evidence, and Context (Required)

- The docs workflow deploys anchor.sigmaprime.io on every push to `unstable`, so docs for unreleased CLI flags go live weeks before a binary exists, and during each release window the site advertises versioned download URLs that 404 (the version bump merges to `unstable` before the release is published).
- Operators are currently seeing docs for flags their binary rejects.
- Separately, the Linux install example uses an arch-less tarball name that no release asset matches, and the version-sync regex mangles arch-qualified names at build time.
- Closes #1209 (alternatives considered and rollout details are recorded there).

## Change Overview (Required)

- `docs.yml` now triggers on `release: published` (prerelease-guarded) plus a bare `workflow_dispatch` for manual redeploys; deploys serialize under a constant concurrency group with `cancel-in-progress: false` so an in-flight `s3 sync --delete` is never killed halfway.
- `sync-version.js` filename regexes drop the greedy optional suffix group that swallowed the architecture component; the installation example is now arch-qualified; the docs README documents the new publication timing.
- Reading order: `docs.yml` (the behavior change), then `sync-version.js` + `installation.mdx` (content fix), then `README.md`.
- Intentionally unchanged: the build itself, linkcheck and CLI-reference checks on PRs/unstable, and the S3 sync mechanics.

## Risks, Trade-offs, and Mitigations (Required)

- The new trigger and the manual-dispatch button only take effect once this file reaches `stable` (default branch) at the next release; until then the live site freezes at its current content (status quo, self-corrects at next release publish).
- Merging this stops unstable-push deploys immediately (push events read the workflow file at the pushed commit; no final unstable deploy fires).
- Docs-only fixes between releases no longer publish automatically; path is cherry-pick to `stable` and `gh workflow run docs.yml --ref stable`.
- Publishing a stale draft release would redeploy that tag's docs; accepted as low-likelihood and recoverable via a manual redeploy from `stable`.

## Validation (Required)

- `actionlint` clean on the modified workflow; `node --check` clean on `sync-version.js`.
- Regex fix verified with a standalone node repro: arch-qualified names now survive version rewriting (previously `anchor-v1.1.0-x86_64-...` became `anchor-vX.Y.Z-...`).
- End-to-end trigger behavior is only observable at the next release publish; first post-release deploy should be checked against the live site.

## Rollback (Required for behavior or runtime changes; optional otherwise)

- Revert the commit; the previous push-to-unstable deploy behavior returns on the next `unstable` push. No data or config impact; the S3 bucket is fully rewritten by any subsequent deploy.