### PR TITLE
fix(fork): reject duplicate domains in explicit schedules

### DIFF
--- a/anchor/common/fork/src/schedule.rs
+++ b/anchor/common/fork/src/schedule.rs
@@ -96,7 +96,11 @@ pub struct ForkSchedule {
 }
 
 impl ForkSchedule {
-    /// Create a new fork schedule with the given fork active from epoch 0.
+    /// Create a fork schedule with every fork up to `fork` active from epoch 0.
+    ///
+    /// Every included fork uses `baseline_domain_type`. This constructor is intended for
+    /// Alan-only network defaults and test schedules. Explicit production fork schedules should
+    /// use [`Self::from_fork_configs`] so ordering and domain uniqueness are validated.
     pub fn new(fork: Fork, baseline_domain_type: DomainType, network_name: &str) -> Self {
         let mut configs = BTreeMap::new();
         for fork in Fork::all().iter().take_while(|&f| f <= &fork) {

--- a/anchor/common/fork/src/schedule.rs
+++ b/anchor/common/fork/src/schedule.rs
@@ -3,7 +3,7 @@
 //! This module provides the `ForkSchedule` type for managing fork activations
 //! and determining which fork is active at a given epoch.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 
 use ssv_types::domain_type::DomainType;
 use types::Epoch;
@@ -133,6 +133,7 @@ impl ForkSchedule {
     /// - Alan fork is missing from configs
     /// - Alan fork is not at epoch 0
     /// - Fork epochs are not in chronological order
+    /// - Fork domain types are not unique
     pub fn from_fork_configs(
         raw_configs: BTreeMap<Fork, (Epoch, DomainType)>,
         network_name: &str,
@@ -151,7 +152,8 @@ impl ForkSchedule {
         // Validate chronological ordering - earlier forks must have < epochs
         // The exception is epoch 0, which may schedule multiple forks (to enable them at genesis)
         let mut prev_epoch: Option<u64> = None;
-        for (fork, (epoch, _)) in &raw_configs {
+        let mut domains = HashMap::new();
+        for (fork, (epoch, domain_type)) in &raw_configs {
             if let Some(prev) = prev_epoch
                 && epoch.as_u64() <= prev
                 && epoch.as_u64() != 0
@@ -161,6 +163,15 @@ impl ForkSchedule {
                     epoch.as_u64()
                 ));
             }
+
+            if let Some(previous_fork) = domains.get(domain_type) {
+                return Err(format!(
+                    "Fork {fork} reuses domain {} already assigned to fork {previous_fork}",
+                    String::from(*domain_type)
+                ));
+            }
+            domains.insert(*domain_type, *fork);
+
             prev_epoch = Some(epoch.as_u64());
         }
 
@@ -346,6 +357,34 @@ mod tests {
         let result = ForkSchedule::from_fork_configs(configs, TEST_NETWORK);
         assert!(result.is_err());
         assert!(result.unwrap_err().contains("must be at epoch 0"));
+    }
+
+    #[test]
+    fn test_from_fork_configs_rejects_duplicate_domains() {
+        let mut configs = BTreeMap::new();
+        configs.insert(Fork::Alan, (Epoch::new(0), BASELINE_DOMAIN));
+        configs.insert(Fork::Boole, (Epoch::new(100), BASELINE_DOMAIN));
+
+        let error = ForkSchedule::from_fork_configs(configs, TEST_NETWORK)
+            .expect_err("fork domains must be unique");
+        assert_eq!(
+            error,
+            "Fork boole reuses domain 00000001 already assigned to fork alan"
+        );
+    }
+
+    #[test]
+    fn test_from_fork_configs_rejects_duplicate_domains_at_epoch_zero() {
+        let mut configs = BTreeMap::new();
+        configs.insert(Fork::Alan, (Epoch::new(0), BASELINE_DOMAIN));
+        configs.insert(Fork::Boole, (Epoch::new(0), BASELINE_DOMAIN));
+
+        let error = ForkSchedule::from_fork_configs(configs, TEST_NETWORK)
+            .expect_err("fork domains must be unique");
+        assert_eq!(
+            error,
+            "Fork boole reuses domain 00000001 already assigned to fork alan"
+        );
     }
 
     #[test]

--- a/anchor/common/ssv_network_config/src/lib.rs
+++ b/anchor/common/ssv_network_config/src/lib.rs
@@ -202,7 +202,7 @@ fn read<T: FromStr>(file: &Path) -> Result<T, String> {
 
 #[cfg(test)]
 mod tests {
-    use std::io::Write;
+    use std::{collections::HashMap, io::Write};
 
     use fork::ALAN_TOPIC_PREFIX;
     use tempfile::TempDir;
@@ -313,6 +313,30 @@ mod tests {
                 network,
                 expected_name
             );
+        }
+    }
+
+    #[test]
+    fn test_builtin_network_fork_domains_are_globally_unique() {
+        let mut domains = HashMap::new();
+
+        for network in [MAINNET, HOLESKY, HOODI] {
+            let config = SsvNetworkConfig::constant(network).unwrap().unwrap();
+
+            for &fork in Fork::all() {
+                let Some(domain_type) = config.fork_schedule.domain_type(fork) else {
+                    continue;
+                };
+
+                if let Some((previous_network, previous_fork)) = domains.get(&domain_type) {
+                    panic!(
+                        "Domain {} is shared by {previous_network}/{previous_fork} and \
+                         {network}/{fork}; built-in network fork domains must be globally unique",
+                        String::from(domain_type)
+                    );
+                }
+                domains.insert(domain_type, (network, fork));
+            }
         }
     }
 

--- a/anchor/common/ssv_network_config/src/lib.rs
+++ b/anchor/common/ssv_network_config/src/lib.rs
@@ -354,6 +354,30 @@ boole:
     }
 
     #[test]
+    fn test_load_rejects_duplicate_fork_domains() {
+        // Arrange
+        let yaml = format!(
+            r#"
+boole:
+  epoch: {}
+  domain_type: "00000001"
+"#,
+            LARGE_BOOLE_EPOCH
+        );
+        let dir = create_test_config_dir(Some(&yaml));
+
+        // Act
+        let error = SsvNetworkConfig::load(dir.path().to_path_buf())
+            .expect_err("fork domains must be unique");
+
+        // Assert
+        assert_eq!(
+            error,
+            "Fork boole reuses domain 00000001 already assigned to fork alan"
+        );
+    }
+
+    #[test]
     fn test_load_with_empty_fork_schedule_only_has_alan() {
         // Arrange
         let dir = create_test_config_dir(Some("{}"));


### PR DESCRIPTION
## Summary

- Reject explicit fork schedules that reuse a signing domain.
- Report the shared domain and both conflicting forks.
- Guard domain uniqueness across every scheduled fork in the built-in network matrix.
- Clarify that `ForkSchedule::new` is for Alan-only defaults and test schedules.

Duplicate domains make forks or networks cryptographically indistinguishable. Anchor now rejects per-schedule collisions at startup and catches built-in cross-network collisions in tests.

## Testing

- `cargo test -p fork -p ssv_network_config -p global_config`
- `make cargo-fmt-check`
- `make lint`