### PR TITLE
fix(fork): publish Boole lifecycle transitions at exact slots

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3303,6 +3303,7 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 name = "fork"
 version = "0.1.0"
 dependencies = [
+ "futures",
  "serde",
  "slot_clock",
  "ssv_types",
@@ -5403,6 +5404,7 @@ dependencies = [
  "ssz_types",
  "subnet_service",
  "task_executor",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "tracing",

--- a/anchor/client/src/lib.rs
+++ b/anchor/client/src/lib.rs
@@ -448,7 +448,6 @@ impl Client {
             fork_schedule.clone(),
             slot_clock.clone(),
             E::slots_per_epoch(),
-            spec.get_slot_duration().as_secs(),
             executor.clone(),
         )?;
 

--- a/anchor/common/fork/Cargo.toml
+++ b/anchor/common/fork/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Sigma Prime <contact@sigmaprime.io>"]
 edition = { workspace = true }
 
 [dependencies]
+futures = { workspace = true }
 serde = { workspace = true }
 slot_clock = { workspace = true }
 ssv_types = { workspace = true }

--- a/anchor/common/fork/src/lifecycle.rs
+++ b/anchor/common/fork/src/lifecycle.rs
@@ -1,13 +1,13 @@
 //! Fork lifecycle state management.
 //!
 //! Provides [`ForkLifecycle`] for tracking the current fork transition state
-//! across all components via a `tokio::sync::watch` channel. The
-//! [`ForkMonitor`](crate::monitor) is the sole writer (sender); all other
-//! components hold receivers.
+//! across all components via a `tokio::sync::watch` channel. The fork monitor
+//! task ([`monitor::spawn`](crate::monitor::spawn)) is the sole writer
+//! (sender); all other components hold receivers.
 
 use crate::ForkConfig;
 
-/// Fork lifecycle state. Updated only by ForkMonitor.
+/// Fork lifecycle state. Updated only by the fork monitor task.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum ForkLifecycle {
     /// Operating on a single fork. No transition in progress.

--- a/anchor/common/fork/src/monitor.rs
+++ b/anchor/common/fork/src/monitor.rs
@@ -1,292 +1,315 @@
 //! Fork transition monitoring.
 //!
-//! This module provides a standalone task that monitors and logs fork transitions,
-//! giving operators visibility into:
-//! - Current active fork at startup
-//! - Entering the preparation window before a fork
-//! - Fork activation when it occurs
+//! A standalone task derives the fork lifecycle from every fresh slot-clock
+//! observation via [`ForkSchedule::lifecycle_at`] and publishes changes on a
+//! watch channel. Because published state is always a pure function of the
+//! observed slot, transitions land at exact slot boundaries, a jump across
+//! several boundaries publishes only the state for the current slot, and a
+//! restart in any window re-derives the same state.
 //!
-//! The monitor pre-computes all fork transition points at creation time from the
-//! deterministic fork schedule. The `run()` method simply sleeps until each
-//! transition slot and sends the corresponding lifecycle update.
-//!
-//! The monitor exits automatically when all scheduled forks have activated.
+//! Sleeps are bounded to one slot so wall-clock corrections are noticed
+//! promptly. Clock failures fail closed by requesting a client-wide shutdown,
+//! as does a backwards clock that crosses a lifecycle boundary: published
+//! state (ENR, handshake, scoring) cannot be rolled back. Both guards live as
+//! long as the process but no longer: the highest observed slot is not
+//! persisted, so a restart with a still-rolled-back clock re-derives and
+//! re-advertises the earlier lifecycle without error.
 
 use std::{sync::Arc, time::Duration};
 
+use futures::channel::mpsc::Sender;
 use slot_clock::SlotClock;
-use task_executor::TaskExecutor;
+use task_executor::{ShutdownReason, TaskExecutor};
 use tokio::sync::watch;
-use tracing::{debug, error, info};
+use tracing::{error, info, warn};
 use types::{Epoch, Slot};
 
 use crate::{FORK_PREPARATION_EPOCHS, Fork, ForkLifecycle, ForkSchedule, SUBSEQUENT_WINDOW_SLOTS};
 
-/// A pre-computed fork transition at a specific slot.
-#[derive(Debug, Clone, PartialEq, Eq)]
-struct ScheduledTransition {
-    slot: Slot,
-    lifecycle: ForkLifecycle,
-}
-
-/// Pre-computed fork monitor with all transition points determined at creation.
+/// Classification of a fresh slot observation against the highest slot seen.
 ///
-/// The full transition timeline is deterministic from the fork schedule, so all
-/// `(slot, ForkLifecycle)` pairs are computed up front. The `run()` method becomes
-/// a simple sleep-and-send loop.
-pub(crate) struct ForkMonitor {
-    /// Lifecycle to send immediately
-    initial: ForkLifecycle,
-    /// Future transitions sorted by slot.
-    transitions: Vec<ScheduledTransition>,
+/// Pure decision logic for the monitor's backwards-clock policy: all effects
+/// (publishing, warning, shutdown) live in [`run`].
+#[derive(Debug, PartialEq, Eq)]
+enum ClockObservation {
+    /// The clock moved forward or held steady.
+    Advanced,
+    /// The clock moved backwards, but the lifecycle derived for the observed
+    /// slot matches the published one; tolerated with a warning.
+    BackwardsWithinWindow,
+    /// The clock moved backwards across a lifecycle boundary. Published state
+    /// cannot be rolled back, so the node must fail closed.
+    BackwardsAcrossBoundary,
 }
 
-impl ForkMonitor {
-    /// Create a new fork monitor by pre-computing all transition points.
-    ///
-    /// For each non-genesis fork (epoch > 0), three transitions are generated:
-    /// - `WarmUp` at the preparation window start (`fork_epoch - 1` epochs)
-    /// - `GracePeriod` at fork activation (`fork_epoch`)
-    /// - `Normal` after the grace period (`fork_epoch + SUBSEQUENT_WINDOW_SLOTS` slots)
-    ///
-    /// All transitions are sorted by slot, then split at `current_slot`:
-    /// - The last transition at or before `current_slot` becomes the initial state.
-    /// - Remaining future transitions are stored for the run loop.
-    ///
-    /// This handles all restart scenarios uniformly — whether the node starts
-    /// before any fork, during a warm-up window, during a grace period, or
-    /// after all forks have activated.
-    fn new(schedule: &ForkSchedule, current_slot: Slot, slots_per_epoch: u64) -> Self {
-        let current_epoch = current_slot.epoch(slots_per_epoch);
-        let current_fork_config = schedule.active_fork_config(current_epoch);
-        info!(fork = %current_fork_config.fork, epoch = %current_epoch, "Fork monitor started");
+/// Classify `now` against the highest slot observed so far.
+fn classify_observation(
+    schedule: &ForkSchedule,
+    slots_per_epoch: u64,
+    highest_observed_slot: Slot,
+    now: Slot,
+) -> ClockObservation {
+    if now >= highest_observed_slot {
+        ClockObservation::Advanced
+    } else if schedule.lifecycle_at(now, slots_per_epoch)
+        == schedule.lifecycle_at(highest_observed_slot, slots_per_epoch)
+    {
+        ClockObservation::BackwardsWithinWindow
+    } else {
+        ClockObservation::BackwardsAcrossBoundary
+    }
+}
 
-        // Step 1: Generate all transitions for every non-genesis fork.
-        //
-        // Each fork produces three transitions at deterministic slots:
-        //   prep_slot ──────> activation ──────> grace_end
-        //   [WarmUp]          [GracePeriod]      [Normal]
-        let mut all_transitions: Vec<ScheduledTransition> = Vec::new();
-
-        for &fork in Fork::all() {
-            let Some(fork_config) = schedule.config(fork) else {
-                continue;
-            };
-            let fork_epoch = fork_config.epoch.as_u64();
-            // Genesis forks (epoch 0) are active from the start — no transitions needed.
-            if fork_epoch == 0 {
-                continue;
-            }
-
-            // The fork active just before this one (safe: fork_epoch > 0).
-            let prev_fork = schedule.active_fork_config(Epoch::new(fork_epoch - 1));
-
-            // Compute the three transition slots for this fork.
-            let prep_slot = fork_epoch.saturating_sub(FORK_PREPARATION_EPOCHS) * slots_per_epoch;
-            let activation = fork_epoch * slots_per_epoch;
-            let grace_end = activation + SUBSEQUENT_WINDOW_SLOTS;
-
-            // Guard: the previous fork's grace period must not overlap this fork's warmup.
-            let prev_activation = prev_fork.epoch.as_u64() * slots_per_epoch;
-            let prev_grace_end = prev_activation + SUBSEQUENT_WINDOW_SLOTS;
-            if prev_activation != 0 && prev_grace_end > prep_slot {
-                error!("Fork preparation overlaps with previous's grace period");
-            }
-
-            // WarmUp: dual-subscribe to current + upcoming fork topics.
-            all_transitions.push(ScheduledTransition {
-                slot: Slot::new(prep_slot),
-                lifecycle: ForkLifecycle::WarmUp {
-                    current: prev_fork.clone(),
-                    upcoming: fork_config.clone(),
-                },
-            });
-            // GracePeriod: fork activates, keep old subscriptions for late messages.
-            all_transitions.push(ScheduledTransition {
-                slot: Slot::new(activation),
-                lifecycle: ForkLifecycle::GracePeriod {
-                    current: fork_config.clone(),
-                    previous: prev_fork.clone(),
-                },
-            });
-            // Normal: grace period ends, drop old fork subscriptions.
-            all_transitions.push(ScheduledTransition {
-                slot: Slot::new(grace_end),
-                lifecycle: ForkLifecycle::Normal {
-                    current: fork_config.clone(),
-                },
-            });
-        }
-
-        // Step 2: Sort by slot, then partition into past and future at current_slot.
-        //
-        // The half-open split [past: slot <= current] [future: slot > current] means:
-        // - A transition exactly at current_slot is considered "already happened".
-        // - The last past transition determines what state we should be in right now.
-        // - If no transitions are past, we're in Normal (pre-fork or genesis-only).
-        //
-        // Example: Boole at epoch 100, restart at activation + 5:
-        //   past:   [WarmUp@ep99, GracePeriod@ep100]  → initial = GracePeriod
-        //   future: [Normal@ep100+32slots]             → run loop sends this later
-        all_transitions.sort_by_key(|t| t.slot);
-        let split = all_transitions.partition_point(|t| t.slot <= current_slot);
-
-        let initial = if split > 0 {
-            all_transitions[split - 1].lifecycle.clone()
-        } else {
-            ForkLifecycle::Normal {
-                current: current_fork_config.clone(),
-            }
+/// Log an error when any fork's preparation window overlaps the previous fork's grace
+/// period. `ForkSchedule::lifecycle_at` resolves such an overlap in favor of
+/// `WarmUp`, which drops the previous fork's topics early; schedules should
+/// keep forks at least `FORK_PREPARATION_EPOCHS` plus the subsequent window
+/// apart.
+fn error_on_overlapping_windows(schedule: &ForkSchedule, slots_per_epoch: u64) {
+    for &fork in Fork::all() {
+        let Some(config) = schedule.config(fork) else {
+            continue;
         };
-
-        let transitions = all_transitions.split_off(split);
-
-        // Log upcoming fork.
-        if let Some((fork, fork_epoch)) = schedule.next_fork_after(current_epoch) {
-            info!(
+        let fork_epoch = config.epoch.as_u64();
+        if fork_epoch == 0 {
+            continue;
+        }
+        let previous = schedule.active_fork_config(Epoch::new(fork_epoch - 1));
+        let previous_activation_slot = previous.epoch.as_u64() * slots_per_epoch;
+        if previous_activation_slot == 0 {
+            continue;
+        }
+        let previous_grace_end = previous_activation_slot + SUBSEQUENT_WINDOW_SLOTS;
+        let preparation_start =
+            fork_epoch.saturating_sub(FORK_PREPARATION_EPOCHS) * slots_per_epoch;
+        if previous_grace_end > preparation_start {
+            error!(
                 fork = %fork,
-                fork_epoch = %fork_epoch,
-                epochs_until = fork_epoch.as_u64().saturating_sub(current_epoch.as_u64()),
-                "Fork scheduled"
+                previous_fork = %previous.fork,
+                "Fork preparation window overlaps the previous fork's grace period"
             );
         }
+    }
+}
 
-        Self {
-            initial,
-            transitions,
+/// Log the operator-facing message for a published lifecycle.
+fn log_transition(lifecycle: &ForkLifecycle) {
+    match lifecycle {
+        ForkLifecycle::WarmUp {
+            current, upcoming, ..
+        } => {
+            info!(
+                current_fork = %current.fork,
+                upcoming_fork = %upcoming.fork,
+                "Entering fork preparation window"
+            );
+        }
+        ForkLifecycle::GracePeriod {
+            current, previous, ..
+        } => {
+            info!(
+                previous_fork = %previous.fork,
+                new_fork = %current.fork,
+                "Fork activated"
+            );
+        }
+        ForkLifecycle::Normal { current, .. } => {
+            info!(
+                current_fork = %current.fork,
+                grace_window_slots = SUBSEQUENT_WINDOW_SLOTS,
+                "Fork transition grace period ended"
+            );
         }
     }
 }
 
-/// Sleep until just before the target slot.
-///
-/// Wakes up 1 slot before the target to ensure we're ready.
-/// This accounts for potential timing variations.
-async fn sleep_until_slot<S: SlotClock>(slot_clock: &S, target_slot: u64, seconds_per_slot: u64) {
-    let Some(current_slot) = slot_clock.now() else {
-        return;
-    };
-
-    // Wake up 1 slot before the target
-    let buffer_slots = 1;
-    let wake_slot = target_slot.saturating_sub(buffer_slots);
-
-    if current_slot.as_u64() >= wake_slot {
-        return; // Already at or past the target
+/// Request a client-wide shutdown. A stale fork lifecycle silently corrupts
+/// networking, scoring, and ENR state, so clock failures must stop the node
+/// rather than leave only the monitor task dead.
+fn request_shutdown(shutdown_tx: &mut Sender<ShutdownReason>, reason: &'static str) {
+    error!(reason, "Fork monitor failed; requesting client shutdown");
+    if let Err(e) = shutdown_tx.try_send(ShutdownReason::Failure(reason))
+        && !e.is_full()
+    {
+        // A full channel means a shutdown is already pending; a closed one means
+        // there is no receiver left to act, which we can only surface in logs.
+        error!("Failed to deliver shutdown request: channel closed");
     }
-
-    let slots_to_wait = wake_slot - current_slot.as_u64();
-    let sleep_duration = Duration::from_secs(slots_to_wait * seconds_per_slot);
-
-    tokio::time::sleep(sleep_duration).await;
 }
 
 /// Run the fork monitor.
 ///
 /// This is the core async logic, separated from `spawn` for testability.
 ///
-/// Pre-computes all transition points from the fork schedule, then sleeps
-/// until each transition slot and sends the corresponding lifecycle update.
-///
-/// When fork transitions occur, [`ForkLifecycle`] updates are sent through the channel:
-/// - `WarmUp`: When entering the preparation window (time to dual-subscribe)
-/// - `GracePeriod`: When the fork activates (update ENR, but keep old subscriptions)
-/// - `Normal`: When the grace period ends (time to unsubscribe old topics)
+/// Each iteration takes a fresh slot-clock observation, derives the lifecycle
+/// for it, and publishes it if it changed, so a transition is never published
+/// before its slot and a jump across several boundaries publishes only the
+/// final state. An unreadable clock, or one that rolls back across a
+/// lifecycle boundary, requests a client-wide shutdown (fail closed). The
+/// loop never exits on its own; it is cancelled with the client.
 async fn run<S: SlotClock>(
-    monitor: ForkMonitor,
+    schedule: Arc<ForkSchedule>,
+    slots_per_epoch: u64,
     slot_clock: S,
-    seconds_per_slot: u64,
+    initial_slot: Slot,
     lifecycle_tx: watch::Sender<ForkLifecycle>,
+    mut shutdown_tx: Sender<ShutdownReason>,
 ) {
-    for transition in monitor.transitions {
-        sleep_until_slot(&slot_clock, transition.slot.as_u64(), seconds_per_slot).await;
+    let mut highest_observed_slot = initial_slot;
+    let mut boundary_unavailable_streak = 0u32;
 
-        match &transition.lifecycle {
-            ForkLifecycle::WarmUp {
-                current, upcoming, ..
-            } => {
-                info!(
-                    current_fork = %current.fork,
-                    upcoming_fork = %upcoming.fork,
-                    "Entering fork preparation window"
+    loop {
+        let Some(now) = slot_clock.now() else {
+            request_shutdown(&mut shutdown_tx, "Fork monitor: slot clock unreadable");
+            return;
+        };
+
+        match classify_observation(&schedule, slots_per_epoch, highest_observed_slot, now) {
+            ClockObservation::Advanced => highest_observed_slot = now,
+            ClockObservation::BackwardsWithinWindow => {
+                warn!(
+                    observed_slot = %now,
+                    highest_observed_slot = %highest_observed_slot,
+                    "Slot clock moved backwards within the current fork lifecycle window"
                 );
             }
-            ForkLifecycle::GracePeriod {
-                current, previous, ..
-            } => {
-                info!(
-                    previous_fork = %previous.fork,
-                    new_fork = %current.fork,
-                    "Fork activated"
+            ClockObservation::BackwardsAcrossBoundary => {
+                error!(
+                    observed_slot = %now,
+                    highest_observed_slot = %highest_observed_slot,
+                    "Slot clock rolled back across a published fork transition"
                 );
-            }
-            ForkLifecycle::Normal { current, .. } => {
-                info!(
-                    current_fork = %current.fork,
-                    grace_window_slots = SUBSEQUENT_WINDOW_SLOTS,
-                    "Fork transition grace period ended"
+                request_shutdown(
+                    &mut shutdown_tx,
+                    "Fork monitor: clock rolled back across a published fork transition",
                 );
+                return;
             }
         }
 
-        let _ = lifecycle_tx.send(transition.lifecycle);
+        // Publish from the highest observed slot so published state never
+        // regresses, even while a within-window backwards clock is tolerated.
+        let lifecycle = schedule.lifecycle_at(highest_observed_slot, slots_per_epoch);
+        let changed = lifecycle_tx.send_if_modified(|current| {
+            if *current == lifecycle {
+                false
+            } else {
+                *current = lifecycle.clone();
+                true
+            }
+        });
+        if changed {
+            log_transition(&lifecycle);
+        }
+
+        // Target the boundary after `now` rather than a second clock reading.
+        // `duration_to_slot` re-reads the clock, so `None` means the boundary
+        // already passed: re-observe at once. Consecutive `None`s instead pace
+        // at one slot, so a clock that never yields a boundary cannot spin.
+        // The cap bounds a sleep computed against a wall clock stepped far back.
+        let one_slot = slot_clock.slot_duration();
+        let sleep_duration = match slot_clock.duration_to_slot(now + 1) {
+            Some(until_boundary) => {
+                boundary_unavailable_streak = 0;
+                until_boundary.min(one_slot)
+            }
+            None => {
+                boundary_unavailable_streak += 1;
+                if boundary_unavailable_streak > 1 {
+                    one_slot
+                } else {
+                    Duration::ZERO
+                }
+            }
+        };
+        tokio::time::sleep(sleep_duration).await;
     }
 }
 
 /// Spawns a standalone task that monitors and logs fork transitions.
 ///
-/// The monitor will exit automatically when all scheduled forks have activated,
-/// or immediately if no forks are scheduled.
-///
-/// When fork transitions occur, the new [`ForkLifecycle`] state is sent through
-/// the watch channel so all receivers see the update immediately.
+/// The task derives the lifecycle from the slot clock once per slot for the
+/// node's lifetime and publishes changes through the returned watch channel,
+/// so all receivers see updates immediately.
 pub fn spawn<S: SlotClock + 'static>(
     fork_schedule: Arc<ForkSchedule>,
     slot_clock: S,
     slots_per_epoch: u64,
-    seconds_per_slot: u64,
     executor: TaskExecutor,
 ) -> Result<watch::Receiver<ForkLifecycle>, String> {
     let Some(current_slot) = slot_clock.now() else {
         return Err("Fork monitor: unable to determine current slot".to_string());
     };
+    let current_epoch = current_slot.epoch(slots_per_epoch);
+    let initial = fork_schedule.lifecycle_at(current_slot, slots_per_epoch);
+    info!(
+        fork = %initial.current_fork_config().fork,
+        epoch = %current_epoch,
+        "Fork monitor started"
+    );
+    if let Some((fork, fork_epoch)) = fork_schedule.next_fork_after(current_epoch) {
+        info!(
+            fork = %fork,
+            fork_epoch = %fork_epoch,
+            epochs_until = fork_epoch.as_u64().saturating_sub(current_epoch.as_u64()),
+            "Fork scheduled"
+        );
+    }
+    error_on_overlapping_windows(&fork_schedule, slots_per_epoch);
 
-    let monitor = ForkMonitor::new(&fork_schedule, current_slot, slots_per_epoch);
-
-    let (lifecycle_tx, lifecycle_rx) = watch::channel(monitor.initial.clone());
-
+    let (lifecycle_tx, lifecycle_rx) = watch::channel(initial);
+    let shutdown_tx = executor.shutdown_sender();
     executor.spawn(
-        async move {
-            run(monitor, slot_clock, seconds_per_slot, lifecycle_tx).await;
-
-            debug!("No more forks scheduled, fork monitor exiting")
-        },
+        run(
+            fork_schedule,
+            slots_per_epoch,
+            slot_clock,
+            current_slot,
+            lifecycle_tx,
+            shutdown_tx,
+        ),
         "fork_monitor",
     );
 
     Ok(lifecycle_rx)
 }
-
 #[cfg(test)]
 mod tests {
-    use std::collections::BTreeMap;
+    use std::{
+        collections::BTreeMap,
+        sync::atomic::{AtomicU64, Ordering},
+        time::Duration,
+    };
 
+    use futures::channel::mpsc::{Receiver, channel};
     use slot_clock::ManualSlotClock;
     use ssv_types::domain_type::DomainType;
-    use types::{ChainSpec, EthSpec, MinimalEthSpec, Slot};
+    use task_executor::test_utils::TestRuntime;
 
     use super::*;
-    use crate::{FORK_PREPARATION_EPOCHS, ForkConfig};
+    use crate::ForkConfig;
 
-    // Epoch constants for ForkMonitor tests
-    const BOOLE_FORK_EPOCH: u64 = 100;
-    const CURRENT_EPOCH: u64 = 50;
-    const PREPARATION_EPOCH: u64 = BOOLE_FORK_EPOCH - FORK_PREPARATION_EPOCHS;
-    const AFTER_FORK_EPOCH: u64 = 150;
+    /// Slots per epoch for these tests. `run` and `lifecycle_at` take this as a plain
+    /// parameter, so a small value keeps the transition slots close together.
+    const TEST_SLOTS_PER_EPOCH: u64 = 8;
+    /// The Boole activation epoch used by most tests.
+    const BOOLE_FORK_EPOCH: u64 = 2;
+    /// First slot of the warm-up window: `FORK_PREPARATION_EPOCHS` before activation.
+    const PREPARATION_START_SLOT: u64 =
+        (BOOLE_FORK_EPOCH - FORK_PREPARATION_EPOCHS) * TEST_SLOTS_PER_EPOCH;
+    /// First slot of the grace period: the Boole activation slot.
+    const ACTIVATION_SLOT: u64 = BOOLE_FORK_EPOCH * TEST_SLOTS_PER_EPOCH;
+    /// First slot after the grace period: back to `Normal`, now on Boole.
+    const GRACE_END_SLOT: u64 = ACTIVATION_SLOT + SUBSEQUENT_WINDOW_SLOTS;
 
-    // Epoch constants for async activation sequence test
-    const ASYNC_BOOLE_FORK_EPOCH: u64 = 10;
-    const ASYNC_START_EPOCH: u64 = 8;
+    /// Slot duration for the async loop tests, small enough to keep virtual time short.
+    const TEST_SLOT_DURATION: Duration = Duration::from_secs(1);
+    /// A slot duration that is not a whole number of seconds, used to catch truncation to
+    /// second precision anywhere in the sleep calculation.
+    const FRACTIONAL_SLOT_DURATION: Duration = Duration::from_millis(1_500);
+    /// The time to a slot boundary as reported by a clock that stepped behind genesis: far
+    /// longer than a slot, and far longer than the monitor may sleep for.
+    const UNUSABLE_SLEEP: Duration = Duration::from_secs(3_600);
 
     // Test network name
     const TEST_NETWORK: &str = "test";
@@ -294,16 +317,6 @@ mod tests {
     // Test domain types
     const TEST_BASELINE_DOMAIN: DomainType = DomainType([0, 0, 0, 1]);
     const TEST_BOOLE_DOMAIN: DomainType = DomainType([0, 0, 0, 2]);
-
-    /// Get slots per epoch from minimal spec (faster tests).
-    fn slots_per_epoch() -> u64 {
-        MinimalEthSpec::slots_per_epoch()
-    }
-
-    /// Get seconds per slot from minimal spec.
-    fn seconds_per_slot() -> u64 {
-        ChainSpec::minimal().get_slot_duration().as_secs()
-    }
 
     fn make_schedule_with_boole(boole_epoch: u64) -> Arc<ForkSchedule> {
         let mut configs = BTreeMap::new();
@@ -323,515 +336,880 @@ mod tests {
         ))
     }
 
-    /// Create a ManualSlotClock at the given epoch.
-    fn clock_at_epoch(epoch: u64) -> ManualSlotClock {
-        let clock = ManualSlotClock::new(
-            Slot::new(0),
-            Duration::from_secs(0),
-            Duration::from_secs(seconds_per_slot()),
-        );
-        clock.set_slot(epoch * slots_per_epoch());
+    /// Create a ManualSlotClock at the given slot, with genesis at the UNIX epoch so slot
+    /// starts and virtual Tokio time share an origin.
+    fn clock_at_slot(slot: u64) -> ManualSlotClock {
+        let clock = ManualSlotClock::new(Slot::new(0), Duration::ZERO, TEST_SLOT_DURATION);
+        clock.set_slot(slot);
         clock
     }
 
-    /// Duration of one epoch.
-    fn epoch_duration() -> Duration {
-        Duration::from_secs(slots_per_epoch() * seconds_per_slot())
+    /// A clock whose current slot is readable but whose reported time to any slot boundary is
+    /// unusable.
+    ///
+    /// This is the shape `SystemTimeSlotClock` takes when it steps behind genesis between two
+    /// reads: `now()` still answers from the first reading, while `duration_to_slot` takes its
+    /// own wall-clock reading and reports the whole remaining time until genesis instead of
+    /// the time to the requested boundary. The over-long report proves the `min(one_slot)` cap
+    /// engages.
+    #[derive(Clone)]
+    struct UnusableNextSlotClock {
+        inner: ManualSlotClock,
     }
 
-    /// Create a test watch channel for lifecycle, returning the sender.
-    /// The receiver is dropped since ForkMonitor tests verify fields directly.
-    fn test_lifecycle_tx() -> watch::Sender<ForkLifecycle> {
-        let (tx, _rx) = watch::channel(ForkLifecycle::Normal {
-            current: ForkConfig::new(Fork::Alan, Epoch::new(0), TEST_BASELINE_DOMAIN),
-        });
-        tx
-    }
-
-    /// Convert epoch to slot for testing.
-    fn epoch_to_slot(epoch: u64) -> Slot {
-        Slot::new(epoch * slots_per_epoch())
-    }
-
-    // ==================== ForkMonitor initialization tests ====================
-
-    #[test]
-    fn test_new_with_scheduled_fork_has_transitions() {
-        // Arrange
-        let schedule = make_schedule_with_boole(BOOLE_FORK_EPOCH);
-
-        // Act
-        let monitor = ForkMonitor::new(&schedule, epoch_to_slot(CURRENT_EPOCH), slots_per_epoch());
-
-        // Assert: initial is Normal{Alan}, with 3 future transitions
-        assert!(
-            matches!(&monitor.initial, ForkLifecycle::Normal { current } if current.fork == Fork::Alan)
-        );
-        assert_eq!(
-            monitor.transitions.len(),
-            3,
-            "Expected WarmUp, GracePeriod, Normal"
-        );
-        assert!(matches!(
-            &monitor.transitions[0].lifecycle,
-            ForkLifecycle::WarmUp { .. }
-        ));
-        assert!(matches!(
-            &monitor.transitions[1].lifecycle,
-            ForkLifecycle::GracePeriod { .. }
-        ));
-        assert!(matches!(
-            &monitor.transitions[2].lifecycle,
-            ForkLifecycle::Normal { .. }
-        ));
-    }
-
-    #[test]
-    fn test_new_without_future_forks_has_no_transitions() {
-        // Arrange
-        let schedule = make_schedule_no_future_forks();
-
-        // Act
-        let monitor = ForkMonitor::new(&schedule, epoch_to_slot(CURRENT_EPOCH), slots_per_epoch());
-
-        // Assert
-        assert!(monitor.transitions.is_empty());
-        assert!(
-            matches!(&monitor.initial, ForkLifecycle::Normal { current } if current.fork == Fork::Alan)
-        );
-    }
-
-    #[test]
-    fn test_new_in_preparation_window_emits_initial_warmup() {
-        // Arrange
-        let schedule = make_schedule_with_boole(BOOLE_FORK_EPOCH);
-
-        // Act
-        let monitor = ForkMonitor::new(
-            &schedule,
-            epoch_to_slot(PREPARATION_EPOCH),
-            slots_per_epoch(),
-        );
-
-        // Assert: initial is WarmUp (past prep slot), 2 future transitions
-        assert!(
-            matches!(
-                &monitor.initial,
-                ForkLifecycle::WarmUp { upcoming, .. } if upcoming.fork == Fork::Boole
-            ),
-            "Should emit WarmUp when starting in preparation window"
-        );
-        assert_eq!(
-            monitor.transitions.len(),
-            2,
-            "Expected GracePeriod + Normal"
-        );
-        assert!(matches!(
-            &monitor.transitions[0].lifecycle,
-            ForkLifecycle::GracePeriod { .. }
-        ));
-        assert!(matches!(
-            &monitor.transitions[1].lifecycle,
-            ForkLifecycle::Normal { .. }
-        ));
-    }
-
-    #[test]
-    fn test_new_restart_at_exact_prep_slot_emits_warmup() {
-        // Arrange: Start exactly at the preparation slot (lower boundary of warm-up window)
-        let schedule = make_schedule_with_boole(BOOLE_FORK_EPOCH);
-        let spe = slots_per_epoch();
-        let prep_slot = Slot::new(PREPARATION_EPOCH * spe);
-
-        // Act
-        let monitor = ForkMonitor::new(&schedule, prep_slot, spe);
-
-        // Assert: initial is WarmUp{Alan, Boole} (exact prep slot is "already happened")
-        assert!(
-            matches!(
-                &monitor.initial,
-                ForkLifecycle::WarmUp { current, upcoming }
-                    if current.fork == Fork::Alan && upcoming.fork == Fork::Boole
-            ),
-            "Should emit WarmUp when restarting at exact preparation slot"
-        );
-
-        // Assert: 2 future transitions remain (GracePeriod + Normal)
-        assert_eq!(
-            monitor.transitions.len(),
-            2,
-            "Expected GracePeriod + Normal"
-        );
-    }
-
-    #[test]
-    fn test_new_after_all_forks_activated_no_transitions() {
-        // Arrange
-        let schedule = make_schedule_with_boole(BOOLE_FORK_EPOCH);
-
-        // Act
-        let monitor = ForkMonitor::new(
-            &schedule,
-            epoch_to_slot(AFTER_FORK_EPOCH),
-            slots_per_epoch(),
-        );
-
-        // Assert: Boole already active, no transitions to process
-        assert!(monitor.transitions.is_empty());
-        assert!(
-            matches!(&monitor.initial, ForkLifecycle::Normal { current, .. } if current.fork == Fork::Boole)
-        );
-    }
-
-    #[test]
-    fn test_new_restart_during_grace_period_emits_grace_period() {
-        // Arrange: Start 1 slot after fork activation — inside the grace period window.
-        let schedule = make_schedule_with_boole(BOOLE_FORK_EPOCH);
-        let grace_slot = Slot::new(BOOLE_FORK_EPOCH * slots_per_epoch() + 1);
-
-        // Act
-        let monitor = ForkMonitor::new(&schedule, grace_slot, slots_per_epoch());
-
-        // Assert: Restart during grace period emits GracePeriod{Boole, Alan}
-        assert!(
-            matches!(
-                &monitor.initial,
-                ForkLifecycle::GracePeriod { current, previous }
-                    if current.fork == Fork::Boole && previous.fork == Fork::Alan
-            ),
-            "Should emit GracePeriod when restarting inside the grace window"
-        );
-
-        // Assert: Exactly 1 scheduled transition — Normal at grace end
-        assert_eq!(
-            monitor.transitions.len(),
-            1,
-            "Expected exactly 1 transition (Normal at grace end)"
-        );
-        assert!(
-            matches!(
-                &monitor.transitions[0].lifecycle,
-                ForkLifecycle::Normal { current } if current.fork == Fork::Boole
-            ),
-            "Scheduled transition should be Normal{{Boole}}"
-        );
-        assert_eq!(
-            monitor.transitions[0].slot,
-            Slot::new(BOOLE_FORK_EPOCH * slots_per_epoch() + SUBSEQUENT_WINDOW_SLOTS),
-            "Normal transition should be scheduled at grace end slot"
-        );
-    }
-
-    #[test]
-    fn test_new_restart_at_exact_activation_emits_grace_period() {
-        // Arrange: Start exactly at the fork activation slot (lower boundary of grace window).
-        let schedule = make_schedule_with_boole(BOOLE_FORK_EPOCH);
-        let activation_slot = Slot::new(BOOLE_FORK_EPOCH * slots_per_epoch());
-
-        // Act
-        let monitor = ForkMonitor::new(&schedule, activation_slot, slots_per_epoch());
-
-        // Assert: Restart at exact activation emits GracePeriod{Boole, Alan}
-        assert!(
-            matches!(
-                &monitor.initial,
-                ForkLifecycle::GracePeriod { current, previous }
-                    if current.fork == Fork::Boole && previous.fork == Fork::Alan
-            ),
-            "Should emit GracePeriod when restarting at exact activation slot"
-        );
-        assert_eq!(
-            monitor.transitions.len(),
-            1,
-            "Expected exactly 1 transition (Normal at grace end)"
-        );
-    }
-
-    #[test]
-    fn test_new_restart_at_grace_end_emits_normal() {
-        // Arrange: Start exactly at grace end slot — grace period has expired.
-        let schedule = make_schedule_with_boole(BOOLE_FORK_EPOCH);
-        let grace_end_slot =
-            Slot::new(BOOLE_FORK_EPOCH * slots_per_epoch() + SUBSEQUENT_WINDOW_SLOTS);
-
-        // Act
-        let monitor = ForkMonitor::new(&schedule, grace_end_slot, slots_per_epoch());
-
-        // Assert: Grace period expired, initial is Normal{Boole}
-        assert!(
-            matches!(
-                &monitor.initial,
-                ForkLifecycle::Normal { current } if current.fork == Fork::Boole
-            ),
-            "Should emit Normal when starting at or after grace end slot"
-        );
-
-        // Assert: No transitions remaining
-        assert!(
-            monitor.transitions.is_empty(),
-            "No transitions should be scheduled after grace period ends"
-        );
-    }
-
-    // ==================== Transition slot verification tests ====================
-
-    #[test]
-    fn test_transitions_warmup_at_correct_slot() {
-        // Arrange
-        let schedule = make_schedule_with_boole(BOOLE_FORK_EPOCH);
-        let expected_slot = (BOOLE_FORK_EPOCH - FORK_PREPARATION_EPOCHS) * slots_per_epoch();
-
-        // Act
-        let monitor = ForkMonitor::new(&schedule, epoch_to_slot(CURRENT_EPOCH), slots_per_epoch());
-
-        // Assert
-        assert_eq!(monitor.transitions[0].slot, Slot::new(expected_slot));
-        assert!(matches!(
-            &monitor.transitions[0].lifecycle,
-            ForkLifecycle::WarmUp { current, upcoming }
-                if current.fork == Fork::Alan
-                    && upcoming.fork == Fork::Boole
-                    && current.domain_type == TEST_BASELINE_DOMAIN
-        ));
-    }
-
-    #[test]
-    fn test_transitions_grace_period_at_correct_slot() {
-        // Arrange
-        let schedule = make_schedule_with_boole(BOOLE_FORK_EPOCH);
-        let expected_slot = BOOLE_FORK_EPOCH * slots_per_epoch();
-
-        // Act
-        let monitor = ForkMonitor::new(&schedule, epoch_to_slot(CURRENT_EPOCH), slots_per_epoch());
-
-        // Assert
-        assert_eq!(monitor.transitions[1].slot, Slot::new(expected_slot));
-        assert!(matches!(
-            &monitor.transitions[1].lifecycle,
-            ForkLifecycle::GracePeriod { current, previous }
-                if current.fork == Fork::Boole
-                    && previous.fork == Fork::Alan
-                    && current.domain_type == TEST_BOOLE_DOMAIN
-        ));
-    }
-
-    #[test]
-    fn test_transitions_normal_at_correct_slot() {
-        // Arrange
-        let schedule = make_schedule_with_boole(BOOLE_FORK_EPOCH);
-        let expected_slot = BOOLE_FORK_EPOCH * slots_per_epoch() + SUBSEQUENT_WINDOW_SLOTS;
-
-        // Act
-        let monitor = ForkMonitor::new(&schedule, epoch_to_slot(CURRENT_EPOCH), slots_per_epoch());
-
-        // Assert
-        assert_eq!(monitor.transitions[2].slot, Slot::new(expected_slot));
-        assert!(matches!(
-            &monitor.transitions[2].lifecycle,
-            ForkLifecycle::Normal { current }
-                if current.fork == Fork::Boole
-                    && current.domain_type == TEST_BOOLE_DOMAIN
-        ));
-    }
-
-    #[test]
-    fn test_full_transition_sequence() {
-        // Arrange
-        let schedule = make_schedule_with_boole(BOOLE_FORK_EPOCH);
-        let spe = slots_per_epoch();
-        let prep_slot = (BOOLE_FORK_EPOCH - FORK_PREPARATION_EPOCHS) * spe;
-        let activation_slot = BOOLE_FORK_EPOCH * spe;
-        let grace_end_slot = activation_slot + SUBSEQUENT_WINDOW_SLOTS;
-
-        // Act
-        let monitor = ForkMonitor::new(&schedule, epoch_to_slot(CURRENT_EPOCH), spe);
-
-        // Assert: All 3 transitions in correct order with correct slots
-        assert_eq!(monitor.transitions.len(), 3);
-
-        assert_eq!(monitor.transitions[0].slot, Slot::new(prep_slot));
-        assert!(matches!(
-            &monitor.transitions[0].lifecycle,
-            ForkLifecycle::WarmUp { .. }
-        ));
-
-        assert_eq!(monitor.transitions[1].slot, Slot::new(activation_slot));
-        assert!(matches!(
-            &monitor.transitions[1].lifecycle,
-            ForkLifecycle::GracePeriod { .. }
-        ));
-
-        assert_eq!(monitor.transitions[2].slot, Slot::new(grace_end_slot));
-        assert!(matches!(
-            &monitor.transitions[2].lifecycle,
-            ForkLifecycle::Normal { .. }
-        ));
-    }
-
-    // ==================== Edge case tests ====================
-
-    #[test]
-    fn test_epoch_zero_forks_produce_no_transitions() {
-        // Arrange: Both Alan and Boole at epoch 0 (all forks active from genesis).
-        let mut configs = BTreeMap::new();
-        configs.insert(Fork::Alan, (Epoch::new(0), TEST_BASELINE_DOMAIN));
-        configs.insert(Fork::Boole, (Epoch::new(0), TEST_BOOLE_DOMAIN));
-        let schedule = Arc::new(
-            ForkSchedule::from_fork_configs(configs, TEST_NETWORK).expect("valid schedule"),
-        );
-
-        // Act
-        let monitor = ForkMonitor::new(&schedule, Slot::new(0), slots_per_epoch());
-
-        // Assert: No transitions — both forks at epoch 0, Boole is the active fork.
-        assert!(monitor.transitions.is_empty());
-        assert!(
-            matches!(&monitor.initial, ForkLifecycle::Normal { current, .. } if current.fork == Fork::Boole)
-        );
-    }
-
-    #[test]
-    fn test_early_fork_produces_all_transitions() {
-        // Arrange: Boole at epoch 2 (very early fork).
-        let schedule = make_schedule_with_boole(2);
-
-        // Act
-        let monitor = ForkMonitor::new(&schedule, Slot::new(0), slots_per_epoch());
-
-        // Assert: All 3 transitions emitted.
-        assert_eq!(monitor.transitions.len(), 3);
-        assert!(matches!(
-            &monitor.transitions[0].lifecycle,
-            ForkLifecycle::WarmUp { .. }
-        ));
-        assert!(matches!(
-            &monitor.transitions[1].lifecycle,
-            ForkLifecycle::GracePeriod { .. }
-        ));
-        assert!(matches!(
-            &monitor.transitions[2].lifecycle,
-            ForkLifecycle::Normal { current, .. } if current.fork == Fork::Boole
-        ));
-    }
-
-    // ==================== Async run() tests ====================
-
-    #[tokio::test]
-    async fn test_run_exits_immediately_when_no_forks_scheduled() {
-        // Arrange
-        let schedule = make_schedule_no_future_forks();
-        let clock = clock_at_epoch(CURRENT_EPOCH);
-        let monitor = ForkMonitor::new(&schedule, epoch_to_slot(CURRENT_EPOCH), slots_per_epoch());
-        let lifecycle_tx = test_lifecycle_tx();
-
-        // Act — completes immediately since there are no transitions
-        run(monitor, clock, seconds_per_slot(), lifecycle_tx).await;
-    }
-
-    #[tokio::test]
-    async fn test_run_exits_immediately_when_fork_already_active() {
-        // Arrange
-        let schedule = make_schedule_with_boole(BOOLE_FORK_EPOCH);
-        let clock = clock_at_epoch(AFTER_FORK_EPOCH);
-        let monitor = ForkMonitor::new(
-            &schedule,
-            epoch_to_slot(AFTER_FORK_EPOCH),
-            slots_per_epoch(),
-        );
-        let lifecycle_tx = test_lifecycle_tx();
-
-        // Act — completes immediately since all forks already activated
-        run(monitor, clock, seconds_per_slot(), lifecycle_tx).await;
-    }
-
-    /// Tests that the monitor correctly processes fork activation and grace period over time.
-    /// Uses tokio's time control to simulate slot progression.
-    #[tokio::test(start_paused = true)]
-    async fn test_run_completes_full_fork_activation_sequence() {
-        // Arrange
-        let schedule = make_schedule_with_boole(ASYNC_BOOLE_FORK_EPOCH);
-        let clock = clock_at_epoch(ASYNC_START_EPOCH);
-        let monitor = ForkMonitor::new(
-            &schedule,
-            epoch_to_slot(ASYNC_START_EPOCH),
-            slots_per_epoch(),
-        );
-        let (lifecycle_tx, mut lifecycle_rx) = watch::channel(monitor.initial.clone());
-
-        // Act: Spawn monitor and advance time through fork activation and grace period
-        let handle = tokio::spawn({
-            let clock = clock.clone();
-            async move {
-                run(monitor, clock, seconds_per_slot(), lifecycle_tx).await;
+    impl SlotClock for UnusableNextSlotClock {
+        fn new(genesis_slot: Slot, genesis_duration: Duration, slot_duration: Duration) -> Self {
+            Self {
+                inner: ManualSlotClock::new(genesis_slot, genesis_duration, slot_duration),
             }
-        });
+        }
 
-        // Let the spawned task start and hit the first sleep
+        fn duration_to_next_slot(&self) -> Option<Duration> {
+            Some(UNUSABLE_SLEEP)
+        }
+
+        fn now(&self) -> Option<Slot> {
+            self.inner.now()
+        }
+
+        fn is_prior_to_genesis(&self) -> Option<bool> {
+            self.inner.is_prior_to_genesis()
+        }
+
+        fn now_duration(&self) -> Option<Duration> {
+            self.inner.now_duration()
+        }
+
+        fn slot_of(&self, now: Duration) -> Option<Slot> {
+            self.inner.slot_of(now)
+        }
+
+        fn slot_duration(&self) -> Duration {
+            self.inner.slot_duration()
+        }
+
+        fn duration_to_slot(&self, _slot: Slot) -> Option<Duration> {
+            Some(UNUSABLE_SLEEP)
+        }
+
+        fn duration_to_next_epoch(&self, slots_per_epoch: u64) -> Option<Duration> {
+            self.inner.duration_to_next_epoch(slots_per_epoch)
+        }
+
+        fn start_of(&self, slot: Slot) -> Option<Duration> {
+            self.inner.start_of(slot)
+        }
+
+        fn genesis_slot(&self) -> Slot {
+            self.inner.genesis_slot()
+        }
+
+        fn genesis_duration(&self) -> Duration {
+            SlotClock::genesis_duration(&self.inner)
+        }
+    }
+
+    /// A clock that advances one slot per `now()` read, whose first `duration_to_slot`
+    /// query fails (the boundary-slipped race) and whose later queries resolve normally.
+    ///
+    /// This isolates the first step of the fallback ladder: a single `None` must re-observe
+    /// immediately, which is provable because the next slot's transition publishes without
+    /// any virtual time passing.
+    #[derive(Clone)]
+    struct BoundaryOnceUnavailableClock {
+        start_slot: u64,
+        now_reads: Arc<AtomicU64>,
+        boundary_reads: Arc<AtomicU64>,
+    }
+
+    impl BoundaryOnceUnavailableClock {
+        fn starting_at(start_slot: u64) -> Self {
+            Self {
+                start_slot,
+                now_reads: Arc::new(AtomicU64::new(0)),
+                boundary_reads: Arc::new(AtomicU64::new(0)),
+            }
+        }
+    }
+
+    impl SlotClock for BoundaryOnceUnavailableClock {
+        fn new(_genesis_slot: Slot, _genesis_duration: Duration, _slot_duration: Duration) -> Self {
+            unimplemented!("constructed via BoundaryOnceUnavailableClock::starting_at")
+        }
+
+        fn now(&self) -> Option<Slot> {
+            let reads = self.now_reads.fetch_add(1, Ordering::SeqCst);
+            Some(Slot::new(self.start_slot + reads))
+        }
+
+        fn is_prior_to_genesis(&self) -> Option<bool> {
+            Some(false)
+        }
+
+        fn now_duration(&self) -> Option<Duration> {
+            None
+        }
+
+        fn slot_of(&self, _now: Duration) -> Option<Slot> {
+            None
+        }
+
+        fn slot_duration(&self) -> Duration {
+            TEST_SLOT_DURATION
+        }
+
+        fn duration_to_slot(&self, _slot: Slot) -> Option<Duration> {
+            (self.boundary_reads.fetch_add(1, Ordering::SeqCst) > 0).then_some(TEST_SLOT_DURATION)
+        }
+
+        fn duration_to_next_slot(&self) -> Option<Duration> {
+            None
+        }
+
+        fn duration_to_next_epoch(&self, _slots_per_epoch: u64) -> Option<Duration> {
+            None
+        }
+
+        fn start_of(&self, _slot: Slot) -> Option<Duration> {
+            None
+        }
+
+        fn genesis_slot(&self) -> Slot {
+            Slot::new(0)
+        }
+
+        fn genesis_duration(&self) -> Duration {
+            Duration::ZERO
+        }
+    }
+
+    /// A clock frozen at one readable slot whose `duration_to_slot` never resolves: `now()`
+    /// keeps succeeding while every boundary query fails.
+    ///
+    /// This is the pathological shape the streak-based fallback exists for: only the first
+    /// consecutive failure may re-observe immediately, every following one must pace at a
+    /// full slot.
+    #[derive(Clone)]
+    struct FrozenNoBoundaryClock {
+        slot: Slot,
+    }
+
+    impl SlotClock for FrozenNoBoundaryClock {
+        fn new(_genesis_slot: Slot, _genesis_duration: Duration, _slot_duration: Duration) -> Self {
+            unimplemented!("constructed directly from a slot")
+        }
+
+        fn now(&self) -> Option<Slot> {
+            Some(self.slot)
+        }
+
+        fn is_prior_to_genesis(&self) -> Option<bool> {
+            Some(false)
+        }
+
+        fn now_duration(&self) -> Option<Duration> {
+            None
+        }
+
+        fn slot_of(&self, _now: Duration) -> Option<Slot> {
+            None
+        }
+
+        fn slot_duration(&self) -> Duration {
+            TEST_SLOT_DURATION
+        }
+
+        fn duration_to_slot(&self, _slot: Slot) -> Option<Duration> {
+            None
+        }
+
+        fn duration_to_next_slot(&self) -> Option<Duration> {
+            None
+        }
+
+        fn duration_to_next_epoch(&self, _slots_per_epoch: u64) -> Option<Duration> {
+            None
+        }
+
+        fn start_of(&self, _slot: Slot) -> Option<Duration> {
+            None
+        }
+
+        fn genesis_slot(&self) -> Slot {
+            Slot::new(0)
+        }
+
+        fn genesis_duration(&self) -> Duration {
+            Duration::ZERO
+        }
+    }
+
+    /// A shutdown channel with the same capacity as the one `TaskExecutor` hands out.
+    fn test_shutdown_channel() -> (Sender<ShutdownReason>, Receiver<ShutdownReason>) {
+        channel(1)
+    }
+
+    /// Assert the monitor failed closed by requesting a client-wide shutdown.
+    fn assert_shutdown_requested(shutdown_rx: &mut Receiver<ShutdownReason>) {
+        match shutdown_rx.try_recv() {
+            Ok(reason) => assert!(
+                matches!(reason, ShutdownReason::Failure(_)),
+                "expected a failure shutdown reason, got {reason:?}"
+            ),
+            Err(e) => panic!("expected a shutdown request, got {e:?}"),
+        }
+    }
+
+    fn assert_no_shutdown_requested(shutdown_rx: &mut Receiver<ShutdownReason>) {
+        if let Ok(reason) = shutdown_rx.try_recv() {
+            panic!("unexpected shutdown request: {reason:?}");
+        }
+    }
+
+    fn alan_config() -> ForkConfig {
+        ForkConfig::new(Fork::Alan, Epoch::new(0), TEST_BASELINE_DOMAIN)
+    }
+
+    fn boole_config() -> ForkConfig {
+        ForkConfig::new(Fork::Boole, Epoch::new(BOOLE_FORK_EPOCH), TEST_BOOLE_DOMAIN)
+    }
+
+    fn normal_alan_lifecycle() -> ForkLifecycle {
+        ForkLifecycle::Normal {
+            current: alan_config(),
+        }
+    }
+
+    fn warmup_lifecycle() -> ForkLifecycle {
+        ForkLifecycle::WarmUp {
+            current: alan_config(),
+            upcoming: boole_config(),
+        }
+    }
+
+    fn grace_period_lifecycle() -> ForkLifecycle {
+        ForkLifecycle::GracePeriod {
+            current: boole_config(),
+            previous: alan_config(),
+        }
+    }
+
+    fn normal_boole_lifecycle() -> ForkLifecycle {
+        ForkLifecycle::Normal {
+            current: boole_config(),
+        }
+    }
+
+    /// A monitor `run` task driven by a test clock, plus the handles a test needs to observe
+    /// it.
+    struct RunningMonitor {
+        handle: tokio::task::JoinHandle<()>,
+        lifecycle_rx: watch::Receiver<ForkLifecycle>,
+        shutdown_rx: Receiver<ShutdownReason>,
+    }
+
+    /// Spawn `run` against the given clock, mirroring `spawn`'s initialization: the watch
+    /// channel starts at the lifecycle derived for the clock's current slot. Yields once so
+    /// the first iteration has run and the task is parked on its slot-boundary sleep.
+    async fn start_run<S: SlotClock + 'static>(
+        schedule: Arc<ForkSchedule>,
+        clock: S,
+    ) -> RunningMonitor {
+        let initial_slot = clock.now().expect("test clock should be readable at start");
+        let (lifecycle_tx, lifecycle_rx) =
+            watch::channel(schedule.lifecycle_at(initial_slot, TEST_SLOTS_PER_EPOCH));
+        let (shutdown_tx, shutdown_rx) = test_shutdown_channel();
+        let handle = tokio::spawn(run(
+            schedule,
+            TEST_SLOTS_PER_EPOCH,
+            clock,
+            initial_slot,
+            lifecycle_tx,
+            shutdown_tx,
+        ));
         tokio::task::yield_now().await;
-
-        // Track observed lifecycle states
-        let mut saw_warmup = false;
-        let mut saw_grace_period = false;
-        let mut saw_normal_boole = false;
-
-        // Advance through epochs until fork activation
-        for epoch in (ASYNC_START_EPOCH + 1)..=ASYNC_BOOLE_FORK_EPOCH {
-            clock.set_slot(epoch * slots_per_epoch());
-            tokio::time::advance(epoch_duration()).await;
-            tokio::task::yield_now().await;
-            check_lifecycle(
-                &mut lifecycle_rx,
-                &mut saw_warmup,
-                &mut saw_grace_period,
-                &mut saw_normal_boole,
-            );
+        RunningMonitor {
+            handle,
+            lifecycle_rx,
+            shutdown_rx,
         }
-
-        // Advance through the grace period (32 slots = 4 epochs on minimal spec)
-        let grace_period_epochs = SUBSEQUENT_WINDOW_SLOTS / slots_per_epoch();
-        for i in 1..=grace_period_epochs {
-            let epoch = ASYNC_BOOLE_FORK_EPOCH + i;
-            clock.set_slot(epoch * slots_per_epoch());
-            tokio::time::advance(epoch_duration()).await;
-            tokio::task::yield_now().await;
-            check_lifecycle(
-                &mut lifecycle_rx,
-                &mut saw_warmup,
-                &mut saw_grace_period,
-                &mut saw_normal_boole,
-            );
-        }
-
-        handle.await.unwrap();
-
-        // Check final state
-        check_lifecycle(
-            &mut lifecycle_rx,
-            &mut saw_warmup,
-            &mut saw_grace_period,
-            &mut saw_normal_boole,
-        );
-
-        assert!(saw_warmup, "Expected WarmUp lifecycle state");
-        assert!(saw_grace_period, "Expected GracePeriod lifecycle state");
-        assert!(saw_normal_boole, "Expected Normal(Boole) lifecycle state");
     }
 
-    /// Helper to check the current lifecycle state against the expected progression.
-    fn check_lifecycle(
-        rx: &mut watch::Receiver<ForkLifecycle>,
-        saw_warmup: &mut bool,
-        saw_grace_period: &mut bool,
-        saw_normal_boole: &mut bool,
-    ) {
-        let state = rx.borrow_and_update().clone();
-        match &state {
-            ForkLifecycle::WarmUp { .. } => *saw_warmup = true,
-            ForkLifecycle::GracePeriod { .. } => *saw_grace_period = true,
-            ForkLifecycle::Normal { current, .. } if current.fork == Fork::Boole => {
-                *saw_normal_boole = true;
-            }
-            _ => {}
+    /// Fire the monitor's pending one-slot sleep and let the woken iteration run.
+    async fn wake_after_one_slot() {
+        tokio::time::advance(TEST_SLOT_DURATION).await;
+        tokio::task::yield_now().await;
+    }
+
+    // ==================== `classify_observation` tests ====================
+
+    #[test]
+    fn test_classify_forward_observation_is_advanced() {
+        // Arrange
+        let schedule = make_schedule_with_boole(BOOLE_FORK_EPOCH);
+
+        // Act
+        let observation =
+            classify_observation(&schedule, TEST_SLOTS_PER_EPOCH, Slot::new(5), Slot::new(6));
+
+        // Assert
+        assert_eq!(observation, ClockObservation::Advanced);
+    }
+
+    #[test]
+    fn test_classify_equal_observation_is_advanced() {
+        // Arrange
+        let schedule = make_schedule_with_boole(BOOLE_FORK_EPOCH);
+
+        // Act
+        let observation =
+            classify_observation(&schedule, TEST_SLOTS_PER_EPOCH, Slot::new(5), Slot::new(5));
+
+        // Assert
+        assert_eq!(observation, ClockObservation::Advanced);
+    }
+
+    #[test]
+    fn test_classify_backwards_within_the_grace_window_is_tolerated() {
+        // Arrange: both slots sit inside the grace period, so the derived lifecycle matches.
+        let schedule = make_schedule_with_boole(BOOLE_FORK_EPOCH);
+
+        // Act
+        let observation = classify_observation(
+            &schedule,
+            TEST_SLOTS_PER_EPOCH,
+            Slot::new(ACTIVATION_SLOT + 5),
+            Slot::new(ACTIVATION_SLOT + 1),
+        );
+
+        // Assert
+        assert_eq!(observation, ClockObservation::BackwardsWithinWindow);
+    }
+
+    #[test]
+    fn test_classify_backwards_onto_the_grace_window_start_is_tolerated() {
+        // Arrange: the observation lands exactly on the activation slot, the half-open
+        // start of the grace window the highest slot is still inside.
+        let schedule = make_schedule_with_boole(BOOLE_FORK_EPOCH);
+
+        // Act
+        let observation = classify_observation(
+            &schedule,
+            TEST_SLOTS_PER_EPOCH,
+            Slot::new(ACTIVATION_SLOT + 5),
+            Slot::new(ACTIVATION_SLOT),
+        );
+
+        // Assert
+        assert_eq!(observation, ClockObservation::BackwardsWithinWindow);
+    }
+
+    #[test]
+    fn test_classify_backwards_across_the_activation_boundary_is_fatal() {
+        // Arrange: the highest slot is in the grace period, the observation in the warm-up
+        // window just before activation.
+        let schedule = make_schedule_with_boole(BOOLE_FORK_EPOCH);
+
+        // Act
+        let observation = classify_observation(
+            &schedule,
+            TEST_SLOTS_PER_EPOCH,
+            Slot::new(ACTIVATION_SLOT),
+            Slot::new(ACTIVATION_SLOT - 1),
+        );
+
+        // Assert
+        assert_eq!(observation, ClockObservation::BackwardsAcrossBoundary);
+    }
+
+    #[test]
+    fn test_classify_backwards_across_the_grace_end_boundary_is_fatal() {
+        // Arrange: the highest slot has left the grace period, the observation is still in it.
+        let schedule = make_schedule_with_boole(BOOLE_FORK_EPOCH);
+
+        // Act
+        let observation = classify_observation(
+            &schedule,
+            TEST_SLOTS_PER_EPOCH,
+            Slot::new(GRACE_END_SLOT),
+            Slot::new(GRACE_END_SLOT - 1),
+        );
+
+        // Assert
+        assert_eq!(observation, ClockObservation::BackwardsAcrossBoundary);
+    }
+
+    #[test]
+    fn test_classify_backwards_from_warmup_into_pre_warmup_normal_is_fatal() {
+        // Arrange: the highest slot is at the exact start of the warm-up window, the
+        // observation just before it, where the lifecycle is still the pre-fork Normal.
+        let schedule = make_schedule_with_boole(BOOLE_FORK_EPOCH);
+
+        // Act
+        let observation = classify_observation(
+            &schedule,
+            TEST_SLOTS_PER_EPOCH,
+            Slot::new(PREPARATION_START_SLOT),
+            Slot::new(PREPARATION_START_SLOT - 1),
+        );
+
+        // Assert
+        assert_eq!(observation, ClockObservation::BackwardsAcrossBoundary);
+    }
+
+    // ==================== `spawn` initial state tests ====================
+
+    /// Spawn the monitor with the clock at the given slot and return the lifecycle receiver.
+    fn spawn_monitor_at_slot(slot: u64) -> Result<watch::Receiver<ForkLifecycle>, String> {
+        let schedule = make_schedule_with_boole(BOOLE_FORK_EPOCH);
+        let runtime = TestRuntime::default();
+        spawn(
+            schedule,
+            clock_at_slot(slot),
+            TEST_SLOTS_PER_EPOCH,
+            runtime.task_executor.clone(),
+        )
+    }
+
+    #[tokio::test]
+    async fn test_spawn_initial_state_is_normal_before_the_preparation_window() {
+        // Arrange and act: the last slot before the warm-up window starts.
+        let lifecycle_rx =
+            spawn_monitor_at_slot(PREPARATION_START_SLOT - 1).expect("spawn should succeed");
+
+        // Assert
+        assert_eq!(*lifecycle_rx.borrow(), normal_alan_lifecycle());
+    }
+
+    #[tokio::test]
+    async fn test_spawn_initial_state_is_warmup_inside_the_preparation_window() {
+        // Arrange and act: the exact first slot of the warm-up window.
+        let lifecycle_rx =
+            spawn_monitor_at_slot(PREPARATION_START_SLOT).expect("spawn should succeed");
+
+        // Assert
+        assert_eq!(*lifecycle_rx.borrow(), warmup_lifecycle());
+    }
+
+    #[tokio::test]
+    async fn test_spawn_initial_state_is_grace_period_inside_the_grace_window() {
+        // Arrange and act: the exact activation slot, the first slot of the grace period.
+        let lifecycle_rx = spawn_monitor_at_slot(ACTIVATION_SLOT).expect("spawn should succeed");
+
+        // Assert
+        assert_eq!(*lifecycle_rx.borrow(), grace_period_lifecycle());
+    }
+
+    #[tokio::test]
+    async fn test_spawn_initial_state_is_normal_after_the_grace_window() {
+        // Arrange and act: the exact first slot after the grace period.
+        let lifecycle_rx = spawn_monitor_at_slot(GRACE_END_SLOT).expect("spawn should succeed");
+
+        // Assert
+        assert_eq!(*lifecycle_rx.borrow(), normal_boole_lifecycle());
+    }
+
+    #[tokio::test]
+    async fn test_spawn_fails_when_the_clock_is_unreadable() {
+        // Arrange: the clock sits before genesis, so `now()` returns `None`.
+        let schedule = make_schedule_with_boole(BOOLE_FORK_EPOCH);
+        let genesis_time = Duration::from_secs(10);
+        let clock = ManualSlotClock::new(Slot::new(0), genesis_time, TEST_SLOT_DURATION);
+        clock.set_current_time(genesis_time - Duration::from_secs(1));
+        let runtime = TestRuntime::default();
+
+        // Act
+        let result = spawn(
+            schedule,
+            clock,
+            TEST_SLOTS_PER_EPOCH,
+            runtime.task_executor.clone(),
+        );
+
+        // Assert
+        assert!(
+            result.is_err(),
+            "spawn must refuse to start without a readable clock"
+        );
+    }
+
+    // ==================== Async `run` tests ====================
+
+    /// The loop sleeps only to the next slot boundary, so it wakes many times before a distant
+    /// transition. Each wake must decide from a fresh observation rather than assume it is
+    /// due, and the transition must land exactly when the clock reaches its slot.
+    #[tokio::test(start_paused = true)]
+    async fn test_run_publishes_the_warmup_transition_at_its_exact_slot() {
+        // Arrange: start well before the warm-up window.
+        let schedule = make_schedule_with_boole(BOOLE_FORK_EPOCH);
+        let clock = clock_at_slot(0);
+        let mut monitor = start_run(schedule, clock.clone()).await;
+
+        // Act: wake the Tokio timer repeatedly while the slot clock stays at slot 0.
+        for _ in 0..3 {
+            wake_after_one_slot().await;
         }
+
+        // Assert: early wakes publish nothing.
+        assert_eq!(
+            *monitor.lifecycle_rx.borrow(),
+            normal_alan_lifecycle(),
+            "Nothing may be published while the slot clock is before the transition"
+        );
+
+        // Act and assert at the slot before the transition
+        clock.set_slot(PREPARATION_START_SLOT - 1);
+        wake_after_one_slot().await;
+        assert_eq!(
+            *monitor.lifecycle_rx.borrow(),
+            normal_alan_lifecycle(),
+            "The transition must not be published one slot early"
+        );
+
+        // Act and assert at the exact transition slot
+        clock.set_slot(PREPARATION_START_SLOT);
+        wake_after_one_slot().await;
+        assert_eq!(*monitor.lifecycle_rx.borrow(), warmup_lifecycle());
+        assert!(!monitor.handle.is_finished(), "Monitor must keep running");
+        assert_no_shutdown_requested(&mut monitor.shutdown_rx);
+    }
+
+    /// Walk the clock across every boundary in order and observe each phase land at its exact
+    /// slot: WarmUp at the preparation slot, GracePeriod at activation, Normal at grace end.
+    #[tokio::test(start_paused = true)]
+    async fn test_run_publishes_each_phase_at_its_boundary_as_the_clock_advances() {
+        // Arrange
+        let schedule = make_schedule_with_boole(BOOLE_FORK_EPOCH);
+        let clock = clock_at_slot(0);
+        let mut monitor = start_run(schedule, clock.clone()).await;
+        assert_eq!(*monitor.lifecycle_rx.borrow(), normal_alan_lifecycle());
+
+        // Act and assert: preparation window opens.
+        clock.set_slot(PREPARATION_START_SLOT);
+        wake_after_one_slot().await;
+        assert_eq!(*monitor.lifecycle_rx.borrow(), warmup_lifecycle());
+
+        // Act and assert: fork activates.
+        clock.set_slot(ACTIVATION_SLOT);
+        wake_after_one_slot().await;
+        assert_eq!(*monitor.lifecycle_rx.borrow(), grace_period_lifecycle());
+
+        // Act and assert: grace period ends.
+        clock.set_slot(GRACE_END_SLOT);
+        wake_after_one_slot().await;
+        assert_eq!(*monitor.lifecycle_rx.borrow(), normal_boole_lifecycle());
+
+        assert!(!monitor.handle.is_finished(), "Monitor must keep running");
+        assert_no_shutdown_requested(&mut monitor.shutdown_rx);
+    }
+
+    /// A clock jump across several boundaries must publish only the lifecycle derived from the
+    /// current slot: the lifecycle is state, not an event stream, so replaying the
+    /// intermediate states would hand receivers fork configurations that are already stale.
+    #[tokio::test(start_paused = true)]
+    async fn test_run_publishes_only_the_final_state_after_a_jump_across_all_boundaries() {
+        // Arrange: start before the warm-up window.
+        let schedule = make_schedule_with_boole(BOOLE_FORK_EPOCH);
+        let clock = clock_at_slot(0);
+        let mut monitor = start_run(schedule, clock.clone()).await;
+
+        // Act: jump the clock past every boundary, giving the loop a single wake to notice.
+        clock.set_slot(GRACE_END_SLOT + 5);
+        wake_after_one_slot().await;
+
+        // Assert: exactly one change is pending and it is the final state. The jump was
+        // observed in a single iteration, so at most one value was ever sent.
+        assert!(
+            monitor.lifecycle_rx.has_changed().expect("sender is alive"),
+            "The jump must publish a change"
+        );
+        assert_eq!(
+            *monitor.lifecycle_rx.borrow_and_update(),
+            normal_boole_lifecycle(),
+            "Only the state for the current slot may be published, not the skipped phases"
+        );
+
+        // Assert: nothing further is published afterwards.
+        wake_after_one_slot().await;
+        assert!(
+            !monitor.lifecycle_rx.has_changed().expect("sender is alive"),
+            "No further publishes may follow the jump"
+        );
+        assert_no_shutdown_requested(&mut monitor.shutdown_rx);
+    }
+
+    /// An unreadable clock freezes the lifecycle wherever it happened to be, which silently
+    /// corrupts networking, scoring and ENR state, so the node must fail closed.
+    #[tokio::test(start_paused = true)]
+    async fn test_run_requests_shutdown_when_clock_becomes_unavailable() {
+        // Arrange: a clock with genesis later than the time we set below.
+        let schedule = make_schedule_with_boole(BOOLE_FORK_EPOCH);
+        let genesis_time = Duration::from_secs(10);
+        let clock = ManualSlotClock::new(Slot::new(0), genesis_time, TEST_SLOT_DURATION);
+        let mut monitor = start_run(schedule, clock.clone()).await;
+
+        // Act: step the clock behind genesis, so `now()` returns `None` on the next wake.
+        clock.set_current_time(genesis_time - Duration::from_secs(1));
+        tokio::time::advance(TEST_SLOT_DURATION).await;
+        monitor
+            .handle
+            .await
+            .expect("fork monitor task should complete");
+
+        // Assert
+        assert_shutdown_requested(&mut monitor.shutdown_rx);
+        assert_eq!(
+            *monitor.lifecycle_rx.borrow(),
+            normal_alan_lifecycle(),
+            "The lifecycle must stay frozen at its last published state"
+        );
+    }
+
+    /// A published lifecycle cannot be taken back, so a clock that rolls back across one
+    /// leaves the node advertising a fork state its own clock says has not happened yet.
+    #[tokio::test(start_paused = true)]
+    async fn test_run_requests_shutdown_when_clock_rolls_back_across_published_transition() {
+        // Arrange: start in the warm-up window, then publish the activation.
+        let schedule = make_schedule_with_boole(BOOLE_FORK_EPOCH);
+        let clock = clock_at_slot(ACTIVATION_SLOT - 2);
+        let mut monitor = start_run(schedule, clock.clone()).await;
+
+        clock.set_slot(ACTIVATION_SLOT);
+        wake_after_one_slot().await;
+        assert_eq!(
+            *monitor.lifecycle_rx.borrow(),
+            grace_period_lifecycle(),
+            "The transition should have been published before the rollback"
+        );
+
+        // Act: roll the clock back across the activation boundary.
+        clock.set_slot(ACTIVATION_SLOT - 1);
+        tokio::time::advance(TEST_SLOT_DURATION).await;
+        monitor
+            .handle
+            .await
+            .expect("fork monitor task should complete");
+
+        // Assert
+        assert_shutdown_requested(&mut monitor.shutdown_rx);
+        assert_eq!(
+            *monitor.lifecycle_rx.borrow(),
+            grace_period_lifecycle(),
+            "The published lifecycle must stay as it was; it cannot be rolled back"
+        );
+    }
+
+    /// A clock correction that stays inside the current lifecycle window changes nothing a
+    /// receiver can observe, so it is tolerated with a warning rather than being fatal, and
+    /// the monitor keeps working afterwards.
+    #[tokio::test(start_paused = true)]
+    async fn test_run_tolerates_a_clock_rollback_within_the_current_window() {
+        // Arrange: start inside the grace period.
+        let schedule = make_schedule_with_boole(BOOLE_FORK_EPOCH);
+        let clock = clock_at_slot(ACTIVATION_SLOT + 5);
+        let mut monitor = start_run(schedule, clock.clone()).await;
+
+        // Act: fall back to an earlier slot that is still inside the grace period.
+        clock.set_slot(ACTIVATION_SLOT + 1);
+        wake_after_one_slot().await;
+
+        // Assert: no publish, no shutdown, and the task keeps running.
+        assert!(
+            !monitor.lifecycle_rx.has_changed().expect("sender is alive"),
+            "A within-window rollback must not publish anything"
+        );
+        assert_eq!(*monitor.lifecycle_rx.borrow(), grace_period_lifecycle());
+        assert!(!monitor.handle.is_finished(), "Monitor must keep running");
+        assert_no_shutdown_requested(&mut monitor.shutdown_rx);
+
+        // Act and assert: the monitor still publishes the next transition once the clock
+        // moves forward again.
+        clock.set_slot(GRACE_END_SLOT);
+        wake_after_one_slot().await;
+        assert_eq!(*monitor.lifecycle_rx.borrow(), normal_boole_lifecycle());
+        assert_no_shutdown_requested(&mut monitor.shutdown_rx);
+    }
+
+    /// The sleep is capped at one slot regardless of what the clock reports, because a clock
+    /// that stepped behind genesis reports the whole time until genesis as the time to the
+    /// requested boundary. Without the cap the monitor would park for that whole span and
+    /// miss every transition due in it.
+    #[tokio::test(start_paused = true)]
+    async fn test_run_caps_the_sleep_at_one_slot_when_the_clock_reports_a_longer_wait() {
+        // Arrange
+        let schedule = make_schedule_with_boole(BOOLE_FORK_EPOCH);
+        let started_at = tokio::time::Instant::now();
+        let clock = UnusableNextSlotClock::new(Slot::new(0), Duration::ZERO, TEST_SLOT_DURATION);
+        let mut monitor = start_run(schedule, clock.clone()).await;
+
+        // Act: one slot of Tokio time, against a clock asking for an hour.
+        clock.inner.set_slot(PREPARATION_START_SLOT);
+        wake_after_one_slot().await;
+
+        // Assert
+        assert_eq!(*monitor.lifecycle_rx.borrow(), warmup_lifecycle());
+        assert!(
+            started_at.elapsed() < UNUSABLE_SLEEP,
+            "The monitor must re-observe within one slot, not after the reported wait"
+        );
+        assert!(!monitor.handle.is_finished(), "Monitor must keep running");
+        assert_no_shutdown_requested(&mut monitor.shutdown_rx);
+    }
+
+    /// When a single `duration_to_slot` returns `None` (the boundary slipped past between
+    /// the two clock reads), the loop falls back to `Duration::ZERO` and re-observes
+    /// immediately instead of oversleeping. The proof: the clock advances one slot per read
+    /// and reaches the preparation slot on the re-observation, so the WarmUp transition
+    /// publishes without any virtual time passing at all.
+    #[tokio::test(start_paused = true)]
+    async fn test_run_rechecks_immediately_after_a_single_unavailable_boundary() {
+        // Arrange: the first run-loop read lands one slot before the transition and its
+        // boundary query fails; the immediate re-observation lands on the transition slot.
+        let schedule = make_schedule_with_boole(BOOLE_FORK_EPOCH);
+        let clock = BoundaryOnceUnavailableClock::starting_at(PREPARATION_START_SLOT - 2);
+        let mut monitor = start_run(schedule, clock).await;
+
+        // Act: yield without advancing time; only a zero-duration sleep lets the loop
+        // re-observe here.
+        for _ in 0..3 {
+            tokio::task::yield_now().await;
+        }
+
+        // Assert
+        assert_eq!(
+            *monitor.lifecycle_rx.borrow(),
+            warmup_lifecycle(),
+            "The re-observation after a single unavailable boundary must happen immediately"
+        );
+        assert!(!monitor.handle.is_finished(), "Monitor must keep running");
+        assert_no_shutdown_requested(&mut monitor.shutdown_rx);
+    }
+
+    /// A pathological clock whose `now()` keeps answering while `duration_to_slot` never
+    /// resolves must not hot-spin on the zero-sleep fallback: only the first consecutive
+    /// failure re-observes immediately, every following one paces at one full slot. Under
+    /// paused time a hot spin would never yield back to this test, so completing the bounded
+    /// advances below is itself the proof of pacing.
+    #[tokio::test(start_paused = true)]
+    async fn test_run_paces_at_one_slot_when_the_boundary_stays_unavailable() {
+        // Arrange: a readable slot before any transition, with no resolvable boundary.
+        let schedule = make_schedule_with_boole(BOOLE_FORK_EPOCH);
+        let clock = FrozenNoBoundaryClock { slot: Slot::new(5) };
+        let mut monitor = start_run(schedule, clock).await;
+
+        // Act: several slots of virtual time; every wake finds the boundary still
+        // unavailable and must park for another full slot.
+        for _ in 0..3 {
+            wake_after_one_slot().await;
+        }
+
+        // Assert: the monitor is still pacing, published nothing new, and did not fail.
+        assert!(!monitor.handle.is_finished(), "Monitor must keep running");
+        assert_eq!(*monitor.lifecycle_rx.borrow(), normal_alan_lifecycle());
+        assert!(
+            !monitor.lifecycle_rx.has_changed().expect("sender is alive"),
+            "A frozen clock must not produce lifecycle changes"
+        );
+        assert_no_shutdown_requested(&mut monitor.shutdown_rx);
+    }
+
+    /// Slot durations are not required to be whole seconds, so nothing in the sleep
+    /// calculation may truncate to second precision and wake the monitor into an early
+    /// publish.
+    #[tokio::test(start_paused = true)]
+    async fn test_run_publishes_at_exact_target_with_fractional_slot_duration() {
+        // Arrange
+        let one_millisecond = Duration::from_millis(1);
+        let schedule = make_schedule_with_boole(BOOLE_FORK_EPOCH);
+        let clock = ManualSlotClock::new(Slot::new(0), Duration::ZERO, FRACTIONAL_SLOT_DURATION);
+        let mut monitor = start_run(schedule, clock.clone()).await;
+
+        // Act and assert at the slot before the transition
+        clock.set_slot(PREPARATION_START_SLOT - 1);
+        tokio::time::advance(FRACTIONAL_SLOT_DURATION).await;
+        tokio::task::yield_now().await;
+        assert_eq!(
+            *monitor.lifecycle_rx.borrow(),
+            normal_alan_lifecycle(),
+            "Lifecycle must not publish one slot before the transition"
+        );
+
+        // Act and assert with the clock one millisecond before the transition slot starts
+        let just_before_target = FRACTIONAL_SLOT_DURATION
+            * u32::try_from(PREPARATION_START_SLOT).expect("small slot")
+            - one_millisecond;
+        clock.set_current_time(just_before_target);
+        tokio::time::advance(FRACTIONAL_SLOT_DURATION).await;
+        tokio::task::yield_now().await;
+        assert_eq!(
+            *monitor.lifecycle_rx.borrow(),
+            normal_alan_lifecycle(),
+            "A fractional slot duration must not be rounded down into an early publish"
+        );
+        assert!(!monitor.handle.is_finished(), "Monitor must keep running");
+
+        // Act and assert at the exact transition slot
+        clock.set_slot(PREPARATION_START_SLOT);
+        tokio::time::advance(one_millisecond).await;
+        tokio::task::yield_now().await;
+        assert_eq!(*monitor.lifecycle_rx.borrow(), warmup_lifecycle());
+        assert_no_shutdown_requested(&mut monitor.shutdown_rx);
+    }
+
+    /// The monitor guards against clock rollbacks for the node's lifetime, so it must keep
+    /// running (and keep the watch sender alive) after the last scheduled fork's grace period
+    /// has ended.
+    #[tokio::test(start_paused = true)]
+    async fn test_run_stays_alive_after_the_final_grace_period_ends() {
+        // Arrange: start well past the grace end of the last scheduled fork.
+        let schedule = make_schedule_with_boole(BOOLE_FORK_EPOCH);
+        let clock = clock_at_slot(GRACE_END_SLOT + 10);
+        let mut monitor = start_run(schedule, clock.clone()).await;
+        assert_eq!(*monitor.lifecycle_rx.borrow(), normal_boole_lifecycle());
+
+        // Act: keep the clock moving for several slots.
+        for slot in (GRACE_END_SLOT + 11)..(GRACE_END_SLOT + 14) {
+            clock.set_slot(slot);
+            wake_after_one_slot().await;
+        }
+
+        // Assert: the task is still running and the sender is still alive (`has_changed`
+        // returns `Ok`, not the closed-channel `Err`).
+        assert!(
+            !monitor.handle.is_finished(),
+            "The monitor must not exit after the final grace period"
+        );
+        assert!(
+            !monitor
+                .lifecycle_rx
+                .has_changed()
+                .expect("the lifecycle sender must stay alive after the final grace period"),
+            "No lifecycle change is expected after the final grace period"
+        );
+        assert_no_shutdown_requested(&mut monitor.shutdown_rx);
+    }
+
+    /// With no future forks scheduled there is nothing to publish, but the monitor still owns
+    /// the rollback and clock-failure guards, so it keeps running.
+    #[tokio::test(start_paused = true)]
+    async fn test_run_keeps_running_when_no_forks_are_scheduled() {
+        // Arrange
+        let schedule = make_schedule_no_future_forks();
+        let clock = clock_at_slot(0);
+        let mut monitor = start_run(schedule, clock.clone()).await;
+
+        // Act
+        for slot in 1..4 {
+            clock.set_slot(slot);
+            wake_after_one_slot().await;
+        }
+
+        // Assert
+        assert_eq!(*monitor.lifecycle_rx.borrow(), normal_alan_lifecycle());
+        assert!(
+            !monitor.handle.is_finished(),
+            "The monitor must keep running with nothing scheduled"
+        );
+        assert_no_shutdown_requested(&mut monitor.shutdown_rx);
     }
 }

--- a/anchor/common/fork/src/schedule.rs
+++ b/anchor/common/fork/src/schedule.rs
@@ -6,9 +6,9 @@
 use std::collections::BTreeMap;
 
 use ssv_types::domain_type::DomainType;
-use types::Epoch;
+use types::{Epoch, Slot};
 
-use crate::Fork;
+use crate::{Fork, ForkLifecycle};
 
 /// Number of epochs before a fork to start preparing (dual-subscribing, etc.).
 ///
@@ -209,6 +209,55 @@ impl ForkSchedule {
             .expect("constructors ensure there is at least one fork at epoch 0")
     }
 
+    /// Derive the fork lifecycle state for a slot directly from the schedule.
+    ///
+    /// This is the single source of truth for lifecycle state: the same slot
+    /// always maps to the same state, so restarts, clock jumps, and steady
+    /// operation all go through one code path.
+    ///
+    /// Windows, using the fork's activation slot `A` (all half-open):
+    /// - `WarmUp` in `[A - FORK_PREPARATION_EPOCHS in slots, A)`
+    /// - `GracePeriod` in `[A, A + SUBSEQUENT_WINDOW_SLOTS)`
+    /// - `Normal` everywhere else
+    ///
+    /// `WarmUp` takes precedence when an upcoming fork's preparation window
+    /// overlaps the current fork's grace period: preparing for the imminent
+    /// fork matters more than retaining the previous fork's topics. Schedules
+    /// that trigger this overlap (forks less than
+    /// `FORK_PREPARATION_EPOCHS + SUBSEQUENT_WINDOW_SLOTS` apart) are
+    /// logged as errors at monitor spawn.
+    pub fn lifecycle_at(&self, slot: Slot, slots_per_epoch: u64) -> ForkLifecycle {
+        let epoch = slot.epoch(slots_per_epoch);
+        let current = self.active_fork_config(epoch).clone();
+
+        // WarmUp: an upcoming fork's preparation window has started.
+        if let Some((upcoming_fork, upcoming_epoch)) = self.next_fork_after(epoch) {
+            let preparation_start_slot = upcoming_epoch
+                .as_u64()
+                .saturating_sub(FORK_PREPARATION_EPOCHS)
+                * slots_per_epoch;
+            if slot.as_u64() >= preparation_start_slot {
+                let upcoming = self
+                    .config(upcoming_fork)
+                    .expect("next_fork_after only returns scheduled forks")
+                    .clone();
+                return ForkLifecycle::WarmUp { current, upcoming };
+            }
+        }
+
+        // GracePeriod: within the subsequent window of a non-genesis activation.
+        // Genesis forks (epoch 0) have no previous fork to grace out of.
+        let activation_slot = current.epoch.as_u64() * slots_per_epoch;
+        if current.epoch.as_u64() > 0 && slot.as_u64() < activation_slot + SUBSEQUENT_WINDOW_SLOTS {
+            let previous = self
+                .active_fork_config(Epoch::new(current.epoch.as_u64() - 1))
+                .clone();
+            return ForkLifecycle::GracePeriod { current, previous };
+        }
+
+        ForkLifecycle::Normal { current }
+    }
+
     /// Get the next scheduled fork after the given epoch.
     pub fn next_fork_after(&self, epoch: Epoch) -> Option<(Fork, Epoch)> {
         self.configs
@@ -229,11 +278,31 @@ mod tests {
     const BASELINE_DOMAIN: DomainType = DomainType([0, 0, 0, 1]);
     const BOOLE_DOMAIN: DomainType = DomainType([0, 0, 0, 2]);
 
+    // Mainnet slots per epoch, used by the `lifecycle_at` boundary tests.
+    const SLOTS_PER_EPOCH: u64 = 32;
+    // The Boole activation epoch used by the `lifecycle_at` boundary tests.
+    const BOOLE_FORK_EPOCH: u64 = 100;
+    // First slot of the warm-up window: `FORK_PREPARATION_EPOCHS` before activation.
+    const PREPARATION_START_SLOT: u64 =
+        (BOOLE_FORK_EPOCH - FORK_PREPARATION_EPOCHS) * SLOTS_PER_EPOCH;
+    // First slot of the grace period: the Boole activation slot.
+    const ACTIVATION_SLOT: u64 = BOOLE_FORK_EPOCH * SLOTS_PER_EPOCH;
+    // First slot after the grace period: back to `Normal`, now on Boole.
+    const GRACE_END_SLOT: u64 = ACTIVATION_SLOT + SUBSEQUENT_WINDOW_SLOTS;
+
     fn schedule_with_boole(epoch: u64) -> ForkSchedule {
         let mut configs = BTreeMap::new();
         configs.insert(Fork::Alan, (Epoch::new(0), BASELINE_DOMAIN));
         configs.insert(Fork::Boole, (Epoch::new(epoch), BOOLE_DOMAIN));
         ForkSchedule::from_fork_configs(configs, TEST_NETWORK).expect("valid test schedule")
+    }
+
+    fn alan_config() -> ForkConfig {
+        ForkConfig::new(Fork::Alan, Epoch::new(0), BASELINE_DOMAIN)
+    }
+
+    fn boole_config_at(epoch: u64) -> ForkConfig {
+        ForkConfig::new(Fork::Boole, Epoch::new(epoch), BOOLE_DOMAIN)
     }
 
     #[test]
@@ -365,5 +434,131 @@ mod tests {
 
         let prefix_holesky = Fork::Boole.topic_prefix("holesky");
         assert_eq!(prefix_holesky, "/ssv/holesky/boole/");
+    }
+
+    // ==================== `lifecycle_at` boundary tests ====================
+    //
+    // Note: the documented WarmUp-over-GracePeriod precedence on overlapping windows cannot
+    // be exercised with the current two-fork enum. An overlap needs a third fork whose
+    // preparation window starts inside Boole's grace period; Alan is the genesis fork (no
+    // grace period of its own) and no fork follows Boole, so no two-fork schedule can
+    // construct the overlap.
+
+    /// Every window boundary is half-open, so each phase must start at its exact slot and end
+    /// one slot before the next phase's start.
+    #[test]
+    fn test_lifecycle_at_boundary_table() {
+        // Arrange
+        let schedule = schedule_with_boole(BOOLE_FORK_EPOCH);
+        let boole = boole_config_at(BOOLE_FORK_EPOCH);
+        let normal_alan = ForkLifecycle::Normal {
+            current: alan_config(),
+        };
+        let warmup = ForkLifecycle::WarmUp {
+            current: alan_config(),
+            upcoming: boole.clone(),
+        };
+        let grace_period = ForkLifecycle::GracePeriod {
+            current: boole.clone(),
+            previous: alan_config(),
+        };
+        let normal_boole = ForkLifecycle::Normal { current: boole };
+        let cases = [
+            // Last slot before the preparation window opens.
+            (PREPARATION_START_SLOT - 1, &normal_alan),
+            // Exact preparation start: 99 * 32 = 3168.
+            (PREPARATION_START_SLOT, &warmup),
+            // Last slot of the warm-up window: 3199.
+            (ACTIVATION_SLOT - 1, &warmup),
+            // Exact activation slot: 3200.
+            (ACTIVATION_SLOT, &grace_period),
+            // Last slot of the grace period: 3200 + 31.
+            (GRACE_END_SLOT - 1, &grace_period),
+            // First slot after the grace period: 3200 + 32.
+            (GRACE_END_SLOT, &normal_boole),
+            // Far after the transition.
+            (GRACE_END_SLOT + 100_000, &normal_boole),
+        ];
+
+        for (slot, expected) in cases {
+            // Act
+            let lifecycle = schedule.lifecycle_at(Slot::new(slot), SLOTS_PER_EPOCH);
+
+            // Assert
+            assert_eq!(&lifecycle, expected, "unexpected lifecycle at slot {slot}");
+        }
+    }
+
+    /// With no future fork scheduled there is no warm-up window, and a genesis fork has no
+    /// previous fork to grace out of, so every slot is `Normal`.
+    #[test]
+    fn test_lifecycle_at_alan_only_schedule_is_always_normal() {
+        // Arrange
+        let schedule = ForkSchedule::new(Fork::Alan, BASELINE_DOMAIN, TEST_NETWORK);
+        let normal_alan = ForkLifecycle::Normal {
+            current: alan_config(),
+        };
+
+        for slot in [0, 1, SLOTS_PER_EPOCH, ACTIVATION_SLOT, u64::MAX / 2] {
+            // Act
+            let lifecycle = schedule.lifecycle_at(Slot::new(slot), SLOTS_PER_EPOCH);
+
+            // Assert
+            assert_eq!(
+                lifecycle, normal_alan,
+                "an Alan-only schedule must be Normal at slot {slot}"
+            );
+        }
+    }
+
+    /// A fork scheduled at epoch 0 activates at genesis: there is no previous fork to grace
+    /// out of, so the grace period must not apply.
+    #[test]
+    fn test_lifecycle_at_genesis_fork_has_no_grace_period() {
+        // Arrange: both forks at epoch 0.
+        let mut configs = BTreeMap::new();
+        configs.insert(Fork::Alan, (Epoch::new(0), BASELINE_DOMAIN));
+        configs.insert(Fork::Boole, (Epoch::new(0), BOOLE_DOMAIN));
+        let schedule =
+            ForkSchedule::from_fork_configs(configs, TEST_NETWORK).expect("valid test schedule");
+
+        // Act
+        let lifecycle = schedule.lifecycle_at(Slot::new(0), SLOTS_PER_EPOCH);
+
+        // Assert
+        assert_eq!(
+            lifecycle,
+            ForkLifecycle::Normal {
+                current: boole_config_at(0),
+            }
+        );
+    }
+
+    /// A fork at epoch 1 has its whole preparation window inside epoch 0, so the warm-up
+    /// starts at genesis itself.
+    #[test]
+    fn test_lifecycle_at_early_fork_preparation_window_starts_at_genesis() {
+        // Arrange
+        let schedule = schedule_with_boole(1);
+        let warmup = ForkLifecycle::WarmUp {
+            current: alan_config(),
+            upcoming: boole_config_at(1),
+        };
+
+        // Act and assert: the warm-up window covers genesis through the last epoch-0 slot.
+        assert_eq!(schedule.lifecycle_at(Slot::new(0), SLOTS_PER_EPOCH), warmup);
+        assert_eq!(
+            schedule.lifecycle_at(Slot::new(SLOTS_PER_EPOCH - 1), SLOTS_PER_EPOCH),
+            warmup
+        );
+
+        // Act and assert: activation at the first epoch-1 slot enters the grace period.
+        assert_eq!(
+            schedule.lifecycle_at(Slot::new(SLOTS_PER_EPOCH), SLOTS_PER_EPOCH),
+            ForkLifecycle::GracePeriod {
+                current: boole_config_at(1),
+                previous: alan_config(),
+            }
+        );
     }
 }

--- a/anchor/network/Cargo.toml
+++ b/anchor/network/Cargo.toml
@@ -37,5 +37,6 @@ version = { workspace = true }
 [dev-dependencies]
 libp2p-swarm-test = { git = "https://github.com/sigp/rust-libp2p.git", rev = "c774d4e71357d7cd2f792c4767d616d2dd369ee3" }
 message_receiver = { workspace = true }
+tempfile = { workspace = true }
 tokio = { workspace = true, features = ["rt", "macros", "time", "test-util"] }
 tracing-subscriber = { workspace = true }

--- a/anchor/network/src/network.rs
+++ b/anchor/network/src/network.rs
@@ -8,7 +8,7 @@ use std::{
 };
 
 use fork::{ForkLifecycle, ForkSchedule};
-use futures::StreamExt;
+use futures::{StreamExt, channel::mpsc::Sender as ShutdownSender};
 use libp2p::{
     Multiaddr, PeerId, Swarm, SwarmBuilder, TransportError,
     core::{
@@ -25,7 +25,7 @@ use libp2p::{
 use message_receiver::{MessageReceiver, Outcome, TopicContext};
 use prometheus_client::registry::Registry;
 use subnet_service::{SUBNET_COUNT, SubnetId, TopicEvent, topic};
-use task_executor::TaskExecutor;
+use task_executor::{ShutdownReason, TaskExecutor};
 use thiserror::Error;
 use tokio::sync::{mpsc, watch};
 use tracing::{debug, error, info, trace, warn};
@@ -65,6 +65,24 @@ pub enum NetworkError {
 
     #[error("DNS transport config error: {0}")]
     DnsTransport(std::io::Error),
+
+    #[error("ENR reconciliation error: {0}")]
+    EnrReconcile(String),
+}
+
+/// Bring the local ENR's `domaintype` in line with the current lifecycle.
+///
+/// A fork may have activated while `Discovery::new` awaited discv5 startup and bootnode
+/// requests, after it had already built the ENR from the older lifecycle. This reads the
+/// lifecycle without marking it seen: if a change is pending, the run loop's `changed()`
+/// arm re-applies it, which `update_enr_domain_type` turns into a no-op when the ENR
+/// already matches.
+fn reconcile_enr_domain(
+    behaviour: &mut AnchorBehaviour,
+    lifecycle_rx: &watch::Receiver<ForkLifecycle>,
+) -> Result<(), String> {
+    let domain = lifecycle_rx.borrow().current_fork_config().domain_type;
+    behaviour.discovery.update_enr_domain_type(domain)
 }
 
 pub struct Network<R: MessageReceiver> {
@@ -83,9 +101,9 @@ pub struct Network<R: MessageReceiver> {
     /// Receiver for fork lifecycle state changes.
     /// Used to update ENR domain type on fork activation.
     lifecycle_rx: watch::Receiver<ForkLifecycle>,
-    /// Previous lifecycle state, used to detect actual domain type changes
-    /// and avoid redundant ENR updates.
-    prev_lifecycle: ForkLifecycle,
+    /// Requests a client-wide shutdown when the network cannot keep its
+    /// advertised state consistent with the fork lifecycle (fail closed).
+    shutdown_tx: ShutdownSender<ShutdownReason>,
 }
 
 impl<R: MessageReceiver> Network<R> {
@@ -101,7 +119,7 @@ impl<R: MessageReceiver> Network<R> {
         executor: TaskExecutor,
         spec: Arc<ChainSpec>,
         fork_schedule: Arc<ForkSchedule>,
-        mut lifecycle_rx: watch::Receiver<ForkLifecycle>,
+        lifecycle_rx: watch::Receiver<ForkLifecycle>,
     ) -> Result<Network<R>, Box<NetworkError>> {
         let local_keypair: Keypair = load_private_key(&config.network_dir.key_file());
 
@@ -113,7 +131,7 @@ impl<R: MessageReceiver> Network<R> {
 
         let mut metrics_registry = Registry::default();
 
-        let behaviour = AnchorBehaviour::new::<E>(
+        let mut behaviour = AnchorBehaviour::new::<E>(
             local_keypair.clone(),
             config,
             &mut metrics_registry,
@@ -126,7 +144,12 @@ impl<R: MessageReceiver> Network<R> {
 
         let peer_id = local_keypair.public().to_peer_id();
 
-        let prev_lifecycle = lifecycle_rx.borrow_and_update().clone();
+        // Failing to reconcile would return a network that advertises a domain
+        // known to disagree with its lifecycle, so it fails construction instead.
+        reconcile_enr_domain(&mut behaviour, &lifecycle_rx)
+            .map_err(|e| Box::new(NetworkError::EnrReconcile(e)))?;
+
+        let shutdown_tx = executor.shutdown_sender();
         let mut network = Network {
             swarm: build_swarm(
                 executor.clone(),
@@ -145,7 +168,7 @@ impl<R: MessageReceiver> Network<R> {
             is_dynamic_target_peers,
             subnet_subscription_counts: HashMap::new(),
             lifecycle_rx,
-            prev_lifecycle,
+            shutdown_tx,
         };
 
         info!(%peer_id, "Network starting");
@@ -201,9 +224,9 @@ impl<R: MessageReceiver> Network<R> {
                 }
 
                 Ok(()) = self.lifecycle_rx.changed() => {
-                    let new = self.lifecycle_rx.borrow_and_update().clone();
-                    self.apply_fork_transition(&new);
-                    self.prev_lifecycle = new;
+                    if let ControlFlow::Break(()) = self.on_lifecycle_changed() {
+                        return;
+                    }
                 }
             }
         }
@@ -430,25 +453,36 @@ impl<R: MessageReceiver> Network<R> {
         }
     }
 
-    /// Handle fork lifecycle state changes.
+    /// Handle a fork lifecycle state change.
     ///
-    /// Only updates the ENR when the domain type actually changes between
-    /// lifecycle states. Transition logging is owned by the fork monitor.
-    fn apply_fork_transition(&mut self, new: &ForkLifecycle) {
-        let prev_domain = self.prev_lifecycle.current_fork_config().domain_type;
-        let new_domain = new.current_fork_config().domain_type;
+    /// Brings the ENR domain in line with the new lifecycle;
+    /// `update_enr_domain_type` no-ops when the ENR already matches, and logs
+    /// when it actually changes. Transition logging is owned by the fork
+    /// monitor. On failure the ENR disagrees with the lifecycle and never
+    /// recovers on its own (the next lifecycle change keeps the same domain),
+    /// so fail closed: request a client-wide shutdown and stop the network
+    /// loop instead of continuing with a stale ENR.
+    fn on_lifecycle_changed(&mut self) -> ControlFlow<()> {
+        let domain = self
+            .lifecycle_rx
+            .borrow_and_update()
+            .current_fork_config()
+            .domain_type;
 
-        // Only update ENR when the domain type actually changed.
-        if new_domain != prev_domain {
-            info!(
-                ?prev_domain,
-                ?new_domain,
-                "Updating ENR domain type after fork transition"
-            );
-            if let Err(e) = self.discovery().update_enr_domain_type(new_domain) {
-                error!(?e, "Failed to update ENR domain type after fork transition");
+        if let Err(e) = self.discovery().update_enr_domain_type(domain) {
+            error!(error = %e, "Failed to update ENR for fork transition; requesting client shutdown");
+            if let Err(e) = self.shutdown_tx.try_send(ShutdownReason::Failure(
+                "Network: failed to update ENR for fork transition",
+            )) && !e.is_full()
+            {
+                // A full channel means a shutdown is already pending; a closed
+                // one means there is no receiver left to act, which we can only
+                // surface in logs.
+                error!("Failed to deliver shutdown request: channel closed");
             }
+            return ControlFlow::Break(());
         }
+        ControlFlow::Continue(())
     }
 
     fn on_new_listen_addr(&mut self, listener_id: ListenerId, address: Multiaddr) {
@@ -922,4 +956,415 @@ fn build_swarm(
         .build();
 
     Ok(swarm)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use fork::{Fork, ForkConfig, ForkLifecycle};
+    use global_config::data_dir::DataDir;
+    use network_utils::listen_addr::{ListenAddr, ListenAddress};
+    use ssv_types::domain_type::DomainType;
+    use subnet_service::topic::create_topic;
+    use task_executor::test_utils::TestRuntime;
+    use tempfile::TempDir;
+    use types::{ChainSpec, Epoch, MinimalEthSpec};
+
+    use super::*;
+
+    const TEST_NETWORK: &str = "test";
+    const ALAN_DOMAIN: DomainType = DomainType([0, 0, 0, 1]);
+    const BOOLE_DOMAIN: DomainType = DomainType([0, 0, 0, 2]);
+    const BOOLE_FORK_EPOCH: u64 = 100;
+    /// Arbitrary subnet used by the topic scoring test.
+    const TEST_SUBNET: u64 = 7;
+    /// Any finite, non-negative rate; the scoring parameters derived from it are what matters.
+    const TEST_MESSAGE_RATE: f64 = 1.5;
+    /// Channel capacities: the tests drive the handlers directly, so nothing is queued.
+    const TEST_CHANNEL_CAPACITY: usize = 1;
+
+    /// A `MessageReceiver` that never sees a message, because these tests drive the network's
+    /// handlers directly instead of gossiping.
+    struct UnusedMessageReceiver;
+
+    impl MessageReceiver for UnusedMessageReceiver {
+        fn receive(
+            &self,
+            _propagation_source: PeerId,
+            _message_id: gossipsub::MessageId,
+            _message: gossipsub::Message,
+            _topic_context: TopicContext,
+        ) -> Result<(), message_receiver::Error> {
+            unreachable!("these tests do not deliver gossip messages")
+        }
+    }
+
+    fn test_fork_schedule() -> (Arc<ForkSchedule>, ForkConfig, ForkConfig) {
+        let mut configs = BTreeMap::new();
+        configs.insert(Fork::Alan, (Epoch::new(0), ALAN_DOMAIN));
+        configs.insert(Fork::Boole, (Epoch::new(BOOLE_FORK_EPOCH), BOOLE_DOMAIN));
+        let schedule = Arc::new(
+            ForkSchedule::from_fork_configs(configs, TEST_NETWORK)
+                .expect("test fork schedule should be valid"),
+        );
+        let alan_config = schedule
+            .config(Fork::Alan)
+            .cloned()
+            .expect("Alan config should exist");
+        let boole_config = schedule
+            .config(Fork::Boole)
+            .cloned()
+            .expect("Boole config should exist");
+        (schedule, alan_config, boole_config)
+    }
+
+    /// A config that binds ephemeral ports and starts neither discv5 nor UPnP, so the network
+    /// can be constructed in a unit test without touching the outside world.
+    fn test_config(network_dir: global_config::data_dir::NetworkDir) -> Config {
+        let mut config = Config::new(network_dir);
+        config.listen_addresses = ListenAddress::V4(ListenAddr {
+            addr: std::net::Ipv4Addr::LOCALHOST,
+            disc_port: 0,
+            quic_port: 0,
+            tcp_port: 0,
+        });
+        config.disable_discovery = true;
+        config.disable_quic_support = true;
+        config.upnp_enabled = false;
+        config
+    }
+
+    /// A bare `AnchorBehaviour` plus its lifecycle channel, standing in for the interval
+    /// inside `try_new` between building the behaviour and reconciling the ENR.
+    struct TestBehaviour {
+        behaviour: AnchorBehaviour,
+        lifecycle_tx: watch::Sender<ForkLifecycle>,
+        lifecycle_rx: watch::Receiver<ForkLifecycle>,
+        alan_config: ForkConfig,
+        boole_config: ForkConfig,
+        // Keep this last so it drops after the behaviour and its ENR file.
+        _temp_dir: TempDir,
+    }
+
+    impl TestBehaviour {
+        async fn new(
+            initial_lifecycle: impl FnOnce(&ForkConfig, &ForkConfig) -> ForkLifecycle,
+        ) -> Self {
+            let temp_dir = TempDir::new().expect("should create temp directory for network dir");
+            let data_dir =
+                DataDir::new(temp_dir.path().to_path_buf()).expect("should create data dir");
+            let config = test_config(data_dir.network_dir());
+
+            let (fork_schedule, alan_config, boole_config) = test_fork_schedule();
+            let (lifecycle_tx, lifecycle_rx) =
+                watch::channel(initial_lifecycle(&alan_config, &boole_config));
+
+            let behaviour = AnchorBehaviour::new::<MinimalEthSpec>(
+                Keypair::generate_secp256k1(),
+                &config,
+                &mut Registry::default(),
+                &ChainSpec::minimal(),
+                &fork_schedule,
+                lifecycle_rx.clone(),
+            )
+            .await
+            .expect("test behaviour should build");
+
+            Self {
+                behaviour,
+                lifecycle_tx,
+                lifecycle_rx,
+                alan_config,
+                boole_config,
+                _temp_dir: temp_dir,
+            }
+        }
+
+        fn send_lifecycle(
+            &self,
+            lifecycle: impl FnOnce(&ForkConfig, &ForkConfig) -> ForkLifecycle,
+        ) {
+            self.lifecycle_tx
+                .send(lifecycle(&self.alan_config, &self.boole_config))
+                .expect("the behaviour should still hold a lifecycle receiver");
+        }
+
+        fn enr_domain_type(&self) -> [u8; 4] {
+            self.behaviour
+                .discovery
+                .local_enr()
+                .get_decodable::<[u8; 4]>("domaintype")
+                .expect("local ENR should carry a domaintype")
+                .expect("domaintype should decode as four bytes")
+        }
+
+        /// The local ENR's sequence number, which only advances when the record is rewritten.
+        fn enr_seq(&self) -> u64 {
+            self.behaviour.discovery.local_enr().seq()
+        }
+    }
+
+    /// A live `Network` plus the handles a test needs to drive it.
+    struct TestNetwork {
+        network: Network<UnusedMessageReceiver>,
+        lifecycle_tx: watch::Sender<ForkLifecycle>,
+        alan_config: ForkConfig,
+        boole_config: ForkConfig,
+        _runtime: TestRuntime,
+        // Keep this last so it drops after the network and its ENR file.
+        _temp_dir: TempDir,
+    }
+
+    impl TestNetwork {
+        async fn new(
+            initial_lifecycle: impl FnOnce(&ForkConfig, &ForkConfig) -> ForkLifecycle,
+        ) -> Self {
+            let temp_dir = TempDir::new().expect("should create temp directory for network dir");
+            let data_dir =
+                DataDir::new(temp_dir.path().to_path_buf()).expect("should create data dir");
+            let config = test_config(data_dir.network_dir());
+
+            let (fork_schedule, alan_config, boole_config) = test_fork_schedule();
+            let (lifecycle_tx, lifecycle_rx) =
+                watch::channel(initial_lifecycle(&alan_config, &boole_config));
+
+            let (_topic_event_tx, topic_event_rx) = mpsc::channel(TEST_CHANNEL_CAPACITY);
+            let (_message_tx, message_rx) = mpsc::channel(TEST_CHANNEL_CAPACITY);
+            let (_outcome_tx, outcome_rx) = mpsc::channel(TEST_CHANNEL_CAPACITY);
+
+            let runtime = TestRuntime::default();
+            let network = Network::try_new::<MinimalEthSpec>(
+                &config,
+                topic_event_rx,
+                message_rx,
+                Arc::new(UnusedMessageReceiver),
+                outcome_rx,
+                runtime.task_executor.clone(),
+                Arc::new(ChainSpec::minimal()),
+                fork_schedule,
+                lifecycle_rx,
+            )
+            .await
+            .expect("test network should build");
+
+            Self {
+                network,
+                lifecycle_tx,
+                alan_config,
+                boole_config,
+                _runtime: runtime,
+                _temp_dir: temp_dir,
+            }
+        }
+
+        fn send_lifecycle(
+            &self,
+            lifecycle: impl FnOnce(&ForkConfig, &ForkConfig) -> ForkLifecycle,
+        ) {
+            self.lifecycle_tx
+                .send(lifecycle(&self.alan_config, &self.boole_config))
+                .expect("network should still hold the lifecycle receiver");
+        }
+
+        /// The `domaintype` currently advertised in the local ENR.
+        fn enr_domain_type(&mut self) -> [u8; 4] {
+            self.network
+                .discovery()
+                .local_enr()
+                .get_decodable::<[u8; 4]>("domaintype")
+                .expect("local ENR should carry a domaintype")
+                .expect("domaintype should decode as four bytes")
+        }
+
+        /// The local ENR's sequence number, which only advances when the record is rewritten.
+        fn enr_seq(&mut self) -> u64 {
+            self.network.discovery().local_enr().seq()
+        }
+    }
+
+    fn normal_on_alan(alan_config: &ForkConfig, _boole_config: &ForkConfig) -> ForkLifecycle {
+        ForkLifecycle::Normal {
+            current: alan_config.clone(),
+        }
+    }
+
+    fn grace_period_current_boole_previous_alan(
+        alan_config: &ForkConfig,
+        boole_config: &ForkConfig,
+    ) -> ForkLifecycle {
+        ForkLifecycle::GracePeriod {
+            current: boole_config.clone(),
+            previous: alan_config.clone(),
+        }
+    }
+
+    fn normal_on_boole(_alan_config: &ForkConfig, boole_config: &ForkConfig) -> ForkLifecycle {
+        ForkLifecycle::Normal {
+            current: boole_config.clone(),
+        }
+    }
+
+    // ==================== ENR domain reconciliation tests ====================
+
+    #[tokio::test]
+    async fn test_try_new_advertises_the_current_lifecycle_domain() {
+        // Arrange and act
+        let mut network = TestNetwork::new(normal_on_alan).await;
+
+        // Assert
+        assert_eq!(network.enr_domain_type(), ALAN_DOMAIN.0);
+    }
+
+    #[tokio::test]
+    async fn test_try_new_advertises_the_domain_of_a_fork_already_active_at_startup() {
+        // Arrange and act
+        let mut network = TestNetwork::new(grace_period_current_boole_previous_alan).await;
+
+        // Assert
+        assert_eq!(network.enr_domain_type(), BOOLE_DOMAIN.0);
+    }
+
+    /// The race the reconcile exists for: `Discovery::new` snapshots the lifecycle and builds
+    /// the ENR from it, then awaits discv5 startup and bootnode requests. A fork activating
+    /// during those awaits reaches the watch channel but not the ENR, so without the
+    /// reconcile the node would advertise the old domain until the run loop first polls the
+    /// channel.
+    #[tokio::test]
+    async fn test_reconcile_picks_up_a_fork_that_activated_during_behaviour_construction() {
+        // Arrange: the ENR Discovery built has only ever seen Alan.
+        let mut fixture = TestBehaviour::new(normal_on_alan).await;
+        assert_eq!(fixture.enr_domain_type(), ALAN_DOMAIN.0);
+
+        // Act: the fork activates in the window `try_new` owns, after the behaviour exists.
+        fixture.send_lifecycle(grace_period_current_boole_previous_alan);
+        reconcile_enr_domain(&mut fixture.behaviour, &fixture.lifecycle_rx)
+            .expect("reconcile should update the ENR");
+
+        // Assert
+        assert_eq!(fixture.enr_domain_type(), BOOLE_DOMAIN.0);
+        assert!(
+            fixture.lifecycle_rx.has_changed().expect("sender is alive"),
+            "the reconcile must not mark the change seen; it stays pending for the run loop"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_lifecycle_change_updates_the_advertised_enr_domain() {
+        // Arrange
+        let mut network = TestNetwork::new(normal_on_alan).await;
+        assert_eq!(network.enr_domain_type(), ALAN_DOMAIN.0);
+
+        // Act
+        network.send_lifecycle(grace_period_current_boole_previous_alan);
+        let control_flow = network.network.on_lifecycle_changed();
+
+        // Assert
+        assert_eq!(control_flow, ControlFlow::Continue(()));
+        assert_eq!(network.enr_domain_type(), BOOLE_DOMAIN.0);
+    }
+
+    /// Most lifecycle transitions keep the current fork, and rewriting the ENR for them would
+    /// burn sequence numbers and re-broadcast an unchanged record for nothing.
+    #[tokio::test]
+    async fn test_lifecycle_change_within_a_fork_leaves_the_enr_untouched() {
+        // Arrange: reach Boole, so the following transition keeps the same domain.
+        let mut network = TestNetwork::new(normal_on_alan).await;
+        network.send_lifecycle(grace_period_current_boole_previous_alan);
+        assert_eq!(
+            network.network.on_lifecycle_changed(),
+            ControlFlow::Continue(())
+        );
+        let seq_after_activation = network.enr_seq();
+
+        // Act: GracePeriod(Boole) -> Normal(Boole) ends the grace window, same domain.
+        network.send_lifecycle(normal_on_boole);
+        let control_flow = network.network.on_lifecycle_changed();
+
+        // Assert
+        assert_eq!(control_flow, ControlFlow::Continue(()));
+        assert_eq!(network.enr_domain_type(), BOOLE_DOMAIN.0);
+        assert_eq!(
+            network.enr_seq(),
+            seq_after_activation,
+            "an unchanged domain must not rewrite the ENR"
+        );
+    }
+
+    /// `reconcile_enr_domain` reads the lifecycle without marking it seen, so a change that
+    /// landed before the reconcile stays pending and the run loop re-applies it later. That
+    /// re-application must be harmless: the ENR already matches, so applying the same
+    /// lifecycle again must not rewrite the record.
+    #[tokio::test]
+    async fn test_reconcile_leaves_a_pending_change_pending_and_reapplication_is_a_no_op() {
+        // Arrange: a fork activates before the reconcile runs.
+        let mut fixture = TestBehaviour::new(normal_on_alan).await;
+        fixture.send_lifecycle(grace_period_current_boole_previous_alan);
+
+        // Act
+        reconcile_enr_domain(&mut fixture.behaviour, &fixture.lifecycle_rx)
+            .expect("reconcile should update the ENR");
+
+        // Assert: the ENR is already correct and the change is still pending for the run loop.
+        assert_eq!(fixture.enr_domain_type(), BOOLE_DOMAIN.0);
+        assert!(
+            fixture.lifecycle_rx.has_changed().expect("sender is alive"),
+            "a change published before the reconcile must stay pending for the run loop"
+        );
+
+        // Act and assert: re-applying the already-matching lifecycle leaves the ENR untouched.
+        let seq_after_reconcile = fixture.enr_seq();
+        reconcile_enr_domain(&mut fixture.behaviour, &fixture.lifecycle_rx)
+            .expect("re-applying an already-matching lifecycle should succeed");
+        assert_eq!(
+            fixture.enr_seq(),
+            seq_after_reconcile,
+            "re-applying an unchanged domain must not rewrite the ENR"
+        );
+    }
+
+    // ==================== Topic scoring tests ====================
+
+    /// Topics subscribed rate-less during WarmUp are scored by a later `RateUpdate`, so that
+    /// event has to install their gossipsub scoring parameters.
+    #[tokio::test]
+    async fn test_rate_update_installs_topic_score_params() {
+        // Arrange
+        let mut network = TestNetwork::new(normal_on_alan).await;
+        let topic = create_topic(
+            &Fork::Boole.topic_prefix(TEST_NETWORK),
+            SubnetId::new(TEST_SUBNET),
+        );
+        let ident_topic = IdentTopic::new(&topic);
+        assert!(
+            network
+                .network
+                .swarm
+                .behaviour()
+                .gossipsub
+                .get_topic_params(&ident_topic)
+                .is_none(),
+            "the topic should be unscored before the rate update"
+        );
+
+        // Act
+        network
+            .network
+            .on_topic_event::<MinimalEthSpec>(TopicEvent::RateUpdate {
+                topic,
+                message_rate: TEST_MESSAGE_RATE,
+            });
+
+        // Assert
+        assert!(
+            network
+                .network
+                .swarm
+                .behaviour()
+                .gossipsub
+                .get_topic_params(&ident_topic)
+                .is_some(),
+            "the rate update should have installed topic score parameters"
+        );
+    }
 }

--- a/anchor/subnet_service/src/subscriptions.rs
+++ b/anchor/subnet_service/src/subscriptions.rs
@@ -837,6 +837,48 @@ mod tests {
             .expect("run must not panic when the lifecycle sender is dropped");
     }
 
+    /// The database arm binds `changed()` with a name rather than `_`, so a dropped
+    /// database sender stops the service instead of leaving the arm permanently ready
+    /// and spinning the loop.
+    #[tokio::test]
+    async fn run_stops_cleanly_when_database_sender_is_dropped() {
+        // Arrange: keep the database arm enabled (subscribe_all_subnets = false) so the
+        // dropped sender reaches it, and own the run task's join handle.
+        let temp_dir = TempDir::new().expect("should create temp directory for test database");
+        let db_path = temp_dir.path().join("subnet_service_db_drop.db");
+        let db = NetworkDatabase::new_as_impostor(&db_path, &OWN_OPERATOR_ID, TEST_NETWORK)
+            .expect("should build test database");
+        let (fork_schedule, alan_config, _boole_config) = test_fork_schedule();
+        let (_lifecycle_tx, lifecycle_rx) = watch::channel(ForkLifecycle::Normal {
+            current: alan_config,
+        });
+        let (tx, _topic_event_rx) = mpsc::channel(SUBNET_COUNT);
+        let service = Arc::new(crate::SubnetService {
+            tx,
+            db: db.watch(),
+            subscribe_all_subnets: false,
+            disable_gossipsub_topic_scoring: true,
+            slot_clock: Arc::new(ManualSlotClock::new(
+                Slot::new(0),
+                Duration::from_secs(0),
+                Duration::from_secs(12),
+            )),
+            chain_spec: Arc::new(ChainSpec::minimal()),
+            router: TopicRouter::new(fork_schedule, MinimalEthSpec::slots_per_epoch()),
+        });
+        let handle = tokio::spawn(service.clone().run::<MinimalEthSpec>(lifecycle_rx));
+
+        // Act: an empty database emits no startup subscriptions, so the loop is already
+        // parked in the select when the sender drops.
+        drop(db);
+
+        // Assert: the task returns rather than spinning, and does not panic.
+        timeout(EVENT_TIMEOUT, handle)
+            .await
+            .expect("run should return after the database sender is dropped")
+            .expect("run must not panic when the database sender is dropped");
+    }
+
     #[tokio::test]
     async fn liquidating_cluster_unsubscribes_its_subnet() {
         // Arrange

--- a/anchor/subnet_service/src/subscriptions.rs
+++ b/anchor/subnet_service/src/subscriptions.rs
@@ -99,7 +99,14 @@ impl<S: SlotClock> SubnetService<S> {
         loop {
             let delay = calculate_duration_to_next_epoch::<E>(&*self.slot_clock);
             tokio::select! {
-                _ = db.changed(), if !self.subscribe_all_subnets => {
+                result = db.changed(), if !self.subscribe_all_subnets => {
+                    // A dropped database sender makes `changed()` return
+                    // immediately and forever, so binding it with `_` would
+                    // spin this arm rather than disable it.
+                    if result.is_err() {
+                        warn!("Database channel closed; stopping subnet service");
+                        return;
+                    }
                     self.handle_subnet_changes::<E>(&mut service_state).await;
                 }
                 _ = sleep(delay), if !self.disable_gossipsub_topic_scoring => {

--- a/anchor/subnet_service/src/subscriptions.rs
+++ b/anchor/subnet_service/src/subscriptions.rs
@@ -105,9 +105,17 @@ impl<S: SlotClock> SubnetService<S> {
                 _ = sleep(delay), if !self.disable_gossipsub_topic_scoring => {
                     self.send_scoring_rate_updates::<E>(&service_state).await;
                 }
-                Ok(()) = lifecycle_rx.changed() => {
+                result = lifecycle_rx.changed() => {
+                    // The fork monitor only drops the sender after requesting a
+                    // client shutdown (or during teardown). Stop the service
+                    // instead of pattern-disabling the arm, which could leave
+                    // the select with no enabled branches and panic.
+                    if result.is_err() {
+                        warn!("Fork lifecycle channel closed; stopping subnet service");
+                        return;
+                    }
                     let new_lifecycle = lifecycle_rx.borrow_and_update().clone();
-                    self.on_lifecycle_transition(new_lifecycle, &mut service_state).await;
+                    self.on_lifecycle_transition::<E>(new_lifecycle, &mut service_state).await;
                     self.handle_subnet_changes::<E>(&mut service_state).await;
                 }
             }
@@ -122,7 +130,18 @@ impl<S: SlotClock> SubnetService<S> {
     /// - WarmUp/Normal → GracePeriod: update fork_to_score, insert current fork
     /// - GracePeriod → Normal: remove & unsubscribe previous fork
     /// - GracePeriod → WarmUp: remove previous + insert upcoming (overlapping transition)
-    async fn on_lifecycle_transition(&self, new: ForkLifecycle, service_state: &mut ServiceState) {
+    ///
+    /// A fork activation (a `fork_to_score` change) also installs scoring
+    /// parameters for the new current fork's already-subscribed topics
+    /// immediately: they were subscribed rate-less during WarmUp, and the
+    /// epoch timer would leave them unscored (no P4 penalty) until the next
+    /// epoch boundary.
+    async fn on_lifecycle_transition<E: EthSpec>(
+        &self,
+        new: ForkLifecycle,
+        service_state: &mut ServiceState,
+    ) {
+        let fork_to_score_changed = service_state.fork_to_score != new.current_fork_config().fork;
         service_state.fork_to_score = new.current_fork_config().fork;
         let removed = match new {
             ForkLifecycle::Normal { current } => service_state.set_subscribed_forks([current]),
@@ -144,6 +163,9 @@ impl<S: SlotClock> SubnetService<S> {
                 error!("Failed to unsubscribe from fork: {:?}", err);
             }
         }
+        if fork_to_score_changed && !self.disable_gossipsub_topic_scoring {
+            self.send_scoring_rate_updates::<E>(service_state).await;
+        }
     }
 
     async fn initial_service_state<E: EthSpec>(
@@ -157,7 +179,7 @@ impl<S: SlotClock> SubnetService<S> {
         };
 
         let initial_lifecycle = lifecycle_rx.borrow_and_update().clone();
-        self.on_lifecycle_transition(initial_lifecycle, &mut service_state)
+        self.on_lifecycle_transition::<E>(initial_lifecycle, &mut service_state)
             .await;
 
         self.handle_subnet_changes::<E>(&mut service_state).await;
@@ -319,10 +341,10 @@ mod tests {
         time::timeout,
     };
     use types::{
-        ChainSpec, Epoch, MinimalEthSpec, Slot, test_utils::generate_deterministic_keypair,
+        ChainSpec, Epoch, EthSpec, MinimalEthSpec, Slot, test_utils::generate_deterministic_keypair,
     };
 
-    use crate::{SUBNET_COUNT, SubnetId, TopicEvent, start_subnet_service};
+    use crate::{SUBNET_COUNT, SubnetId, TopicEvent, TopicRouter, start_subnet_service};
 
     const TEST_NETWORK: &str = "test";
     const ALAN_DOMAIN: DomainType = DomainType([0, 0, 0, 1]);
@@ -373,6 +395,14 @@ mod tests {
         /// `subnet_message_rate` returns `None` when scoring is disabled.
         fn new_normal_on_alan_with_scoring() -> Self {
             Self::new_with_flags(normal_on_alan, false, false)
+        }
+
+        /// All-subnet subscriptions with gossipsub topic scoring enabled, so lifecycle
+        /// transitions also exercise the scoring rate updates a fork activation triggers.
+        fn new_with_scoring(
+            initial_lifecycle: impl FnOnce(&ForkConfig, &ForkConfig) -> ForkLifecycle,
+        ) -> Self {
+            Self::new_with_flags(initial_lifecycle, true, false)
         }
 
         /// Build a service with an initial lifecycle and ready-to-assert event receiver.
@@ -597,7 +627,131 @@ mod tests {
         // Assert
         // WarmUp(Alan->Boole) and GracePeriod(current=Boole, previous=Alan) track the same fork
         // set, so no subscribe/unsubscribe topic events should be emitted for this
-        // transition.
+        // transition. This harness also disables topic scoring, so the fork activation emits
+        // no rate updates either.
+        harness.assert_no_additional_events().await;
+    }
+
+    /// A fork activation must not leave the new current fork's topics unscored until the next
+    /// epoch boundary: they were subscribed rate-less during WarmUp, so the transition itself
+    /// has to install their scoring parameters.
+    #[tokio::test]
+    async fn warmup_to_grace_period_with_scoring_rescores_current_fork_topics() {
+        // Arrange
+        let mut harness = TestHarness::new_with_scoring(warmup_from_alan_to_boole);
+        harness.consume_startup_events(SUBNET_COUNT * 2).await;
+
+        // Act: no epoch boundary is crossed, only the lifecycle transition.
+        harness.transition_to_grace_period_current_boole_previous_alan();
+        let events = harness.recv_transition_events(SUBNET_COUNT).await;
+
+        // Assert: every Boole topic is rescored, and the fork set is unchanged so nothing is
+        // subscribed or unsubscribed.
+        assert_all_events_match(&events, "Boole rate update event", is_boole_rate_update);
+        harness.assert_no_additional_events().await;
+    }
+
+    /// Restarting into `Normal` and then receiving `GracePeriod` skips the WarmUp step, so
+    /// this transition subscribes the Boole topics for the first time. The activation rescore
+    /// runs before those subscriptions exist and therefore emits nothing; the subscribes
+    /// themselves carry the rates, so every topic is scored without duplicate rate updates.
+    #[tokio::test]
+    async fn normal_to_grace_period_with_scoring_subscribes_current_fork_topics_with_rates() {
+        // Arrange
+        let mut harness = TestHarness::new_with_scoring(normal_on_alan);
+        harness.consume_startup_events(SUBNET_COUNT).await;
+
+        // Act
+        harness.transition_to_grace_period_current_boole_previous_alan();
+        let events = harness.recv_transition_events(SUBNET_COUNT).await;
+
+        // Assert: every event is a Boole subscribe that already carries a rate, and no
+        // separate rate updates follow.
+        assert_all_events_match(&events, "Boole subscribe event", is_boole_subscribe);
+        for (index, event) in events.iter().enumerate() {
+            let TopicEvent::Subscribe { message_rate, .. } = event else {
+                unreachable!("asserted above that every event is a subscribe");
+            };
+            assert!(
+                message_rate.is_some(),
+                "Boole subscribe at index {index} should carry a message rate when scoring is enabled"
+            );
+        }
+        harness.assert_no_additional_events().await;
+    }
+
+    /// A restart can miss the grace period entirely: WarmUp is followed directly by
+    /// `Normal{current: Boole}`. The removal of the previous fork emits its unsubscribes
+    /// first (`on_lifecycle_transition` handles removals before the rescore), and because
+    /// `fork_to_score` flips to Boole, the Boole topics subscribed rate-less during WarmUp
+    /// are rescored in the same transition. The subnet diff afterwards adds nothing because
+    /// the Boole set is already complete.
+    #[tokio::test]
+    async fn warmup_to_normal_with_scoring_unsubscribes_previous_and_rescores_current_fork() {
+        // Arrange
+        let mut harness = TestHarness::new_with_scoring(warmup_from_alan_to_boole);
+        harness.consume_startup_events(SUBNET_COUNT * 2).await;
+
+        // Act: skip the grace period, jumping straight to Normal on Boole.
+        harness.transition_to_normal_on_boole();
+        let events = harness.recv_transition_events(SUBNET_COUNT * 2).await;
+
+        // Assert: all Alan unsubscribes first, then a rate update for every Boole topic.
+        let (unsubscribes, rate_updates) = events.split_at(SUBNET_COUNT);
+        assert_all_events_match(unsubscribes, "Alan unsubscribe event", is_alan_unsubscribe);
+        assert_all_events_match(
+            rate_updates,
+            "Boole rate update event",
+            is_boole_rate_update,
+        );
+        harness.assert_no_additional_events().await;
+    }
+
+    /// A service that starts directly in `GracePeriod{current: Boole}` (a restart after the
+    /// fork activated) runs the activation rescore path during startup, but at that point no
+    /// topics are subscribed yet, so the rescore emits nothing. Startup therefore emits only
+    /// the initial subscribes for both tracked forks, and the subscribes for the fork being
+    /// scored already carry message rates, so no topic is left unscored.
+    #[tokio::test]
+    async fn initial_grace_period_with_scoring_emits_rated_subscribes_and_no_rate_updates() {
+        // Arrange
+        let mut harness = TestHarness::new_with_scoring(grace_period_current_boole_previous_alan);
+
+        // Act: capture everything startup emits.
+        let events = harness.recv_transition_events(SUBNET_COUNT * 2).await;
+
+        // Assert: every startup event is a subscribe; the startup rescore ran against an
+        // empty subscription set, so no separate rate updates appear.
+        assert_all_events_match(&events, "subscribe event", is_subscribe_event);
+        let alan_subscribes = events
+            .iter()
+            .filter(|event| is_alan_subscribe(event))
+            .count();
+        let boole_subscribes = events
+            .iter()
+            .filter(|event| is_boole_subscribe(event))
+            .count();
+        assert_eq!(alan_subscribes, SUBNET_COUNT);
+        assert_eq!(boole_subscribes, SUBNET_COUNT);
+
+        // Assert: Boole is the fork being scored, so its subscribes carry rates; Alan is the
+        // graced-out previous fork, so its subscribes are rate-less.
+        for (index, event) in events.iter().enumerate() {
+            let TopicEvent::Subscribe { message_rate, .. } = event else {
+                unreachable!("asserted above that every event is a subscribe");
+            };
+            if is_boole_subscribe(event) {
+                assert!(
+                    message_rate.is_some(),
+                    "Boole subscribe at index {index} should carry a message rate"
+                );
+            } else {
+                assert!(
+                    message_rate.is_none(),
+                    "Alan subscribe at index {index} should not carry a message rate"
+                );
+            }
+        }
         harness.assert_no_additional_events().await;
     }
 
@@ -623,6 +777,57 @@ mod tests {
         assert_eq!(alan_subscribes, SUBNET_COUNT);
         assert_eq!(boole_subscribes, SUBNET_COUNT);
         harness.assert_no_additional_events().await;
+    }
+
+    /// Dropping the lifecycle sender must stop the run loop cleanly. With
+    /// `subscribe_all_subnets` disabling the db arm and `disable_gossipsub_topic_scoring`
+    /// disabling the epoch timer, the lifecycle arm is the only live select branch, so its
+    /// `Err` result is the loop's only exit; without that handling the select would have no
+    /// enabled branches left and panic.
+    #[tokio::test]
+    async fn run_stops_cleanly_when_lifecycle_sender_is_dropped() {
+        // Arrange: build the service directly so the test owns the run task's join handle.
+        let temp_dir = TempDir::new().expect("should create temp directory for test database");
+        let db_path = temp_dir.path().join("subnet_service_sender_drop.db");
+        let db = NetworkDatabase::new_as_impostor(&db_path, &OWN_OPERATOR_ID, TEST_NETWORK)
+            .expect("should build test database");
+        let (fork_schedule, alan_config, _boole_config) = test_fork_schedule();
+        let (lifecycle_tx, lifecycle_rx) = watch::channel(ForkLifecycle::Normal {
+            current: alan_config,
+        });
+        let (tx, mut topic_event_rx) = mpsc::channel(SUBNET_COUNT);
+        let service = Arc::new(crate::SubnetService {
+            tx,
+            db: db.watch(),
+            subscribe_all_subnets: true,
+            disable_gossipsub_topic_scoring: true,
+            slot_clock: Arc::new(ManualSlotClock::new(
+                Slot::new(0),
+                Duration::from_secs(0),
+                Duration::from_secs(12),
+            )),
+            chain_spec: Arc::new(ChainSpec::minimal()),
+            router: TopicRouter::new(fork_schedule, MinimalEthSpec::slots_per_epoch()),
+        });
+        let handle = tokio::spawn(service.clone().run::<MinimalEthSpec>(lifecycle_rx));
+
+        // Drain the startup subscribes so the loop is parked in the select.
+        for _ in 0..SUBNET_COUNT {
+            timeout(EVENT_TIMEOUT, topic_event_rx.recv())
+                .await
+                .expect("timed out waiting for startup subscribe")
+                .expect("topic event channel closed unexpectedly");
+        }
+
+        // Act
+        drop(lifecycle_tx);
+
+        // Assert: the task returns, and returns cleanly (a panic would surface as a
+        // JoinError).
+        timeout(EVENT_TIMEOUT, handle)
+            .await
+            .expect("run should return after the lifecycle sender is dropped")
+            .expect("run must not panic when the lifecycle sender is dropped");
     }
 
     #[tokio::test]
@@ -854,6 +1059,13 @@ mod tests {
         matches!(
             event,
             TopicEvent::Subscribe { topic, .. } if topic.starts_with(boole_topic_prefix())
+        )
+    }
+
+    fn is_boole_rate_update(event: &TopicEvent) -> bool {
+        matches!(
+            event,
+            TopicEvent::RateUpdate { topic, .. } if topic.starts_with(boole_topic_prefix())
         )
     }
 


### PR DESCRIPTION
## Problem, Evidence, and Context (Required)

The fork monitor never honored the transition slots it computed. `sleep_until_slot` subtracted a slot from every target and published immediately on waking, so `WarmUp`, `GracePeriod`, and `Normal` all landed one slot early. Measured on `unstable` in ssv-mini with Boole at epoch 6: transitions fired at slots **159 / 191 / 223** instead of 160 / 192 / 224.

Early `GracePeriod` is the one that matters on the wire: it flips ENR, handshake, discovery, and scoring to the new fork while messages for that slot are still Alan, since sender routing and validation derive the fork from the message slot and switch correctly at activation.

Three further defects sat behind the same code:

- **Clock failure was not fail-closed.** An unreadable clock made `sleep_until_slot` return instantly, so the loop published every remaining transition back to back regardless of the actual slot. A node restarted long before the fork would immediately behave as if Boole were live.
- **Long sleeps ignored wall-clock corrections.** A single pre-computed sleep runs against a monotonic deadline, so an NTP step during a multi-slot sleep left the lifecycle stale until the original timer expired.
- **Startup could permanently miss the ENR transition.** `Discovery::new` snapshots the lifecycle domain before awaiting discv5 startup and bootnode requests. A fork activating inside that window left a stale ENR that never self-corrected, since later lifecycle changes kept the same domain.

Exact activation also exposed a scoring dependency the early flip had been masking: Boole topics are subscribed rate-less during `WarmUp`, and at activation the fork set does not change, so no subscribe or rate event was emitted and Boole topics carried no score parameters (including the P4 invalid-message penalty) for the first 32 post-fork slots.

Closes #1191

## Change Overview (Required)

`ForkSchedule::lifecycle_at(slot, slots_per_epoch)` is now the single source of truth: the same slot always maps to the same lifecycle. The monitor task loops on a fresh clock observation each slot, derives the lifecycle, and publishes only when it changed. Exact-slot publication, publishing just the current state after a multi-boundary jump, and restart re-derivation all follow from that shape instead of from index bookkeeping.

**Reading order:** start with `schedule.rs` (`lifecycle_at`, the window definitions), then `monitor.rs` (`classify_observation` plus the ~40-line `run` loop). `network.rs` and `subscriptions.rs` are small consumer changes. `monitor.rs` is effectively a rewrite, so it reads far better as a file than as a diff; roughly 85% of the insertions are tests.

Consumer changes: the network reconciles the ENR domain during `try_new` and fails closed if a runtime ENR update fails (previously logged and never retried); the subnet service installs scoring parameters for the activating fork's already-subscribed topics at activation.

**What did not change:** the fork schedule math, window constants, `ForkLifecycle` itself, the watch-channel distribution model, per-transition operator logs, and all slot-derived sender routing and validation.

## Risks, Trade-offs, and Mitigations (Required)

- **Fail-closed on clock failure is new behavior.** An unreadable clock or a backwards clock crossing a lifecycle boundary now requests a client shutdown. Published ENR, handshake, and scoring state cannot be rolled back, so the alternative is a silent split brain. Post-genesis, `SystemTimeSlotClock::now()` only returns `None` when the wall clock reads before genesis, so this is not a transient condition. Backwards movement *within* a window is tolerated with a warning.
- **The guards are process-scoped.** The highest observed slot is not persisted, so a supervisor restart with a still-rolled-back clock re-derives the earlier lifecycle without error. Documented in the module docs; watermark persistence is a filed follow-up.
- **The monitor no longer exits** after the final transition. Cost is one clock read and one pure computation per slot; measured below.
- **Deployment note:** during the final pre-fork slot, an old and a fixed node disagree about the lifecycle. This is the intended correction, and interop is governed by slot-derived routing on both sides.

## Validation (Required)

Unit: `fork` 44, `network` 63, `subnet_service` 65, plus the full release suite, `cargo fmt`, and `clippy -D warnings`.

Live validation on ssv-mini against go-ssv `stage` (874ba31), 2 Anchor + 2 go-ssv, 10 managed validators, Boole at epoch 6. Four runs, all clean-pass:

| Run | Test | Result |
|---|---|---|
| 1 | Clean control | All 6 transitions exact (2 nodes x 3), 1.4-11 ms into slot |
| 2 | Freeze across all boundaries | Node paused at slot 159, resumed 225: exactly one publish (`Normal{Boole}`), no replay, correct ENR, zero anomalies |
| 3 | Restart timing | Restart at 189 still flipped at exactly 192; restart at 200 derived `GracePeriod` and advertised Boole immediately |
| 4 | Base A/B | Pre-fix image reproduces the bug at 159 / 191 / 223 |

The A/B is the controlled comparison. The base image fired **4.9 s and 6.4 s** into its (wrong) slots and the two nodes drifted ~1.5 s apart from each other, because each slept a computed duration from its own start time. This branch landed **1.4-11 ms** into the correct slot with the two nodes agreeing within 40 microseconds. It also confirms the check discriminates rather than always passing.

Supporting: ENR flipped `0x00000000` to `0x00000001` at activation; zero `Failed to set topic score params` across the 128-topic burst; **zero handshake rejections on all four nodes in every run**; finality advanced and duties continued throughout.

Resource impact of the never-exiting monitor: post-transition CPU across candidate runs (0.74-3.73%) varies more than any candidate-versus-base difference (base 0.89%), and the base image's memory slope is *higher* (157 KB/slot vs 107-130). No spinning, no growth.

## Rollback (Required)

Revert the commit. No config, CLI, database, or wire-format changes. Reverting restores the one-slot-early behavior and the non-fail-closed clock handling.

## Additional Info / Next Steps (Optional)

Follow-ups filed, all in the Boole milestone and none of them fork blockers:

- #1230 detect slot-clock regression at startup. The fail-closed guards added here are process-scoped, so a restart with a still-rolled-back clock re-derives the earlier lifecycle. Filed as client-wide detection rather than a fork watermark, because a backwards clock breaks duties and attestations too, not just the fork lifecycle.
- #1231 tolerate both fork domains during the transition window, plus the 32 versus 34 slot `SUBSEQUENT_WINDOW_SLOTS` parity question with go-ssv.
- #1232 move the monitor out of `common/fork`, share the shutdown helper across its three call sites, and make an overlapping fork schedule a construction error.

The `db.changed()` arm is no longer deferred: it is fixed in this PR. It bound `changed()` with `_`, which matches `Err`, so a dropped database sender left the arm enabled and firing forever rather than disabling it. That is a different failure mode from the lifecycle arm's (a hot loop rather than a select-arm-disable panic), and it is pinned by a test verified to fail against the previous binding.

Not covered by live testing: the fail-closed paths themselves, which need a libfaketime image. They have unit coverage, and the runs did exercise the dangerous direction, since multi-minute forward jumps produced zero anomalies and no spurious shutdowns.
