### PR TITLE
chore(deps): bump Lighthouse to unstable HEAD e58ec88fe and migrate sign_attestations to SingleAttestation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1204,7 +1204,7 @@ dependencies = [
  "futures-lite",
  "parking",
  "polling",
- "rustix",
+ "rustix 1.1.4",
  "slab",
  "windows-sys 0.61.2",
 ]
@@ -1390,7 +1390,7 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 [[package]]
 name = "beacon_node_fallback"
 version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?rev=81d576943#81d576943835d443f43b6dda52769784ed82bd47"
+source = "git+https://github.com/sigp/lighthouse?rev=e58ec88fe#e58ec88fe9a8f755a0d92a80b25fd76100d08d49"
 dependencies = [
  "bls",
  "clap",
@@ -1490,7 +1490,7 @@ dependencies = [
 [[package]]
 name = "bls"
 version = "0.2.0"
-source = "git+https://github.com/sigp/lighthouse?rev=81d576943#81d576943835d443f43b6dda52769784ed82bd47"
+source = "git+https://github.com/sigp/lighthouse?rev=e58ec88fe#e58ec88fe9a8f755a0d92a80b25fd76100d08d49"
 dependencies = [
  "alloy-primitives 1.5.7",
  "blst",
@@ -2606,7 +2606,7 @@ dependencies = [
 [[package]]
 name = "eip_3076"
 version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?rev=81d576943#81d576943835d443f43b6dda52769784ed82bd47"
+source = "git+https://github.com/sigp/lighthouse?rev=e58ec88fe#e58ec88fe9a8f755a0d92a80b25fd76100d08d49"
 dependencies = [
  "bls",
  "ethereum_serde_utils 0.8.0",
@@ -2830,7 +2830,7 @@ dependencies = [
 [[package]]
 name = "eth2"
 version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?rev=81d576943#81d576943835d443f43b6dda52769784ed82bd47"
+source = "git+https://github.com/sigp/lighthouse?rev=e58ec88fe#e58ec88fe9a8f755a0d92a80b25fd76100d08d49"
 dependencies = [
  "bls",
  "context_deserialize",
@@ -2840,6 +2840,7 @@ dependencies = [
  "ethereum_serde_utils 0.8.0",
  "ethereum_ssz",
  "ethereum_ssz_derive",
+ "fork_choice",
  "futures",
  "futures-util",
  "mediatype",
@@ -2859,7 +2860,7 @@ dependencies = [
 [[package]]
 name = "eth2_config"
 version = "0.2.0"
-source = "git+https://github.com/sigp/lighthouse?rev=81d576943#81d576943835d443f43b6dda52769784ed82bd47"
+source = "git+https://github.com/sigp/lighthouse?rev=e58ec88fe#e58ec88fe9a8f755a0d92a80b25fd76100d08d49"
 dependencies = [
  "paste",
  "types",
@@ -2868,7 +2869,7 @@ dependencies = [
 [[package]]
 name = "eth2_interop_keypairs"
 version = "0.2.0"
-source = "git+https://github.com/sigp/lighthouse?rev=81d576943#81d576943835d443f43b6dda52769784ed82bd47"
+source = "git+https://github.com/sigp/lighthouse?rev=e58ec88fe#e58ec88fe9a8f755a0d92a80b25fd76100d08d49"
 dependencies = [
  "bls",
  "ethereum_hashing 0.8.0",
@@ -2881,7 +2882,7 @@ dependencies = [
 [[package]]
 name = "eth2_key_derivation"
 version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?rev=81d576943#81d576943835d443f43b6dda52769784ed82bd47"
+source = "git+https://github.com/sigp/lighthouse?rev=e58ec88fe#e58ec88fe9a8f755a0d92a80b25fd76100d08d49"
 dependencies = [
  "bls",
  "num-bigint-dig",
@@ -2893,7 +2894,7 @@ dependencies = [
 [[package]]
 name = "eth2_keystore"
 version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?rev=81d576943#81d576943835d443f43b6dda52769784ed82bd47"
+source = "git+https://github.com/sigp/lighthouse?rev=e58ec88fe#e58ec88fe9a8f755a0d92a80b25fd76100d08d49"
 dependencies = [
  "aes",
  "bls",
@@ -2917,7 +2918,7 @@ dependencies = [
 [[package]]
 name = "eth2_network_config"
 version = "0.2.0"
-source = "git+https://github.com/sigp/lighthouse?rev=81d576943#81d576943835d443f43b6dda52769784ed82bd47"
+source = "git+https://github.com/sigp/lighthouse?rev=e58ec88fe#e58ec88fe9a8f755a0d92a80b25fd76100d08d49"
 dependencies = [
  "bytes",
  "discv5",
@@ -2986,8 +2987,7 @@ dependencies = [
 [[package]]
 name = "ethereum_ssz"
 version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e462875ad8693755ea8913d6e905715c76ea4836e2254e18c9cf0f7a8f8c2a13"
+source = "git+https://github.com/sigp/ethereum_ssz?rev=2059c21ba52cd3a7e39a8ad537012b761812a393#2059c21ba52cd3a7e39a8ad537012b761812a393"
 dependencies = [
  "alloy-primitives 1.5.7",
  "context_deserialize",
@@ -3002,8 +3002,7 @@ dependencies = [
 [[package]]
 name = "ethereum_ssz_derive"
 version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daf022360bdbe9456eda5f35718a50476d5b2a0d51a97ed4eae27420737a6fba"
+source = "git+https://github.com/sigp/ethereum_ssz?rev=2059c21ba52cd3a7e39a8ad537012b761812a393#2059c21ba52cd3a7e39a8ad537012b761812a393"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",
@@ -3141,7 +3140,7 @@ dependencies = [
 [[package]]
 name = "filesystem"
 version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?rev=81d576943#81d576943835d443f43b6dda52769784ed82bd47"
+source = "git+https://github.com/sigp/lighthouse?rev=e58ec88fe#e58ec88fe9a8f755a0d92a80b25fd76100d08d49"
 dependencies = [
  "winapi",
  "windows-acl",
@@ -3168,7 +3167,7 @@ dependencies = [
 [[package]]
 name = "fixed_bytes"
 version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?rev=81d576943#81d576943835d443f43b6dda52769784ed82bd47"
+source = "git+https://github.com/sigp/lighthouse?rev=e58ec88fe#e58ec88fe9a8f755a0d92a80b25fd76100d08d49"
 dependencies = [
  "alloy-primitives 1.5.7",
  "safe_arith",
@@ -3236,6 +3235,23 @@ dependencies = [
  "ssv_types",
  "task_executor",
  "tokio",
+ "tracing",
+ "types",
+]
+
+[[package]]
+name = "fork_choice"
+version = "0.1.0"
+source = "git+https://github.com/sigp/lighthouse?rev=e58ec88fe#e58ec88fe9a8f755a0d92a80b25fd76100d08d49"
+dependencies = [
+ "ethereum_ssz",
+ "ethereum_ssz_derive",
+ "fixed_bytes",
+ "logging 0.2.0",
+ "metrics",
+ "proto_array",
+ "state_processing",
+ "superstruct",
  "tracing",
  "types",
 ]
@@ -3505,7 +3521,7 @@ dependencies = [
 [[package]]
 name = "graffiti_file"
 version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?rev=81d576943#81d576943835d443f43b6dda52769784ed82bd47"
+source = "git+https://github.com/sigp/lighthouse?rev=e58ec88fe#e58ec88fe9a8f755a0d92a80b25fd76100d08d49"
 dependencies = [
  "bls",
  "serde",
@@ -3592,11 +3608,11 @@ dependencies = [
 [[package]]
 name = "health_metrics"
 version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?rev=81d576943#81d576943835d443f43b6dda52769784ed82bd47"
+source = "git+https://github.com/sigp/lighthouse?rev=e58ec88fe#e58ec88fe9a8f755a0d92a80b25fd76100d08d49"
 dependencies = [
  "eth2",
  "metrics",
- "procfs",
+ "procfs 0.18.0",
  "psutil",
 ]
 
@@ -4138,9 +4154,18 @@ dependencies = [
 [[package]]
 name = "int_to_bytes"
 version = "0.2.0"
-source = "git+https://github.com/sigp/lighthouse?rev=81d576943#81d576943835d443f43b6dda52769784ed82bd47"
+source = "git+https://github.com/sigp/lighthouse?rev=e58ec88fe#e58ec88fe9a8f755a0d92a80b25fd76100d08d49"
 dependencies = [
  "bytes",
+]
+
+[[package]]
+name = "integer-sqrt"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "276ec31bcb4a9ee45f58bec6f9ec700ae4cf4f4f8f2fa7e06cb406bd5ffdd770"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -4352,7 +4377,7 @@ dependencies = [
 [[package]]
 name = "kzg"
 version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?rev=81d576943#81d576943835d443f43b6dda52769784ed82bd47"
+source = "git+https://github.com/sigp/lighthouse?rev=e58ec88fe#e58ec88fe9a8f755a0d92a80b25fd76100d08d49"
 dependencies = [
  "educe",
  "ethereum_hashing 0.8.0",
@@ -4827,6 +4852,12 @@ checksum = "2e126dda6f34391ab7b444f9922055facc83c07a910da3eb16f1e4d9c45dc777"
 
 [[package]]
 name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
@@ -4872,7 +4903,7 @@ dependencies = [
 [[package]]
 name = "logging"
 version = "0.2.0"
-source = "git+https://github.com/sigp/lighthouse?rev=81d576943#81d576943835d443f43b6dda52769784ed82bd47"
+source = "git+https://github.com/sigp/lighthouse?rev=e58ec88fe#e58ec88fe9a8f755a0d92a80b25fd76100d08d49"
 dependencies = [
  "chrono",
  "logroller",
@@ -4918,7 +4949,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 [[package]]
 name = "lru_cache"
 version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?rev=81d576943#81d576943835d443f43b6dda52769784ed82bd47"
+source = "git+https://github.com/sigp/lighthouse?rev=e58ec88fe#e58ec88fe9a8f755a0d92a80b25fd76100d08d49"
 dependencies = [
  "fnv",
 ]
@@ -4999,7 +5030,7 @@ dependencies = [
 [[package]]
 name = "merkle_proof"
 version = "0.2.0"
-source = "git+https://github.com/sigp/lighthouse?rev=81d576943#81d576943835d443f43b6dda52769784ed82bd47"
+source = "git+https://github.com/sigp/lighthouse?rev=e58ec88fe#e58ec88fe9a8f755a0d92a80b25fd76100d08d49"
 dependencies = [
  "alloy-primitives 1.5.7",
  "ethereum_hashing 0.8.0",
@@ -5097,7 +5128,7 @@ dependencies = [
 [[package]]
 name = "metrics"
 version = "0.2.0"
-source = "git+https://github.com/sigp/lighthouse?rev=81d576943#81d576943835d443f43b6dda52769784ed82bd47"
+source = "git+https://github.com/sigp/lighthouse?rev=e58ec88fe#e58ec88fe9a8f755a0d92a80b25fd76100d08d49"
 dependencies = [
  "prometheus",
 ]
@@ -5105,8 +5136,7 @@ dependencies = [
 [[package]]
 name = "milhouse"
 version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "259dd9da2ae5e0278b95da0b7ecef9c18c309d0a2d9e6db57ed33b9e8910c5e7"
+source = "git+https://github.com/sigp/milhouse?rev=c70f128976ac0d60ea65a978dabd117a921c36ee#c70f128976ac0d60ea65a978dabd117a921c36ee"
 dependencies = [
  "alloy-primitives 1.5.7",
  "context_deserialize",
@@ -5344,7 +5374,7 @@ dependencies = [
 [[package]]
 name = "network_utils"
 version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?rev=81d576943#81d576943835d443f43b6dda52769784ed82bd47"
+source = "git+https://github.com/sigp/lighthouse?rev=e58ec88fe#e58ec88fe9a8f755a0d92a80b25fd76100d08d49"
 dependencies = [
  "discv5",
  "libp2p-identity",
@@ -5821,7 +5851,7 @@ dependencies = [
  "concurrent-queue",
  "hermit-abi",
  "pin-project-lite",
- "rustix",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -5922,7 +5952,7 @@ dependencies = [
 [[package]]
 name = "pretty_reqwest_error"
 version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?rev=81d576943#81d576943835d443f43b6dda52769784ed82bd47"
+source = "git+https://github.com/sigp/lighthouse?rev=e58ec88fe#e58ec88fe9a8f755a0d92a80b25fd76100d08d49"
 dependencies = [
  "reqwest",
  "sensitive_url",
@@ -6005,13 +6035,36 @@ dependencies = [
 
 [[package]]
 name = "procfs"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "731e0d9356b0c25f16f33b5be79b1c57b562f141ebfcdb0ad8ac2c13a24293b4"
+dependencies = [
+ "bitflags 2.11.0",
+ "hex",
+ "lazy_static",
+ "procfs-core 0.16.0",
+ "rustix 0.38.44",
+]
+
+[[package]]
+name = "procfs"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25485360a54d6861439d60facef26de713b1e126bf015ec8f98239467a2b82f7"
 dependencies = [
  "bitflags 2.11.0",
- "procfs-core",
- "rustix",
+ "procfs-core 0.18.0",
+ "rustix 1.1.4",
+]
+
+[[package]]
+name = "procfs-core"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d3554923a69f4ce04c4a754260c338f505ce22642d3830e049a399fc2059a29"
+dependencies = [
+ "bitflags 2.11.0",
+ "hex",
 ]
 
 [[package]]
@@ -6033,8 +6086,10 @@ dependencies = [
  "cfg-if",
  "fnv",
  "lazy_static",
+ "libc",
  "memchr",
  "parking_lot",
+ "procfs 0.16.0",
  "thiserror 1.0.69",
 ]
 
@@ -6118,7 +6173,7 @@ dependencies = [
 [[package]]
 name = "proto_array"
 version = "0.2.0"
-source = "git+https://github.com/sigp/lighthouse?rev=81d576943#81d576943835d443f43b6dda52769784ed82bd47"
+source = "git+https://github.com/sigp/lighthouse?rev=e58ec88fe#e58ec88fe9a8f755a0d92a80b25fd76100d08d49"
 dependencies = [
  "ethereum_ssz",
  "ethereum_ssz_derive",
@@ -6825,6 +6880,19 @@ dependencies = [
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags 2.11.0",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
@@ -6832,7 +6900,7 @@ dependencies = [
  "bitflags 2.11.0",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.12.1",
  "windows-sys 0.52.0",
 ]
 
@@ -7372,7 +7440,7 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 [[package]]
 name = "slashing_protection"
 version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?rev=81d576943#81d576943835d443f43b6dda52769784ed82bd47"
+source = "git+https://github.com/sigp/lighthouse?rev=e58ec88fe#e58ec88fe9a8f755a0d92a80b25fd76100d08d49"
 dependencies = [
  "bls",
  "eip_3076",
@@ -7392,7 +7460,7 @@ dependencies = [
 [[package]]
 name = "slot_clock"
 version = "0.2.0"
-source = "git+https://github.com/sigp/lighthouse?rev=81d576943#81d576943835d443f43b6dda52769784ed82bd47"
+source = "git+https://github.com/sigp/lighthouse?rev=e58ec88fe#e58ec88fe9a8f755a0d92a80b25fd76100d08d49"
 dependencies = [
  "metrics",
  "parking_lot",
@@ -7540,8 +7608,7 @@ dependencies = [
 [[package]]
 name = "ssz_types"
 version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d625e4de8e0057eefe7e0b1510ba1dd7adf10cd375fad6cc7fcceac7c39623c9"
+source = "git+https://github.com/sigp/ssz_types?rev=9203d56ad2d7bc5f12133d043e085843f81edcd6#9203d56ad2d7bc5f12133d043e085843f81edcd6"
 dependencies = [
  "context_deserialize",
  "educe",
@@ -7560,6 +7627,34 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "state_processing"
+version = "0.2.0"
+source = "git+https://github.com/sigp/lighthouse?rev=e58ec88fe#e58ec88fe9a8f755a0d92a80b25fd76100d08d49"
+dependencies = [
+ "bls",
+ "educe",
+ "ethereum_hashing 0.8.0",
+ "ethereum_ssz",
+ "ethereum_ssz_derive",
+ "fixed_bytes",
+ "int_to_bytes",
+ "integer-sqrt",
+ "itertools 0.14.0",
+ "merkle_proof",
+ "metrics",
+ "milhouse",
+ "rand 0.9.2",
+ "rayon",
+ "safe_arith",
+ "smallvec",
+ "ssz_types",
+ "tracing",
+ "tree_hash",
+ "typenum",
+ "types",
+]
 
 [[package]]
 name = "static_assertions"
@@ -7641,7 +7736,7 @@ dependencies = [
 [[package]]
 name = "swap_or_not_shuffle"
 version = "0.2.0"
-source = "git+https://github.com/sigp/lighthouse?rev=81d576943#81d576943835d443f43b6dda52769784ed82bd47"
+source = "git+https://github.com/sigp/lighthouse?rev=e58ec88fe#e58ec88fe9a8f755a0d92a80b25fd76100d08d49"
 dependencies = [
  "alloy-primitives 1.5.7",
  "ethereum_hashing 0.8.0",
@@ -7744,7 +7839,7 @@ checksum = "c63f48baada5c52e65a29eef93ab4f8982681b67f9e8d29c7b05abcfec2b9ffe"
 [[package]]
 name = "task_executor"
 version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?rev=81d576943#81d576943835d443f43b6dda52769784ed82bd47"
+source = "git+https://github.com/sigp/lighthouse?rev=e58ec88fe#e58ec88fe9a8f755a0d92a80b25fd76100d08d49"
 dependencies = [
  "async-channel 1.9.0",
  "futures",
@@ -7764,7 +7859,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.2",
  "once_cell",
- "rustix",
+ "rustix 1.1.4",
  "windows-sys 0.52.0",
 ]
 
@@ -7774,7 +7869,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60b8cb979cb11c32ce1603f8137b22262a9d131aaa5c37b5678025f22b8becd0"
 dependencies = [
- "rustix",
+ "rustix 1.1.4",
  "windows-sys 0.60.2",
 ]
 
@@ -8203,8 +8298,7 @@ dependencies = [
 [[package]]
 name = "tree_hash"
 version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7fd51aa83d2eb83b04570808430808b5d24fdbf479a4d5ac5dee4a2e2dd2be4"
+source = "git+https://github.com/sigp/tree_hash?rev=03d9fa474586c125f306dd7a00cf46284575a01f#03d9fa474586c125f306dd7a00cf46284575a01f"
 dependencies = [
  "alloy-primitives 1.5.7",
  "ethereum_hashing 0.8.0",
@@ -8216,8 +8310,7 @@ dependencies = [
 [[package]]
 name = "tree_hash_derive"
 version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8840ad4d852e325d3afa7fde8a50b2412f89dce47d7eb291c0cc7f87cd040f38"
+source = "git+https://github.com/sigp/tree_hash?rev=03d9fa474586c125f306dd7a00cf46284575a01f#03d9fa474586c125f306dd7a00cf46284575a01f"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",
@@ -8278,7 +8371,7 @@ checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 [[package]]
 name = "types"
 version = "0.2.1"
-source = "git+https://github.com/sigp/lighthouse?rev=81d576943#81d576943835d443f43b6dda52769784ed82bd47"
+source = "git+https://github.com/sigp/lighthouse?rev=e58ec88fe#e58ec88fe9a8f755a0d92a80b25fd76100d08d49"
 dependencies = [
  "alloy-primitives 1.5.7",
  "alloy-rlp",
@@ -8467,7 +8560,7 @@ dependencies = [
 [[package]]
 name = "validator_metrics"
 version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?rev=81d576943#81d576943835d443f43b6dda52769784ed82bd47"
+source = "git+https://github.com/sigp/lighthouse?rev=e58ec88fe#e58ec88fe9a8f755a0d92a80b25fd76100d08d49"
 dependencies = [
  "metrics",
 ]
@@ -8475,7 +8568,7 @@ dependencies = [
 [[package]]
 name = "validator_services"
 version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?rev=81d576943#81d576943835d443f43b6dda52769784ed82bd47"
+source = "git+https://github.com/sigp/lighthouse?rev=e58ec88fe#e58ec88fe9a8f755a0d92a80b25fd76100d08d49"
 dependencies = [
  "beacon_node_fallback",
  "bls",
@@ -8500,7 +8593,7 @@ dependencies = [
 [[package]]
 name = "validator_store"
 version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?rev=81d576943#81d576943835d443f43b6dda52769784ed82bd47"
+source = "git+https://github.com/sigp/lighthouse?rev=e58ec88fe#e58ec88fe9a8f755a0d92a80b25fd76100d08d49"
 dependencies = [
  "bls",
  "eth2",
@@ -9269,7 +9362,7 @@ dependencies = [
 [[package]]
 name = "workspace_members"
 version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?rev=81d576943#81d576943835d443f43b6dda52769784ed82bd47"
+source = "git+https://github.com/sigp/lighthouse?rev=e58ec88fe#e58ec88fe9a8f755a0d92a80b25fd76100d08d49"
 dependencies = [
  "cargo_metadata",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,23 +73,23 @@ ssv_types = { path = "anchor/common/ssv_types" }
 subnet_service = { path = "anchor/subnet_service" }
 version = { path = "anchor/common/version" }
 
-# Lighthouse latest from unstable (81d576943)
-beacon_node_fallback = { git = "https://github.com/sigp/lighthouse", rev = "81d576943" }
-bls = { git = "https://github.com/sigp/lighthouse", rev = "81d576943" }
-eth2 = { git = "https://github.com/sigp/lighthouse", rev = "81d576943" }
-eth2_keystore = { git = "https://github.com/sigp/lighthouse", rev = "81d576943" }
-eth2_network_config = { git = "https://github.com/sigp/lighthouse", rev = "81d576943" }
-health_metrics = { git = "https://github.com/sigp/lighthouse", rev = "81d576943" }
-metrics = { git = "https://github.com/sigp/lighthouse", rev = "81d576943" }
-network_utils = { git = "https://github.com/sigp/lighthouse", rev = "81d576943" }
-slashing_protection = { git = "https://github.com/sigp/lighthouse", rev = "81d576943" }
-slot_clock = { git = "https://github.com/sigp/lighthouse", rev = "81d576943" }
-task_executor = { git = "https://github.com/sigp/lighthouse", rev = "81d576943" }
-types = { git = "https://github.com/sigp/lighthouse", rev = "81d576943" }
-validator_metrics = { git = "https://github.com/sigp/lighthouse", rev = "81d576943" }
-validator_services = { git = "https://github.com/sigp/lighthouse", rev = "81d576943" }
-validator_store = { git = "https://github.com/sigp/lighthouse", rev = "81d576943" }
-workspace_members = { git = "https://github.com/sigp/lighthouse", rev = "81d576943" }
+# Lighthouse latest from unstable (e58ec88fe)
+beacon_node_fallback = { git = "https://github.com/sigp/lighthouse", rev = "e58ec88fe" }
+bls = { git = "https://github.com/sigp/lighthouse", rev = "e58ec88fe" }
+eth2 = { git = "https://github.com/sigp/lighthouse", rev = "e58ec88fe" }
+eth2_keystore = { git = "https://github.com/sigp/lighthouse", rev = "e58ec88fe" }
+eth2_network_config = { git = "https://github.com/sigp/lighthouse", rev = "e58ec88fe" }
+health_metrics = { git = "https://github.com/sigp/lighthouse", rev = "e58ec88fe" }
+metrics = { git = "https://github.com/sigp/lighthouse", rev = "e58ec88fe" }
+network_utils = { git = "https://github.com/sigp/lighthouse", rev = "e58ec88fe" }
+slashing_protection = { git = "https://github.com/sigp/lighthouse", rev = "e58ec88fe" }
+slot_clock = { git = "https://github.com/sigp/lighthouse", rev = "e58ec88fe" }
+task_executor = { git = "https://github.com/sigp/lighthouse", rev = "e58ec88fe" }
+types = { git = "https://github.com/sigp/lighthouse", rev = "e58ec88fe" }
+validator_metrics = { git = "https://github.com/sigp/lighthouse", rev = "e58ec88fe" }
+validator_services = { git = "https://github.com/sigp/lighthouse", rev = "e58ec88fe" }
+validator_store = { git = "https://github.com/sigp/lighthouse", rev = "e58ec88fe" }
+workspace_members = { git = "https://github.com/sigp/lighthouse", rev = "e58ec88fe" }
 
 alloy = { version = "1.2.1", features = [
     "sol-types",
@@ -178,6 +178,17 @@ unicode-normalization = "0.1.25"
 zeroize = "1.8.1"
 
 [patch.crates-io]
+# Mirrors Lighthouse's own `[patch.crates-io]` at the pinned rev. Patches only take
+# effect from the root workspace, so Lighthouse's copy is inert here and these must
+# be kept in sync with it or the `types` crate will not compile.
+# FIXME(eip-7688): EIP-7688 development patches
+ssz_types = { git = "https://github.com/sigp/ssz_types", rev = "9203d56ad2d7bc5f12133d043e085843f81edcd6" }
+milhouse = { git = "https://github.com/sigp/milhouse", rev = "c70f128976ac0d60ea65a978dabd117a921c36ee" }
+ethereum_ssz = { git = "https://github.com/sigp/ethereum_ssz", rev = "2059c21ba52cd3a7e39a8ad537012b761812a393" }
+ethereum_ssz_derive = { git = "https://github.com/sigp/ethereum_ssz", rev = "2059c21ba52cd3a7e39a8ad537012b761812a393" }
+tree_hash = { git = "https://github.com/sigp/tree_hash", rev = "03d9fa474586c125f306dd7a00cf46284575a01f" }
+tree_hash_derive = { git = "https://github.com/sigp/tree_hash", rev = "03d9fa474586c125f306dd7a00cf46284575a01f" }
+
 libp2p = { git = "https://github.com/sigp/rust-libp2p.git", rev = "3563de5ed20e509885592b391aa816992eef55d4" }
 libp2p-core = { git = "https://github.com/sigp/rust-libp2p.git", rev = "3563de5ed20e509885592b391aa816992eef55d4" }
 libp2p-swarm = { git = "https://github.com/sigp/rust-libp2p.git", rev = "3563de5ed20e509885592b391aa816992eef55d4" }

--- a/anchor/common/ssv_types/src/consensus.rs
+++ b/anchor/common/ssv_types/src/consensus.rs
@@ -23,10 +23,11 @@ use typenum::{
     Pow, Prod, Sum, U2, U3, U4, U5, U11, U13, U23, U56, U64, U131, U308, U700, U852, U1000, U10000,
 };
 use types::{
-    AggregateAndProofBase, AggregateAndProofElectra, AttestationBase, AttestationData,
-    AttestationElectra, BeaconBlock, BlindedBeaconBlock, ChainSpec, Checkpoint, CommitteeIndex,
-    Domain, EthSpec, ExecutionPayloadEnvelope, ExecutionRequestsGloas, ForkName, Hash256,
-    SignedRoot, Slot, SyncCommitteeContribution, consts::gloas::BUILDER_INDEX_SELF_BUILD,
+    AggregateAndProof, AggregateAndProofBase, AggregateAndProofElectra, AggregateAndProofGloas,
+    Attestation, AttestationBase, AttestationData, AttestationElectra, AttestationGloas,
+    BeaconBlock, BlindedBeaconBlock, ChainSpec, Checkpoint, CommitteeIndex, Domain, EthSpec,
+    ExecutionPayloadEnvelope, ExecutionRequestsGloas, ForkName, Hash256, SignedRoot, Slot,
+    SyncCommitteeContribution, consts::gloas::BUILDER_INDEX_SELF_BUILD,
 };
 
 use crate::{CommitteeId, ValidatorIndex, message::*, partial_sig::PartialSignatureKind};
@@ -327,7 +328,14 @@ impl QbftData for EnvelopeConsensusData {
 /// with its tree-hash root, preserving SSZ merkleization parity: the blinded envelope's root
 /// equals the full envelope's root, so a signature over the blinded signing root is valid for
 /// the full envelope.
+///
+/// EIP-7688 makes the full `ExecutionPayloadEnvelope` a progressive container, so this mirror
+/// must merkleize progressively too or the parity above breaks (SIP-94 §6).
 #[derive(Clone, Debug, PartialEq, Encode, Decode, TreeHash)]
+#[tree_hash(
+    struct_behaviour = "progressive_container",
+    active_fields(1, 1, 1, 1, 1)
+)]
 pub struct BlindedExecutionPayloadEnvelope<E: EthSpec> {
     /// Tree-hash root of the full `payload` (`ExecutionPayloadGloas`).
     pub payload_root: Hash256,
@@ -442,11 +450,20 @@ impl<E: EthSpec> ProposerConsensusDataValidator<E> {
         // is only used for `Proposer`.
         match value.duty.r#type {
             BEACON_ROLE_AGGREGATOR => {
-                if value.version < DataVersion(ForkName::Electra) {
-                    AggregateAndProofBase::<E>::from_ssz_bytes(&value.data_ssz)?;
-                } else {
-                    AggregateAndProofElectra::<E>::from_ssz_bytes(&value.data_ssz)?;
+                // SIP-94 §2: `version` is leader-supplied and selects the decode shape (and
+                // thus the signing-root merkleization), so bind it to our own candidate before
+                // decoding. The proposer branch pins `version` to the duty-slot fork in
+                // `validate_block_proposal` instead.
+                if value.version != our_value.version {
+                    return Err(DataValidationError::VersionMismatch {
+                        expected: ForkName::from(our_value.version),
+                        got: ForkName::from(value.version),
+                    });
                 }
+                value
+                    .version
+                    .decode_aggregate_and_proof::<E>(&value.data_ssz)
+                    .map_err(DataValidationError::ForkDecode)?;
             }
             BEACON_ROLE_PROPOSER => {
                 self.validate_block_proposal(value)?;
@@ -535,6 +552,8 @@ impl<E: EthSpec> ProposerConsensusDataValidator<E> {
 pub enum DataValidationError {
     #[error("Unable to decode ssz in ProposerConsensusData: {0:?}")]
     DecodeError(DecodeError),
+    #[error("Unable to decode consensus payload: {0}")]
+    ForkDecode(ForkDecodeError),
     #[error("Invalid duty type for QBFT: {0:?}")]
     InvalidDutyType(BeaconRole),
     #[error("Slot mismatches: expected {expected}, got {got}")]
@@ -665,7 +684,8 @@ pub struct AggregatorCommitteeConsensusData<E: EthSpec> {
     /// Committee indexes that have aggregated attestations
     pub aggregator_committee_indexes: VariableList<u64, MaxCommitteeIndexes>,
     /// Aggregated attestations as SSZ bytes, one per committee index
-    /// Using bytes because attestation type varies by fork (Base vs Electra)
+    /// Using bytes because the attestation wire shape varies by fork; `version` selects the
+    /// decode shape (see [`DataVersion::decode_attestation`])
     pub aggregated_attestations:
         VariableList<VariableList<u8, MaxAggregatedAttestationBytes>, MaxCommitteeIndexes>,
     /// Validators selected as sync committee contributors with their selection proofs
@@ -736,8 +756,10 @@ pub enum AggregatorCommitteeValidationError {
     SyncSubcommitteeUnusedIndex,
     #[error("No validators assigned")]
     NoValidatorsAssigned,
-    #[error("Failed to decode attestation: {0:?}")]
-    AttestationDecodeError(ssz::DecodeError),
+    #[error("Failed to decode attestation: {0}")]
+    AttestationDecodeError(ForkDecodeError),
+    #[error("Data version mismatch: expected {expected:?}, got {got:?}")]
+    VersionMismatch { expected: ForkName, got: ForkName },
 }
 
 /// Validator for AggregatorCommitteeConsensusData during QBFT consensus.
@@ -751,9 +773,22 @@ impl<E: EthSpec> QbftDataValidator<AggregatorCommitteeConsensusData<E>>
     fn validate(
         &self,
         value: &AggregatorCommitteeConsensusData<E>,
-        _our_value: &AggregatorCommitteeConsensusData<E>,
+        our_value: &AggregatorCommitteeConsensusData<E>,
     ) -> bool {
-        match self.do_validation(value) {
+        // SIP-94 §2: `version` is leader-supplied and selects the decode shape (and thus the
+        // signing-root merkleization), so bind it to our own candidate before any decoding.
+        // The check lives here, not in `do_validation`, because `do_validation` is the
+        // ssv-spec parity surface exercised directly by spec_tests; this binding is
+        // Anchor-specific and must stay out of that entry point.
+        let result = if value.version == our_value.version {
+            self.do_validation(value)
+        } else {
+            Err(AggregatorCommitteeValidationError::VersionMismatch {
+                expected: ForkName::from(our_value.version),
+                got: ForkName::from(value.version),
+            })
+        };
+        match result {
             Ok(_) => true,
             Err(err) => {
                 warn!(%err, "Operator proposed invalid aggregator committee consensus data");
@@ -836,13 +871,10 @@ impl<E: EthSpec> AggregatorCommitteeDataValidator<E> {
 
         // Ensure attestation objects are decoded correctly
         for att_bytes in value.aggregated_attestations.iter() {
-            if value.version >= DataVersion::from(ForkName::Electra) {
-                AttestationElectra::<E>::from_ssz_bytes(att_bytes)
-                    .map_err(AggregatorCommitteeValidationError::AttestationDecodeError)?;
-            } else {
-                AttestationBase::<E>::from_ssz_bytes(att_bytes)
-                    .map_err(AggregatorCommitteeValidationError::AttestationDecodeError)?;
-            }
+            value
+                .version
+                .decode_attestation::<E>(att_bytes)
+                .map_err(AggregatorCommitteeValidationError::AttestationDecodeError)?;
         }
 
         // Sync committee contributors validation
@@ -914,6 +946,7 @@ impl Encode for DataVersion {
             ForkName::Electra => 6,
             ForkName::Fulu => 7,
             ForkName::Gloas => 8,
+            ForkName::Heze => 9,
         };
         num.ssz_append(buf)
     }
@@ -947,8 +980,97 @@ impl Decode for DataVersion {
             6 => ForkName::Electra,
             7 => ForkName::Fulu,
             8 => ForkName::Gloas,
+            9 => ForkName::Heze,
             _ => return Err(DecodeError::NoMatchingVariant),
         }))
+    }
+}
+
+/// Error from fork-aware decoding of consensus-data payload bytes.
+#[derive(Error, Debug)]
+pub enum ForkDecodeError {
+    #[error("unable to decode ssz: {0:?}")]
+    Decode(DecodeError),
+    #[error("no wire shape pinned for fork {0}")]
+    UnsupportedFork(ForkName),
+}
+
+/// The wire shape a fork selects for attestation-family containers.
+enum WireShape {
+    Base,
+    Electra,
+    Gloas,
+}
+
+impl DataVersion {
+    /// Map this version to its attestation-family wire shape.
+    ///
+    /// The single home of the fork-to-shape equivalence classes; both decode helpers below go
+    /// through it. The match is deliberately exhaustive: Heze has no wire shape pinned at the
+    /// current Lighthouse pin and fails closed until one is.
+    fn wire_shape(&self) -> Result<WireShape, ForkDecodeError> {
+        match self.0 {
+            ForkName::Base
+            | ForkName::Altair
+            | ForkName::Bellatrix
+            | ForkName::Capella
+            | ForkName::Deneb => Ok(WireShape::Base),
+            ForkName::Electra | ForkName::Fulu => Ok(WireShape::Electra),
+            ForkName::Gloas => Ok(WireShape::Gloas),
+            ForkName::Heze => Err(ForkDecodeError::UnsupportedFork(ForkName::Heze)),
+        }
+    }
+
+    /// The version to stamp on consensus data carrying this attestation, i.e. the inverse of
+    /// [`Self::decode_attestation`]'s shape selection (each shape's representative fork).
+    pub fn for_attestation_shape<E: EthSpec>(attestation: &Attestation<E>) -> Self {
+        match attestation {
+            Attestation::Base(_) => ForkName::Base.into(),
+            Attestation::Electra(_) => ForkName::Electra.into(),
+            Attestation::Gloas(_) => ForkName::Gloas.into(),
+        }
+    }
+
+    /// Decode an SSZ `Attestation` with the wire shape this version selects.
+    ///
+    /// EIP-7688 makes the Gloas shapes serialization-compatible with Electra's, so decoding
+    /// with the wrong shape can still succeed byte-for-byte; what changes is merkleization,
+    /// so the wrong shape yields wrong signing roots on identical bytes (SIP-94 §2).
+    pub fn decode_attestation<E: EthSpec>(
+        &self,
+        bytes: &[u8],
+    ) -> Result<Attestation<E>, ForkDecodeError> {
+        match self.wire_shape()? {
+            WireShape::Base => AttestationBase::from_ssz_bytes(bytes)
+                .map(Attestation::Base)
+                .map_err(ForkDecodeError::Decode),
+            WireShape::Electra => AttestationElectra::from_ssz_bytes(bytes)
+                .map(Attestation::Electra)
+                .map_err(ForkDecodeError::Decode),
+            WireShape::Gloas => AttestationGloas::from_ssz_bytes(bytes)
+                .map(Attestation::Gloas)
+                .map_err(ForkDecodeError::Decode),
+        }
+    }
+
+    /// Decode an SSZ `AggregateAndProof` with the wire shape this version selects.
+    ///
+    /// See [`Self::decode_attestation`] for the shape-selection rules.
+    pub fn decode_aggregate_and_proof<E: EthSpec>(
+        &self,
+        bytes: &[u8],
+    ) -> Result<AggregateAndProof<E>, ForkDecodeError> {
+        match self.wire_shape()? {
+            WireShape::Base => AggregateAndProofBase::from_ssz_bytes(bytes)
+                .map(AggregateAndProof::Base)
+                .map_err(ForkDecodeError::Decode),
+            WireShape::Electra => AggregateAndProofElectra::from_ssz_bytes(bytes)
+                .map(AggregateAndProof::Electra)
+                .map_err(ForkDecodeError::Decode),
+            WireShape::Gloas => AggregateAndProofGloas::from_ssz_bytes(bytes)
+                .map(AggregateAndProof::Gloas)
+                .map_err(ForkDecodeError::Decode),
+        }
     }
 }
 
@@ -967,6 +1089,7 @@ impl TreeHash for DataVersion {
             ForkName::Electra => 6,
             ForkName::Fulu => 7,
             ForkName::Gloas => 8,
+            ForkName::Heze => 9,
         };
         num.tree_hash_packed_encoding()
     }
@@ -985,6 +1108,7 @@ impl TreeHash for DataVersion {
             ForkName::Electra => 6,
             ForkName::Fulu => 7,
             ForkName::Gloas => 8,
+            ForkName::Heze => 9,
         };
         num.tree_hash_root()
     }
@@ -1642,6 +1766,7 @@ mod tests {
 
     use bls::{AggregateSignature, FixedBytesExtended};
     use eth2::types::FullBlockContents;
+    use ssz::ProgressiveBitList;
     use ssz_types::{BitList, BitVector};
     use types::{
         BeaconBlockDeneb, BeaconBlockGloas, Checkpoint, EmptyBlock, Epoch, ExecutionPayloadGloas,
@@ -1736,17 +1861,8 @@ mod tests {
         let attestation = AttestationBase::<MainnetEthSpec> {
             aggregation_bits: BitList::with_capacity(128).unwrap(),
             data: AttestationData {
-                slot: Slot::new(1000),
                 index,
-                beacon_block_root: Hash256::zero(),
-                source: Checkpoint {
-                    epoch: Epoch::new(10),
-                    root: Hash256::zero(),
-                },
-                target: Checkpoint {
-                    epoch: Epoch::new(11),
-                    root: Hash256::zero(),
-                },
+                ..decode_test_attestation_data()
             },
             signature: AggregateSignature::infinity(),
         };
@@ -4066,6 +4182,406 @@ mod tests {
         assert!(
             validator.validate(&value, &value),
             "validate() must accept regardless of version and duty.r#type"
+        );
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════════════
+    // DataVersion Fork-Aware Decode Helper Tests (EIP-7688 / SIP-94 §2)
+    // ═══════════════════════════════════════════════════════════════════════════════
+
+    /// Forks whose attestation/aggregate wire shape is the Base one.
+    const BASE_SHAPE_FORKS: [ForkName; 5] = [
+        ForkName::Base,
+        ForkName::Altair,
+        ForkName::Bellatrix,
+        ForkName::Capella,
+        ForkName::Deneb,
+    ];
+    /// Forks whose attestation/aggregate wire shape is the Electra one.
+    const ELECTRA_SHAPE_FORKS: [ForkName; 2] = [ForkName::Electra, ForkName::Fulu];
+
+    /// Attestation data shared by the decode-helper fixtures.
+    fn decode_test_attestation_data() -> AttestationData {
+        AttestationData {
+            slot: Slot::new(1000),
+            index: 0,
+            beacon_block_root: Hash256::zero(),
+            source: Checkpoint {
+                epoch: Epoch::new(10),
+                root: Hash256::zero(),
+            },
+            target: Checkpoint {
+                epoch: Epoch::new(11),
+                root: Hash256::zero(),
+            },
+        }
+    }
+
+    /// Base-shaped attestation with one aggregation bit set.
+    fn base_shape_attestation() -> AttestationBase<MainnetEthSpec> {
+        let mut aggregation_bits = BitList::with_capacity(128).unwrap();
+        aggregation_bits.set(0, true).unwrap();
+        AttestationBase {
+            aggregation_bits,
+            data: decode_test_attestation_data(),
+            signature: AggregateSignature::infinity(),
+        }
+    }
+
+    /// Electra-shaped attestation with one aggregation bit and one committee bit set.
+    fn electra_shape_attestation() -> AttestationElectra<MainnetEthSpec> {
+        let mut aggregation_bits = BitList::with_capacity(128).unwrap();
+        aggregation_bits.set(0, true).unwrap();
+        let mut committee_bits = BitVector::default();
+        committee_bits.set(5, true).unwrap();
+        AttestationElectra {
+            aggregation_bits,
+            data: decode_test_attestation_data(),
+            signature: AggregateSignature::infinity(),
+            committee_bits,
+        }
+    }
+
+    /// Gloas-shaped attestation with one aggregation bit and one committee bit set.
+    fn gloas_shape_attestation() -> AttestationGloas<MainnetEthSpec> {
+        let mut aggregation_bits = ProgressiveBitList::with_capacity(128);
+        aggregation_bits.set(0, true).unwrap();
+        let mut committee_bits = BitVector::default();
+        committee_bits.set(5, true).unwrap();
+        AttestationGloas {
+            aggregation_bits,
+            data: decode_test_attestation_data(),
+            signature: AggregateSignature::infinity(),
+            committee_bits,
+        }
+    }
+
+    fn base_shape_aggregate_and_proof() -> AggregateAndProofBase<MainnetEthSpec> {
+        AggregateAndProofBase {
+            aggregator_index: 7,
+            aggregate: base_shape_attestation(),
+            selection_proof: Signature::empty(),
+        }
+    }
+
+    fn electra_shape_aggregate_and_proof() -> AggregateAndProofElectra<MainnetEthSpec> {
+        AggregateAndProofElectra {
+            aggregator_index: 7,
+            aggregate: electra_shape_attestation(),
+            selection_proof: Signature::empty(),
+        }
+    }
+
+    fn gloas_shape_aggregate_and_proof() -> AggregateAndProofGloas<MainnetEthSpec> {
+        AggregateAndProofGloas {
+            aggregator_index: 7,
+            aggregate: gloas_shape_attestation(),
+            selection_proof: Signature::empty(),
+        }
+    }
+
+    #[test]
+    fn decode_attestation_selects_base_shape_for_pre_electra_versions() {
+        let bytes = base_shape_attestation().as_ssz_bytes();
+        for fork in BASE_SHAPE_FORKS {
+            let decoded = DataVersion::from(fork)
+                .decode_attestation::<MainnetEthSpec>(&bytes)
+                .unwrap_or_else(|e| panic!("{fork} must decode the Base shape: {e:?}"));
+            assert!(
+                matches!(decoded, Attestation::Base(_)),
+                "{fork} must select the Base attestation shape"
+            );
+        }
+    }
+
+    #[test]
+    fn decode_attestation_selects_electra_shape_for_electra_and_fulu() {
+        let bytes = electra_shape_attestation().as_ssz_bytes();
+        for fork in ELECTRA_SHAPE_FORKS {
+            let decoded = DataVersion::from(fork)
+                .decode_attestation::<MainnetEthSpec>(&bytes)
+                .unwrap_or_else(|e| panic!("{fork} must decode the Electra shape: {e:?}"));
+            assert!(
+                matches!(decoded, Attestation::Electra(_)),
+                "{fork} must select the Electra attestation shape"
+            );
+        }
+    }
+
+    #[test]
+    fn decode_attestation_selects_gloas_shape_for_gloas() {
+        let bytes = gloas_shape_attestation().as_ssz_bytes();
+        let decoded = DataVersion::from(ForkName::Gloas)
+            .decode_attestation::<MainnetEthSpec>(&bytes)
+            .expect("Gloas must decode the Gloas shape");
+        assert!(
+            matches!(decoded, Attestation::Gloas(_)),
+            "Gloas must select the Gloas attestation shape"
+        );
+    }
+
+    #[test]
+    fn decode_attestation_fails_closed_for_heze() {
+        // Even well-formed bytes for the latest pinned shape must be rejected: Heze has no wire
+        // shape pinned at the current Lighthouse pin.
+        let bytes = gloas_shape_attestation().as_ssz_bytes();
+        let result = DataVersion::from(ForkName::Heze).decode_attestation::<MainnetEthSpec>(&bytes);
+        assert!(
+            matches!(
+                result,
+                Err(ForkDecodeError::UnsupportedFork(ForkName::Heze))
+            ),
+            "Heze must fail closed, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn decode_aggregate_and_proof_selects_base_shape_for_pre_electra_versions() {
+        let bytes = base_shape_aggregate_and_proof().as_ssz_bytes();
+        for fork in BASE_SHAPE_FORKS {
+            let decoded = DataVersion::from(fork)
+                .decode_aggregate_and_proof::<MainnetEthSpec>(&bytes)
+                .unwrap_or_else(|e| panic!("{fork} must decode the Base shape: {e:?}"));
+            assert!(
+                matches!(decoded, AggregateAndProof::Base(_)),
+                "{fork} must select the Base aggregate-and-proof shape"
+            );
+        }
+    }
+
+    #[test]
+    fn decode_aggregate_and_proof_selects_electra_shape_for_electra_and_fulu() {
+        let bytes = electra_shape_aggregate_and_proof().as_ssz_bytes();
+        for fork in ELECTRA_SHAPE_FORKS {
+            let decoded = DataVersion::from(fork)
+                .decode_aggregate_and_proof::<MainnetEthSpec>(&bytes)
+                .unwrap_or_else(|e| panic!("{fork} must decode the Electra shape: {e:?}"));
+            assert!(
+                matches!(decoded, AggregateAndProof::Electra(_)),
+                "{fork} must select the Electra aggregate-and-proof shape"
+            );
+        }
+    }
+
+    #[test]
+    fn decode_aggregate_and_proof_selects_gloas_shape_for_gloas() {
+        let bytes = gloas_shape_aggregate_and_proof().as_ssz_bytes();
+        let decoded = DataVersion::from(ForkName::Gloas)
+            .decode_aggregate_and_proof::<MainnetEthSpec>(&bytes)
+            .expect("Gloas must decode the Gloas shape");
+        assert!(
+            matches!(decoded, AggregateAndProof::Gloas(_)),
+            "Gloas must select the Gloas aggregate-and-proof shape"
+        );
+    }
+
+    #[test]
+    fn decode_aggregate_and_proof_fails_closed_for_heze() {
+        let bytes = gloas_shape_aggregate_and_proof().as_ssz_bytes();
+        let result =
+            DataVersion::from(ForkName::Heze).decode_aggregate_and_proof::<MainnetEthSpec>(&bytes);
+        assert!(
+            matches!(
+                result,
+                Err(ForkDecodeError::UnsupportedFork(ForkName::Heze))
+            ),
+            "Heze must fail closed, got {result:?}"
+        );
+    }
+
+    /// EIP-7495 makes progressive containers serialization-compatible with their positional
+    /// counterparts: the SAME Electra-shaped bytes decode successfully under BOTH the Electra
+    /// and the Gloas shape. What changes is merkleization (positional vs progressive), so the
+    /// two decoded values produce different tree hash roots on identical bytes. This is exactly
+    /// why `version` must select the decode shape (SIP-94 §2): decode success alone cannot
+    /// detect a shape mismatch.
+    #[test]
+    fn identical_attestation_bytes_decode_under_both_shapes_with_distinct_roots() {
+        let bytes = electra_shape_attestation().as_ssz_bytes();
+
+        let electra = DataVersion::from(ForkName::Electra)
+            .decode_attestation::<MainnetEthSpec>(&bytes)
+            .expect("Electra-shaped bytes must decode under the Electra shape");
+        let gloas = DataVersion::from(ForkName::Gloas)
+            .decode_attestation::<MainnetEthSpec>(&bytes)
+            .expect("EIP-7495: the same bytes must also decode under the Gloas shape");
+
+        assert!(matches!(electra, Attestation::Electra(_)));
+        assert!(matches!(gloas, Attestation::Gloas(_)));
+        // Serialization compatibility holds in both directions: both decodes re-encode to the
+        // original bytes.
+        assert_eq!(electra.as_ssz_bytes(), bytes);
+        assert_eq!(gloas.as_ssz_bytes(), bytes);
+        // Positional (Electra) vs progressive (Gloas) merkleization: the roots must differ.
+        assert_ne!(
+            electra.tree_hash_root(),
+            gloas.tree_hash_root(),
+            "identical bytes must merkleize differently under positional vs progressive shapes"
+        );
+    }
+
+    /// Same as the attestation root test, for `AggregateAndProof`: identical Electra-shaped
+    /// bytes decode under both shapes, but the signing root over the container differs, so an
+    /// operator decoding with the wrong shape would sign a root its peers reject.
+    #[test]
+    fn identical_aggregate_bytes_decode_under_both_shapes_with_distinct_signing_roots() {
+        let bytes = electra_shape_aggregate_and_proof().as_ssz_bytes();
+
+        let electra = DataVersion::from(ForkName::Electra)
+            .decode_aggregate_and_proof::<MainnetEthSpec>(&bytes)
+            .expect("Electra-shaped bytes must decode under the Electra shape");
+        let gloas = DataVersion::from(ForkName::Gloas)
+            .decode_aggregate_and_proof::<MainnetEthSpec>(&bytes)
+            .expect("EIP-7495: the same bytes must also decode under the Gloas shape");
+
+        assert!(matches!(electra, AggregateAndProof::Electra(_)));
+        assert!(matches!(gloas, AggregateAndProof::Gloas(_)));
+        assert_eq!(electra.as_ssz_bytes(), bytes);
+        assert_eq!(gloas.as_ssz_bytes(), bytes);
+        assert_ne!(
+            electra.tree_hash_root(),
+            gloas.tree_hash_root(),
+            "identical bytes must merkleize differently under positional vs progressive shapes"
+        );
+        let domain = Hash256::repeat_byte(0xD0);
+        assert_ne!(
+            electra.signing_root(domain),
+            gloas.signing_root(domain),
+            "the signing root over the container must differ between the two shapes"
+        );
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════════════
+    // do_validation Aggregator-Branch Version Binding Tests (SIP-94 §2)
+    // ═══════════════════════════════════════════════════════════════════════════════
+
+    /// Builds an aggregator-duty `ProposerConsensusData` stamped with `fork`, carrying
+    /// `data_ssz`. The duty slot is arbitrary: the aggregator branch binds `version` to our own
+    /// candidate, not to the fork schedule.
+    fn aggregator_consensus_data(fork: ForkName, data_ssz: Vec<u8>) -> ProposerConsensusData {
+        let mut duty = test_proposer_duty(Slot::new(1000));
+        duty.r#type = BEACON_ROLE_AGGREGATOR;
+        ProposerConsensusData {
+            duty,
+            version: DataVersion::from(fork),
+            data_ssz: VariableList::new(data_ssz).expect("aggregate bytes should fit in DataSSZ"),
+        }
+    }
+
+    #[test]
+    /// Tests that the aggregator branch rejects a value whose leader-supplied `version` differs
+    /// from our own candidate's, BEFORE any decoding: the value is well-formed for its claimed
+    /// version, so the rejection can only come from the version binding.
+    fn do_validation_rejects_aggregator_version_mismatch() {
+        let our_value = aggregator_consensus_data(
+            ForkName::Electra,
+            electra_shape_aggregate_and_proof().as_ssz_bytes(),
+        );
+        let value = aggregator_consensus_data(
+            ForkName::Deneb,
+            base_shape_aggregate_and_proof().as_ssz_bytes(),
+        );
+
+        let (_dir, validator) = test_block_proposal_validator(Arc::new(ChainSpec::mainnet()), true);
+        let result = validator.do_validation(&value, &our_value);
+
+        assert_version_mismatch(result, ForkName::Electra, ForkName::Deneb);
+    }
+
+    #[test]
+    /// Tests that the aggregator branch accepts a value whose `version` matches our candidate's
+    /// and whose bytes decode under that version's shape.
+    fn do_validation_accepts_aggregator_matching_version() {
+        let our_value = aggregator_consensus_data(
+            ForkName::Electra,
+            electra_shape_aggregate_and_proof().as_ssz_bytes(),
+        );
+        let value = our_value.clone();
+
+        let (_dir, validator) = test_block_proposal_validator(Arc::new(ChainSpec::mainnet()), true);
+        let result = validator.do_validation(&value, &our_value);
+
+        assert!(
+            result.is_ok(),
+            "matching aggregator version should validate, got {:?}",
+            result.err()
+        );
+    }
+
+    #[test]
+    /// Tests that `AggregatorCommitteeDataValidator::validate` binds the leader-supplied
+    /// `version` to our own candidate's (SIP-94 §2): a value that is valid on its own terms is
+    /// still rejected when our candidate carries a different version.
+    fn aggregator_committee_validator_rejects_version_mismatch() {
+        let validator = create_aggregator_committee_validator();
+        // Same fixture as our Deneb-stamped candidate below, differing only in the stamped
+        // version and the matching (Electra-shaped) attestation bytes.
+        let electra_value = AggregatorCommitteeConsensusData::<MainnetEthSpec> {
+            version: DataVersion::from(ForkName::Electra),
+            aggregated_attestations: VariableList::new(vec![
+                VariableList::new(electra_shape_attestation().as_ssz_bytes()).unwrap(),
+            ])
+            .unwrap(),
+            ..create_populated_consensus_data()
+        };
+        // Control: the value passes when our candidate carries the same version, so the
+        // rejection below can only come from the version binding.
+        assert!(
+            validator.validate(&electra_value, &electra_value),
+            "control: the value must be valid under a matching version"
+        );
+
+        // Our own candidate is stamped Deneb; the Electra-stamped value must be rejected.
+        let our_value = create_populated_consensus_data();
+        assert!(
+            !validator.validate(&electra_value, &our_value),
+            "validate() must return false when the value's version differs from our candidate's"
+        );
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════════════
+    // Max-Size Gloas Aggregate vs MaxAggregatedAttestationBytes
+    // ═══════════════════════════════════════════════════════════════════════════════
+
+    /// `MaxAggregatedAttestationBytes` (131,308) comes from go-ssv's `ssz-max:"64,131308"`
+    /// bound, derived pre-Gloas. A maximum-size Gloas aggregate (every committee bit set,
+    /// aggregation bits spanning every validator in the slot) must still fit, otherwise Gloas
+    /// aggregates could not be carried in `AggregatorCommitteeConsensusData`.
+    #[test]
+    fn max_size_gloas_aggregate_fits_aggregated_attestation_bound() {
+        use typenum::Unsigned;
+
+        let max_validators_per_slot = <MainnetEthSpec as EthSpec>::MaxValidatorsPerSlot::to_usize();
+        let max_committees_per_slot = <MainnetEthSpec as EthSpec>::MaxCommitteesPerSlot::to_usize();
+
+        let mut aggregation_bits = ProgressiveBitList::with_capacity(max_validators_per_slot);
+        for i in 0..max_validators_per_slot {
+            aggregation_bits.set(i, true).expect("bit within capacity");
+        }
+        let mut committee_bits = BitVector::default();
+        for i in 0..max_committees_per_slot {
+            committee_bits
+                .set(i, true)
+                .expect("committee bit within capacity");
+        }
+
+        let attestation = AttestationGloas::<MainnetEthSpec> {
+            aggregation_bits,
+            data: decode_test_attestation_data(),
+            signature: AggregateSignature::infinity(),
+            committee_bits,
+        };
+
+        let bytes = attestation.as_ssz_bytes();
+        let bound = MaxAggregatedAttestationBytes::to_usize();
+        assert!(
+            bytes.len() <= bound,
+            "max-size Gloas aggregate ({} bytes) must fit the {bound} byte bound",
+            bytes.len()
+        );
+        assert!(
+            VariableList::<u8, MaxAggregatedAttestationBytes>::new(bytes).is_ok(),
+            "max-size Gloas aggregate must fit the aggregated_attestations element type"
         );
     }
 }

--- a/anchor/network/src/peer_manager/discovery.rs
+++ b/anchor/network/src/peer_manager/discovery.rs
@@ -42,9 +42,9 @@ impl PeerDiscovery {
 
         // Update peer store with TCP and QUIC addresses (not plain UDP)
         for multiaddr in enr
-            .multiaddr_tcp()
+            .dialable_multiaddrs_tcp()
             .iter()
-            .chain(enr.multiaddr_quic().iter())
+            .chain(enr.dialable_multiaddrs_quic().iter())
         {
             peer_store.on_swarm_event(&FromSwarm::NewExternalAddrOfPeer(NewExternalAddrOfPeer {
                 peer_id: id,

--- a/anchor/spec_tests/src/utils/error_codes.rs
+++ b/anchor/spec_tests/src/utils/error_codes.rs
@@ -131,6 +131,8 @@ pub fn aggregator_committee_validation_error_code(err: AggregatorCommitteeValida
         E::SyncSubcommitteeUnusedIndex => AGG_COMM_SC_SUBNET_UNUSED,
         E::NoValidatorsAssigned => AGG_COMM_NO_VALIDATORS,
         E::AttestationDecodeError(_) => AGG_COMM_ATTESTATION_DECODE,
+        // Anchor-specific version binding (SIP-94 §2); no Go equivalent.
+        E::VersionMismatch { .. } => UNMAPPED_ERROR_CODE,
     }
 }
 

--- a/anchor/validator_store/src/lib.rs
+++ b/anchor/validator_store/src/lib.rs
@@ -12,7 +12,7 @@ use std::{
     time::Duration,
 };
 
-use bls::{PublicKeyBytes, SecretKey, Signature};
+use bls::{AggregateSignature, PublicKeyBytes, SecretKey, Signature};
 use database::{NetworkDatabase, NonUniqueIndex, UniqueIndex};
 use eth2::types::{BlockContents, BlockContentsTuple, FullBlockContents, PublishBlockRequest};
 use fork::{Fork, ForkSchedule};
@@ -47,7 +47,7 @@ use ssv_types::{
         AggregatorCommitteeConsensusData, AggregatorCommitteeDataValidator, BEACON_ROLE_AGGREGATOR,
         BEACON_ROLE_PROPOSER, BEACON_ROLE_SYNC_COMMITTEE_CONTRIBUTION, BeaconVote,
         BeaconVoteValidator, Contribution, ContributionWrapper, Contributions, DataVersion,
-        GloasBeaconVote, GloasBeaconVoteValidator, ProposerConsensusData,
+        ForkDecodeError, GloasBeaconVote, GloasBeaconVoteValidator, ProposerConsensusData,
         ProposerConsensusDataValidator, QbftData, SelectionProofBatchId, ValidatorDuty,
     },
     msgid::Role,
@@ -63,14 +63,13 @@ use tokio::{
 };
 use tracing::{Instrument, Span, debug, error, field, info, info_span, trace, warn};
 use types::{
-    AbstractExecPayload, Address, AggregateAndProof, AggregateAndProofBase,
-    AggregateAndProofElectra, Attestation, AttestationBase, AttestationElectra, BeaconBlock,
-    BeaconBlockRef, BlindedPayload, ChainSpec, Checkpoint, ContributionAndProof, Domain, Epoch,
-    EthSpec, ExecutionPayloadEnvelope, ForkName, FullPayload, Graffiti, Hash256,
-    PayloadAttestationData, PayloadAttestationMessage, ProposerPreferences, SelectionProof,
-    SignedAggregateAndProof, SignedBeaconBlock, SignedBlindedBeaconBlock,
-    SignedContributionAndProof, SignedExecutionPayloadEnvelope, SignedProposerPreferences,
-    SignedRoot, SignedValidatorRegistrationData, SignedVoluntaryExit, Slot, SlotData,
+    AbstractExecPayload, Address, AggregateAndProof, Attestation, BeaconBlock, BeaconBlockRef,
+    BlindedPayload, ChainSpec, Checkpoint, ContributionAndProof, Domain, Epoch, EthSpec,
+    ExecutionPayloadEnvelope, ForkName, FullPayload, Graffiti, Hash256, PayloadAttestationData,
+    PayloadAttestationMessage, ProposerPreferences, SelectionProof, SignedAggregateAndProof,
+    SignedBeaconBlock, SignedBlindedBeaconBlock, SignedContributionAndProof,
+    SignedExecutionPayloadEnvelope, SignedProposerPreferences, SignedRoot,
+    SignedValidatorRegistrationData, SignedVoluntaryExit, SingleAttestation, Slot, SlotData,
     SyncAggregatorSelectionData, SyncCommitteeContribution, SyncCommitteeMessage,
     SyncSelectionProof, SyncSubnetId, ValidatorRegistrationData, VoluntaryExit,
 };
@@ -123,6 +122,19 @@ struct DecidedVote {
     target: Checkpoint,
     decided_hash: Hash256,
     decided_index: Option<u64>,
+}
+
+/// A reconstructed committee attestation awaiting slashing protection.
+///
+/// `publishable` is false when the duty's `attester_index` or `committee_index` did not match
+/// Anchor's own metadata. Those indices are not part of the attestation signing root, so the
+/// signature is safe to produce (and must be: the committee's partial-signature batch size is
+/// exact, so no duty may be dropped before collection), but the malformed `SingleAttestation`
+/// is withheld from publication after its data is recorded in the slashing DB.
+struct AttestationCandidate {
+    attestation: SingleAttestation,
+    pubkey: PublicKeyBytes,
+    publishable: bool,
 }
 
 impl<T> SigningRequest<T> {
@@ -1044,10 +1056,7 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> AnchorValidator
             let signing_epoch = aggregate.aggregate.data().target.epoch;
             let (validator, cluster) = self.get_validator_and_cluster(aggregate.pubkey)?;
 
-            let version = match &aggregate.aggregate {
-                Attestation::Base(_) => ForkName::Base.into(),
-                Attestation::Electra(_) => ForkName::Electra.into(),
-            };
+            let version = DataVersion::for_attestation_shape(&aggregate.aggregate);
 
             let message = AggregateAndProof::from_attestation(
                 aggregate.aggregator_index,
@@ -1111,17 +1120,10 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> AnchorValidator
                 Completed::Success(data) => data,
             };
 
-            let message = if ForkName::from(data.version) < ForkName::Electra {
-                AggregateAndProof::Base(
-                    AggregateAndProofBase::from_ssz_bytes(&data.data_ssz)
-                        .map_err(|e| Error::SpecificError(SpecificError::InvalidQbftData(e)))?,
-                )
-            } else {
-                AggregateAndProof::Electra(
-                    AggregateAndProofElectra::from_ssz_bytes(&data.data_ssz)
-                        .map_err(|e| Error::SpecificError(SpecificError::InvalidQbftData(e)))?,
-                )
-            };
+            let message: AggregateAndProof<E> = data
+                .version
+                .decode_aggregate_and_proof(&data.data_ssz)
+                .map_err(|e| Error::SpecificError(e.into()))?;
 
             debug!(
                 aggregator_index = ?message.aggregator_index(),
@@ -1651,18 +1653,43 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> AnchorValidator
         &self,
         committee_id: CommitteeId,
         cluster: Cluster,
-        attestations: Vec<(ValidatorMetadata, AttestationToSign<E>)>,
-    ) -> Result<Vec<(u64, Attestation<E>, PublicKeyBytes)>, Error> {
+        attestations: Vec<(ValidatorMetadata, AttestationToSign)>,
+    ) -> Result<Vec<AttestationCandidate>, Error> {
         // Early return and log error for empty attestations
         let Some((_, first_attestation)) = attestations.first() else {
             warn!("sign_committee_attestations called with empty attestations");
             return Ok(vec![]);
         };
-        let slot = first_attestation.attestation.data().slot;
+        let slot = first_attestation.data.slot;
 
         let voting_context_tx = self.get_voting_context(slot).await?;
         let validator_attestation_committees =
             self.get_attesting_validators_in_committee(&voting_context_tx, committee_id);
+
+        // The duty's identity fields are echoed back verbatim in the returned
+        // `SingleAttestation`, so pin them against our own metadata. Consensus never touches
+        // them (it only rewrites `att.data`), so the check can run up front; a mismatched duty
+        // still signs (see `AttestationCandidate`), it is only withheld from publication.
+        let mismatched_duties: HashSet<PublicKeyBytes> = attestations
+            .iter()
+            .filter_map(|(validator, att)| {
+                let expected_attester = validator.index.map(|idx| *idx as u64);
+                let expected_committee = validator_attestation_committees.get(&att.pubkey).copied();
+                let publishable = expected_attester == Some(att.attester_index)
+                    && expected_committee == Some(att.committee_index);
+                if !publishable {
+                    warn!(
+                        pubkey = ?att.pubkey,
+                        attester_index = att.attester_index,
+                        ?expected_attester,
+                        committee_index = att.committee_index,
+                        ?expected_committee,
+                        "Attestation duty identity mismatch, withholding from publication"
+                    );
+                }
+                (!publishable).then_some(att.pubkey)
+            })
+            .collect();
 
         let decided = self
             .decide_committee_vote(
@@ -1679,21 +1706,21 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> AnchorValidator
 
         // Prepare all validators and apply consensus results upfront
         // (metadata already resolved by `group_by_committee`)
-        let prepared: Vec<SigningRequest<AttestationToSign<E>>> = attestations
+        let prepared: Vec<SigningRequest<AttestationToSign>> = attestations
             .into_iter()
             .map(|(validator, mut att)| {
                 // Apply consensus result to this attestation
-                att.attestation.data_mut().beacon_block_root = decided.block_root;
-                att.attestation.data_mut().source = decided.source;
-                att.attestation.data_mut().target = decided.target;
+                att.data.beacon_block_root = decided.block_root;
+                att.data.source = decided.source;
+                att.data.target = decided.target;
                 // Gloas: all operators sign over the single cluster-decided attestation index so
                 // signing roots match cluster-wide. Pre-Gloas (`None`) leaves the
                 // BN-supplied index untouched (`committee_index` pre-Electra, `0` at Electra+).
                 if let Some(index) = decided.decided_index {
-                    att.attestation.data_mut().index = index;
+                    att.data.index = index;
                 }
 
-                let signing_root = att.attestation.data().signing_root(domain_hash);
+                let signing_root = att.data.signing_root(domain_hash);
                 SigningRequest {
                     validator,
                     signing_root,
@@ -1732,19 +1759,17 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> AnchorValidator
                 }
             };
 
-            let AttestationToSign {
-                validator_index,
-                pubkey,
-                validator_committee_index,
-                mut attestation,
-            } = att;
-
-            if let Err(e) = attestation.add_signature(&signature, validator_committee_index) {
-                error!(error = ?e, ?pubkey, "Failed to add signature to attestation, skipping");
-                continue;
-            }
-
-            results.push((validator_index, attestation, pubkey));
+            results.push(AttestationCandidate {
+                publishable: !mismatched_duties.contains(&att.pubkey),
+                attestation: SingleAttestation {
+                    committee_index: att.committee_index,
+                    attester_index: att.attester_index,
+                    data: att.data,
+                    // A single-entry aggregate carrying the reconstructed threshold signature.
+                    signature: AggregateSignature::from(&signature),
+                },
+                pubkey: att.pubkey,
+            });
         }
 
         Ok(results)
@@ -1783,16 +1808,12 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> AnchorValidator
             .get(decided_aggregate_idx)
             .ok_or("Aggregate attestation bytes not found in decided data")?;
 
-        // Decode based on fork version
-        let decided_aggregate = if decided_data.version < DataVersion::from(ForkName::Electra) {
-            AttestationBase::from_ssz_bytes(decided_aggregate_bytes)
-                .map(Attestation::Base)
-                .map_err(|e| format!("Failed to decode decided aggregate: {e:?}"))?
-        } else {
-            AttestationElectra::from_ssz_bytes(decided_aggregate_bytes)
-                .map(Attestation::Electra)
-                .map_err(|e| format!("Failed to decode decided aggregate: {e:?}"))?
-        };
+        // Decode with the shape the decided version selects (Gloas merkleizes progressively,
+        // so the shape drives the signing root computed below).
+        let decided_aggregate: Attestation<E> = decided_data
+            .version
+            .decode_attestation(decided_aggregate_bytes)
+            .map_err(|e| format!("Failed to decode decided aggregate: {e}"))?;
 
         let decided_selection_proof =
             SelectionProof::from(decided_aggregator.selection_proof.clone());
@@ -1908,21 +1929,25 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> AnchorValidator
 
     /// Provide slashing protection for attestations, safely updating the slashing protection DB.
     ///
-    /// Returns a vec of safe attestations which have passed slashing protection. Unsafe
-    /// attestations will be dropped and result in warning logs.
+    /// Every candidate's data is recorded (when slashing protection is enabled), including
+    /// non-publishable ones, so the slashing DB reflects locally emitted partial signatures.
+    /// Returns only attestations that are both slash-safe and publishable; the rest are
+    /// dropped with warning logs.
     fn slashing_protection_attestations(
         &self,
-        attestations: Vec<(u64, Attestation<E>, PublicKeyBytes)>,
-    ) -> Result<Vec<(u64, Attestation<E>)>, Error> {
-        let mut safe_attestations = Vec::with_capacity(attestations.len());
-        let mut attestations_to_check = Vec::with_capacity(attestations.len());
+        candidates: Vec<AttestationCandidate>,
+    ) -> Result<Vec<SingleAttestation>, Error> {
+        let mut safe_attestations = Vec::with_capacity(candidates.len());
+        let mut attestations_to_check = Vec::with_capacity(candidates.len());
 
-        for (_, attestation, validator_pubkey) in &attestations {
-            let domain_hash =
-                self.get_domain(attestation.data().target.epoch, Domain::BeaconAttester);
+        for candidate in &candidates {
+            let domain_hash = self.get_domain(
+                candidate.attestation.data.target.epoch,
+                Domain::BeaconAttester,
+            );
             attestations_to_check.push((
-                attestation.data(),
-                validator_pubkey,
+                &candidate.attestation.data,
+                &candidate.pubkey,
                 domain_hash,
                 if self.disable_slashing_protection {
                     CheckSlashability::No
@@ -1944,15 +1969,21 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> AnchorValidator
             .map(convert_slashing_result)
             .collect();
 
-        for ((validator_index, attestation, validator_pubkey), slashing_status) in
-            attestations.into_iter().zip(results)
-        {
+        for (candidate, slashing_status) in candidates.into_iter().zip(results) {
             match slashing_status {
-                Ok(()) => {
-                    safe_attestations.push((validator_index, attestation));
+                Ok(()) if candidate.publishable => {
+                    safe_attestations.push(candidate.attestation);
                     validator_metrics::inc_counter_vec(
                         &validator_metrics::SIGNED_ATTESTATIONS_TOTAL,
                         &[validator_metrics::SUCCESS],
+                    );
+                }
+                Ok(()) => {
+                    // Identity mismatch was logged at assembly; the entry is now recorded in
+                    // the slashing DB but withheld from publication.
+                    validator_metrics::inc_counter_vec(
+                        &validator_metrics::SIGNED_ATTESTATIONS_TOTAL,
+                        &[metrics::OTHER_ERROR],
                     );
                 }
                 Err(Error::SameData) => {
@@ -1982,7 +2013,7 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> AnchorValidator
                 Err(e) => {
                     error!(
                         error = ?e,
-                        public_key = ?validator_pubkey,
+                        public_key = ?candidate.pubkey,
                         "Unexpected error during slashing protection check"
                     );
                     validator_metrics::inc_counter_vec(
@@ -2535,6 +2566,8 @@ pub enum SpecificError {
     QbftError(QbftError),
     Timeout,
     InvalidQbftData(DecodeError),
+    /// Decided consensus data specified a fork with no pinned wire shape (fail closed)
+    UnsupportedForkData(ForkName),
     TooManySyncSubnetsToSign,
     NoDataAgreed,
     Metadata,
@@ -2602,6 +2635,15 @@ impl From<ArithError> for SpecificError {
 impl From<QbftError> for SpecificError {
     fn from(err: QbftError) -> SpecificError {
         SpecificError::QbftError(err)
+    }
+}
+
+impl From<ForkDecodeError> for SpecificError {
+    fn from(err: ForkDecodeError) -> SpecificError {
+        match err {
+            ForkDecodeError::Decode(e) => SpecificError::InvalidQbftData(e),
+            ForkDecodeError::UnsupportedFork(fork) => SpecificError::UnsupportedForkData(fork),
+        }
     }
 }
 
@@ -3440,8 +3482,8 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> ValidatorStore
 
     fn sign_attestations(
         self: &Arc<Self>,
-        attestations: Vec<AttestationToSign<E>>,
-    ) -> impl Stream<Item = Result<Vec<(u64, Attestation<Self::E>)>, Error>> + Send {
+        attestations: Vec<AttestationToSign>,
+    ) -> impl Stream<Item = Result<Vec<SingleAttestation>, Error>> + Send {
         if !*self.is_synced.borrow() {
             return Either::Left(stream::once(futures::future::ready(Err(
                 Error::SpecificError(SpecificError::NotSynced),

--- a/anchor/validator_store/src/lib.rs
+++ b/anchor/validator_store/src/lib.rs
@@ -1984,7 +1984,7 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> AnchorValidator
                     // the slashing DB but withheld from publication.
                     validator_metrics::inc_counter_vec(
                         &validator_metrics::SIGNED_ATTESTATIONS_TOTAL,
-                        &[metrics::OTHER_ERROR],
+                        &[metrics::WITHHELD],
                     );
                 }
                 Err(Error::SameData) => {

--- a/anchor/validator_store/src/lib.rs
+++ b/anchor/validator_store/src/lib.rs
@@ -124,19 +124,6 @@ struct DecidedVote {
     decided_index: Option<u64>,
 }
 
-/// A reconstructed committee attestation awaiting slashing protection.
-///
-/// `publishable` is false when the duty's `attester_index` or `committee_index` did not match
-/// Anchor's own metadata. Those indices are not part of the attestation signing root, so the
-/// signature is safe to produce (and must be: the committee's partial-signature batch size is
-/// exact, so no duty may be dropped before collection), but the malformed `SingleAttestation`
-/// is withheld from publication after its data is recorded in the slashing DB.
-struct AttestationCandidate {
-    attestation: SingleAttestation,
-    pubkey: PublicKeyBytes,
-    publishable: bool,
-}
-
 impl<T> SigningRequest<T> {
     /// Look up this validator's collected signature, consuming the request.
     ///
@@ -1655,7 +1642,7 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> AnchorValidator
         committee_id: CommitteeId,
         cluster: Cluster,
         attestations: Vec<(ValidatorMetadata, AttestationToSign)>,
-    ) -> Result<Vec<AttestationCandidate>, Error> {
+    ) -> Result<Vec<(SingleAttestation, PublicKeyBytes)>, Error> {
         // Early return and log error for empty attestations
         let Some((_, first_attestation)) = attestations.first() else {
             warn!("sign_committee_attestations called with empty attestations");
@@ -1667,30 +1654,47 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> AnchorValidator
         let validator_attestation_committees =
             self.get_attesting_validators_in_committee(&voting_context_tx, committee_id);
 
-        // The duty's identity fields are echoed back verbatim in the returned
-        // `SingleAttestation`, so pin them against our own metadata. Consensus never touches
-        // them (it only rewrites `att.data`), so the check can run up front; a mismatched duty
-        // still signs (see `AttestationCandidate`), it is only withheld from publication.
-        let mismatched_duties: HashSet<PublicKeyBytes> = attestations
-            .iter()
-            .filter_map(|(validator, att)| {
-                let expected_attester = validator.index.map(|idx| *idx as u64);
-                let expected_committee = validator_attestation_committees.get(&att.pubkey).copied();
-                let publishable = expected_attester == Some(att.attester_index)
-                    && expected_committee == Some(att.committee_index);
-                if !publishable {
-                    warn!(
-                        pubkey = ?att.pubkey,
-                        attester_index = att.attester_index,
-                        ?expected_attester,
-                        committee_index = att.committee_index,
-                        ?expected_committee,
-                        "Attestation duty identity mismatch, withholding from publication"
-                    );
-                }
-                (!publishable).then_some(att.pubkey)
-            })
-            .collect();
+        // The duty's identity fields are echoed verbatim into the returned `SingleAttestation`
+        // and are not part of the signing root, so a divergence cannot produce an unsafe
+        // signature, and the beacon node validates the fields authoritatively at publication.
+        // Surface divergences anyway: the same slot-start snapshot feeds the preliminary
+        // slashing checks and the exact collector batch size, so a divergence means drifted
+        // inputs, not just a doomed publish. Attester mismatches warn because validator
+        // indices are permanent once assigned; committee drift is expected under a mid-slot
+        // dependent-root change and stays informational.
+        for (validator, att) in &attestations {
+            let expected_attester = validator.index.map(|idx| *idx as u64);
+            let expected_committee = validator_attestation_committees.get(&att.pubkey).copied();
+            let reason = if expected_attester != Some(att.attester_index) {
+                metrics::IDENTITY_MISMATCH_ATTESTER_INDEX
+            } else if expected_committee.is_none() {
+                metrics::IDENTITY_MISMATCH_MISSING_FROM_SNAPSHOT
+            } else if expected_committee != Some(att.committee_index) {
+                metrics::IDENTITY_MISMATCH_COMMITTEE_INDEX
+            } else {
+                continue;
+            };
+            metrics::inc_counter_vec(&metrics::ATTESTATION_DUTY_IDENTITY_MISMATCHES, &[reason]);
+            if reason == metrics::IDENTITY_MISMATCH_ATTESTER_INDEX {
+                warn!(
+                    pubkey = ?att.pubkey,
+                    attester_index = att.attester_index,
+                    ?expected_attester,
+                    committee_index = att.committee_index,
+                    ?expected_committee,
+                    reason,
+                    "Attestation duty identity differs from Anchor metadata, publishing anyway"
+                );
+            } else {
+                info!(
+                    pubkey = ?att.pubkey,
+                    committee_index = att.committee_index,
+                    ?expected_committee,
+                    reason,
+                    "Attestation duty identity differs from Anchor metadata, publishing anyway"
+                );
+            }
+        }
 
         let decided = self
             .decide_committee_vote(
@@ -1760,17 +1764,16 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> AnchorValidator
                 }
             };
 
-            results.push(AttestationCandidate {
-                publishable: !mismatched_duties.contains(&att.pubkey),
-                attestation: SingleAttestation {
+            results.push((
+                SingleAttestation {
                     committee_index: att.committee_index,
                     attester_index: att.attester_index,
                     data: att.data,
                     // A single-entry aggregate carrying the reconstructed threshold signature.
                     signature: AggregateSignature::from(&signature),
                 },
-                pubkey: att.pubkey,
-            });
+                att.pubkey,
+            ));
         }
 
         Ok(results)
@@ -1930,25 +1933,22 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> AnchorValidator
 
     /// Provide slashing protection for attestations, safely updating the slashing protection DB.
     ///
-    /// Every candidate's data is recorded (when slashing protection is enabled), including
-    /// non-publishable ones, so the slashing DB reflects locally emitted partial signatures.
-    /// Returns only attestations that are both slash-safe and publishable; the rest are
-    /// dropped with warning logs.
+    /// Every attestation's data is recorded (when slashing protection is enabled), so the
+    /// slashing DB reflects locally emitted partial signatures. Returns the attestations that
+    /// passed slashing protection; the rest are dropped with warning logs.
     fn slashing_protection_attestations(
         &self,
-        candidates: Vec<AttestationCandidate>,
+        attestations: Vec<(SingleAttestation, PublicKeyBytes)>,
     ) -> Result<Vec<SingleAttestation>, Error> {
-        let mut safe_attestations = Vec::with_capacity(candidates.len());
-        let mut attestations_to_check = Vec::with_capacity(candidates.len());
+        let mut safe_attestations = Vec::with_capacity(attestations.len());
+        let mut attestations_to_check = Vec::with_capacity(attestations.len());
 
-        for candidate in &candidates {
-            let domain_hash = self.get_domain(
-                candidate.attestation.data.target.epoch,
-                Domain::BeaconAttester,
-            );
+        for (attestation, pubkey) in &attestations {
+            let domain_hash =
+                self.get_domain(attestation.data.target.epoch, Domain::BeaconAttester);
             attestations_to_check.push((
-                &candidate.attestation.data,
-                &candidate.pubkey,
+                &attestation.data,
+                pubkey,
                 domain_hash,
                 if self.disable_slashing_protection {
                     CheckSlashability::No
@@ -1970,21 +1970,13 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> AnchorValidator
             .map(convert_slashing_result)
             .collect();
 
-        for (candidate, slashing_status) in candidates.into_iter().zip(results) {
+        for ((attestation, pubkey), slashing_status) in attestations.into_iter().zip(results) {
             match slashing_status {
-                Ok(()) if candidate.publishable => {
-                    safe_attestations.push(candidate.attestation);
+                Ok(()) => {
+                    safe_attestations.push(attestation);
                     validator_metrics::inc_counter_vec(
                         &validator_metrics::SIGNED_ATTESTATIONS_TOTAL,
                         &[validator_metrics::SUCCESS],
-                    );
-                }
-                Ok(()) => {
-                    // Identity mismatch was logged at assembly; the entry is now recorded in
-                    // the slashing DB but withheld from publication.
-                    validator_metrics::inc_counter_vec(
-                        &validator_metrics::SIGNED_ATTESTATIONS_TOTAL,
-                        &[metrics::WITHHELD],
                     );
                 }
                 Err(Error::SameData) => {
@@ -2014,7 +2006,7 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> AnchorValidator
                 Err(e) => {
                     error!(
                         error = ?e,
-                        public_key = ?candidate.pubkey,
+                        public_key = ?pubkey,
                         "Unexpected error during slashing protection check"
                     );
                     validator_metrics::inc_counter_vec(

--- a/anchor/validator_store/src/metadata_service.rs
+++ b/anchor/validator_store/src/metadata_service.rs
@@ -1484,10 +1484,10 @@ mod tests {
             DataVersion, MaxAggregatedAttestationBytes, QbftDataValidator,
         },
     };
-    use ssz::Encode;
+    use ssz::{Encode, ProgressiveBitList};
     use ssz_types::{BitList, BitVector};
     use types::{
-        AttestationBase, AttestationData, AttestationElectra, Checkpoint, Epoch, ForkName,
+        AttestationBase, AttestationData, AttestationGloas, Checkpoint, Epoch, ForkName,
         MainnetEthSpec, SelectionProof, Slot, SyncCommitteeContribution,
     };
 
@@ -1725,7 +1725,7 @@ mod tests {
         vote: &SlotVote,
         committee_index: usize,
     ) -> Attestation<MainnetEthSpec> {
-        let mut aggregation_bits = BitList::with_capacity(128).expect("valid capacity");
+        let mut aggregation_bits = ProgressiveBitList::with_capacity(128);
         aggregation_bits
             .set(committee_index, true)
             .expect("committee index fits aggregation bits");
@@ -1734,7 +1734,7 @@ mod tests {
             .set(committee_index, true)
             .expect("committee index fits committee bits");
 
-        Attestation::Electra(AttestationElectra {
+        Attestation::Gloas(AttestationGloas {
             aggregation_bits,
             data: AttestationData {
                 slot,

--- a/anchor/validator_store/src/metrics.rs
+++ b/anchor/validator_store/src/metrics.rs
@@ -8,6 +8,9 @@ pub const BEACON_VOTE: &str = "beacon_vote";
 pub const SYNC_CONTRIBUTION_AND_PROOF: &str = "sync_contribution_and_proof";
 pub const TIMEOUT: &str = "timeout";
 pub const OTHER_ERROR: &str = "other_error";
+/// Signed and recorded in the slashing DB, but withheld from publication
+/// (e.g. attestation duty identity mismatch).
+pub const WITHHELD: &str = "withheld";
 pub const TRIGGER_HEAD_EVENT: &str = "head_event";
 pub const TRIGGER_TIMER: &str = "timer";
 

--- a/anchor/validator_store/src/metrics.rs
+++ b/anchor/validator_store/src/metrics.rs
@@ -8,9 +8,6 @@ pub const BEACON_VOTE: &str = "beacon_vote";
 pub const SYNC_CONTRIBUTION_AND_PROOF: &str = "sync_contribution_and_proof";
 pub const TIMEOUT: &str = "timeout";
 pub const OTHER_ERROR: &str = "other_error";
-/// Signed and recorded in the slashing DB, but withheld from publication
-/// (e.g. attestation duty identity mismatch).
-pub const WITHHELD: &str = "withheld";
 pub const TRIGGER_HEAD_EVENT: &str = "head_event";
 pub const TRIGGER_TIMER: &str = "timer";
 
@@ -36,6 +33,26 @@ pub static SIGNED_PROPOSER_PREFERENCES_TOTAL: LazyLock<Result<IntCounterVec>> =
             "anchor_signed_proposer_preferences_total",
             "Total count of ProposerPreferences signings",
             &["status"],
+        )
+    });
+
+/// The duty's `attester_index` differs from Anchor's stored validator index; indices are
+/// permanent once assigned, so this is never reorg drift.
+pub const IDENTITY_MISMATCH_ATTESTER_INDEX: &str = "attester_index";
+/// The duty's `committee_index` differs from the slot-start voting-assignments snapshot.
+pub const IDENTITY_MISMATCH_COMMITTEE_INDEX: &str = "committee_index";
+/// The duty's pubkey is absent from the slot-start attesting snapshot.
+pub const IDENTITY_MISMATCH_MISSING_FROM_SNAPSHOT: &str = "missing_from_snapshot";
+
+/// Attestation duties whose identity fields differ from Anchor's own metadata. Diagnostic
+/// only: the fields are not part of the signing root, publication proceeds, and the beacon
+/// node validates them authoritatively.
+pub static ATTESTATION_DUTY_IDENTITY_MISMATCHES: LazyLock<Result<IntCounterVec>> =
+    LazyLock::new(|| {
+        try_create_int_counter_vec(
+            "anchor_attestation_duty_identity_mismatches_total",
+            "Attestation duties whose identity fields differ from Anchor metadata, by reason",
+            &["reason"],
         )
     });
 

--- a/anchor/validator_store/src/testing/committee_attestation.rs
+++ b/anchor/validator_store/src/testing/committee_attestation.rs
@@ -4,13 +4,11 @@ use std::time::Duration;
 use futures::StreamExt;
 use signature_collector::SignatureRequester;
 use ssv_types::OperatorId;
-use types::{Attestation, MainnetEthSpec};
 use validator_store::ValidatorStore;
 
 use super::common::*;
 use crate::Error;
 
-type SignAttestationsResult = Vec<Result<Vec<(u64, Attestation<MainnetEthSpec>)>, Error>>;
 const PRIMARY_COMMITTEE_VALIDATOR_COUNT: usize = 2;
 const SINGLE_VALIDATOR_COMMITTEE_VALIDATOR_COUNT: usize = 1;
 
@@ -151,6 +149,46 @@ async fn sign_attestations_failure_isolation() {
         second.is_err(),
         "stuck committee should not produce a result"
     );
+}
+
+/// Each returned `SingleAttestation` must echo the duty's identity fields (`attester_index` and
+/// `committee_index`) verbatim: the store signs only `data`, and Lighthouse's attestation service
+/// publishes the identity fields exactly as returned.
+#[tokio::test(flavor = "multi_thread")]
+async fn sign_attestations_echoes_duty_identity_fields() {
+    // Arrange
+    let our_operator_id = OperatorId(1);
+    let committee = create_committee_setup(
+        &[OperatorId(1), OperatorId(2), OperatorId(3), OperatorId(4)],
+        PRIMARY_COMMITTEE_VALIDATOR_COUNT,
+        0,
+    );
+    let harness = ValidatorStoreTestHarness::new(vec![committee], our_operator_id);
+    harness.seed_voting_context();
+    let attestations = vec![
+        harness.create_attestation(0, 0),
+        harness.create_attestation(0, 1),
+    ];
+    let expected_identities: Vec<(u64, u64)> = attestations
+        .iter()
+        .map(|duty| (duty.attester_index, duty.committee_index))
+        .collect();
+    // Precondition: the duties carry distinct identity pairs, so echoing is falsifiable.
+    assert_ne!(expected_identities[0], expected_identities[1]);
+
+    // Act
+    let signed = run_sign_attestations(&harness, attestations).await;
+
+    // Assert: one attestation per validator, each echoing its duty's identity fields.
+    assert_eq!(signed.len(), PRIMARY_COMMITTEE_VALIDATOR_COUNT);
+    for (attester_index, committee_index) in expected_identities {
+        assert!(
+            signed.iter().any(|att| att.attester_index == attester_index
+                && att.committee_index == committee_index),
+            "expected an attestation echoing attester_index {attester_index} and \
+             committee_index {committee_index}"
+        );
+    }
 }
 
 /// `sign_attestations` returns an immediate `NotSynced` error when not synced.

--- a/anchor/validator_store/src/testing/committee_attestation_gloas.rs
+++ b/anchor/validator_store/src/testing/committee_attestation_gloas.rs
@@ -18,15 +18,12 @@ use ssv_types::{
     consensus::{BeaconVote, GloasBeaconVote, QbftData},
 };
 use types::{
-    Attestation, AttestationData, ChainSpec, Checkpoint, Domain, Epoch, EthSpec, Hash256,
-    MainnetEthSpec, SignedRoot, Slot,
+    AttestationData, ChainSpec, Checkpoint, Domain, Epoch, EthSpec, Hash256, MainnetEthSpec,
+    SignedRoot, Slot,
 };
 use validator_store::ValidatorStore;
 
 use super::common::*;
-use crate::Error;
-
-type SignAttestationsResult = Vec<Result<Vec<(u64, Attestation<MainnetEthSpec>)>, Error>>;
 
 const COMMITTEE_OPERATORS: [OperatorId; 4] =
     [OperatorId(1), OperatorId(2), OperatorId(3), OperatorId(4)];
@@ -66,22 +63,6 @@ fn expected_attester_signing_root(
     data.signing_root(domain)
 }
 
-/// Drives `sign_attestations` to completion and unwraps every committee batch.
-async fn run_sign_attestations(
-    harness: &ValidatorStoreTestHarness,
-    attestations: Vec<validator_store::AttestationToSign<MainnetEthSpec>>,
-) -> Vec<(u64, Attestation<MainnetEthSpec>)> {
-    let results: SignAttestationsResult = harness
-        .validator_store
-        .sign_attestations(attestations)
-        .collect()
-        .await;
-    results
-        .into_iter()
-        .flat_map(|batch| batch.expect("committee batch should succeed"))
-        .collect()
-}
-
 // ==================== Gloas: decided index applied ====================
 
 /// At Gloas, the single cluster-decided `attestation_data_index` must be written onto every
@@ -116,10 +97,9 @@ async fn gloas_decided_index_applied_to_every_validator_attestation() {
         COMMITTEE_VALIDATOR_COUNT,
         "expected one signed attestation per validator"
     );
-    for (_, attestation) in &signed {
+    for attestation in &signed {
         assert_eq!(
-            attestation.data().index,
-            DECIDED_INDEX,
+            attestation.data.index, DECIDED_INDEX,
             "Gloas must apply the cluster-decided index to data.index, not the local seed"
         );
     }
@@ -213,13 +193,11 @@ async fn gloas_all_operators_converge_on_decided_index_signing_root() {
         "the converged root must be the root computed over the decided index"
     );
     assert_eq!(
-        signed_a[0].1.data().index,
-        DECIDED_INDEX,
+        signed_a[0].data.index, DECIDED_INDEX,
         "operator A must sign the decided index"
     );
     assert_eq!(
-        signed_b[0].1.data().index,
-        DECIDED_INDEX,
+        signed_b[0].data.index, DECIDED_INDEX,
         "operator B must sign the decided index"
     );
 }
@@ -253,10 +231,9 @@ async fn pre_gloas_electra_attestation_index_is_zero_and_untouched() {
 
     // Assert: index stays 0 (Electra+ BN-supplied value), never overwritten.
     assert_eq!(signed.len(), COMMITTEE_VALIDATOR_COUNT);
-    for (_, attestation) in &signed {
+    for attestation in &signed {
         assert_eq!(
-            attestation.data().index,
-            0,
+            attestation.data.index, 0,
             "pre-Gloas Electra attestation index must remain 0 and untouched"
         );
     }
@@ -312,7 +289,7 @@ async fn pre_gloas_pre_electra_attestation_index_equals_committee_index() {
         harness.create_attestation_with_index(0, 1, committee_index),
     ];
     for attestation in &attestations {
-        let duty_data = attestation.attestation.data();
+        let duty_data = &attestation.data;
         assert_ne!(duty_data.beacon_block_root, voting_block_root);
         assert_ne!(duty_data.source, voting_source);
         assert_ne!(duty_data.target, voting_target);
@@ -323,15 +300,14 @@ async fn pre_gloas_pre_electra_attestation_index_equals_committee_index() {
 
     // Assert: the BN-supplied committee index survives unchanged.
     assert_eq!(signed.len(), COMMITTEE_VALIDATOR_COUNT);
-    for (_, attestation) in &signed {
+    for attestation in &signed {
         assert_eq!(
-            attestation.data().index,
-            committee_index,
+            attestation.data.index, committee_index,
             "pre-Electra attestation index must equal the BN committee index, untouched"
         );
-        assert_eq!(attestation.data().beacon_block_root, voting_block_root);
-        assert_eq!(attestation.data().source, voting_source);
-        assert_eq!(attestation.data().target, voting_target);
+        assert_eq!(attestation.data.beacon_block_root, voting_block_root);
+        assert_eq!(attestation.data.source, voting_source);
+        assert_eq!(attestation.data.target, voting_target);
     }
 
     // Assert: consensus and signing use the shared voting-context vote, while retaining the
@@ -415,9 +391,9 @@ async fn sync_and_attestation_paths_seed_identical_gloas_instance() {
 
     // Act: drive the attestation path, capture its committee base hash + committee id.
     let duty = harness.create_attestation(0, 0);
-    assert_ne!(duty.attestation.data().beacon_block_root, voting_block_root);
-    assert_ne!(duty.attestation.data().source, voting_source);
-    assert_ne!(duty.attestation.data().target, voting_target);
+    assert_ne!(duty.data.beacon_block_root, voting_block_root);
+    assert_ne!(duty.data.source, voting_source);
+    assert_ne!(duty.data.target, voting_target);
     let attestation_signed = run_sign_attestations(&harness, vec![duty]).await;
     let (attestation_base_hash, attestation_committee_id, _) = committee_call_data(&harness);
 
@@ -436,7 +412,7 @@ async fn sync_and_attestation_paths_seed_identical_gloas_instance() {
     // Assert: the attestation path applies all decided voting-context fields, not the incoming
     // duty's fields. The mock changes only the index, preserving the remaining seed fields.
     assert_eq!(attestation_signed.len(), 1);
-    let signed_data = attestation_signed[0].1.data();
+    let signed_data = &attestation_signed[0].data;
     assert_eq!(signed_data.beacon_block_root, voting_block_root);
     assert_eq!(signed_data.source, voting_source);
     assert_eq!(signed_data.target, voting_target);

--- a/anchor/validator_store/src/testing/committee_attestation_slashing.rs
+++ b/anchor/validator_store/src/testing/committee_attestation_slashing.rs
@@ -3,7 +3,7 @@
 //! The default harness disables slashing protection (under `CheckSlashability::No` nothing is
 //! recorded), so these tests enable it. With protection enabled the harness registers every
 //! validator in the slashing DB, `slashing_protection_attestations` records every signed
-//! candidate, and only slash-safe (and publishable) attestations reach the returned batch.
+//! candidate, and slash-safe attestations reach the returned batch.
 use futures::StreamExt;
 use signature_collector::SignatureRequester;
 use slashing_protection::{CheckSlashability, NotSafe, Safe};
@@ -132,14 +132,14 @@ async fn slashing_protection_blocks_conflicting_attestation() {
     );
 }
 
-// ==================== Identity mismatch: publishable flag ====================
+// ==================== Identity mismatch: published and recorded ====================
 
 /// A duty whose `attester_index` does not match our own metadata still signs (dropping it before
-/// collection would stall the committee's exact-count partial-signature batch) and still reaches
-/// the slashing DB, but is withheld from the returned publication batch. The other validators'
-/// attestations are unaffected.
+/// collection would stall the committee's exact-count partial-signature batch), is recorded in
+/// the slashing DB, and IS returned for publication with the duty's identity fields echoed
+/// verbatim; the beacon node is the authority on identity fields.
 #[tokio::test(flavor = "multi_thread")]
-async fn identity_mismatch_recorded_in_slashing_db_but_withheld_from_publication() {
+async fn identity_mismatch_published_and_recorded_in_slashing_db() {
     // Arrange: validator 0 keeps its correct identity, validator 1's duty carries a wrong
     // attester_index.
     let harness = slashing_enabled_harness();
@@ -148,6 +148,7 @@ async fn identity_mismatch_recorded_in_slashing_db_but_withheld_from_publication
     let good_attester_index = good.attester_index;
     let mut bad = harness.create_attestation(0, 1);
     bad.attester_index += 100;
+    let bad_attester_index = bad.attester_index;
     let bad_pubkey = bad.pubkey;
 
     // Act
@@ -157,7 +158,7 @@ async fn identity_mismatch_recorded_in_slashing_db_but_withheld_from_publication
         .collect()
         .await;
 
-    // Assert: only the well-formed duty is returned for publication.
+    // Assert: both duties are returned for publication, identity fields echoed verbatim.
     assert_eq!(results.len(), 1, "expected one stream item per committee");
     let signed: Vec<SingleAttestation> = results
         .into_iter()
@@ -165,12 +166,20 @@ async fn identity_mismatch_recorded_in_slashing_db_but_withheld_from_publication
         .collect();
     assert_eq!(
         signed.len(),
-        1,
-        "the mismatched duty must be absent from the publication batch"
+        COMMITTEE_VALIDATOR_COUNT,
+        "the mismatched duty must be published alongside the well-formed one"
     );
-    assert_eq!(
-        signed[0].attester_index, good_attester_index,
+    assert!(
+        signed
+            .iter()
+            .any(|att| att.attester_index == good_attester_index),
         "the well-formed duty must be published normally"
+    );
+    assert!(
+        signed
+            .iter()
+            .any(|att| att.attester_index == bad_attester_index),
+        "the mismatched duty's attester_index must be echoed verbatim"
     );
 
     // Assert: the signature collector still sent for BOTH validators with the full committee
@@ -199,7 +208,7 @@ async fn identity_mismatch_recorded_in_slashing_db_but_withheld_from_publication
     }
     drop(captured);
 
-    // Assert: the mismatched validator's signed data WAS recorded in the slashing DB. The exact
+    // Assert: the mismatched validator's signed data was recorded in the slashing DB. The exact
     // data the production path signed is the seeded zero vote at TEST_SLOT (pre-Electra path
     // leaves data.index at 0), which equals the duty data `create_attestation` builds; probing it
     // again yields `SameData`, which only an existing identical record can produce.

--- a/anchor/validator_store/src/testing/committee_attestation_slashing.rs
+++ b/anchor/validator_store/src/testing/committee_attestation_slashing.rs
@@ -1,0 +1,242 @@
+//! Slashing-protection tests for the committee attestation path.
+//!
+//! The default harness disables slashing protection (under `CheckSlashability::No` nothing is
+//! recorded), so these tests enable it. With protection enabled the harness registers every
+//! validator in the slashing DB, `slashing_protection_attestations` records every signed
+//! candidate, and only slash-safe (and publishable) attestations reach the returned batch.
+use futures::StreamExt;
+use signature_collector::SignatureRequester;
+use slashing_protection::{CheckSlashability, NotSafe, Safe};
+use ssv_types::{OperatorId, consensus::BeaconVote};
+use types::{AttestationData, Domain, EthSpec, Hash256, MainnetEthSpec, SingleAttestation, Slot};
+use validator_store::ValidatorStore;
+
+use super::common::*;
+
+const COMMITTEE_OPERATORS: [OperatorId; 4] =
+    [OperatorId(1), OperatorId(2), OperatorId(3), OperatorId(4)];
+const OUR_OPERATOR: OperatorId = OperatorId(1);
+const COMMITTEE_VALIDATOR_COUNT: usize = 2;
+
+/// Builds a single-committee harness with slashing protection ENABLED (validators registered).
+fn slashing_enabled_harness() -> ValidatorStoreTestHarness {
+    let committee = create_committee_setup(&COMMITTEE_OPERATORS, COMMITTEE_VALIDATOR_COUNT, 0);
+    ValidatorStoreTestHarness::new_with_options(
+        vec![committee],
+        OUR_OPERATOR,
+        HarnessOptions {
+            disable_slashing_protection: false,
+            ..Default::default()
+        },
+    )
+}
+
+/// Drives `sign_attestations` for both committee validators and unwraps the single batch.
+async fn sign_both_validators(harness: &ValidatorStoreTestHarness) -> Vec<SingleAttestation> {
+    let attestations = vec![
+        harness.create_attestation(0, 0),
+        harness.create_attestation(0, 1),
+    ];
+    run_sign_attestations(harness, attestations).await
+}
+
+/// Builds a `BeaconVote` at target/source epoch 0 with the given block root, so two votes with
+/// distinct roots are a double vote (same target epoch, different data) once both are signed.
+fn vote_with_block_root(block_root: Hash256) -> BeaconVote {
+    BeaconVote {
+        block_root,
+        source: ValidatorStoreTestHarness::zero_checkpoint(),
+        target: ValidatorStoreTestHarness::zero_checkpoint(),
+    }
+}
+
+/// Recomputes the attester domain the production path uses for `TEST_SLOT` (target epoch 0).
+fn attester_domain(harness: &ValidatorStoreTestHarness) -> Hash256 {
+    let epoch = Slot::new(TEST_SLOT).epoch(MainnetEthSpec::slots_per_epoch());
+    harness.spec.get_domain(
+        epoch,
+        Domain::BeaconAttester,
+        &harness.spec.fork_at_epoch(epoch),
+        harness.genesis_validators_root,
+    )
+}
+
+// ==================== Slashing protection through the migrated path ====================
+
+/// First-time attestations pass slashing protection and are all returned for publication.
+#[tokio::test(flavor = "multi_thread")]
+async fn slashing_protection_returns_first_time_attestations() {
+    // Arrange
+    let harness = slashing_enabled_harness();
+    harness.seed_base_voting_context_with_vote(vote_with_block_root(Hash256::repeat_byte(0xAA)));
+
+    // Act
+    let signed = sign_both_validators(&harness).await;
+
+    // Assert
+    assert_eq!(
+        signed.len(),
+        COMMITTEE_VALIDATOR_COUNT,
+        "first-time attestations must all pass slashing protection"
+    );
+}
+
+/// Re-signing the exact same attestation data is detected as `SameData` and skipped: the second
+/// batch succeeds but publishes nothing.
+#[tokio::test(flavor = "multi_thread")]
+async fn slashing_protection_skips_same_data_resign() {
+    // Arrange
+    let harness = slashing_enabled_harness();
+    harness.seed_base_voting_context_with_vote(vote_with_block_root(Hash256::repeat_byte(0xAA)));
+    let first = sign_both_validators(&harness).await;
+    assert_eq!(first.len(), COMMITTEE_VALIDATOR_COUNT);
+
+    // Act: sign the same duties over the unchanged voting context.
+    let second = sign_both_validators(&harness).await;
+
+    // Assert: the batch succeeds (asserted inside the helper) but every entry is skipped.
+    assert!(
+        second.is_empty(),
+        "previously signed attestation data must be skipped as SameData, got {} entries",
+        second.len()
+    );
+}
+
+/// A conflicting attestation (same target epoch, different data) is blocked by slashing
+/// protection: signing still runs, but nothing is returned for publication.
+#[tokio::test(flavor = "multi_thread")]
+async fn slashing_protection_blocks_conflicting_attestation() {
+    // Arrange: sign over one vote first.
+    let harness = slashing_enabled_harness();
+    harness.seed_base_voting_context_with_vote(vote_with_block_root(Hash256::repeat_byte(0xAA)));
+    let first = sign_both_validators(&harness).await;
+    assert_eq!(first.len(), COMMITTEE_VALIDATOR_COUNT);
+
+    // Act: re-seed a vote with the same target epoch but a different block root (a double vote)
+    // and sign again.
+    harness.seed_base_voting_context_with_vote(vote_with_block_root(Hash256::repeat_byte(0xBB)));
+    let second = sign_both_validators(&harness).await;
+
+    // Assert: the conflicting batch is fully withheld.
+    assert!(
+        second.is_empty(),
+        "conflicting attestations must be blocked as slashable, got {} entries",
+        second.len()
+    );
+    // The filter is applied AFTER signature collection: both rounds collected one signature per
+    // validator, so the second round's signing calls still happened.
+    assert_eq!(
+        harness.captured_calls.lock().len(),
+        2 * COMMITTEE_VALIDATOR_COUNT,
+        "slashing protection must filter at publication, not before signature collection"
+    );
+}
+
+// ==================== Identity mismatch: publishable flag ====================
+
+/// A duty whose `attester_index` does not match our own metadata still signs (dropping it before
+/// collection would stall the committee's exact-count partial-signature batch) and still reaches
+/// the slashing DB, but is withheld from the returned publication batch. The other validators'
+/// attestations are unaffected.
+#[tokio::test(flavor = "multi_thread")]
+async fn identity_mismatch_recorded_in_slashing_db_but_withheld_from_publication() {
+    // Arrange: validator 0 keeps its correct identity, validator 1's duty carries a wrong
+    // attester_index.
+    let harness = slashing_enabled_harness();
+    harness.seed_voting_context();
+    let good = harness.create_attestation(0, 0);
+    let good_attester_index = good.attester_index;
+    let mut bad = harness.create_attestation(0, 1);
+    bad.attester_index += 100;
+    let bad_pubkey = bad.pubkey;
+
+    // Act
+    let results: SignAttestationsResult = harness
+        .validator_store
+        .sign_attestations(vec![good, bad])
+        .collect()
+        .await;
+
+    // Assert: only the well-formed duty is returned for publication.
+    assert_eq!(results.len(), 1, "expected one stream item per committee");
+    let signed: Vec<SingleAttestation> = results
+        .into_iter()
+        .flat_map(|batch| batch.expect("committee batch should succeed"))
+        .collect();
+    assert_eq!(
+        signed.len(),
+        1,
+        "the mismatched duty must be absent from the publication batch"
+    );
+    assert_eq!(
+        signed[0].attester_index, good_attester_index,
+        "the well-formed duty must be published normally"
+    );
+
+    // Assert: the signature collector still sent for BOTH validators with the full committee
+    // batch size, so the mismatch caused no committee stall.
+    let captured = harness.captured_calls.lock();
+    assert_eq!(
+        captured.len(),
+        COMMITTEE_VALIDATOR_COUNT,
+        "the mismatched duty must still go through signature collection"
+    );
+    for call in captured.iter() {
+        let SignatureRequester::Committee {
+            validator_partial_signature_batch_size,
+            ..
+        } = &call.requester
+        else {
+            panic!(
+                "expected SignatureRequester::Committee, got: {:?}",
+                call.requester
+            );
+        };
+        assert_eq!(
+            *validator_partial_signature_batch_size, COMMITTEE_VALIDATOR_COUNT,
+            "the batch size must still count every attesting validator in the committee"
+        );
+    }
+    drop(captured);
+
+    // Assert: the mismatched validator's signed data WAS recorded in the slashing DB. The exact
+    // data the production path signed is the seeded zero vote at TEST_SLOT (pre-Electra path
+    // leaves data.index at 0), which equals the duty data `create_attestation` builds; probing it
+    // again yields `SameData`, which only an existing identical record can produce.
+    let signed_data = harness.create_attestation(0, 1).data;
+    let domain = attester_domain(&harness);
+    let same_data_probe = harness
+        .slashing_protection
+        .check_and_insert_attestations(&[(
+            &signed_data,
+            &bad_pubkey,
+            domain,
+            CheckSlashability::Yes,
+        )])
+        .expect("slashing DB transaction should succeed");
+    assert!(
+        matches!(same_data_probe[0], Ok(Safe::SameData)),
+        "the mismatched validator's data must already be recorded, got {:?}",
+        same_data_probe[0]
+    );
+
+    // And a conflicting attestation for the same validator is now refused as a double vote.
+    let conflicting_data = AttestationData {
+        beacon_block_root: Hash256::repeat_byte(0xCC),
+        ..signed_data
+    };
+    let conflict_probe = harness
+        .slashing_protection
+        .check_and_insert_attestations(&[(
+            &conflicting_data,
+            &bad_pubkey,
+            domain,
+            CheckSlashability::Yes,
+        )])
+        .expect("slashing DB transaction should succeed");
+    assert!(
+        matches!(conflict_probe[0], Err(NotSafe::InvalidAttestation(_))),
+        "a conflicting attestation for the mismatched validator must be refused, got {:?}",
+        conflict_probe[0]
+    );
+}

--- a/anchor/validator_store/src/testing/common.rs
+++ b/anchor/validator_store/src/testing/common.rs
@@ -8,6 +8,7 @@ use std::{any::Any, collections::HashMap, future::Future, pin::Pin, sync::Arc, t
 use bls::{AggregateSignature, FixedBytesExtended, PublicKeyBytes, Signature};
 use database::{NetworkDatabase, PendingStateUpdates};
 use fork::{Fork, ForkSchedule};
+use futures::StreamExt;
 use parking_lot::Mutex;
 use qbft::Completed;
 use qbft_manager::{ConsensusDecider, QbftDecidable, QbftError, TimeoutMode};
@@ -32,14 +33,35 @@ use tempfile::TempDir;
 use tokio::sync::watch;
 use types::{
     Attestation, AttestationBase, AttestationData, ChainSpec, Checkpoint, Epoch, EthSpec, Graffiti,
-    Hash256, MainnetEthSpec, SelectionProof, Slot,
+    Hash256, MainnetEthSpec, SelectionProof, SingleAttestation, Slot,
 };
-use validator_store::{AggregateToSign, AttestationToSign, SyncMessageToSign};
+use validator_store::{AggregateToSign, AttestationToSign, SyncMessageToSign, ValidatorStore};
 
-use crate::{AggregationAssignments, AnchorValidatorStore, VotingAssignments, VotingContext};
+use crate::{
+    AggregationAssignments, AnchorValidatorStore, Error, VotingAssignments, VotingContext,
+};
 
 pub(super) const TEST_SLOT: u64 = 1;
 const SLOT_DURATION_SECS: u64 = 12;
+
+/// The raw item stream `sign_attestations` yields: one `Result` batch per committee.
+pub(super) type SignAttestationsResult = Vec<Result<Vec<SingleAttestation>, Error>>;
+
+/// Drives `sign_attestations` to completion and unwraps every committee batch.
+pub(super) async fn run_sign_attestations(
+    harness: &ValidatorStoreTestHarness,
+    attestations: Vec<AttestationToSign>,
+) -> Vec<SingleAttestation> {
+    let results: SignAttestationsResult = harness
+        .validator_store
+        .sign_attestations(attestations)
+        .collect()
+        .await;
+    results
+        .into_iter()
+        .flat_map(|batch| batch.expect("committee batch should succeed"))
+        .collect()
+}
 
 // ==================== Mock consensus decider ====================
 
@@ -271,8 +293,9 @@ impl Default for HarnessOptions {
         Self {
             collector_failure: None,
             collector_hangs: false,
-            // Slashing protection is disabled by default because the harness never registers
-            // validators in the slashing DB, which would fail block/attestation signing paths.
+            // Slashing protection is disabled by default; most tests do not exercise it. When a
+            // test enables it, the harness registers every configured validator in the slashing
+            // DB so the signing paths can record and check attestations.
             disable_slashing_protection: true,
             spec: Arc::new(ChainSpec::mainnet()),
             forced_gloas_index: None,
@@ -322,6 +345,9 @@ pub(super) struct ValidatorStoreTestHarness {
     /// Genesis validators root the store was built with (`Hash256::zero()`), needed alongside
     /// `spec` to recompute signing roots.
     pub(super) genesis_validators_root: Hash256,
+    /// The slashing DB the store writes to, exposed so tests that enable slashing protection can
+    /// probe what the production path recorded.
+    pub(super) slashing_protection: Arc<SlashingDatabase>,
     _slashing_db_dir: TempDir,
     _exit_signal: async_channel::Sender<()>,
 }
@@ -420,6 +446,18 @@ impl ValidatorStoreTestHarness {
                 .expect("slashing DB should succeed"),
         );
 
+        // When slashing protection is enabled, register every validator so the signing paths can
+        // record and check attestations instead of failing with `UnregisteredValidator`.
+        if !options.disable_slashing_protection {
+            slashing_protection
+                .register_validators(
+                    committee_setups
+                        .iter()
+                        .flat_map(|setup| setup.validators.iter().map(|v| &v.public_key)),
+                )
+                .expect("validator registration should succeed");
+        }
+
         let (is_synced_tx, is_synced_rx) = watch::channel(true);
 
         let decider = match options.forced_gloas_index {
@@ -434,7 +472,7 @@ impl ValidatorStoreTestHarness {
             database,
             mock_collector,
             Arc::new(decider),
-            slashing_protection,
+            Arc::clone(&slashing_protection),
             options.disable_slashing_protection,
             slot_clock.clone(),
             Arc::clone(&spec),
@@ -456,6 +494,7 @@ impl ValidatorStoreTestHarness {
             is_synced_tx,
             spec,
             genesis_validators_root,
+            slashing_protection,
             _slashing_db_dir: slashing_db_dir,
             _exit_signal: exit_signal,
         }
@@ -484,7 +523,7 @@ impl ValidatorStoreTestHarness {
         }
     }
 
-    fn zero_checkpoint() -> Checkpoint {
+    pub(super) fn zero_checkpoint() -> Checkpoint {
         Checkpoint {
             epoch: Epoch::new(0),
             root: Hash256::zero(),
@@ -631,7 +670,7 @@ impl ValidatorStoreTestHarness {
         &self,
         committee_idx: usize,
         validator_idx: usize,
-    ) -> AttestationToSign<MainnetEthSpec> {
+    ) -> AttestationToSign {
         self.create_attestation_at_slot(committee_idx, validator_idx, TEST_SLOT)
     }
 
@@ -640,34 +679,32 @@ impl ValidatorStoreTestHarness {
         committee_idx: usize,
         validator_idx: usize,
         slot: u64,
-    ) -> AttestationToSign<MainnetEthSpec> {
+    ) -> AttestationToSign {
         let validator = &self.committee_setups[committee_idx].validators[validator_idx];
         let validator_index = validator
             .index
             .expect("test validator should have an index");
 
         AttestationToSign {
-            validator_index: *validator_index as u64,
+            attester_index: *validator_index as u64,
             pubkey: validator.public_key,
-            validator_committee_index: 0,
-            attestation: Attestation::Base(AttestationBase {
-                aggregation_bits: ssz_types::BitList::with_capacity(128)
-                    .expect("bitlist should be valid"),
-                data: AttestationData {
-                    slot: Slot::new(slot),
-                    index: 0,
-                    beacon_block_root: Hash256::zero(),
-                    source: Checkpoint {
-                        epoch: Epoch::new(0),
-                        root: Hash256::zero(),
-                    },
-                    target: Checkpoint {
-                        epoch: Epoch::new(0),
-                        root: Hash256::zero(),
-                    },
+            // Matches the `attesting_committees` entry seeded by
+            // `test_slot_voting_assignments` (the validator's position within its committee),
+            // so the duty passes the production identity check by default.
+            committee_index: validator_idx as u64,
+            data: AttestationData {
+                slot: Slot::new(slot),
+                index: 0,
+                beacon_block_root: Hash256::zero(),
+                source: Checkpoint {
+                    epoch: Epoch::new(0),
+                    root: Hash256::zero(),
                 },
-                signature: AggregateSignature::infinity(),
-            }),
+                target: Checkpoint {
+                    epoch: Epoch::new(0),
+                    root: Hash256::zero(),
+                },
+            },
         }
     }
 
@@ -679,9 +716,9 @@ impl ValidatorStoreTestHarness {
         committee_idx: usize,
         validator_idx: usize,
         index: u64,
-    ) -> AttestationToSign<MainnetEthSpec> {
+    ) -> AttestationToSign {
         let mut att = self.create_attestation(committee_idx, validator_idx);
-        att.attestation.data_mut().index = index;
+        att.data.index = index;
         att
     }
 

--- a/anchor/validator_store/src/testing/mod.rs
+++ b/anchor/validator_store/src/testing/mod.rs
@@ -3,5 +3,6 @@ mod common;
 mod committee_aggregate;
 mod committee_attestation;
 mod committee_attestation_gloas;
+mod committee_attestation_slashing;
 mod payload_attestation;
 mod proposer_preferences;


### PR DESCRIPTION
## Problem, Evidence, and Context (Required)

- The epbs branch does not compile against the latest Lighthouse unstable. The pin window includes sigp/lighthouse#9578, which reshaped the attestation signing interface, and the EIP-7688 merge (sigp/lighthouse#9450), which changed how Gloas attestation types compute signing roots.
- Without the EIP-7688 part, aggregation breaks on a Gloas devnet: upgraded beacon nodes reject aggregates whose signing roots use the old positional merkleization. So the bump and the conformance work ship together.
- Closes #1214. Spec: SIP-94 (ssvlabs/SIPs#94, commit 72a18283d). Previous pin bump: #1123.

## Change Overview (Required)

- Bump the 16 Lighthouse crate revs to e58ec88fe and mirror Lighthouse's six EIP-7688 `[patch.crates-io]` git pins into our root workspace (Cargo only applies patches from the root workspace).
- Migrate `validator_store` to the new signing interface: `AttestationToSign` is no longer generic and carries only `AttestationData`; `sign_attestations` now returns `SingleAttestation` batches. Duty identity fields (`attester_index`, `committee_index`) are compared against our own metadata as a diagnostic only (warn/info log plus a reason-labelled counter); publication proceeds regardless, since the fields are not part of the signing root and the beacon node validates them authoritatively. A duty cannot be dropped before signature collection because the committee's partial-signature batch size is exact and dropping would stall the whole committee.
- Add two fork-aware decode helpers on `DataVersion` in `ssv_types` (one for `Attestation`, one for `AggregateAndProof`). Gloas decodes the EIP-7688 progressive shapes; Heze fails closed until a wire shape is pinned upstream. All four fork-conditional decode sites now go through them.
- Bind the leader-supplied `version` to our own candidate in both aggregator validators, matching the existing proposer check.
- Merkleize `BlindedExecutionPayloadEnvelope` as a progressive container so blinded/full root parity holds at the new pin (SIP-94 section 6).
- Smaller adaptations: Heze `DataVersion` arms, EnrExt `dialable_multiaddrs_*` rename.
- Reading order: `Cargo.toml`, then `ssv_types/src/consensus.rs` (helpers, version binding, envelope), then `validator_store/src/lib.rs` (migration), then tests.
- Not changed: SSV wire encodings, QBFT value hashes, and partial-signature messages are byte-identical (EIP-7688 progressive types serialize the same as their positional counterparts; only merkleization differs). Pre-Gloas networks behave exactly as before.

## Risks, Trade-offs, and Mitigations (Required)

- On Gloas networks, operators computing progressive signing roots and operators computing positional ones would split threshold-signature reconstruction on identical decided bytes. Rollout must be lockstep on Gloas devnets. No cross-client risk: go-ssv cannot represent versions past Fulu.
- The patched SSZ crates apply workspace-wide, so they could in principle shift our own wire encodings. The ssv-spec fixture tests act as the tripwire and pass unchanged.
- The patch mirror must be re-diffed against Lighthouse's on every future pin bump (marked with a FIXME).

## Validation (Required)

- Full workspace test suite green, including ssv-spec fixtures.
- New tests: identity mismatch reaches the slashing DB, is published with the duty's identity fields echoed verbatim, and does not stall the committee; per-fork decode shape selection and Heze fail-closed; identical bytes decoded as Electra and Gloas shapes produce different roots (EIP-7495 serialization compatibility); version-binding rejections in both validators; max-size Gloas aggregate fits the 131,308-byte bound; blinded/full envelope root parity against the pinned Lighthouse type.
- `cargo fmt`, clippy, and `cargo check --workspace --all-targets` clean.

## Rollback (Required for behavior or runtime changes; optional otherwise)

- Revert the single commit. No config, data, or DB migrations. Only relevant before any Gloas devnet is running.

## Blockers / Dependencies (Optional)

- N/A
