### PR TITLE
fix(validator_store): publish VotingAssignments 50ms past slot boundary

### DIFF
--- a/anchor/validator_store/src/metadata_service.rs
+++ b/anchor/validator_store/src/metadata_service.rs
@@ -63,6 +63,19 @@ const WAD_SOFT_TIMEOUT: Duration = Duration::from_secs(1);
 const WAD_HARD_TIMEOUT: Duration = Duration::from_secs(3);
 const BLOCK_SLOT_LOOKUP_TIMEOUT: Duration = Duration::from_millis(500);
 
+/// Publish `VotingAssignments` this long after the slot boundary.
+///
+/// The boundary sleep runs on the monotonic timer but the slot is read from the
+/// wall clock, and the two drift apart by a few milliseconds over a full-slot
+/// sleep. A wake landing marginally before the boundary would read the previous
+/// slot, republish it, and skip the new one (issue #1223). This margin absorbs
+/// that drift. 50 ms mirrors the message validator's `CLOCK_ERROR_TOLERANCE`,
+/// the clock error the SSV network already budgets for between nodes. Nothing
+/// consumes the assignments this early: the soonest consumers are the
+/// selection-proof flows (deadline 2/3 slot) and the voting-context build
+/// (triggered no earlier than a head event).
+const VOTING_ASSIGNMENTS_PUBLISH_DELAY: Duration = Duration::from_millis(50);
+
 /// Builds each validator's per-subnet position counts from raw sync committee positions.
 fn build_sync_validator_assignments<E, I, P>(
     duties: I,
@@ -194,6 +207,24 @@ async fn wait_for_head_event<T: SlotClock>(
     }
 }
 
+/// Drive `publish` once per slot, shortly after each slot boundary.
+///
+/// The delay past the boundary is what makes this correct: sleeping exactly to
+/// the boundary lets a marginally early timer wake read the previous slot,
+/// republish it, and skip the new one (issue #1223). See
+/// [`VOTING_ASSIGNMENTS_PUBLISH_DELAY`].
+async fn run_slot_start_publisher<T: SlotClock>(slot_clock: T, mut publish: impl FnMut()) {
+    loop {
+        if let Some(duration_to_next_slot) = slot_clock.duration_to_next_slot() {
+            sleep(duration_to_next_slot + VOTING_ASSIGNMENTS_PUBLISH_DELAY).await;
+            publish();
+        } else {
+            error!("Failed to read slot clock");
+            sleep(slot_clock.slot_duration()).await;
+        }
+    }
+}
+
 impl<E: EthSpec, T: SlotClock + 'static> MetadataService<E, T> {
     #[expect(clippy::too_many_arguments)]
     pub fn new(
@@ -245,21 +276,13 @@ impl<E: EthSpec, T: SlotClock + 'static> MetadataService<E, T> {
         let self_clone_phase1 = self.clone();
         executor.spawn(
             async move {
-                loop {
-                    if let Some(duration_to_next_slot) =
-                        self_clone_phase1.slot_clock.duration_to_next_slot()
-                    {
-                        // Sleep until slot start
-                        sleep(duration_to_next_slot).await;
-
-                        if let Err(err) = self_clone_phase1.update_voting_assignments() {
-                            error!(err, "Failed to update validator voting assignments");
-                        }
-                    } else {
-                        error!("Failed to read slot clock");
-                        sleep(slot_duration).await;
+                let slot_clock = self_clone_phase1.slot_clock.clone();
+                run_slot_start_publisher(slot_clock, move || {
+                    if let Err(err) = self_clone_phase1.update_voting_assignments() {
+                        error!(err, "Failed to update validator voting assignments");
                     }
-                }
+                })
+                .await
             },
             "voting_assignments_service",
         );
@@ -2447,5 +2470,105 @@ mod tests {
         };
 
         assert!(!from_head_event);
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════════════════
+    // Slot start publisher tests
+    //
+    // The virtual tokio timer stands in for the monotonic timer the publisher sleeps on,
+    // and the manual slot clock stands in for the wall clock it reads slots from. Driving
+    // them separately is what lets these tests reproduce the drift between the two.
+    // ═══════════════════════════════════════════════════════════════════════════════════
+
+    use parking_lot::Mutex;
+
+    const SLOT_DURATION: Duration = Duration::from_secs(SLOT_DURATION_SECS);
+    /// How far the wall clock trails the virtual timer when the boundary sleep wakes. The
+    /// drift observed in issue #1223 was 1 ms to 5 ms.
+    const WALL_CLOCK_LAG: Duration = Duration::from_millis(3);
+    /// Slot boundaries crossed by `publishes_each_slot_exactly_once`.
+    const LOCKSTEP_SLOTS: u64 = 3;
+
+    /// Spawn the publisher, recording the slot its clock reads at each publish. Production
+    /// reads the slot inside `update_voting_assignments`, so the recorded slot is the one
+    /// that would have been published.
+    async fn spawn_slot_start_publisher(slot_clock: &ManualSlotClock) -> Arc<Mutex<Vec<Slot>>> {
+        let published = Arc::new(Mutex::new(Vec::new()));
+        let publish_clock = slot_clock.clone();
+        let recorded = published.clone();
+        tokio::spawn(run_slot_start_publisher(slot_clock.clone(), move || {
+            let slot = publish_clock.now().expect("manual slot clock is readable");
+            recorded.lock().push(slot);
+        }));
+        // Let the publisher arm its first sleep before either clock moves.
+        tokio::task::yield_now().await;
+        published
+    }
+
+    /// Advance the virtual timer, giving a sleep that expires within the step a scheduling
+    /// round to run. `tokio::time::advance` only wakes the sleeper, it does not poll it, so
+    /// without the extra round the publish would be observed a step late.
+    async fn advance_virtual_time(duration: Duration) {
+        tokio::time::advance(duration).await;
+        tokio::task::yield_now().await;
+    }
+
+    /// Move the wall clock and the virtual timer forward by the same amount. The wall clock
+    /// moves first so a timer firing within the step reads the time the step ends at.
+    async fn advance_in_lockstep(slot_clock: &ManualSlotClock, duration: Duration) {
+        slot_clock.advance_time(duration);
+        advance_virtual_time(duration).await;
+    }
+
+    /// Regression test for issue #1223.
+    ///
+    /// A boundary sleep that wakes a few milliseconds before the wall clock reaches the
+    /// slot boundary used to republish the previous slot, and the next iteration then slept
+    /// past the new slot entirely, so waiters on it saw `MetadataSlotPassed`. The publish
+    /// offset has to hold the publish back until the wall clock has crossed.
+    #[tokio::test(start_paused = true)]
+    async fn early_wake_still_publishes_the_new_slot() {
+        // Arrange: publisher armed at the start of TEST_SLOT.
+        let slot_clock = make_test_slot_clock();
+        let published = spawn_slot_start_publisher(&slot_clock).await;
+
+        // Act: fire the boundary sleep with the wall clock still short of the boundary.
+        slot_clock.advance_time(SLOT_DURATION - WALL_CLOCK_LAG);
+        advance_virtual_time(SLOT_DURATION).await;
+
+        assert!(
+            published.lock().is_empty(),
+            "publishing at the early wake would read slot {TEST_SLOT} again"
+        );
+
+        // The wall clock crosses the boundary within the publish offset.
+        advance_in_lockstep(&slot_clock, VOTING_ASSIGNMENTS_PUBLISH_DELAY).await;
+
+        // Assert: the new slot is published once, and the previous slot is not repeated.
+        assert_eq!(
+            published.lock().as_slice(),
+            [Slot::new(TEST_SLOT + 1)],
+            "an early wake must still publish the new slot exactly once"
+        );
+    }
+
+    /// Without drift, every slot boundary produces exactly one publish for that slot.
+    #[tokio::test(start_paused = true)]
+    async fn publishes_each_slot_exactly_once() {
+        // Arrange: publisher armed at the start of TEST_SLOT.
+        let slot_clock = make_test_slot_clock();
+        let published = spawn_slot_start_publisher(&slot_clock).await;
+
+        // Act: settle onto the publish offset, then cross one boundary per step.
+        advance_in_lockstep(&slot_clock, VOTING_ASSIGNMENTS_PUBLISH_DELAY).await;
+        for _ in 0..LOCKSTEP_SLOTS {
+            advance_in_lockstep(&slot_clock, SLOT_DURATION).await;
+        }
+
+        // Assert: one publish per boundary, slots strictly increasing by one.
+        let expected: Vec<Slot> = (1..=LOCKSTEP_SLOTS)
+            .map(|offset| Slot::new(TEST_SLOT + offset))
+            .collect();
+        assert_eq!(published.lock().as_slice(), expected);
     }
 }


### PR DESCRIPTION
## Problem, Evidence, and Context

- `MetadataService` Phase 1 sleeps to the slot boundary and then reads the wall clock. A timer wake a few milliseconds early reads the previous slot, republishes it, and the next iteration sleeps past the new slot. Waiters fail with `MetadataSlotPassed`, and the Phase 2/3 cascade costs the operator three slots of committee participation.
- Observed on a 512-slot scale-100 devnet soak: 6 skipped slots, 3 of them quorum-losing across a 4-operator committee, with wakes measured 1 to 5 ms before the boundary.
- Addresses the Anchor side of #1223. The proposer-scheduler half of that issue lives in Lighthouse and is tracked separately.

## Change Overview

- Phase 1 now sleeps `duration_to_next_slot() + 50ms`, the same idiom Phase 3 already uses (its 2/3-slot offset makes it immune to this race) and the same shape Lighthouse uses for slot-keyed work. 50 ms mirrors the message validator's `CLOCK_ERROR_TOLERANCE`, the inter-node clock error the network already budgets for, and is 10-50x the measured drift.
- The loop is extracted into a small `run_slot_start_publisher` helper so the race is unit-testable.
- Reading order: the `VOTING_ASSIGNMENTS_PUBLISH_DELAY` doc comment, then the helper, then the two tests.
- Intentionally unchanged: `update_voting_assignments` itself, the waiter contract, and Phase 2/3 scheduling.

## Risks, Trade-offs, and Mitigations

- Assignments publish 50 ms later. Every consumer was traced: the selection-proof flows hold an absolute 2/3-slot deadline and the voting-context build triggers no earlier than a head event. Nothing reads the data inside the first 50 ms; block proposals never read it at all.
- A backwards clock step larger than 50 ms during one sleep produces a duplicate publication of the previous slot. Harmless under the waiter contract, which only fails a waiter when a newer slot arrives, and it self-corrects at the next boundary. All other clock-fault behavior is unchanged from the previous code.

## Validation

- New deterministic regression test drives the early wake under paused time by holding the wall clock short of the boundary when the timer fires; it fails with the offset removed (mutation-checked) and passes with it.
- Steady-state test asserts one publication per slot, strictly increasing.
- Full `make test` (including ssv-spec tests): 622 passed, 0 failed. fmt and clippy clean.
- Validated on a 4-operator, 100-validator ssv-mini devnet (same harness class that reproduced the race): in a 128-slot scored window under Boole, every node published exactly once per slot with strictly increasing slots, zero `MetadataSlotPassed`, and 120 of 123 produced blocks carried sync participation of 500+/512 on a finalizing chain. The two slots without publications coincided with a measured 34-second host-VM stall (all containers silent), not publisher behavior.

## Rollback

- Revert the single commit. No config, database, or wire-format impact.
