### PR TITLE
fix(validator_store): sign the decided AggregatorCommittee worklist once per slot

### DIFF
--- a/anchor/common/ssv_types/src/consensus.rs
+++ b/anchor/common/ssv_types/src/consensus.rs
@@ -526,34 +526,6 @@ pub struct AggregatorCommitteeConsensusData<E: EthSpec> {
         VariableList<SyncCommitteeContribution<E>, MaxSyncContributions>,
 }
 
-impl<E: EthSpec> AggregatorCommitteeConsensusData<E> {
-    /// Counts the total number of expected post-consensus signatures for this committee.
-    ///
-    /// This includes both aggregators and contributors that match the given filter.
-    /// Used to ensure all signatures are batched into a single message rather than
-    /// being split across multiple messages.
-    ///
-    /// Returns: count(aggregators) + count(contributors) filtered by committee membership
-    pub fn post_consensus_signature_count<F>(&self, is_in_committee: F) -> usize
-    where
-        F: Fn(&ValidatorIndex) -> bool,
-    {
-        let aggregator_count = self
-            .aggregators
-            .iter()
-            .filter(|agg| is_in_committee(&agg.validator_index))
-            .count();
-
-        let contributor_count = self
-            .contributors
-            .iter()
-            .filter(|contrib| is_in_committee(&contrib.validator_index))
-            .count();
-
-        aggregator_count + contributor_count
-    }
-}
-
 impl<E: EthSpec> QbftData for AggregatorCommitteeConsensusData<E> {
     type Hash = Hash256;
 

--- a/anchor/validator_store/src/aggregator_post_consensus.rs
+++ b/anchor/validator_store/src/aggregator_post_consensus.rs
@@ -1,0 +1,542 @@
+//! Post-consensus signing for Boole+ `AggregatorCommittee` duties.
+//!
+//! One QBFT decision carries both attestation aggregates and sync contributions for an SSV
+//! committee, and the operator must emit exactly one committee partial-signature message per
+//! `(committee, slot)` covering everything it can sign. Lighthouse asks for signatures through two
+//! independent callbacks, one per object class, so neither callback can own that message: whichever
+//! one fires, the other class still has to be signed (issue #1227).
+//!
+//! The signing set is therefore a property of the duty, not of any callback. The slot pipeline
+//! starts one execution per committee when it publishes the decided value at 2/3 slot, and the
+//! callbacks only look up their own results. This is the ssv-spec-normative shape, where the
+//! decided value drives what gets signed and local state only filters.
+
+use std::{
+    collections::{HashMap, HashSet, hash_map::Entry},
+    future::Future,
+    sync::Arc,
+};
+
+use bls::Signature;
+use database::{NonUniqueIndex, UniqueIndex};
+use futures::{
+    FutureExt,
+    future::{BoxFuture, Shared},
+};
+use qbft_manager::ConsensusDecider;
+use slot_clock::SlotClock;
+use ssv_types::{
+    Cluster, CommitteeId, ValidatorIndex, ValidatorMetadata,
+    consensus::{AggregatorCommitteeConsensusData, AssignedAggregator, DataVersion, QbftData},
+    msgid::Role,
+    partial_sig::PartialSignatureKind,
+};
+use ssz::Decode;
+use tokio::time::Instant;
+use tracing::{debug, error, warn};
+use types::{
+    AggregateAndProof, Attestation, AttestationBase, AttestationElectra, ContributionAndProof,
+    Domain, EthSpec, ForkName, Hash256, SelectionProof, SignedRoot, Slot,
+};
+
+use crate::{
+    AggregationAssignments, AnchorValidatorStore, CollectionMode, Error, SigningRequest,
+    SpecificError,
+};
+
+/// Epochs to retain finished `AggregatorCommittee` post-consensus executions.
+///
+/// Matches the message validator's per-signer duplicate-detection window, so a very late Lighthouse
+/// callback finds the execution it belongs to rather than nothing. Each entry is one small future
+/// per committee-slot.
+const AGGREGATOR_POST_CONSENSUS_RETAIN_EPOCHS: u64 = 2;
+
+/// A result shared between the detached task producing it and any number of joiners.
+type SharedResult<T> = Shared<BoxFuture<'static, Result<T, Arc<Error>>>>;
+
+pub(crate) type AggregatorPostConsensusShared<E> =
+    SharedResult<Arc<AggregatorPostConsensusOutcome<E>>>;
+
+/// One decided root this operator signs, with the handle to its signature.
+///
+/// The underlying `collect_signature` call runs in its own task, so the local partial reaches the
+/// committee batch even when no callback ever awaits the signature.
+pub(crate) struct PreparedRoot<M> {
+    pub(crate) request: SigningRequest<M>,
+    pub(crate) signature: SharedResult<Signature>,
+}
+
+/// Everything this operator signs for one decided `AggregatorCommittee` round, keyed by the
+/// identities the Lighthouse callbacks look up: validator index for aggregates,
+/// `(validator index, subcommittee index)` for contributions.
+pub(crate) struct AggregatorPostConsensusOutcome<E: EthSpec> {
+    pub(crate) aggregates: HashMap<ValidatorIndex, PreparedRoot<AggregateAndProof<E>>>,
+    pub(crate) contributions: HashMap<(ValidatorIndex, u64), PreparedRoot<ContributionAndProof<E>>>,
+}
+
+/// The signing worklist derived from one decided `AggregatorCommitteeConsensusData`.
+struct DecidedWorklist<E: EthSpec> {
+    aggregates: HashMap<ValidatorIndex, SigningRequest<AggregateAndProof<E>>>,
+    contributions: HashMap<(ValidatorIndex, u64), SigningRequest<ContributionAndProof<E>>>,
+}
+
+fn post_consensus_aborted() -> Arc<Error> {
+    Arc::new(Error::SpecificError(SpecificError::PostConsensusAborted))
+}
+
+/// Await a detached task spawned with `TaskExecutor::spawn_handle`, mapping every way it can die
+/// without a result (spawn refused, executor exit, panic) onto `PostConsensusAborted`.
+async fn join_detached_task<R>(
+    handle: Option<tokio::task::JoinHandle<Option<R>>>,
+) -> Result<R, Arc<Error>> {
+    match handle {
+        Some(handle) => handle.await.ok().flatten(),
+        None => None,
+    }
+    .ok_or_else(post_consensus_aborted)
+}
+
+impl<T: SlotClock + 'static, E: EthSpec, C: ConsensusDecider<E> + 'static>
+    AnchorValidatorStore<T, E, C>
+{
+    /// Start one post-consensus execution per committee in freshly built assignments.
+    ///
+    /// This is the only place executions are created. Callbacks look results up and never start
+    /// work, so exactly one committee message per `(committee, slot)` holds by construction rather
+    /// than by locking. Called from `update_aggregation_assignments` before the watch channel is
+    /// published, so any consumer that can observe the assignments can also observe the execution.
+    ///
+    /// Pre-Boole there is no consensus data and this is a no-op.
+    pub(crate) fn start_aggregator_post_consensus(
+        self: &Arc<Self>,
+        assignments: &AggregationAssignments<E>,
+    ) {
+        let slot = assignments.slot;
+        let mut executions = self.aggregator_post_consensus.lock();
+
+        let cutoff =
+            slot.saturating_sub(AGGREGATOR_POST_CONSENSUS_RETAIN_EPOCHS * E::slots_per_epoch());
+        executions.retain(|(_, execution_slot), _| *execution_slot >= cutoff);
+
+        for (&committee_id, decided_data) in &assignments.consensus_data_by_ssv_committee {
+            let store = Arc::clone(self);
+            let decided_data = Arc::clone(decided_data);
+            let execution = self.spawn_shared("aggregator_post_consensus", async move {
+                store
+                    .run_aggregator_post_consensus(committee_id, slot, decided_data)
+                    .await
+            });
+            executions.insert((committee_id, slot), execution);
+        }
+    }
+
+    /// Join the post-consensus execution for `(committee, slot)`, returning the outcome and the
+    /// deadline that bounded the join, for the caller to reuse when draining its own roots.
+    ///
+    /// The single deadline (one slot past the duty slot's end) is an anti-hang backstop, not a
+    /// duty-freshness bound: QBFT `SlotTime` rounds legitimately decide after the slot ends and
+    /// reconstruction needs a network round trip after that, so bounding at slot end would discard
+    /// results decided in contended rounds.
+    pub(crate) async fn post_consensus_outcome(
+        &self,
+        committee_id: CommitteeId,
+        slot: Slot,
+    ) -> Result<(Instant, Arc<AggregatorPostConsensusOutcome<E>>), Error> {
+        // Waiting on the assignments is what makes the lookup below race-free: the execution was
+        // registered before this slot's assignments were published.
+        self.get_aggregation_assignments(slot).await?;
+
+        let execution = self
+            .aggregator_post_consensus
+            .lock()
+            .get(&(committee_id, slot))
+            .cloned()
+            .ok_or(Error::SpecificError(SpecificError::ConsensusDataNotFound))?;
+
+        let deadline = self.get_instant_in_slot(slot, self.spec.get_slot_duration() * 2)?;
+        let outcome = tokio::time::timeout_at(deadline, execution)
+            .await
+            .map_err(|_| Error::SpecificError(SpecificError::Timeout))?
+            .map_err(|e| (*e).clone())?;
+
+        Ok((deadline, outcome))
+    }
+
+    /// Spawn `fut` detached and hand out a `Shared` view of its result.
+    fn spawn_shared<R: Clone + Send + Sync + 'static>(
+        &self,
+        task_name: &'static str,
+        fut: impl Future<Output = Result<R, Arc<Error>>> + Send + 'static,
+    ) -> SharedResult<R> {
+        let handle = self.task_executor.spawn_handle(fut, task_name);
+        async move { join_detached_task(handle).await.and_then(|result| result) }
+            .boxed()
+            .shared()
+    }
+
+    /// Decide the committee's value, then submit every root this operator can sign from it.
+    ///
+    /// Which Lighthouse callbacks happen to fire has no influence on what is signed, only on what
+    /// is returned to Lighthouse.
+    async fn run_aggregator_post_consensus(
+        self: Arc<Self>,
+        committee_id: CommitteeId,
+        slot: Slot,
+        our_consensus_data: Arc<AggregatorCommitteeConsensusData<E>>,
+    ) -> Result<Arc<AggregatorPostConsensusOutcome<E>>, Arc<Error>> {
+        let Some(cluster) = self.committee_cluster(&committee_id) else {
+            warn!(
+                ?committee_id,
+                %slot,
+                "No active cluster for committee, skipping aggregator post-consensus"
+            );
+            return Ok(Arc::new(AggregatorPostConsensusOutcome {
+                aggregates: HashMap::new(),
+                contributions: HashMap::new(),
+            }));
+        };
+        let cluster = Arc::new(cluster);
+
+        let decided_data = self
+            .run_aggregator_committee_consensus(committee_id, slot, &cluster, &our_consensus_data)
+            .await
+            .map_err(Arc::new)?;
+
+        let worklist = self.build_decided_worklist(&decided_data, &committee_id, slot);
+
+        // The batch size is the number of partials this operator actually submits. Peers do not
+        // validate completeness for `AggregatorCommittee` (committee views may differ), and a count
+        // local filtering cannot reach stalls the batch forever.
+        let batch_size = worklist.aggregates.len() + worklist.contributions.len();
+        if batch_size == 0 {
+            debug!(
+                ?committee_id,
+                %slot,
+                "No locally signable entries in decided aggregator committee data"
+            );
+        }
+        let collection_mode = CollectionMode::Committee {
+            validator_partial_signature_batch_size: batch_size,
+            base_hash: decided_data.hash(),
+        };
+
+        Ok(Arc::new(AggregatorPostConsensusOutcome {
+            aggregates: self.prepare_roots(worklist.aggregates, &collection_mode, &cluster, slot),
+            contributions: self.prepare_roots(
+                worklist.contributions,
+                &collection_mode,
+                &cluster,
+                slot,
+            ),
+        }))
+    }
+
+    /// Any active cluster in the committee.
+    ///
+    /// `Cluster::committee_id` is derived from `cluster_members`, so every cluster sharing a
+    /// committee has the same operator set and the same `f`, which is all consensus and the
+    /// signature threshold need. Per-validator liquidation is still filtered in the worklist.
+    fn committee_cluster(&self, committee_id: &CommitteeId) -> Option<Cluster> {
+        let state = self.database.state();
+        state
+            .metadata()
+            .get_all_by(committee_id)
+            .find_map(|validator| {
+                let cluster = state.clusters().get_by(&validator.cluster_id)?;
+                (!cluster.liquidated).then(|| cluster.clone())
+            })
+    }
+
+    /// Spawn one detached signing task per worklist entry.
+    fn prepare_roots<K: std::hash::Hash + Eq, M>(
+        self: &Arc<Self>,
+        requests: HashMap<K, SigningRequest<M>>,
+        collection_mode: &CollectionMode,
+        cluster: &Arc<Cluster>,
+        slot: Slot,
+    ) -> HashMap<K, PreparedRoot<M>> {
+        requests
+            .into_iter()
+            .map(|(key, request)| {
+                let signature = self.spawn_root_collection(
+                    collection_mode.clone(),
+                    request.validator.clone(),
+                    Arc::clone(cluster),
+                    request.signing_root,
+                    slot,
+                );
+                (key, PreparedRoot { request, signature })
+            })
+            .collect()
+    }
+
+    /// Spawn one root's signature collection as its own detached task.
+    ///
+    /// The task hands the partial to the committee batch even if no callback ever awaits the
+    /// returned handle, so an absent or dropped Lighthouse callback cannot strand the batch below
+    /// its expected size.
+    fn spawn_root_collection(
+        self: &Arc<Self>,
+        collection_mode: CollectionMode,
+        validator: ValidatorMetadata,
+        cluster: Arc<Cluster>,
+        signing_root: Hash256,
+        slot: Slot,
+    ) -> SharedResult<Signature> {
+        let store = Arc::clone(self);
+        self.spawn_shared("aggregator_post_consensus_root", async move {
+            let result = store
+                .collect_signature(
+                    PartialSignatureKind::PostConsensus,
+                    Role::AggregatorCommittee,
+                    collection_mode,
+                    &validator,
+                    &cluster,
+                    signing_root,
+                    slot,
+                )
+                .await;
+            if let Err(e) = &result {
+                // Callbacks only see failures for roots they requested; log here so a failed
+                // unrequested root (which leaves the committee batch under-filled and unsent) is
+                // still visible to operators.
+                error!(
+                    ?signing_root,
+                    pubkey = ?validator.public_key,
+                    error = ?e,
+                    "Post-consensus root signing failed; the committee batch for this duty \
+                     may not be sent"
+                );
+            }
+            result.map_err(Arc::new)
+        })
+    }
+
+    /// Build the signing worklist from a decided value.
+    ///
+    /// Resolves metadata, cluster status and share availability for every decided entry under one
+    /// database snapshot, then keys the result by signing identity: validator index for aggregates,
+    /// `(validator, subcommittee)` for contributions. Keying by identity collapses repeated decided
+    /// entries (a root submitted twice would double-count the batch) and holds every validator
+    /// inside the receivers' five-roots-per-validator cap; a decided value carrying conflicting
+    /// roots for one identity signs the first and logs the rest.
+    fn build_decided_worklist(
+        &self,
+        decided_data: &AggregatorCommitteeConsensusData<E>,
+        committee_id: &CommitteeId,
+        slot: Slot,
+    ) -> DecidedWorklist<E> {
+        let decided_indices: HashSet<ValidatorIndex> = decided_data
+            .aggregators
+            .iter()
+            .chain(decided_data.contributors.iter())
+            .map(|entry| entry.validator_index)
+            .collect();
+
+        // One snapshot for metadata, liquidation and share rows, so entries cannot mix database
+        // states. Released before any signing.
+        let locals: HashMap<ValidatorIndex, ValidatorMetadata> = {
+            let state = self.database.state();
+            state
+                .metadata()
+                .get_all_by(committee_id)
+                .filter_map(|validator| {
+                    let index = validator.index.filter(|i| decided_indices.contains(i))?;
+                    let cluster = state.clusters().get_by(&validator.cluster_id)?;
+                    if cluster.liquidated {
+                        return None;
+                    }
+                    // Without a share row this operator cannot sign for the validator, and counting
+                    // it would leave the committee batch permanently short.
+                    state.shares().get_by(&validator.public_key)?;
+                    Some((index, validator.clone()))
+                })
+                .collect()
+        };
+
+        let epoch = slot.epoch(E::slots_per_epoch());
+        let aggregate_domain = self.get_domain(epoch, Domain::AggregateAndProof);
+        let contribution_domain = self.get_domain(epoch, Domain::ContributionAndProof);
+
+        let mut aggregates = HashMap::new();
+        for decided_aggregator in decided_data.aggregators.iter() {
+            let Some(validator) = locals.get(&decided_aggregator.validator_index) else {
+                continue;
+            };
+            let request = match Self::resolve_decided_aggregate(
+                decided_data,
+                decided_aggregator,
+                validator,
+                slot,
+                aggregate_domain,
+            ) {
+                Ok(request) => request,
+                Err(e) => {
+                    debug!(
+                        validator_index = ?decided_aggregator.validator_index,
+                        error = e,
+                        "Skipping decided aggregate"
+                    );
+                    continue;
+                }
+            };
+            match aggregates.entry(decided_aggregator.validator_index) {
+                Entry::Vacant(vacant) => {
+                    vacant.insert(request);
+                }
+                Entry::Occupied(kept) if kept.get().signing_root != request.signing_root => warn!(
+                    validator_index = ?decided_aggregator.validator_index,
+                    "Decided value contains conflicting aggregate roots for one validator, \
+                     signing the first"
+                ),
+                Entry::Occupied(_) => {}
+            }
+        }
+
+        let mut contributions = HashMap::new();
+        for decided_contributor in decided_data.contributors.iter() {
+            let Some(validator) = locals.get(&decided_contributor.validator_index) else {
+                continue;
+            };
+            let request = match Self::resolve_decided_contribution(
+                decided_data,
+                decided_contributor,
+                validator,
+                slot,
+                contribution_domain,
+            ) {
+                Ok(request) => request,
+                Err(e) => {
+                    debug!(
+                        validator_index = ?decided_contributor.validator_index,
+                        subcommittee_index = decided_contributor.committee_index,
+                        error = e,
+                        "Skipping decided contribution"
+                    );
+                    continue;
+                }
+            };
+            match contributions.entry((
+                decided_contributor.validator_index,
+                decided_contributor.committee_index,
+            )) {
+                Entry::Vacant(vacant) => {
+                    vacant.insert(request);
+                }
+                Entry::Occupied(kept) if kept.get().signing_root != request.signing_root => warn!(
+                    validator_index = ?decided_contributor.validator_index,
+                    subcommittee_index = decided_contributor.committee_index,
+                    "Decided value contains conflicting contribution roots for one identity, \
+                     signing the first"
+                ),
+                Entry::Occupied(_) => {}
+            }
+        }
+
+        DecidedWorklist {
+            aggregates,
+            contributions,
+        }
+    }
+
+    /// Resolve one decided aggregator entry into a signable `AggregateAndProof`.
+    ///
+    /// Finds the matching committee index, decodes the aggregate attestation from SSZ, and binds
+    /// the decoded slot to the duty slot. The signing domain comes from the duty slot's epoch,
+    /// matching the beacon spec (domain at the epoch of `aggregate.data.slot`) and go-ssv's
+    /// expected roots.
+    fn resolve_decided_aggregate(
+        decided_data: &AggregatorCommitteeConsensusData<E>,
+        decided_aggregator: &AssignedAggregator,
+        validator: &ValidatorMetadata,
+        slot: Slot,
+        domain_hash: Hash256,
+    ) -> Result<SigningRequest<AggregateAndProof<E>>, String> {
+        let aggregator_index = decided_aggregator.validator_index.0 as u64;
+
+        let committee_index = decided_aggregator.committee_index;
+
+        // Find the position of this committee index in decided data
+        let decided_aggregate_idx = decided_data
+            .aggregator_committee_indexes
+            .iter()
+            .position(|&idx| idx == committee_index)
+            .ok_or("Committee index not found in decided data")?;
+
+        let decided_aggregate_bytes = decided_data
+            .aggregated_attestations
+            .get(decided_aggregate_idx)
+            .ok_or("Aggregate attestation bytes not found in decided data")?;
+
+        // Decode based on fork version
+        let decided_aggregate = if decided_data.version < DataVersion::from(ForkName::Electra) {
+            AttestationBase::from_ssz_bytes(decided_aggregate_bytes)
+                .map(Attestation::Base)
+                .map_err(|e| format!("Failed to decode decided aggregate: {e:?}"))?
+        } else {
+            AttestationElectra::from_ssz_bytes(decided_aggregate_bytes)
+                .map(Attestation::Electra)
+                .map_err(|e| format!("Failed to decode decided aggregate: {e:?}"))?
+        };
+
+        let aggregate_slot = decided_aggregate.data().slot;
+        if aggregate_slot != slot {
+            return Err(format!(
+                "Decided aggregate slot {aggregate_slot} does not match duty slot {slot}"
+            ));
+        }
+
+        let decided_selection_proof =
+            SelectionProof::from(decided_aggregator.selection_proof.clone());
+
+        let message = AggregateAndProof::from_attestation(
+            aggregator_index,
+            decided_aggregate,
+            decided_selection_proof,
+        );
+
+        Ok(SigningRequest {
+            validator: validator.clone(),
+            signing_root: message.signing_root(domain_hash),
+            duty_data: message,
+        })
+    }
+
+    /// Resolve one decided contributor entry into a signable `ContributionAndProof`.
+    fn resolve_decided_contribution(
+        decided_data: &AggregatorCommitteeConsensusData<E>,
+        decided_contributor: &AssignedAggregator,
+        validator: &ValidatorMetadata,
+        slot: Slot,
+        domain_hash: Hash256,
+    ) -> Result<SigningRequest<ContributionAndProof<E>>, String> {
+        let subcommittee_index = decided_contributor.committee_index;
+
+        // Find the contribution for this subcommittee
+        let decided_contribution = decided_data
+            .sync_committee_contributions
+            .iter()
+            .find(|c| c.subcommittee_index == subcommittee_index)
+            .ok_or(
+                "Contribution not in consensus data - likely filtered due to beacon API failure",
+            )?;
+        if decided_contribution.slot != slot {
+            return Err(format!(
+                "Decided contribution slot {} does not match duty slot {slot}",
+                decided_contribution.slot
+            ));
+        }
+
+        let message = ContributionAndProof {
+            aggregator_index: decided_contributor.validator_index.0 as u64,
+            contribution: decided_contribution.clone(),
+            selection_proof: decided_contributor.selection_proof.clone(),
+        };
+
+        Ok(SigningRequest {
+            validator: validator.clone(),
+            signing_root: message.signing_root(domain_hash),
+            duty_data: message,
+        })
+    }
+}

--- a/anchor/validator_store/src/aggregator_post_consensus.rs
+++ b/anchor/validator_store/src/aggregator_post_consensus.rs
@@ -119,14 +119,21 @@ impl<T: SlotClock + 'static, E: EthSpec, C: ConsensusDecider<E> + 'static>
         executions.retain(|(_, execution_slot), _| *execution_slot >= cutoff);
 
         for (&committee_id, decided_data) in &assignments.consensus_data_by_ssv_committee {
-            let store = Arc::clone(self);
-            let decided_data = Arc::clone(decided_data);
-            let execution = self.spawn_shared("aggregator_post_consensus", async move {
-                store
-                    .run_aggregator_post_consensus(committee_id, slot, decided_data)
-                    .await
-            });
-            executions.insert((committee_id, slot), execution);
+            // Vacant-only, so registration is idempotent. Overwriting would spawn a second QBFT
+            // round and a second set of detached signing tasks while the first set kept running,
+            // putting two committee messages on the wire for one slot, which peers reject with a
+            // gossip penalty. The slot pipeline publishes once per slot today, but that is a
+            // property of another module's timing loop; keeping this vacant-only makes
+            // exactly-once hold here regardless of how often it is called.
+            if let Entry::Vacant(vacant) = executions.entry((committee_id, slot)) {
+                let store = Arc::clone(self);
+                let decided_data = Arc::clone(decided_data);
+                vacant.insert(self.spawn_shared("aggregator_post_consensus", async move {
+                    store
+                        .run_aggregator_post_consensus(committee_id, slot, decided_data)
+                        .await
+                }));
+            }
         }
     }
 

--- a/anchor/validator_store/src/lib.rs
+++ b/anchor/validator_store/src/lib.rs
@@ -245,11 +245,12 @@ pub struct AnchorValidatorStore<
     task_executor: TaskExecutor,
     /// Once-only post-consensus signing executions for `AggregatorCommittee` duties (Boole+).
     ///
-    /// One entry per `(committee, slot)`. The first Lighthouse callback (aggregate or
-    /// contribution class) spawns the execution as a detached task; concurrent and later
-    /// callbacks of either class join the same `Shared` future, so the complete decided
-    /// worklist is signed and batched exactly once no matter which callbacks fire, in what
-    /// order, or whether their futures are dropped.
+    /// One entry per `(committee, slot)`, registered by the slot pipeline in
+    /// [`Self::update_aggregation_assignments`] before those assignments are published, and only
+    /// when the entry is vacant. That registration is the single writer, so the complete decided
+    /// worklist is signed and batched exactly once no matter which Lighthouse callbacks fire, in
+    /// what order, or whether their futures are dropped. Callbacks only read this map as a
+    /// detached `Shared` future; they never start work.
     aggregator_post_consensus:
         Mutex<HashMap<(CommitteeId, Slot), AggregatorPostConsensusShared<E>>>,
 }

--- a/anchor/validator_store/src/lib.rs
+++ b/anchor/validator_store/src/lib.rs
@@ -1,3 +1,4 @@
+mod aggregator_post_consensus;
 mod instrumentation;
 pub mod metadata_service;
 mod metrics;
@@ -17,7 +18,7 @@ use database::{NetworkDatabase, NonUniqueIndex, UniqueIndex};
 use eth2::types::{BlockContents, BlockContentsTuple, FullBlockContents, PublishBlockRequest};
 use fork::{Fork, ForkSchedule};
 use futures::{
-    Stream,
+    Stream, StreamExt,
     future::{Either, join_all},
     stream,
     stream::FuturesUnordered,
@@ -46,7 +47,7 @@ use ssv_types::{
     consensus::{
         AggregatorCommitteeConsensusData, AggregatorCommitteeDataValidator, BEACON_ROLE_AGGREGATOR,
         BEACON_ROLE_PROPOSER, BEACON_ROLE_SYNC_COMMITTEE_CONTRIBUTION, BeaconVote,
-        BeaconVoteValidator, Contribution, ContributionWrapper, Contributions, DataVersion,
+        BeaconVoteValidator, Contribution, ContributionWrapper, Contributions,
         ProposerConsensusData, ProposerConsensusDataValidator, QbftData, SelectionProofBatchId,
         ValidatorDuty,
     },
@@ -65,13 +66,12 @@ use tokio::{
 use tracing::{Instrument, Span, debug, error, field, info, info_span, trace, warn};
 use types::{
     AbstractExecPayload, Address, AggregateAndProof, AggregateAndProofBase,
-    AggregateAndProofElectra, Attestation, AttestationBase, AttestationElectra, BeaconBlock,
-    BeaconBlockRef, BlindedPayload, ChainSpec, ContributionAndProof, Domain, Epoch, EthSpec,
-    ExecutionPayloadEnvelope, ForkName, FullPayload, Graffiti, Hash256, PayloadAttestationData,
-    PayloadAttestationMessage, ProposerPreferences, SelectionProof, SignedAggregateAndProof,
-    SignedBeaconBlock, SignedBlindedBeaconBlock, SignedContributionAndProof,
-    SignedExecutionPayloadEnvelope, SignedProposerPreferences, SignedRoot,
-    SignedValidatorRegistrationData, SignedVoluntaryExit, Slot, SlotData,
+    AggregateAndProofElectra, Attestation, BeaconBlock, BeaconBlockRef, BlindedPayload, ChainSpec,
+    ContributionAndProof, Domain, Epoch, EthSpec, ExecutionPayloadEnvelope, ForkName, FullPayload,
+    Graffiti, Hash256, PayloadAttestationData, PayloadAttestationMessage, ProposerPreferences,
+    SelectionProof, SignedAggregateAndProof, SignedBeaconBlock, SignedBlindedBeaconBlock,
+    SignedContributionAndProof, SignedExecutionPayloadEnvelope, SignedProposerPreferences,
+    SignedRoot, SignedValidatorRegistrationData, SignedVoluntaryExit, Slot, SlotData,
     SyncAggregatorSelectionData, SyncCommitteeContribution, SyncCommitteeMessage,
     SyncSelectionProof, SyncSubnetId, ValidatorRegistrationData, VoluntaryExit,
 };
@@ -81,6 +81,8 @@ use validator_store::{
     Error as ValidatorStoreError, ProposalData, SignedBlock, SyncMessageToSign, UnsignedBlock,
     ValidatorStore,
 };
+
+use crate::aggregator_post_consensus::AggregatorPostConsensusShared;
 
 /// Number of epochs of slashing protection history to keep.
 ///
@@ -102,6 +104,7 @@ const SYNC_COMMITTEE_CONTRIBUTION_LOG_NAME: &str = "sync committee contribution"
 ///
 /// The shared fields (`validator`, `signing_root`) drive `collect_prepared_signatures`,
 /// while `duty_data` carries duty-specific context needed by the assembly step.
+#[derive(Clone)]
 struct SigningRequest<T> {
     validator: ValidatorMetadata,
     signing_root: Hash256,
@@ -109,21 +112,68 @@ struct SigningRequest<T> {
 }
 
 impl<T> SigningRequest<T> {
-    /// Look up this validator's collected signature, consuming the request.
+    /// Look up this request's collected signature, consuming the request.
     ///
     /// Returns `Ok((duty_data, signature))` on success, or `Err(pubkey)` if
     /// the validator index is missing or no signature was collected.
-    fn resolve(
-        self,
-        signatures: &HashMap<ValidatorIndex, Signature>,
-    ) -> Result<(T, Signature), PublicKeyBytes> {
+    ///
+    /// Keyed by `(index, root)` rather than index alone because one validator can hold several
+    /// distinct roots in a single batch (an `AggregatorCommittee` duty allows one aggregate plus
+    /// one contribution per subcommittee).
+    fn resolve(self, signatures: &CollectedSignatures) -> Result<(T, Signature), PublicKeyBytes> {
         let sig = self
             .validator
             .index
-            .and_then(|idx| signatures.get(&idx).cloned())
+            .and_then(|idx| signatures.get(&(idx, self.signing_root)).cloned())
             .ok_or(self.validator.public_key)?;
         Ok((self.duty_data, sig))
     }
+}
+
+/// Signatures collected for one committee batch, keyed by the request that produced each.
+type CollectedSignatures = HashMap<(ValidatorIndex, Hash256), Signature>;
+
+/// Drive signature collection to completion, keeping each result as it resolves.
+///
+/// Results are taken one at a time rather than as a group so that a root which never reaches
+/// quorum withholds only itself. `deadline`, when set, bounds the wait and leaves the roots still
+/// outstanding out of the returned map; callers surface those through `SigningRequest::resolve`
+/// failing for the affected request.
+async fn drain_signatures<F, E>(
+    mut pending: FuturesUnordered<F>,
+    deadline: Option<Instant>,
+) -> CollectedSignatures
+where
+    F: Future<Output = (ValidatorIndex, Hash256, Result<Signature, E>)>,
+    E: Debug,
+{
+    let mut signatures = HashMap::with_capacity(pending.len());
+    let collect = async {
+        while let Some((index, signing_root, result)) = pending.next().await {
+            match result {
+                Ok(signature) => {
+                    signatures.insert((index, signing_root), signature);
+                }
+                Err(e) => {
+                    error!(?index, ?signing_root, error = ?e, "Failed to collect signature");
+                }
+            }
+        }
+    };
+
+    match deadline {
+        Some(deadline) => {
+            if tokio::time::timeout_at(deadline, collect).await.is_err() {
+                warn!(
+                    unresolved = pending.len(),
+                    "Deadline passed before every signature resolved"
+                );
+            }
+        }
+        None => collect.await,
+    }
+
+    signatures
 }
 
 /// Handle committee signing errors with consistent timeout/failure metrics.
@@ -193,6 +243,15 @@ pub struct AnchorValidatorStore<
     strict_mfp: bool,
     is_synced: watch::Receiver<bool>,
     task_executor: TaskExecutor,
+    /// Once-only post-consensus signing executions for `AggregatorCommittee` duties (Boole+).
+    ///
+    /// One entry per `(committee, slot)`. The first Lighthouse callback (aggregate or
+    /// contribution class) spawns the execution as a detached task; concurrent and later
+    /// callbacks of either class join the same `Shared` future, so the complete decided
+    /// worklist is signed and batched exactly once no matter which callbacks fire, in what
+    /// order, or whether their futures are dropped.
+    aggregator_post_consensus:
+        Mutex<HashMap<(CommitteeId, Slot), AggregatorPostConsensusShared<E>>>,
 }
 
 /// How far into `slot` the clock currently is, or `None` if the clock cannot answer.
@@ -352,6 +411,7 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> AnchorValidator
             strict_mfp,
             is_synced,
             task_executor,
+            aggregator_post_consensus: Mutex::new(HashMap::new()),
         })
     }
 
@@ -461,13 +521,13 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> AnchorValidator
         validator_partial_signature_batch_size: usize,
         data_hash: Hash256,
         prepared: &[SigningRequest<D>],
-    ) -> Result<HashMap<ValidatorIndex, Signature>, Error> {
+    ) -> Result<CollectedSignatures, Error> {
         let collection_mode = CollectionMode::Committee {
             validator_partial_signature_batch_size,
             base_hash: data_hash,
         };
 
-        let futures: Vec<_> = prepared
+        let pending: FuturesUnordered<_> = prepared
             .iter()
             .filter_map(|item| {
                 let index = item.validator.index?;
@@ -484,45 +544,27 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> AnchorValidator
                             slot,
                         )
                         .await;
-                    (index, result)
+                    (index, item.signing_root, result)
                 })
             })
             .collect();
 
-        let results = join_all(futures).await;
-
-        let mut signatures = HashMap::with_capacity(results.len());
-        for (index, result) in results {
-            match result {
-                Ok(sig) => {
-                    signatures.insert(index, sig);
-                }
-                Err(e) => {
-                    error!(?index, error = ?e, "Failed to collect signature for validator");
-                }
-            }
-        }
-
-        Ok(signatures)
+        Ok(drain_signatures(pending, None).await)
     }
 
     /// Run `AggregatorCommittee` QBFT consensus for a committee at 2/3 slot.
     ///
-    /// Shared by `sign_committee_aggregate_and_proofs` and
-    /// `sign_committee_sync_committee_contributions`.
-    async fn run_aggregator_committee_consensus(
+    /// Called once per `(committee, slot)` by the post-consensus execution in
+    /// [`crate::aggregator_post_consensus`], which supplies the value this operator proposes.
+    pub(crate) async fn run_aggregator_committee_consensus(
         &self,
         committee_id: CommitteeId,
         slot: Slot,
         cluster: &Cluster,
-        metric_label: &str,
+        our_consensus_data: &AggregatorCommitteeConsensusData<E>,
     ) -> Result<AggregatorCommitteeConsensusData<E>, Error> {
-        let aggregation_assignments = self.get_aggregation_assignments(slot).await?;
-        let our_consensus_data = aggregation_assignments
-            .get_consensus_data(&committee_id)
-            .ok_or(Error::SpecificError(SpecificError::ConsensusDataNotFound))?;
-
-        let timer = metrics::start_timer_vec(&metrics::CONSENSUS_TIMES, &[metric_label]);
+        let timer =
+            metrics::start_timer_vec(&metrics::CONSENSUS_TIMES, &[metrics::AGGREGATOR_COMMITTEE]);
         let timeout_mode = TimeoutMode::SlotTime {
             instance_start_time: self
                 .get_instant_in_slot(slot, self.spec.get_slot_duration() * 2 / 3)?,
@@ -535,7 +577,7 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> AnchorValidator
                     committee: committee_id,
                     instance_height: slot.as_usize().into(),
                 },
-                (*our_consensus_data).clone(),
+                our_consensus_data.clone(),
                 Box::new(AggregatorCommitteeDataValidator::new()),
                 timeout_mode,
                 &cluster.cluster_members,
@@ -914,8 +956,8 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> AnchorValidator
     /// Get aggregator voting assignments, waiting if not yet available for this slot.
     ///
     /// This method waits until `AggregationAssignments` for the requested slot becomes available.
-    /// Called by `sign_committee_aggregate_and_proofs` and
-    /// `produce_signed_contribution_and_proof_boole` at 2/3 slot.
+    /// Called by `run_aggregator_post_consensus` (via `run_aggregator_committee_consensus`)
+    /// at 2/3 slot.
     ///
     /// Returns an error if the requested slot has already passed or if the watch channel is closed.
     pub async fn get_aggregation_assignments(
@@ -949,7 +991,12 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> AnchorValidator
     /// This publishes the `AggregationAssignments` to all subscribers via the watch channel.
     /// At 2/3 slot, selection proofs have been computed by Lighthouse, so
     /// `DutyAndProof.selection_proof.is_some()` accurately indicates `is_aggregator`.
-    pub fn update_aggregation_assignments(&self, info: AggregationAssignments<E>) {
+    ///
+    /// It also starts each Boole+ committee's post-consensus signing execution, before publishing,
+    /// so that every consumer able to observe these assignments can also observe the execution they
+    /// belong to. See [`crate::aggregator_post_consensus`].
+    pub fn update_aggregation_assignments(self: &Arc<Self>, info: AggregationAssignments<E>) {
+        self.start_aggregator_post_consensus(&info);
         self.aggregation_assignments_tx
             .send_replace(Some(Arc::new(info)));
     }
@@ -1363,16 +1410,15 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> AnchorValidator
         .await
     }
 
-    /// Boole+ committee-based contribution signing: single QBFT consensus per committee,
-    /// batch signature collection for all contributors.
+    /// Boole+ committee-based contribution signing: join the per-`(committee, slot)`
+    /// post-consensus execution and return the requested contributions from its outcome.
     ///
-    /// Cannot use `collect_prepared_signatures` because a validator in multiple subcommittees
-    /// needs multiple signatures with different signing roots, but that helper deduplicates
-    /// by `ValidatorIndex`. Uses `collect_signature` directly instead.
+    /// The execution signs the complete decided worklist (both object classes) regardless of
+    /// which Lighthouse callbacks fire; this callback only filters. See
+    /// [`crate::aggregator_post_consensus`].
     async fn sign_committee_sync_committee_contributions(
         &self,
         committee_id: CommitteeId,
-        cluster: Cluster,
         contributions: Vec<(ValidatorMetadata, ContributionToSign<E>)>,
     ) -> Result<Vec<SignedContributionAndProof<E>>, Error> {
         let Some((_, first)) = contributions.first() else {
@@ -1380,31 +1426,49 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> AnchorValidator
             return Ok(vec![]);
         };
         let slot = first.contribution.slot;
-        let epoch = slot.epoch(E::slots_per_epoch());
 
-        let decided_data = self
-            .run_aggregator_committee_consensus(
-                committee_id,
-                slot,
-                &cluster,
-                metrics::SYNC_CONTRIBUTION_AND_PROOF,
-            )
-            .await?;
+        let (deadline, outcome) = self.post_consensus_outcome(committee_id, slot).await?;
 
-        let domain_hash = self.get_domain(epoch, Domain::ContributionAndProof);
-
-        // Prepare all validators: find each in decided data, build ContributionAndProof
-        // (metadata already resolved by `group_by_committee`)
-        let mut prepared: Vec<SigningRequest<ContributionAndProof<E>>> =
-            Vec::with_capacity(contributions.len());
-
+        // Select this callback's own identities out of the shared outcome. The execution signs the
+        // whole decided value, so anything missing here is an entry the cluster did not decide on.
+        let mut prepared = Vec::with_capacity(contributions.len());
+        let pending = FuturesUnordered::new();
         for (validator, contrib) in &contributions {
-            let validator_index = match validator.index {
-                Some(idx) => idx,
-                None => {
-                    debug!(
-                        pubkey = ?contrib.aggregator_pubkey,
-                        "Validator missing index, skipping contribution"
+            let root = validator.index.and_then(|index| {
+                outcome
+                    .contributions
+                    .get(&(index, contrib.contribution.subcommittee_index))
+                    .map(|root| (index, root))
+            });
+            let Some((index, root)) = root else {
+                debug!(
+                    pubkey = ?contrib.aggregator_pubkey,
+                    subcommittee_index = contrib.contribution.subcommittee_index,
+                    "Requested contribution not in the decided worklist, skipping due to \
+                     divergent operator views"
+                );
+                validator_metrics::inc_counter_vec(
+                    &validator_metrics::SIGNED_SYNC_COMMITTEE_CONTRIBUTIONS_TOTAL,
+                    &[metrics::OTHER_ERROR],
+                );
+                continue;
+            };
+            let signing_root = root.request.signing_root;
+            let signature = root.signature.clone();
+            pending.push(async move { (index, signing_root, signature.await) });
+            prepared.push(root.request.clone());
+        }
+
+        let signatures = drain_signatures(pending, Some(deadline)).await;
+
+        let mut results = Vec::with_capacity(prepared.len());
+        for request in prepared {
+            let (message, signature) = match request.resolve(&signatures) {
+                Ok(resolved) => resolved,
+                Err(pubkey) => {
+                    warn!(
+                        ?pubkey,
+                        "Missing signature, skipping sync committee contribution"
                     );
                     validator_metrics::inc_counter_vec(
                         &validator_metrics::SIGNED_SYNC_COMMITTEE_CONTRIBUTIONS_TOTAL,
@@ -1414,118 +1478,19 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> AnchorValidator
                 }
             };
 
-            let subcommittee_index = contrib.contribution.subcommittee_index;
-
-            // Find this validator+subcommittee in the decided data
-            let Some(decided_contributor) = decided_data.contributors.iter().find(|c| {
-                c.validator_index == validator_index && c.committee_index == subcommittee_index
-            }) else {
-                debug!(
-                    ?validator_index,
-                    subcommittee_index,
-                    "Validator not in decided data, skipping due to divergent operator views"
-                );
-                validator_metrics::inc_counter_vec(
-                    &validator_metrics::SIGNED_SYNC_COMMITTEE_CONTRIBUTIONS_TOTAL,
-                    &[metrics::OTHER_ERROR],
-                );
-                continue;
-            };
-
-            // Find the contribution for this subcommittee
-            let Some(decided_contribution) = decided_data
-                .sync_committee_contributions
-                .iter()
-                .find(|c| c.subcommittee_index == subcommittee_index)
-            else {
-                debug!(
-                    subcommittee_index,
-                    pubkey = ?contrib.aggregator_pubkey,
-                    "Contribution not in consensus data - likely filtered due to beacon API failure"
-                );
-                validator_metrics::inc_counter_vec(
-                    &validator_metrics::SIGNED_SYNC_COMMITTEE_CONTRIBUTIONS_TOTAL,
-                    &[metrics::OTHER_ERROR],
-                );
-                continue;
-            };
-
-            let message = ContributionAndProof {
-                aggregator_index: contrib.aggregator_index,
-                contribution: decided_contribution.clone(),
-                selection_proof: decided_contributor.selection_proof.clone(),
-            };
-
-            let signing_root = message.signing_root(domain_hash);
-            prepared.push(SigningRequest {
-                validator: validator.clone(),
-                signing_root,
-                duty_data: message,
-            });
-        }
-
-        // Collect signatures — using `collect_signature` directly because a validator in
-        // multiple subcommittees produces multiple `SigningRequest`s with different signing
-        // roots, which `collect_prepared_signatures` cannot handle (it deduplicates by
-        // `ValidatorIndex`).
-        let committee_validator_indices = self.get_committee_validator_indices(&committee_id);
-        let validator_partial_signature_batch_size = decided_data
-            .post_consensus_signature_count(|idx| committee_validator_indices.contains(idx));
-        let data_hash = decided_data.hash();
-        let collection_mode = CollectionMode::Committee {
-            validator_partial_signature_batch_size,
-            base_hash: data_hash,
-        };
-
-        let sig_futures: Vec<_> = prepared
-            .iter()
-            .map(|req| {
-                self.collect_signature(
-                    PartialSignatureKind::PostConsensus,
-                    Role::AggregatorCommittee,
-                    collection_mode.clone(),
-                    &req.validator,
-                    &cluster,
-                    req.signing_root,
-                    slot,
-                )
-            })
-            .collect();
-
-        let signature_results = join_all(sig_futures).await;
-
-        // Assemble results
-        let mut results = Vec::with_capacity(prepared.len());
-        for (req, sig_result) in prepared.into_iter().zip(signature_results) {
-            match sig_result {
-                Ok(signature) => {
-                    let message = req.duty_data;
-                    debug!(
-                        aggregator_index = ?message.aggregator_index,
-                        slot = %message.contribution.slot,
-                        block_root = ?message.contribution.beacon_block_root,
-                        subcommittee_index = message.contribution.subcommittee_index,
-                        num_set_aggregation_bits = message.contribution.aggregation_bits.num_set_bits(),
-                        "Signed ContributionAndProof (Boole+ committee consensus)"
-                    );
-                    validator_metrics::inc_counter_vec(
-                        &validator_metrics::SIGNED_SYNC_COMMITTEE_CONTRIBUTIONS_TOTAL,
-                        &[validator_metrics::SUCCESS],
-                    );
-                    results.push(SignedContributionAndProof { message, signature });
-                }
-                Err(e) => {
-                    error!(
-                        pubkey = ?req.validator.public_key,
-                        error = ?e,
-                        "Failed to collect signature for sync contribution"
-                    );
-                    validator_metrics::inc_counter_vec(
-                        &validator_metrics::SIGNED_SYNC_COMMITTEE_CONTRIBUTIONS_TOTAL,
-                        &[metrics::OTHER_ERROR],
-                    );
-                }
-            }
+            debug!(
+                aggregator_index = ?message.aggregator_index,
+                slot = %message.contribution.slot,
+                block_root = ?message.contribution.beacon_block_root,
+                subcommittee_index = message.contribution.subcommittee_index,
+                num_set_aggregation_bits = message.contribution.aggregation_bits.num_set_bits(),
+                "Signed ContributionAndProof (Boole+ committee consensus)"
+            );
+            validator_metrics::inc_counter_vec(
+                &validator_metrics::SIGNED_SYNC_COMMITTEE_CONTRIBUTIONS_TOTAL,
+                &[validator_metrics::SUCCESS],
+            );
+            results.push(SignedContributionAndProof { message, signature });
         }
 
         Ok(results)
@@ -1764,73 +1729,15 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> AnchorValidator
         Ok(results)
     }
 
-    /// Resolve a single validator's aggregate from decided consensus data.
+    /// Boole+ committee-based aggregate signing: join the per-`(committee, slot)`
+    /// post-consensus execution and return the requested aggregates from its outcome.
     ///
-    /// Looks up the aggregator in decided data, finds the matching committee index,
-    /// decodes the aggregate attestation from SSZ, and builds an `AggregateAndProof`.
-    fn resolve_decided_aggregate(
-        decided_data: &AggregatorCommitteeConsensusData<E>,
-        validator: ValidatorMetadata,
-        agg: &AggregateToSign<E>,
-        domain_hash: Hash256,
-    ) -> Result<SigningRequest<(u64, AggregateAndProof<E>)>, String> {
-        let validator_index = validator.index.ok_or("Validator missing index")?;
-
-        // Find this validator in the decided data
-        let decided_aggregator = decided_data
-            .aggregators
-            .iter()
-            .find(|a| a.validator_index == validator_index)
-            .ok_or("Validator not in decided data")?;
-
-        let committee_index = decided_aggregator.committee_index;
-
-        // Find the position of this committee index in decided data
-        let decided_aggregate_idx = decided_data
-            .aggregator_committee_indexes
-            .iter()
-            .position(|&idx| idx == committee_index)
-            .ok_or("Committee index not found in decided data")?;
-
-        let decided_aggregate_bytes = decided_data
-            .aggregated_attestations
-            .get(decided_aggregate_idx)
-            .ok_or("Aggregate attestation bytes not found in decided data")?;
-
-        // Decode based on fork version
-        let decided_aggregate = if decided_data.version < DataVersion::from(ForkName::Electra) {
-            AttestationBase::from_ssz_bytes(decided_aggregate_bytes)
-                .map(Attestation::Base)
-                .map_err(|e| format!("Failed to decode decided aggregate: {e:?}"))?
-        } else {
-            AttestationElectra::from_ssz_bytes(decided_aggregate_bytes)
-                .map(Attestation::Electra)
-                .map_err(|e| format!("Failed to decode decided aggregate: {e:?}"))?
-        };
-
-        let decided_selection_proof =
-            SelectionProof::from(decided_aggregator.selection_proof.clone());
-
-        let message = AggregateAndProof::from_attestation(
-            agg.aggregator_index,
-            decided_aggregate,
-            decided_selection_proof,
-        );
-
-        let signing_root = message.signing_root(domain_hash);
-        Ok(SigningRequest {
-            validator,
-            signing_root,
-            duty_data: (agg.aggregator_index, message),
-        })
-    }
-
-    /// Boole+ committee-based aggregate signing: single QBFT consensus per committee,
-    /// batch signature collection for all aggregators.
+    /// The execution signs the complete decided worklist (both object classes) regardless of
+    /// which Lighthouse callbacks fire; this callback only filters. See
+    /// [`crate::aggregator_post_consensus`].
     async fn sign_committee_aggregate_and_proofs(
         &self,
         committee_id: CommitteeId,
-        cluster: Cluster,
         aggregates: Vec<(ValidatorMetadata, AggregateToSign<E>)>,
     ) -> Result<Vec<SignedAggregateAndProof<E>>, Error> {
         let Some((_, first)) = aggregates.first() else {
@@ -1838,62 +1745,43 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> AnchorValidator
             return Ok(vec![]);
         };
         let slot = first.aggregate.data().slot;
-        let signing_epoch = first.aggregate.data().target.epoch;
 
-        let decided_data = self
-            .run_aggregator_committee_consensus(
-                committee_id,
-                slot,
-                &cluster,
-                metrics::AGGREGATE_AND_PROOF,
-            )
-            .await?;
+        let (deadline, outcome) = self.post_consensus_outcome(committee_id, slot).await?;
 
-        let domain_hash = self.get_domain(signing_epoch, Domain::AggregateAndProof);
-
-        // Prepare all validators: find each in decided data, decode aggregate, build message
-        // (metadata already resolved by `group_by_committee`)
-        let mut prepared: Vec<SigningRequest<(u64, AggregateAndProof<E>)>> =
-            Vec::with_capacity(aggregates.len());
-
-        for (validator, agg) in aggregates {
-            match Self::resolve_decided_aggregate(&decided_data, validator, &agg, domain_hash) {
-                Ok(request) => prepared.push(request),
-                Err(e) => {
-                    debug!(pubkey = ?agg.pubkey, error = e, "Skipping aggregate");
-                    validator_metrics::inc_counter_vec(
-                        &validator_metrics::SIGNED_AGGREGATES_TOTAL,
-                        &[metrics::OTHER_ERROR],
-                    );
-                }
-            }
+        // Select this callback's own identities out of the shared outcome. The execution signs the
+        // whole decided value, so anything missing here is an entry the cluster did not decide on.
+        let mut prepared = Vec::with_capacity(aggregates.len());
+        let pending = FuturesUnordered::new();
+        for (validator, agg) in &aggregates {
+            let root = validator
+                .index
+                .and_then(|index| outcome.aggregates.get(&index).map(|root| (index, root)));
+            let Some((index, root)) = root else {
+                debug!(
+                    pubkey = ?agg.pubkey,
+                    "Requested aggregate not in the decided worklist, skipping due to divergent \
+                     operator views"
+                );
+                validator_metrics::inc_counter_vec(
+                    &validator_metrics::SIGNED_AGGREGATES_TOTAL,
+                    &[metrics::OTHER_ERROR],
+                );
+                continue;
+            };
+            let signing_root = root.request.signing_root;
+            let signature = root.signature.clone();
+            pending.push(async move { (index, signing_root, signature.await) });
+            prepared.push(root.request.clone());
         }
 
-        // Collect signatures and assemble results
-        let committee_validator_indices = self.get_committee_validator_indices(&committee_id);
-        let validator_partial_signature_batch_size = decided_data
-            .post_consensus_signature_count(|idx| committee_validator_indices.contains(idx));
-
-        let signatures = self
-            .collect_prepared_signatures(
-                Role::AggregatorCommittee,
-                slot,
-                &cluster,
-                validator_partial_signature_batch_size,
-                decided_data.hash(),
-                &prepared,
-            )
-            .await?;
+        let signatures = drain_signatures(pending, Some(deadline)).await;
 
         let mut results = Vec::with_capacity(prepared.len());
-        for req in prepared {
-            let ((aggregator_index, message), signature) = match req.resolve(&signatures) {
+        for request in prepared {
+            let (message, signature) = match request.resolve(&signatures) {
                 Ok(resolved) => resolved,
                 Err(pubkey) => {
-                    warn!(
-                        ?pubkey,
-                        "Missing validator index or signature for aggregator, skipping"
-                    );
+                    warn!(?pubkey, "Missing signature, skipping aggregate");
                     validator_metrics::inc_counter_vec(
                         &validator_metrics::SIGNED_AGGREGATES_TOTAL,
                         &[metrics::OTHER_ERROR],
@@ -1903,7 +1791,7 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> AnchorValidator
             };
 
             debug!(
-                ?aggregator_index,
+                aggregator_index = message.aggregator_index(),
                 data = ?message.aggregate().data(),
                 num_set_aggregation_bits = message.aggregate().num_set_aggregation_bits(),
                 "Signed AggregateAndProof (Boole+ committee consensus)"
@@ -2351,6 +2239,9 @@ pub enum SpecificError {
     ContributionNotInConsensus(u64),
     /// This validator not found in consensus data (Boole+)
     ValidatorNotInConsensus(ValidatorIndex),
+    /// The detached `AggregatorCommittee` post-consensus execution died before producing a
+    /// result (executor shutdown, spawn refusal, or task panic)
+    PostConsensusAborted,
 }
 
 impl From<CollectionError> for SpecificError {
@@ -2822,18 +2713,14 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> ValidatorStore
 
             let committee_futures: FuturesUnordered<_> = committee_mapping
                 .into_iter()
-                .map(|(committee_id, (cluster, aggregates))| {
+                .map(|(committee_id, (_cluster, aggregates))| {
                     let this = Arc::clone(self);
                     async move {
                         run_committee_signing(
                             committee_id,
                             aggregates.len(),
                             &validator_metrics::SIGNED_AGGREGATES_TOTAL,
-                            this.sign_committee_aggregate_and_proofs(
-                                committee_id,
-                                cluster,
-                                aggregates,
-                            ),
+                            this.sign_committee_aggregate_and_proofs(committee_id, aggregates),
                         )
                         .await
                     }
@@ -3146,7 +3033,7 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> ValidatorStore
 
             let committee_futures: FuturesUnordered<_> = committee_mapping
                 .into_iter()
-                .map(|(committee_id, (cluster, contributions))| {
+                .map(|(committee_id, (_cluster, contributions))| {
                     let this = Arc::clone(self);
                     async move {
                         run_committee_signing(
@@ -3155,7 +3042,6 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> ValidatorStore
                             &validator_metrics::SIGNED_SYNC_COMMITTEE_CONTRIBUTIONS_TOTAL,
                             this.sign_committee_sync_committee_contributions(
                                 committee_id,
-                                cluster,
                                 contributions,
                             ),
                         )

--- a/anchor/validator_store/src/metrics.rs
+++ b/anchor/validator_store/src/metrics.rs
@@ -3,6 +3,7 @@ use std::sync::LazyLock;
 pub use metrics::*;
 
 pub const AGGREGATE_AND_PROOF: &str = "aggregate_and_proof";
+pub const AGGREGATOR_COMMITTEE: &str = "aggregator_committee";
 pub const BLOCK: &str = "block";
 pub const BEACON_VOTE: &str = "beacon_vote";
 pub const SYNC_CONTRIBUTION_AND_PROOF: &str = "sync_contribution_and_proof";

--- a/anchor/validator_store/src/testing/aggregator_post_consensus.rs
+++ b/anchor/validator_store/src/testing/aggregator_post_consensus.rs
@@ -1,0 +1,898 @@
+//! Integration tests for the Boole+ `AggregatorCommittee` post-consensus execution.
+//!
+//! One QBFT decision carries both attestation aggregates and sync contributions. The
+//! per-`(committee, slot)` execution signs the complete decided worklist regardless of which
+//! Lighthouse callbacks fire; the callbacks only filter the shared outcome down to their own
+//! requested items. These tests pin the regression from issue #1227: a callback of one class
+//! must still produce the partial signatures for the other class, so the shared committee
+//! batch never stalls below its expected size.
+//!
+//! The worklist tasks are detached, so captured `sign_and_collect` calls arrive
+//! asynchronously; assertions on capture counts poll with a deadline and then let the
+//! captures settle before asserting exact counts.
+
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+    time::Duration,
+};
+
+use bls::{AggregateSignature, FixedBytesExtended, PublicKeyBytes, Signature};
+use futures::StreamExt;
+use signature_collector::SignatureRequester;
+use ssv_types::{
+    CommitteeId, OperatorId, ValidatorIndex, ValidatorMetadata,
+    consensus::{AggregatorCommitteeConsensusData, AssignedAggregator, DataVersion, QbftData},
+    msgid::Role,
+    partial_sig::PartialSignatureKind,
+};
+use ssz::Encode;
+use ssz_types::VariableList;
+use types::{
+    AttestationBase, AttestationData, Checkpoint, Epoch, ForkName, Hash256, MainnetEthSpec,
+    SignedAggregateAndProof, SignedContributionAndProof, Slot, SyncCommitteeContribution,
+    SyncSelectionProof,
+};
+use validator_store::{ContributionToSign, ValidatorStore};
+
+use super::common::*;
+use crate::{AggregationAssignments, Error};
+
+type SignAggregatesResult = Vec<Result<Vec<SignedAggregateAndProof<MainnetEthSpec>>, Error>>;
+type SignContributionsResult = Vec<Result<Vec<SignedContributionAndProof<MainnetEthSpec>>, Error>>;
+
+const COMMITTEE_OPERATOR_IDS: [OperatorId; 4] =
+    [OperatorId(1), OperatorId(2), OperatorId(3), OperatorId(4)];
+const OUR_OPERATOR_ID: OperatorId = OperatorId(1);
+
+const COMMITTEE_INDEX: usize = 0;
+const STARTING_VALIDATOR_INDEX: usize = 0;
+const AGGREGATE_VALIDATOR_IDX: usize = 0;
+const CONTRIBUTOR_VALIDATOR_IDX: usize = 1;
+const MIXED_COMMITTEE_VALIDATOR_COUNT: usize = 2;
+const SINGLE_VALIDATOR_COUNT: usize = 1;
+/// Position of the only validator in single-validator fixtures.
+const SOLE_VALIDATOR_IDX: usize = 0;
+
+const BEACON_COMMITTEE_INDEX: u64 = 0;
+const CONFLICTING_BEACON_COMMITTEE_INDEX: u64 = 1;
+const CONTRIBUTION_SUBCOMMITTEES: [u64; 2] = [0, 1];
+const ALL_SUBCOMMITTEES: [u64; 4] = [0, 1, 2, 3];
+const MISSING_SUBCOMMITTEE_INDEX: u64 = 2;
+
+/// Decided validator indices with no local metadata, so the worklist filters them out.
+const FOREIGN_AGGREGATOR_INDEX: usize = 900;
+const FOREIGN_CONTRIBUTOR_INDEX: usize = 901;
+
+/// One aggregate root plus one contribution root per subcommittee in the standard mixed
+/// decided value.
+const MIXED_WORKLIST_SIZE: usize = 1 + CONTRIBUTION_SUBCOMMITTEES.len();
+
+const CAPTURE_TIMEOUT: Duration = Duration::from_secs(2);
+const CAPTURE_POLL_INTERVAL: Duration = Duration::from_millis(10);
+/// Extra wait after the expected capture count is reached, to catch spurious extra captures.
+const SETTLE_DELAY: Duration = Duration::from_millis(200);
+const STREAM_TIMEOUT: Duration = Duration::from_secs(5);
+
+// ==================== Fixture ====================
+
+/// One committee plus the identifiers needed to seed decided values for it.
+///
+/// The harness owns its `CommitteeSetup`s privately, so the committee ID and validator
+/// metadata are captured before handing the setup over.
+struct AggregatorCommitteeFixture {
+    harness: ValidatorStoreTestHarness,
+    committee_id: CommitteeId,
+}
+
+impl AggregatorCommitteeFixture {
+    fn new(validator_count: usize) -> Self {
+        let setup = create_committee_setup(
+            &COMMITTEE_OPERATOR_IDS,
+            validator_count,
+            STARTING_VALIDATOR_INDEX,
+        );
+        let committee_id = setup.cluster.committee_id();
+        let harness = ValidatorStoreTestHarness::new(vec![setup], OUR_OPERATOR_ID);
+        Self {
+            harness,
+            committee_id,
+        }
+    }
+
+    fn validator_metadata(&self, position: usize) -> ValidatorMetadata {
+        self.harness.validator_metadata(COMMITTEE_INDEX, position)
+    }
+
+    fn validator_index(&self, position: usize) -> ValidatorIndex {
+        self.validator_metadata(position)
+            .index
+            .expect("test validator should have an index")
+    }
+
+    fn pubkey(&self, position: usize) -> PublicKeyBytes {
+        self.validator_metadata(position).public_key
+    }
+
+    /// Seeds `AggregationAssignments` at `TEST_SLOT` with the given consensus data for this
+    /// committee. The mock decider echoes the proposal, so this is also the decided value.
+    fn seed_decided_value(
+        &self,
+        data: AggregatorCommitteeConsensusData<MainnetEthSpec>,
+    ) -> Arc<AggregatorCommitteeConsensusData<MainnetEthSpec>> {
+        let data = Arc::new(data);
+        self.harness
+            .validator_store
+            .update_aggregation_assignments(AggregationAssignments {
+                slot: Slot::new(TEST_SLOT),
+                aggregator_committees: HashMap::new(),
+                multi_sync_aggregators: HashMap::new(),
+                consensus_data_by_ssv_committee: HashMap::from([(
+                    self.committee_id,
+                    Arc::clone(&data),
+                )]),
+            });
+        data
+    }
+
+    /// Seeds `AggregationAssignments` at `TEST_SLOT` without consensus data for any committee, so
+    /// no execution is registered and the callbacks fail with `ConsensusDataNotFound`.
+    fn seed_assignments_without_consensus_data(&self) {
+        self.harness
+            .validator_store
+            .update_aggregation_assignments(AggregationAssignments {
+                slot: Slot::new(TEST_SLOT),
+                aggregator_committees: HashMap::new(),
+                multi_sync_aggregators: HashMap::new(),
+                consensus_data_by_ssv_committee: HashMap::new(),
+            });
+    }
+
+    /// Seeds the standard mixed decided value: one aggregate for the aggregate validator plus
+    /// one contribution per subcommittee in [`CONTRIBUTION_SUBCOMMITTEES`] for the contributor.
+    fn seed_mixed_decided_value(&self) -> Arc<AggregatorCommitteeConsensusData<MainnetEthSpec>> {
+        let aggregator = self.validator_index(AGGREGATE_VALIDATOR_IDX);
+        let contributor = self.validator_index(CONTRIBUTOR_VALIDATOR_IDX);
+        self.seed_decided_value(build_decided_data(
+            &[(aggregator, BEACON_COMMITTEE_INDEX)],
+            &[
+                (contributor, CONTRIBUTION_SUBCOMMITTEES[0]),
+                (contributor, CONTRIBUTION_SUBCOMMITTEES[1]),
+            ],
+        ))
+    }
+
+    fn create_contribution(
+        &self,
+        position: usize,
+        subcommittee_index: u64,
+    ) -> ContributionToSign<MainnetEthSpec> {
+        let validator = self.validator_metadata(position);
+        ContributionToSign {
+            aggregator_index: *validator
+                .index
+                .expect("test validator should have an index") as u64,
+            aggregator_pubkey: validator.public_key,
+            contribution: test_contribution(subcommittee_index),
+            selection_proof: SyncSelectionProof::from(Signature::empty()),
+        }
+    }
+
+    async fn collect_contributions(
+        &self,
+        contributions: Vec<ContributionToSign<MainnetEthSpec>>,
+    ) -> SignContributionsResult {
+        let stream = self
+            .harness
+            .validator_store
+            .sign_sync_committee_contributions(contributions);
+        tokio::time::timeout(STREAM_TIMEOUT, stream.collect())
+            .await
+            .expect("contribution callback should complete within the stream timeout")
+    }
+
+    async fn collect_aggregates(
+        &self,
+        aggregates: Vec<validator_store::AggregateToSign<MainnetEthSpec>>,
+    ) -> SignAggregatesResult {
+        let stream = self
+            .harness
+            .validator_store
+            .sign_aggregate_and_proofs(aggregates);
+        tokio::time::timeout(STREAM_TIMEOUT, stream.collect())
+            .await
+            .expect("aggregate callback should complete within the stream timeout")
+    }
+}
+
+// ==================== Decided value construction ====================
+
+fn assigned(validator_index: ValidatorIndex, committee_index: u64) -> AssignedAggregator {
+    AssignedAggregator {
+        validator_index,
+        selection_proof: Signature::empty(),
+        committee_index,
+    }
+}
+
+/// An aggregate attestation payload at `TEST_SLOT`. Distinct `committee_index` values produce
+/// distinct signing roots.
+fn test_aggregate_attestation(committee_index: u64) -> AttestationBase<MainnetEthSpec> {
+    AttestationBase {
+        aggregation_bits: ssz_types::BitList::with_capacity(128).expect("bitlist should be valid"),
+        data: AttestationData {
+            slot: Slot::new(TEST_SLOT),
+            index: committee_index,
+            beacon_block_root: Hash256::zero(),
+            source: Checkpoint {
+                epoch: Epoch::new(0),
+                root: Hash256::zero(),
+            },
+            target: Checkpoint {
+                epoch: Epoch::new(0),
+                root: Hash256::zero(),
+            },
+        },
+        signature: AggregateSignature::infinity(),
+    }
+}
+
+/// A sync contribution at `TEST_SLOT`. Distinct `subcommittee_index` values produce distinct
+/// signing roots.
+fn test_contribution(subcommittee_index: u64) -> SyncCommitteeContribution<MainnetEthSpec> {
+    SyncCommitteeContribution {
+        slot: Slot::new(TEST_SLOT),
+        beacon_block_root: Hash256::zero(),
+        subcommittee_index,
+        aggregation_bits: Default::default(),
+        signature: AggregateSignature::infinity(),
+    }
+}
+
+/// Builds an `AggregatorCommitteeConsensusData` from decided entries.
+///
+/// `aggregators` and `contributors` are `(validator_index, committee_index)` pairs; the
+/// attestation and contribution payload lists are derived from them (one payload per unique
+/// index).
+fn build_decided_data(
+    aggregators: &[(ValidatorIndex, u64)],
+    contributors: &[(ValidatorIndex, u64)],
+) -> AggregatorCommitteeConsensusData<MainnetEthSpec> {
+    // One payload per unique committee/subcommittee index, in first-seen order.
+    let mut aggregate_committee_indexes: Vec<u64> = Vec::new();
+    for &(_, committee_index) in aggregators {
+        if !aggregate_committee_indexes.contains(&committee_index) {
+            aggregate_committee_indexes.push(committee_index);
+        }
+    }
+    let mut contribution_subcommittees: Vec<u64> = Vec::new();
+    for &(_, subcommittee_index) in contributors {
+        if !contribution_subcommittees.contains(&subcommittee_index) {
+            contribution_subcommittees.push(subcommittee_index);
+        }
+    }
+    let aggregators: Vec<_> = aggregators
+        .iter()
+        .map(|&(validator_index, committee_index)| assigned(validator_index, committee_index))
+        .collect();
+    let aggregated_attestations: Vec<_> = aggregate_committee_indexes
+        .iter()
+        .map(|&committee_index| {
+            VariableList::new(test_aggregate_attestation(committee_index).as_ssz_bytes())
+                .expect("attestation bytes should fit")
+        })
+        .collect();
+    let contributors: Vec<_> = contributors
+        .iter()
+        .map(|&(validator_index, subcommittee_index)| assigned(validator_index, subcommittee_index))
+        .collect();
+    let sync_committee_contributions: Vec<_> = contribution_subcommittees
+        .iter()
+        .map(|&subcommittee_index| test_contribution(subcommittee_index))
+        .collect();
+
+    AggregatorCommitteeConsensusData {
+        version: DataVersion::from(ForkName::Deneb),
+        aggregators: VariableList::new(aggregators).expect("aggregator list should be valid"),
+        aggregator_committee_indexes: VariableList::new(aggregate_committee_indexes)
+            .expect("committee indexes should be valid"),
+        aggregated_attestations: VariableList::new(aggregated_attestations)
+            .expect("aggregated attestations should be valid"),
+        contributors: VariableList::new(contributors).expect("contributor list should be valid"),
+        sync_committee_contributions: VariableList::new(sync_committee_contributions)
+            .expect("contributions should be valid"),
+    }
+}
+
+// ==================== Capture assertions ====================
+
+/// The committee-requester view of one captured `sign_and_collect` call.
+struct CapturedCommitteeCall {
+    pubkey: PublicKeyBytes,
+    signing_root: Hash256,
+    batch_size: usize,
+    base_hash: Hash256,
+}
+
+/// Snapshots the captured calls, asserting every call is an `AggregatorCommittee`
+/// post-consensus call with a `Committee` requester.
+fn committee_calls(harness: &ValidatorStoreTestHarness) -> Vec<CapturedCommitteeCall> {
+    harness
+        .captured_calls
+        .lock()
+        .iter()
+        .map(|call| {
+            assert_eq!(call.metadata.role, Role::AggregatorCommittee);
+            assert_eq!(call.metadata.kind, PartialSignatureKind::PostConsensus);
+            assert_eq!(call.metadata.slot, Slot::new(TEST_SLOT));
+            match &call.requester {
+                SignatureRequester::Committee {
+                    validator_partial_signature_batch_size,
+                    base_hash,
+                } => CapturedCommitteeCall {
+                    pubkey: call.validator_pubkey,
+                    signing_root: call.signing_root,
+                    batch_size: *validator_partial_signature_batch_size,
+                    base_hash: *base_hash,
+                },
+                other => panic!("expected SignatureRequester::Committee, got: {other:?}"),
+            }
+        })
+        .collect()
+}
+
+/// Asserts every call shares the expected local batch size and decided-value batch identity.
+fn assert_batch_identity(
+    calls: &[CapturedCommitteeCall],
+    expected_batch_size: usize,
+    expected_base_hash: Hash256,
+) {
+    for call in calls {
+        assert_eq!(
+            call.batch_size, expected_batch_size,
+            "every root should join the same local committee batch"
+        );
+        assert_eq!(
+            call.base_hash, expected_base_hash,
+            "every root should carry the decided-value hash as its batch identity"
+        );
+    }
+}
+
+fn distinct_roots(calls: &[CapturedCommitteeCall]) -> HashSet<Hash256> {
+    calls.iter().map(|call| call.signing_root).collect()
+}
+
+fn calls_for_pubkey(calls: &[CapturedCommitteeCall], pubkey: PublicKeyBytes) -> usize {
+    calls.iter().filter(|call| call.pubkey == pubkey).count()
+}
+
+/// Polls until at least `expected` calls were captured, panicking after [`CAPTURE_TIMEOUT`].
+///
+/// The worklist signing tasks are detached, so captures arrive asynchronously relative to the
+/// Lighthouse callback futures.
+async fn wait_for_captured_calls(harness: &ValidatorStoreTestHarness, expected: usize) {
+    let deadline = tokio::time::Instant::now() + CAPTURE_TIMEOUT;
+    loop {
+        let count = harness.captured_calls.lock().len();
+        if count >= expected {
+            return;
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "expected {expected} captured sign_and_collect calls within {CAPTURE_TIMEOUT:?}, \
+             got {count}"
+        );
+        tokio::time::sleep(CAPTURE_POLL_INTERVAL).await;
+    }
+}
+
+/// Waits for `expected` captures, then lets stragglers settle and asserts the count is exact.
+async fn assert_captured_calls_settle_at(harness: &ValidatorStoreTestHarness, expected: usize) {
+    wait_for_captured_calls(harness, expected).await;
+    tokio::time::sleep(SETTLE_DELAY).await;
+    let count = harness.captured_calls.lock().len();
+    assert_eq!(
+        count, expected,
+        "capture count should settle at exactly {expected}"
+    );
+}
+
+/// Unwraps a single-committee stream result into its signed batch.
+fn single_batch<T>(results: Vec<Result<Vec<T>, Error>>) -> Vec<T> {
+    assert_eq!(results.len(), 1, "expected one committee stream item");
+    results
+        .into_iter()
+        .next()
+        .expect("committee stream item should exist")
+        .expect("committee signing should succeed")
+}
+
+// ==================== Complete-worklist tests ====================
+
+/// A contribution-only Lighthouse callback must still trigger signing of the decided
+/// aggregate: the detached execution signs the complete mixed worklist, and every root joins
+/// one three-entry committee batch keyed by the decided-value hash.
+#[tokio::test(flavor = "multi_thread")]
+async fn contribution_only_callback_signs_complete_mixed_worklist() {
+    // Arrange
+    let fixture = AggregatorCommitteeFixture::new(MIXED_COMMITTEE_VALIDATOR_COUNT);
+    let decided = fixture.seed_mixed_decided_value();
+    let contributions = CONTRIBUTION_SUBCOMMITTEES
+        .iter()
+        .map(|&subcommittee| fixture.create_contribution(CONTRIBUTOR_VALIDATOR_IDX, subcommittee))
+        .collect();
+
+    // Act: only the contribution callback fires.
+    let results = fixture.collect_contributions(contributions).await;
+
+    // Assert: the callback returns exactly its own two contributions.
+    let mut signed = single_batch(results);
+    signed.sort_by_key(|item| item.message.contribution.subcommittee_index);
+    assert_eq!(
+        signed.len(),
+        CONTRIBUTION_SUBCOMMITTEES.len(),
+        "the contribution callback should return only its requested contributions"
+    );
+    for (item, &subcommittee) in signed.iter().zip(CONTRIBUTION_SUBCOMMITTEES.iter()) {
+        assert_eq!(item.message.contribution.subcommittee_index, subcommittee);
+        assert_eq!(
+            item.message.aggregator_index,
+            *fixture.validator_index(CONTRIBUTOR_VALIDATOR_IDX) as u64
+        );
+    }
+
+    // The aggregate root is signed by a detached task even though no aggregate callback fired.
+    assert_captured_calls_settle_at(&fixture.harness, MIXED_WORKLIST_SIZE).await;
+    let calls = committee_calls(&fixture.harness);
+    assert_eq!(
+        distinct_roots(&calls).len(),
+        MIXED_WORKLIST_SIZE,
+        "aggregate and per-subcommittee contribution roots must stay distinct"
+    );
+    assert_batch_identity(&calls, MIXED_WORKLIST_SIZE, decided.hash());
+    assert_eq!(
+        calls_for_pubkey(&calls, fixture.pubkey(AGGREGATE_VALIDATOR_IDX)),
+        1,
+        "the decided aggregate must be signed without an aggregate callback"
+    );
+    assert_eq!(
+        calls_for_pubkey(&calls, fixture.pubkey(CONTRIBUTOR_VALIDATOR_IDX)),
+        CONTRIBUTION_SUBCOMMITTEES.len(),
+        "the contributor must sign one root per subcommittee"
+    );
+}
+
+/// The mirror case: an aggregate-only callback must still trigger signing of both decided
+/// contributions.
+#[tokio::test(flavor = "multi_thread")]
+async fn aggregate_only_callback_signs_complete_mixed_worklist() {
+    // Arrange
+    let fixture = AggregatorCommitteeFixture::new(MIXED_COMMITTEE_VALIDATOR_COUNT);
+    let decided = fixture.seed_mixed_decided_value();
+    let aggregates = vec![
+        fixture
+            .harness
+            .create_aggregate(COMMITTEE_INDEX, AGGREGATE_VALIDATOR_IDX),
+    ];
+
+    // Act: only the aggregate callback fires.
+    let results = fixture.collect_aggregates(aggregates).await;
+
+    // Assert: the callback returns exactly its own aggregate.
+    let signed = single_batch(results);
+    assert_eq!(
+        signed.len(),
+        1,
+        "the aggregate callback should return only its requested aggregate"
+    );
+
+    // Both contribution roots are signed by detached tasks without a contribution callback.
+    assert_captured_calls_settle_at(&fixture.harness, MIXED_WORKLIST_SIZE).await;
+    let calls = committee_calls(&fixture.harness);
+    assert_eq!(distinct_roots(&calls).len(), MIXED_WORKLIST_SIZE);
+    assert_batch_identity(&calls, MIXED_WORKLIST_SIZE, decided.hash());
+    assert_eq!(
+        calls_for_pubkey(&calls, fixture.pubkey(AGGREGATE_VALIDATOR_IDX)),
+        1
+    );
+    assert_eq!(
+        calls_for_pubkey(&calls, fixture.pubkey(CONTRIBUTOR_VALIDATOR_IDX)),
+        CONTRIBUTION_SUBCOMMITTEES.len(),
+        "the decided contributions must be signed without a contribution callback"
+    );
+}
+
+/// The slot pipeline signs the complete decided worklist with no Lighthouse callback involved.
+///
+/// This is the property the whole design rests on: what gets signed is a function of the decided
+/// value alone, so a class Lighthouse never asks about can no longer leave the committee batch
+/// short of its expected size.
+#[tokio::test(flavor = "multi_thread")]
+async fn decided_worklist_is_signed_without_any_callback() {
+    // Arrange and act: publishing the assignments is the entire trigger.
+    let fixture = AggregatorCommitteeFixture::new(MIXED_COMMITTEE_VALIDATOR_COUNT);
+    let decided = fixture.seed_mixed_decided_value();
+
+    // Assert: every decided root of both classes was submitted to one correctly sized batch.
+    assert_captured_calls_settle_at(&fixture.harness, MIXED_WORKLIST_SIZE).await;
+    let calls = committee_calls(&fixture.harness);
+    assert_eq!(
+        distinct_roots(&calls).len(),
+        MIXED_WORKLIST_SIZE,
+        "both object classes must be signed without either callback firing"
+    );
+    assert_batch_identity(&calls, MIXED_WORKLIST_SIZE, decided.hash());
+}
+
+/// Both callbacks read the same execution: neither re-runs consensus nor duplicates signatures,
+/// and each returns only its own items.
+#[tokio::test(flavor = "multi_thread")]
+async fn both_callbacks_share_one_execution() {
+    // Arrange
+    let fixture = AggregatorCommitteeFixture::new(MIXED_COMMITTEE_VALIDATOR_COUNT);
+    let decided = fixture.seed_mixed_decided_value();
+    let contributions = CONTRIBUTION_SUBCOMMITTEES
+        .iter()
+        .map(|&subcommittee| fixture.create_contribution(CONTRIBUTOR_VALIDATOR_IDX, subcommittee))
+        .collect();
+    let aggregates = vec![
+        fixture
+            .harness
+            .create_aggregate(COMMITTEE_INDEX, AGGREGATE_VALIDATOR_IDX),
+    ];
+
+    // Act: contribution callback first, then the aggregate callback joins the cached outcome.
+    let contribution_results = fixture.collect_contributions(contributions).await;
+    let aggregate_results = fixture.collect_aggregates(aggregates).await;
+
+    // Assert: each callback returned only its own items.
+    assert_eq!(
+        single_batch(contribution_results).len(),
+        CONTRIBUTION_SUBCOMMITTEES.len(),
+        "the contribution callback should return only its contributions"
+    );
+    assert_eq!(
+        single_batch(aggregate_results).len(),
+        1,
+        "the aggregate callback should return only its aggregate"
+    );
+
+    // The union is signed exactly once: no duplicate captures from the second callback.
+    assert_captured_calls_settle_at(&fixture.harness, MIXED_WORKLIST_SIZE).await;
+    let calls = committee_calls(&fixture.harness);
+    assert_eq!(distinct_roots(&calls).len(), MIXED_WORKLIST_SIZE);
+    assert_batch_identity(&calls, MIXED_WORKLIST_SIZE, decided.hash());
+}
+
+/// Dropping a callback future must not cancel the execution it is reading: the complete worklist
+/// is still signed, and a later callback still gets its items from the same execution.
+#[tokio::test(flavor = "multi_thread")]
+async fn dropped_callback_future_still_completes_worklist() {
+    // Arrange
+    let fixture = AggregatorCommitteeFixture::new(MIXED_COMMITTEE_VALIDATOR_COUNT);
+    let decided = fixture.seed_mixed_decided_value();
+    let contributions: Vec<_> = CONTRIBUTION_SUBCOMMITTEES
+        .iter()
+        .map(|&subcommittee| fixture.create_contribution(CONTRIBUTOR_VALIDATOR_IDX, subcommittee))
+        .collect();
+
+    // Act: poll the contribution callback once, then drop it. A zero timeout polls the inner
+    // future exactly once before the deadline elapses; if the callback happens to win the race the
+    // scenario degrades to the sequential case.
+    let stream = fixture
+        .harness
+        .validator_store
+        .sign_sync_committee_contributions(contributions);
+    let _ = tokio::time::timeout(Duration::ZERO, stream.collect::<SignContributionsResult>()).await;
+
+    // Assert: the detached execution still signs the complete worklist.
+    assert_captured_calls_settle_at(&fixture.harness, MIXED_WORKLIST_SIZE).await;
+    let calls = committee_calls(&fixture.harness);
+    assert_batch_identity(&calls, MIXED_WORKLIST_SIZE, decided.hash());
+
+    // A later aggregate callback joins the finished execution and gets its aggregate.
+    let aggregates = vec![
+        fixture
+            .harness
+            .create_aggregate(COMMITTEE_INDEX, AGGREGATE_VALIDATOR_IDX),
+    ];
+    let signed = single_batch(fixture.collect_aggregates(aggregates).await);
+    assert_eq!(
+        signed.len(),
+        1,
+        "a late aggregate callback should resolve from the cached execution"
+    );
+
+    // Still no duplicate captures after the late callback.
+    tokio::time::sleep(SETTLE_DELAY).await;
+    assert_eq!(
+        fixture.harness.captured_calls.lock().len(),
+        MIXED_WORKLIST_SIZE
+    );
+}
+
+/// One validator owning an aggregate plus contributions in all four subcommittees keeps five
+/// distinct signing roots in one five-entry batch.
+#[tokio::test(flavor = "multi_thread")]
+async fn multi_root_validator_keeps_distinct_roots() {
+    // Arrange
+    const EXPECTED_WORKLIST_SIZE: usize = 1 + ALL_SUBCOMMITTEES.len();
+    let fixture = AggregatorCommitteeFixture::new(SINGLE_VALIDATOR_COUNT);
+    let validator = fixture.validator_index(AGGREGATE_VALIDATOR_IDX);
+    let contributors: Vec<_> = ALL_SUBCOMMITTEES
+        .iter()
+        .map(|&subcommittee| (validator, subcommittee))
+        .collect();
+    let decided = fixture.seed_decided_value(build_decided_data(
+        &[(validator, BEACON_COMMITTEE_INDEX)],
+        &contributors,
+    ));
+    let contributions = ALL_SUBCOMMITTEES
+        .iter()
+        .map(|&subcommittee| fixture.create_contribution(SOLE_VALIDATOR_IDX, subcommittee))
+        .collect();
+
+    // Act
+    let results = fixture.collect_contributions(contributions).await;
+
+    // Assert
+    assert_eq!(single_batch(results).len(), ALL_SUBCOMMITTEES.len());
+    assert_captured_calls_settle_at(&fixture.harness, EXPECTED_WORKLIST_SIZE).await;
+    let calls = committee_calls(&fixture.harness);
+    assert_eq!(
+        distinct_roots(&calls).len(),
+        EXPECTED_WORKLIST_SIZE,
+        "one validator's aggregate and four contribution roots must stay distinct"
+    );
+    assert_batch_identity(&calls, EXPECTED_WORKLIST_SIZE, decided.hash());
+    assert_eq!(
+        calls_for_pubkey(&calls, fixture.pubkey(AGGREGATE_VALIDATOR_IDX)),
+        EXPECTED_WORKLIST_SIZE
+    );
+}
+
+// ==================== Divergent-view and normalization tests ====================
+
+/// A requested item absent from the decided value is skipped, while the other requested
+/// items succeed and the batch size counts only decided entries.
+#[tokio::test(flavor = "multi_thread")]
+async fn requested_item_missing_from_decided_value() {
+    // Arrange: the decided value covers subcommittees 0 and 1, but the callback also asks
+    // for subcommittee 2.
+    let fixture = AggregatorCommitteeFixture::new(MIXED_COMMITTEE_VALIDATOR_COUNT);
+    let decided = fixture.seed_mixed_decided_value();
+    let contributions = CONTRIBUTION_SUBCOMMITTEES
+        .iter()
+        .chain(std::iter::once(&MISSING_SUBCOMMITTEE_INDEX))
+        .map(|&subcommittee| fixture.create_contribution(CONTRIBUTOR_VALIDATOR_IDX, subcommittee))
+        .collect();
+
+    // Act
+    let results = fixture.collect_contributions(contributions).await;
+
+    // Assert: only the decided subcommittees come back.
+    let signed = single_batch(results);
+    let returned_subcommittees: HashSet<u64> = signed
+        .iter()
+        .map(|item| item.message.contribution.subcommittee_index)
+        .collect();
+    assert_eq!(
+        returned_subcommittees,
+        HashSet::from(CONTRIBUTION_SUBCOMMITTEES),
+        "the undecided subcommittee must be skipped, not signed"
+    );
+
+    // The batch covers the decided union only, without the missing item.
+    assert_captured_calls_settle_at(&fixture.harness, MIXED_WORKLIST_SIZE).await;
+    let calls = committee_calls(&fixture.harness);
+    assert_batch_identity(&calls, MIXED_WORKLIST_SIZE, decided.hash());
+}
+
+/// Exact duplicate decided entries collapse to one worklist entry each, so the batch size
+/// reflects the deduplicated union.
+#[tokio::test(flavor = "multi_thread")]
+async fn duplicate_decided_entries_normalized() {
+    // Arrange: the same aggregator entry twice and the same contributor entry twice.
+    const EXPECTED_DEDUPED_SIZE: usize = 2;
+    let fixture = AggregatorCommitteeFixture::new(MIXED_COMMITTEE_VALIDATOR_COUNT);
+    let aggregator = fixture.validator_index(AGGREGATE_VALIDATOR_IDX);
+    let contributor = fixture.validator_index(CONTRIBUTOR_VALIDATOR_IDX);
+    let decided = fixture.seed_decided_value(build_decided_data(
+        &[
+            (aggregator, BEACON_COMMITTEE_INDEX),
+            (aggregator, BEACON_COMMITTEE_INDEX),
+        ],
+        &[
+            (contributor, CONTRIBUTION_SUBCOMMITTEES[0]),
+            (contributor, CONTRIBUTION_SUBCOMMITTEES[0]),
+        ],
+    ));
+    let contributions =
+        vec![fixture.create_contribution(CONTRIBUTOR_VALIDATOR_IDX, CONTRIBUTION_SUBCOMMITTEES[0])];
+
+    // Act
+    let results = fixture.collect_contributions(contributions).await;
+
+    // Assert
+    assert_eq!(single_batch(results).len(), 1);
+    assert_captured_calls_settle_at(&fixture.harness, EXPECTED_DEDUPED_SIZE).await;
+    let calls = committee_calls(&fixture.harness);
+    assert_eq!(
+        distinct_roots(&calls).len(),
+        EXPECTED_DEDUPED_SIZE,
+        "duplicates must collapse to one entry per (validator, signing_root)"
+    );
+    assert_batch_identity(&calls, EXPECTED_DEDUPED_SIZE, decided.hash());
+}
+
+/// Conflicting aggregate roots for one validator sign only the first, keeping that validator
+/// within the receivers' per-validator root cap while unrelated entries are unaffected.
+#[tokio::test(flavor = "multi_thread")]
+async fn conflicting_aggregate_roots_sign_only_the_first() {
+    // Arrange: the aggregator appears twice with different committee indexes, each resolving
+    // to a different attestation payload and therefore a different signing root.
+    const EXPECTED_SIGNED_SIZE: usize = 2;
+    let fixture = AggregatorCommitteeFixture::new(MIXED_COMMITTEE_VALIDATOR_COUNT);
+    let aggregator = fixture.validator_index(AGGREGATE_VALIDATOR_IDX);
+    let contributor = fixture.validator_index(CONTRIBUTOR_VALIDATOR_IDX);
+    let decided = fixture.seed_decided_value(build_decided_data(
+        &[
+            (aggregator, BEACON_COMMITTEE_INDEX),
+            (aggregator, CONFLICTING_BEACON_COMMITTEE_INDEX),
+        ],
+        &[(contributor, CONTRIBUTION_SUBCOMMITTEES[0])],
+    ));
+    let contributions =
+        vec![fixture.create_contribution(CONTRIBUTOR_VALIDATOR_IDX, CONTRIBUTION_SUBCOMMITTEES[0])];
+
+    // Act
+    let results = fixture.collect_contributions(contributions).await;
+
+    // Assert: exactly one of the conflicting aggregates is signed, the contribution is
+    // unaffected, and the batch counts both.
+    assert_eq!(single_batch(results).len(), 1);
+    assert_captured_calls_settle_at(&fixture.harness, EXPECTED_SIGNED_SIZE).await;
+    let calls = committee_calls(&fixture.harness);
+    assert_eq!(
+        calls_for_pubkey(&calls, fixture.pubkey(AGGREGATE_VALIDATOR_IDX)),
+        1,
+        "a validator with conflicting decided aggregate roots must sign exactly one of them"
+    );
+    assert_eq!(
+        calls_for_pubkey(&calls, fixture.pubkey(CONTRIBUTOR_VALIDATOR_IDX)),
+        1,
+        "the unrelated contribution must be unaffected by the malformed aggregate entries"
+    );
+    assert_eq!(
+        distinct_roots(&calls).len(),
+        EXPECTED_SIGNED_SIZE,
+        "each signed identity contributes exactly one distinct root"
+    );
+    assert_batch_identity(&calls, EXPECTED_SIGNED_SIZE, decided.hash());
+}
+
+// ==================== Empty and error path tests ====================
+
+/// A decided value naming only validators this operator has no metadata for produces an empty
+/// worklist: the callbacks return empty batches and no signature is ever collected.
+#[tokio::test(flavor = "multi_thread")]
+async fn empty_worklist_returns_empty() {
+    // Arrange: the decided entries reference foreign validator indices, while the callbacks
+    // reference the local validator (required to pass committee grouping).
+    let fixture = AggregatorCommitteeFixture::new(SINGLE_VALIDATOR_COUNT);
+    fixture.seed_decided_value(build_decided_data(
+        &[(
+            ValidatorIndex(FOREIGN_AGGREGATOR_INDEX),
+            BEACON_COMMITTEE_INDEX,
+        )],
+        &[(
+            ValidatorIndex(FOREIGN_CONTRIBUTOR_INDEX),
+            CONTRIBUTION_SUBCOMMITTEES[0],
+        )],
+    ));
+    let aggregates = vec![
+        fixture
+            .harness
+            .create_aggregate(COMMITTEE_INDEX, AGGREGATE_VALIDATOR_IDX),
+    ];
+    let contributions =
+        vec![fixture.create_contribution(SOLE_VALIDATOR_IDX, CONTRIBUTION_SUBCOMMITTEES[0])];
+
+    // Act
+    let aggregate_results = fixture.collect_aggregates(aggregates).await;
+    let contribution_results = fixture.collect_contributions(contributions).await;
+
+    // Assert: both callbacks yield an empty batch and nothing is signed.
+    assert!(
+        single_batch(aggregate_results).is_empty(),
+        "no locally signable decided entry means an empty aggregate batch"
+    );
+    assert!(
+        single_batch(contribution_results).is_empty(),
+        "no locally signable decided entry means an empty contribution batch"
+    );
+    assert_captured_calls_settle_at(&fixture.harness, 0).await;
+}
+
+/// Missing consensus data for the committee fails the execution; the trait layer swallows the
+/// error into an empty batch (`run_committee_signing`) and nothing is signed.
+#[tokio::test(flavor = "multi_thread")]
+async fn consensus_data_missing_errors() {
+    // Arrange: assignments exist for the slot, but carry no consensus data for any committee,
+    // so the execution fails with `ConsensusDataNotFound`. (Seeding nothing at all would park
+    // the callbacks on the assignments watch channel instead of erroring.)
+    let fixture = AggregatorCommitteeFixture::new(MIXED_COMMITTEE_VALIDATOR_COUNT);
+    fixture.seed_assignments_without_consensus_data();
+    let aggregates = vec![
+        fixture
+            .harness
+            .create_aggregate(COMMITTEE_INDEX, AGGREGATE_VALIDATOR_IDX),
+    ];
+    let contributions =
+        vec![fixture.create_contribution(CONTRIBUTOR_VALIDATOR_IDX, CONTRIBUTION_SUBCOMMITTEES[0])];
+
+    // Act: both callback classes hit the same cached execution error.
+    let aggregate_results = fixture.collect_aggregates(aggregates).await;
+    let contribution_results = fixture.collect_contributions(contributions).await;
+
+    // Assert: `run_committee_signing` swallows the failure into one empty stream item per
+    // committee, and no signature collection is ever attempted.
+    assert!(
+        single_batch(aggregate_results).is_empty(),
+        "a failed execution should yield an empty aggregate batch"
+    );
+    assert!(
+        single_batch(contribution_results).is_empty(),
+        "a failed execution should yield an empty contribution batch"
+    );
+    assert_captured_calls_settle_at(&fixture.harness, 0).await;
+}
+
+/// Decided payloads whose slot does not match the duty slot are excluded from the worklist, so
+/// the batch settles at the surviving count instead of stalling.
+#[tokio::test(flavor = "multi_thread")]
+async fn slot_mismatched_decided_payloads_are_excluded() {
+    // Arrange: the standard mixed decided value, but both contribution payloads carry the
+    // wrong slot; only the aggregate survives slot binding.
+    let fixture = AggregatorCommitteeFixture::new(MIXED_COMMITTEE_VALIDATOR_COUNT);
+    let aggregator = fixture.validator_index(AGGREGATE_VALIDATOR_IDX);
+    let contributor = fixture.validator_index(CONTRIBUTOR_VALIDATOR_IDX);
+    let mut decided = build_decided_data(
+        &[(aggregator, BEACON_COMMITTEE_INDEX)],
+        &[
+            (contributor, CONTRIBUTION_SUBCOMMITTEES[0]),
+            (contributor, CONTRIBUTION_SUBCOMMITTEES[1]),
+        ],
+    );
+    for contribution in decided.sync_committee_contributions.iter_mut() {
+        contribution.slot = Slot::new(TEST_SLOT + 1);
+    }
+    fixture.seed_decided_value(decided);
+    let contributions = vec![
+        fixture.create_contribution(CONTRIBUTOR_VALIDATOR_IDX, CONTRIBUTION_SUBCOMMITTEES[0]),
+        fixture.create_contribution(CONTRIBUTOR_VALIDATOR_IDX, CONTRIBUTION_SUBCOMMITTEES[1]),
+    ];
+
+    // Act
+    let results = fixture.collect_contributions(contributions).await;
+
+    // Assert: the requested contributions resolve to nothing (their decided payloads were
+    // excluded), while the aggregate still gets signed with a batch sized to the survivors.
+    assert!(
+        single_batch(results).is_empty(),
+        "slot-mismatched contributions should not be returned"
+    );
+    const EXPECTED_SURVIVOR_COUNT: usize = 1;
+    assert_captured_calls_settle_at(&fixture.harness, EXPECTED_SURVIVOR_COUNT).await;
+    let calls = committee_calls(&fixture.harness);
+    assert_eq!(
+        calls[0].pubkey,
+        fixture.pubkey(AGGREGATE_VALIDATOR_IDX),
+        "the surviving entry should be the aggregate"
+    );
+    assert_eq!(
+        calls[0].batch_size, EXPECTED_SURVIVOR_COUNT,
+        "the batch size should count only surviving entries"
+    );
+}

--- a/anchor/validator_store/src/testing/aggregator_post_consensus.rs
+++ b/anchor/validator_store/src/testing/aggregator_post_consensus.rs
@@ -525,6 +525,33 @@ async fn decided_worklist_is_signed_without_any_callback() {
     assert_batch_identity(&calls, MIXED_WORKLIST_SIZE, decided.hash());
 }
 
+/// Republishing assignments for a slot must not register a second execution.
+///
+/// Registration is the single writer that makes "exactly one committee message per
+/// `(committee, slot)`" true. If a republish overwrote the entry it would spawn a second QBFT
+/// round and a second set of detached signing tasks while the first set kept running, putting two
+/// post-consensus messages on the wire for one slot, which peers reject with a gossip penalty.
+#[tokio::test(flavor = "multi_thread")]
+async fn republished_assignments_do_not_resubmit() {
+    // Arrange: let the first publish fully submit its worklist.
+    let fixture = AggregatorCommitteeFixture::new(MIXED_COMMITTEE_VALIDATOR_COUNT);
+    let decided = fixture.seed_mixed_decided_value();
+    assert_captured_calls_settle_at(&fixture.harness, MIXED_WORKLIST_SIZE).await;
+
+    // Act: publish the same slot again.
+    fixture.seed_mixed_decided_value();
+
+    // Assert: still exactly one submission of the worklist, not two.
+    assert_captured_calls_settle_at(&fixture.harness, MIXED_WORKLIST_SIZE).await;
+    let calls = committee_calls(&fixture.harness);
+    assert_eq!(
+        distinct_roots(&calls).len(),
+        MIXED_WORKLIST_SIZE,
+        "a republish must not resubmit the worklist"
+    );
+    assert_batch_identity(&calls, MIXED_WORKLIST_SIZE, decided.hash());
+}
+
 /// Both callbacks read the same execution: neither re-runs consensus nor duplicates signatures,
 /// and each returns only its own items.
 #[tokio::test(flavor = "multi_thread")]

--- a/anchor/validator_store/src/testing/common.rs
+++ b/anchor/validator_store/src/testing/common.rs
@@ -65,6 +65,7 @@ impl<E: EthSpec> ConsensusDecider<E> for MockConsensusDecider {
 pub(super) type CapturedCalls = Arc<Mutex<Vec<CapturedSignatureCall>>>;
 
 pub(super) struct CapturedSignatureCall {
+    pub(super) metadata: SignatureMetadata,
     pub(super) requester: SignatureRequester,
     pub(super) validator_pubkey: PublicKeyBytes,
     pub(super) signing_root: Hash256,
@@ -80,11 +81,12 @@ struct MockSignatureCollector {
 impl SignatureCollecting for MockSignatureCollector {
     fn sign_and_collect(
         &self,
-        _metadata: SignatureMetadata,
+        metadata: SignatureMetadata,
         requester: SignatureRequester,
         signing_data: ValidatorSigningData,
     ) -> Pin<Box<dyn Future<Output = Result<Arc<Signature>, CollectionError>> + Send + '_>> {
         self.captured.lock().push(CapturedSignatureCall {
+            metadata,
             requester,
             validator_pubkey: signing_data.validator_pubkey,
             signing_root: signing_data.root,

--- a/anchor/validator_store/src/testing/mod.rs
+++ b/anchor/validator_store/src/testing/mod.rs
@@ -1,5 +1,6 @@
 mod common;
 
+mod aggregator_post_consensus;
 mod committee_aggregate;
 mod committee_attestation;
 mod proposer_delay;


### PR DESCRIPTION
## Problem, Evidence, and Context (Required)

At Boole, one QBFT decision can carry both attestation aggregates and sync contributions. Anchor
signed these from two separate Lighthouse callbacks. Each callback signed only its own object type.
But both sized the shared partial-signature batch from the full decided value.

If the decided value held an object type that the local Lighthouse never asked for, the batch never
filled. The operator then never sent its one post-consensus message. The duty failed for the whole
cluster, not just for that operator.

We first saw this on a mixed Anchor and go-ssv network. On ssv-mini it breaks about 1.2% of
post-fork `AggregatorCommittee` duties, so it is a steady loss on any mixed network.

Closes #1227.

## Change Overview (Required)

Anchor now builds the signing list from the decided value instead of from what Lighthouse asked
for. Local state (share, cluster status, metadata) only filters that list.

The slot pipeline starts one signing job per committee when it publishes the decided value. This is
the only place that starts a job, so one committee sends exactly one message per slot. The two
callbacks now only read the result.

The batch size is the number of entries Anchor actually submits, so local filtering can always
reach it.

Read `aggregator_post_consensus.rs` first, then the trigger in `update_aggregation_assignments`,
then the two callbacks.

The signature collector is untouched, and `collect_signature` is byte-identical to before, so
pre-Boole paths cannot change.

## Risks, Trade-offs, and Mitigations (Required)

Two behavior changes to be aware of:

- QBFT for `AggregatorCommittee` now starts at 2/3 slot from the pipeline. Before, it started when
  the first callback arrived.
- A per-root timeout now counts as `OTHER_ERROR` instead of `TIMEOUT`. This matches the existing
  BeaconVote path, and it is visible on dashboards.

Blast radius is `validator_store` plus one deleted helper in `ssv_types`.

Anchor signs every decided entry that it holds a share for. go-ssv also filters by local duty and
signs fewer. Signing extra roots is safe here, because peers do not check completeness for this
duty, and one validator stays inside the 5-root cap.

## Validation (Required)

66 unit tests, plus `make lint`, `make cargo-fmt-check`, and a full release `make test`, all clean.

Live A/B on ssv-mini with 2 Anchor and 2 go-ssv operators at a 3-of-4 threshold. Everything was
identical between the two arms except the Anchor build.

| | Old code | This PR |
|---|---|---|
| Post-fork `AggregatorCommittee` duties | 667 | 1996 |
| Failed duties | **8** | **0** |

Every one of the 8 failures looks the same. Only the two go-ssv operators sent a post-consensus
message. Both Anchor operators sent nothing, which left 2 of 4 partials against a threshold of 3.
On this branch that never happened once.

We also restarted an operator after the fork, because this PR keeps the signing jobs in memory. The
node misses 4 slots and then recovers on its own, with no stuck batch.

## Rollback (Required for behavior or runtime changes; optional otherwise)

Revert the commits. There are no config, CLI, database, or wire-format changes, and nothing new is
written to disk.

## Blockers / Dependencies (Optional)

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
