### PR TITLE
feat(client): fork-gated post-Gloas proposer delay

### DIFF
--- a/anchor/cli/src/cli.rs
+++ b/anchor/cli/src/cli.rs
@@ -528,8 +528,8 @@ pub struct PayloadBuildingOptions {
         help = "Counterpart of --proposer-delay-ms applied from the Gloas (ePBS) fork onward: \
                 each proposer duty uses whichever value matches the fork at its slot, with no \
                 fallback between them. Post-ePBS slots leave less headroom after the block \
-                request, so this value has a hard cap that --allow-dangerous-proposer-delay \
-                does not raise.",
+                request, so this value has a hard 1000ms cap that \
+                --allow-dangerous-proposer-delay does not raise.",
         display_order = 0
     )]
     pub proposer_delay_epbs_ms: u64,

--- a/anchor/cli/src/cli.rs
+++ b/anchor/cli/src/cli.rs
@@ -515,16 +515,31 @@ pub struct PayloadBuildingOptions {
                 the start of the slot, not extra latency: if the RANDAO pre-consensus round \
                 already finished later than this, no additional wait happens. A recommended \
                 starting value is 300. Higher values increase the risk of missing the block \
-                proposal.",
+                proposal. Applies to slots before the Gloas (ePBS) fork; from that fork on, \
+                --proposer-delay-epbs-ms applies instead.",
         display_order = 0
     )]
     pub proposer_delay_ms: u64,
 
     #[clap(
         long,
+        value_name = "MILLISECONDS",
+        default_value_t = 0,
+        help = "Counterpart of --proposer-delay-ms applied from the Gloas (ePBS) fork onward: \
+                each proposer duty uses whichever value matches the fork at its slot, with no \
+                fallback between them. Post-ePBS slots leave less headroom after the block \
+                request, so this value has a hard cap that --allow-dangerous-proposer-delay \
+                does not raise.",
+        display_order = 0
+    )]
+    pub proposer_delay_epbs_ms: u64,
+
+    #[clap(
+        long,
         help = "Permit a --proposer-delay-ms above the safety threshold. Delays this large \
                 significantly increase the risk of missed block proposals. Only set this if you \
-                understand the trade-off.",
+                understand the trade-off. Does not apply to --proposer-delay-epbs-ms, which has \
+                a hard cap instead.",
         display_order = 0
     )]
     pub allow_dangerous_proposer_delay: bool,

--- a/anchor/client/src/config.rs
+++ b/anchor/client/src/config.rs
@@ -3,6 +3,7 @@
 
 use std::{net::IpAddr, path::PathBuf, time::Duration};
 
+use anchor_validator_store::ProposerDelays;
 use beacon_node_fallback::{ApiTopic, beacon_node_health::BeaconNodeSyncDistanceTiers};
 use cli::{NetworkOptions, Node};
 use global_config::{GlobalConfig, defaults::DEFAULT_NODE_ENDPOINTS};
@@ -52,6 +53,33 @@ fn proposer_delay_from_millis(millis: u64, allow_dangerous: bool) -> Result<Dura
             "--allow-dangerous-proposer-delay has no effect: it is only required above \
              {DANGEROUS_PROPOSER_DELAY_MS}ms, and --proposer-delay-ms is {millis}."
         );
+    }
+    Ok(Duration::from_millis(millis))
+}
+
+/// Hard maximum for the post-ePBS proposer delay, refused unconditionally.
+///
+/// Matches go-ssv's cap on `ProposerDelayEPBS`, which deliberately has no override: the post-ePBS
+/// proposal deadline is tighter, so there is no dangerous-but-acknowledged band. Coincidentally
+/// equal to [`DANGEROUS_PROPOSER_DELAY_MS`]; the policies are independent, do not merge them.
+const MAX_PROPOSER_DELAY_EPBS_MS: u64 = 1_000;
+
+/// Refuses anything above [`MAX_PROPOSER_DELAY_EPBS_MS`], with no acknowledgement escape hatch.
+///
+/// `allow_dangerous` is consulted only to tailor the refusal: an operator who set the flag
+/// expecting it to raise this cap is told it does not apply, and one who did not is not pointed at
+/// a flag that cannot help.
+fn proposer_delay_epbs_from_millis(millis: u64, allow_dangerous: bool) -> Result<Duration, String> {
+    if millis > MAX_PROPOSER_DELAY_EPBS_MS {
+        let refusal = format!(
+            "--proposer-delay-epbs-ms {millis} exceeds the {MAX_PROPOSER_DELAY_EPBS_MS}ms maximum. \
+             The post-ePBS proposal deadline is tighter, so the cap is unconditional."
+        );
+        return Err(if allow_dangerous {
+            format!("{refusal} --allow-dangerous-proposer-delay does not apply to this value.")
+        } else {
+            refusal
+        });
     }
     Ok(Duration::from_millis(millis))
 }
@@ -109,9 +137,10 @@ pub struct Config {
     pub builder_boost_factor: Option<u64>,
     /// Should external payloads always be preferred
     pub prefer_builder_proposals: bool,
-    /// Minimum offset from the start of the slot before a proposer duty requests its beacon block,
-    /// giving builders longer to bid for it. Zero disables the behaviour.
-    pub proposer_delay: Duration,
+    /// Minimum offsets from the start of the slot before a proposer duty requests its beacon
+    /// block, giving builders longer to bid for it. One value per side of the Gloas fork, each
+    /// disabled at zero.
+    pub proposer_delays: ProposerDelays,
     /// Controls whether the latency measurement service is enabled
     pub disable_latency_measurement_service: bool,
     /// Enables the beacon head monitor that reacts to head updates from connected beacon nodes.
@@ -167,7 +196,7 @@ impl Config {
             impostor: None,
             builder_boost_factor: None,
             prefer_builder_proposals: false,
-            proposer_delay: Duration::ZERO,
+            proposer_delays: ProposerDelays::default(),
             gas_limit: 36_000_000,
             disable_latency_measurement_service: false,
             enable_beacon_head_monitor: true,
@@ -283,12 +312,19 @@ pub fn from_cli(mut cli_args: Node, global_config: GlobalConfig) -> Result<Confi
 
     config.gas_limit = cli_args.payload_building_options.gas_limit;
 
-    config.proposer_delay = proposer_delay_from_millis(
-        cli_args.payload_building_options.proposer_delay_ms,
-        cli_args
-            .payload_building_options
-            .allow_dangerous_proposer_delay,
-    )?;
+    let allow_dangerous_proposer_delay = cli_args
+        .payload_building_options
+        .allow_dangerous_proposer_delay;
+    config.proposer_delays = ProposerDelays {
+        pre_gloas: proposer_delay_from_millis(
+            cli_args.payload_building_options.proposer_delay_ms,
+            allow_dangerous_proposer_delay,
+        )?,
+        gloas: proposer_delay_epbs_from_millis(
+            cli_args.payload_building_options.proposer_delay_epbs_ms,
+            allow_dangerous_proposer_delay,
+        )?,
+    };
 
     // Http API server
     config.http_api.enabled = cli_args.http_api_options.http;
@@ -636,5 +672,45 @@ mod tests {
             "must not suggest a flag that cannot help, got: {err}"
         );
         assert!(proposer_delay_from_millis(MAX_PROPOSER_DELAY_MS, true).is_ok());
+    }
+
+    #[test]
+    fn proposer_delay_epbs_default_is_disabled() {
+        assert_eq!(
+            proposer_delay_epbs_from_millis(0, false),
+            Ok(Duration::ZERO)
+        );
+    }
+
+    #[test]
+    fn proposer_delay_epbs_at_the_cap_needs_no_acknowledgement() {
+        assert_eq!(
+            proposer_delay_epbs_from_millis(300, false),
+            Ok(Duration::from_millis(300))
+        );
+        assert_eq!(
+            proposer_delay_epbs_from_millis(MAX_PROPOSER_DELAY_EPBS_MS, false),
+            Ok(Duration::from_millis(MAX_PROPOSER_DELAY_EPBS_MS)),
+            "the cap itself is allowed; only values above it are refused"
+        );
+    }
+
+    #[test]
+    fn proposer_delay_epbs_above_the_cap_is_refused_unconditionally() {
+        // Without the acknowledgement flag, the refusal must not point at a flag that cannot help.
+        let err = proposer_delay_epbs_from_millis(MAX_PROPOSER_DELAY_EPBS_MS + 1, false)
+            .expect_err("should be refused");
+        assert!(
+            !err.contains("--allow-dangerous-proposer-delay"),
+            "must not suggest a flag that cannot help, got: {err}"
+        );
+
+        // With it, still refused: the flag gates only the pre-Gloas value, and the error says so.
+        let err = proposer_delay_epbs_from_millis(MAX_PROPOSER_DELAY_EPBS_MS + 1, true)
+            .expect_err("should be refused regardless of acknowledgement");
+        assert!(
+            err.contains("--allow-dangerous-proposer-delay does not apply"),
+            "the error must tell the operator the flag does not raise this cap, got: {err}"
+        );
     }
 }

--- a/anchor/client/src/lib.rs
+++ b/anchor/client/src/lib.rs
@@ -648,7 +648,7 @@ impl Client {
             config.gas_limit,
             config.builder_boost_factor,
             config.prefer_builder_proposals,
-            config.proposer_delay,
+            config.proposer_delays,
             config.strict_mfp,
             is_synced.clone(),
             executor.clone(),
@@ -820,6 +820,20 @@ impl Client {
         registration_service
             .start_validator_registration_service(&spec)
             .map_err(|e| format!("Unable to start validator registration service: {e}"))?;
+
+        // The proposer delays do not fall back to each other, so a pre-Gloas-only configuration
+        // silently loses its delay at the fork. Warn at startup, but only on networks where
+        // Gloas is actually scheduled; anywhere else this would be a permanent false alarm.
+        if spec.is_gloas_scheduled()
+            && !config.proposer_delays.pre_gloas.is_zero()
+            && config.proposer_delays.gloas.is_zero()
+        {
+            warn!(
+                "--proposer-delay-ms is set but --proposer-delay-epbs-ms is not: the delay will \
+                 stop applying at the Gloas (ePBS) fork. Set --proposer-delay-epbs-ms to keep a \
+                 delay after it."
+            );
+        }
 
         // PTC payload-attestation duty (Gloas / ePBS). Start only when Gloas is scheduled,
         // mirroring LH's VC (validator_client/src/lib.rs:657). The service also self-gates per

--- a/anchor/validator_store/src/lib.rs
+++ b/anchor/validator_store/src/lib.rs
@@ -219,8 +219,8 @@ pub struct AnchorValidatorStore<
     // operator controls
     builder_boost_factor: Option<u64>,
     prefer_builder_proposals: bool,
-    /// See [`await_proposer_delay`] for the semantics.
-    proposer_delay: Duration,
+    /// See [`ProposerDelays`] and [`await_proposer_delay`] for the semantics.
+    proposer_delays: ProposerDelays,
     strict_mfp: bool,
     is_synced: watch::Receiver<bool>,
     task_executor: TaskExecutor,
@@ -293,12 +293,49 @@ impl ProposerDelayDecision {
     }
 }
 
+/// The configured proposer delays, one per side of the Gloas (ePBS) fork.
+///
+/// Each proposer duty uses whichever value matches the Ethereum fork at its slot, selected by
+/// [`proposer_delay_at_epoch`]. The values are independent, with no fallback between them, and
+/// both default to zero (disabled). This mirrors go-ssv's `ProposerDelay` / `ProposerDelayEPBS`
+/// pair: the split exists because ePBS retimes the proposal deadline, so the safe ranges differ.
+///
+/// Unvalidated by construction; the per-value caps are enforced in `client`'s config parsing.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct ProposerDelays {
+    /// Applied to duties in slots before the Gloas fork.
+    pub pre_gloas: Duration,
+    /// Applied to duties in slots at or after the Gloas fork.
+    pub gloas: Duration,
+}
+
+/// Which configured proposer delay applies to a duty in `epoch`: the ePBS value from the Gloas
+/// fork on, the regular value before it. Forks activate on epoch boundaries, so the duty epoch
+/// determines the fork at the duty slot exactly; this is go-ssv's `proposerDelayForSlot` keyed by
+/// the epoch the `ValidatorStore` seam already receives.
+///
+/// Also returns the matching low-cardinality source label for the duty span, so an operator can
+/// tell "delay off" from "the fork switched values" when the wait reads zero after Gloas.
+fn proposer_delay_at_epoch(
+    spec: &ChainSpec,
+    delays: ProposerDelays,
+    epoch: Epoch,
+) -> (Duration, &'static str) {
+    if spec.fork_name_at_epoch(epoch).gloas_enabled() {
+        (delays.gloas, "gloas")
+    } else {
+        (delays.pre_gloas, "pre_gloas")
+    }
+}
+
 /// Holds this proposer duty until `proposer_delay` into its slot, recording the outcome either way,
 /// including the no-wait cases.
 ///
 /// The delay is a *floor* from the start of the slot, not extra latency: a duty whose RANDAO
-/// pre-consensus already ran past it waits no longer. This matches go-ssv's `ProposerDelay`, so the
-/// same configured value yields the same request time on either client.
+/// pre-consensus already ran past it waits no longer. `proposer_delay` is already fork-selected by
+/// [`proposer_delay_at_epoch`], so this matches go-ssv's `ProposerDelay` before Gloas and
+/// `ProposerDelayEPBS` after it, and the same configured value yields the same request time on
+/// either client.
 ///
 /// `elapsed` is passed in rather than re-read so the wait and
 /// [`metrics::RANDAO_REVEAL_COMPLETION_OFFSET`] share one measurement; operators are told to
@@ -355,7 +392,7 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> AnchorValidator
         gas_limit: u64,
         builder_boost_factor: Option<u64>,
         prefer_builder_proposals: bool,
-        proposer_delay: Duration,
+        proposer_delays: ProposerDelays,
         strict_mfp: bool,
         is_synced: watch::Receiver<bool>,
         task_executor: TaskExecutor,
@@ -380,7 +417,7 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> AnchorValidator
             gas_limit,
             builder_boost_factor,
             prefer_builder_proposals,
-            proposer_delay,
+            proposer_delays,
             strict_mfp,
             is_synced,
             task_executor,
@@ -3098,10 +3135,11 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> ValidatorStore
 
     /// Runs RANDAO pre-consensus and reconstructs the reveal for this proposer duty.
     ///
-    /// Also holds until `--proposer-delay-ms` into the slot before returning, so it can block for
-    /// as long as that setting allows. The reveal is a required parameter of the block request,
-    /// so Lighthouse cannot ask earlier and this is the last point Anchor owns before it does.
-    /// See `await_proposer_delay`.
+    /// Also holds until the configured proposer delay into the slot before returning, so it can
+    /// block for as long as that setting allows. Which delay applies (`--proposer-delay-ms` before
+    /// Gloas, `--proposer-delay-epbs-ms` from it on) is decided by the fork at the clock slot. The
+    /// reveal is a required parameter of the block request, so Lighthouse cannot ask earlier and
+    /// this is the last point Anchor owns before it does. See `await_proposer_delay`.
     async fn randao_reveal(
         &self,
         validator_pubkey: PublicKeyBytes,
@@ -3117,6 +3155,7 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> ValidatorStore
             randao_completed_ms = field::Empty,
             proposer_delay_outcome = field::Empty,
             proposer_delay_waited_ms = field::Empty,
+            proposer_delay_source = field::Empty,
             signing_epoch = signing_epoch.as_u64(),
             failure_reason = field::Empty,
             outcome = field::Empty,
@@ -3172,7 +3211,13 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> ValidatorStore
                     "Proposer randao reveal reconstructed"
                 );
 
-                await_proposer_delay(self.proposer_delay, randao_completed).await;
+                // Keyed to the duty's epoch (Lighthouse passes the duty slot's epoch), not the
+                // clock: forks flip on epoch boundaries, so this is exactly the fork at the duty
+                // slot even if entry straddles one.
+                let (proposer_delay, delay_source) =
+                    proposer_delay_at_epoch(&self.spec, self.proposer_delays, signing_epoch);
+                Span::current().record("proposer_delay_source", delay_source);
+                await_proposer_delay(proposer_delay, randao_completed).await;
 
                 Ok(signature)
             }
@@ -4368,6 +4413,76 @@ mod tests {
         assert!(ProposerDelayDecision::Disabled.wait().is_none());
         assert!(ProposerDelayDecision::TargetPassed.wait().is_none());
         assert!(ProposerDelayDecision::ClockUnavailable.wait().is_none());
+    }
+
+    /// Distinct values on both sides so a swapped branch cannot pass.
+    const BOUNDARY_TEST_DELAYS: ProposerDelays = ProposerDelays {
+        pre_gloas: Duration::from_millis(300),
+        gloas: Duration::from_millis(700),
+    };
+
+    /// Mainnet spec with Gloas scheduled at the given epoch. `None` is passed explicitly rather
+    /// than relying on the mainnet default, so these tests survive a pin that schedules Gloas.
+    fn spec_with_gloas(gloas_fork_epoch: Option<Epoch>) -> ChainSpec {
+        let mut spec = ChainSpec::mainnet();
+        spec.gloas_fork_epoch = gloas_fork_epoch;
+        spec
+    }
+
+    /// Forks activate at the first slot of their epoch, so the epoch boundary here is exactly
+    /// the Gloas boundary slot.
+    #[test]
+    fn proposer_delay_switches_at_the_gloas_activation_epoch() {
+        let activation = Epoch::new(100);
+        let spec = spec_with_gloas(Some(activation));
+
+        assert_eq!(
+            proposer_delay_at_epoch(&spec, BOUNDARY_TEST_DELAYS, activation - 1),
+            (BOUNDARY_TEST_DELAYS.pre_gloas, "pre_gloas")
+        );
+        assert_eq!(
+            proposer_delay_at_epoch(&spec, BOUNDARY_TEST_DELAYS, activation),
+            (BOUNDARY_TEST_DELAYS.gloas, "gloas")
+        );
+    }
+
+    #[test]
+    fn proposer_delay_uses_pre_gloas_value_when_gloas_unscheduled() {
+        let spec = spec_with_gloas(None);
+
+        // Not zero-because-gloas-default: the pre-Gloas value must apply at any epoch.
+        assert_eq!(
+            proposer_delay_at_epoch(&spec, BOUNDARY_TEST_DELAYS, Epoch::new(100_000)),
+            (BOUNDARY_TEST_DELAYS.pre_gloas, "pre_gloas")
+        );
+    }
+
+    /// A zero on the fork-selected side must stay zero: the values are independent, with no
+    /// fallback to the other side's nonzero value in either direction.
+    #[test]
+    fn proposer_delay_zero_on_the_selected_side_never_falls_back() {
+        let activation = Epoch::new(100);
+        let spec = spec_with_gloas(Some(activation));
+
+        let only_pre_gloas = ProposerDelays {
+            pre_gloas: Duration::from_millis(300),
+            gloas: Duration::ZERO,
+        };
+        assert_eq!(
+            proposer_delay_at_epoch(&spec, only_pre_gloas, activation),
+            (Duration::ZERO, "gloas"),
+            "a Gloas duty must not fall back to the pre-Gloas value"
+        );
+
+        let only_gloas = ProposerDelays {
+            pre_gloas: Duration::ZERO,
+            gloas: Duration::from_millis(700),
+        };
+        assert_eq!(
+            proposer_delay_at_epoch(&spec, only_gloas, activation - 1),
+            (Duration::ZERO, "pre_gloas"),
+            "a pre-Gloas duty must not fall back to the Gloas value"
+        );
     }
 
     /// Creates a test `VotingAssignments` with the given parameters.

--- a/anchor/validator_store/src/lib.rs
+++ b/anchor/validator_store/src/lib.rs
@@ -3137,7 +3137,7 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> ValidatorStore
     ///
     /// Also holds until the configured proposer delay into the slot before returning, so it can
     /// block for as long as that setting allows. Which delay applies (`--proposer-delay-ms` before
-    /// Gloas, `--proposer-delay-epbs-ms` from it on) is decided by the fork at the clock slot. The
+    /// Gloas, `--proposer-delay-epbs-ms` from it on) is decided by the fork at the duty's slot. The
     /// reveal is a required parameter of the block request, so Lighthouse cannot ask earlier and
     /// this is the last point Anchor owns before it does. See `await_proposer_delay`.
     async fn randao_reveal(

--- a/anchor/validator_store/src/testing/common.rs
+++ b/anchor/validator_store/src/testing/common.rs
@@ -38,7 +38,8 @@ use types::{
 use validator_store::{AggregateToSign, AttestationToSign, SyncMessageToSign, ValidatorStore};
 
 use crate::{
-    AggregationAssignments, AnchorValidatorStore, Error, VotingAssignments, VotingContext,
+    AggregationAssignments, AnchorValidatorStore, Error, ProposerDelays, VotingAssignments,
+    VotingContext,
 };
 
 pub(super) const TEST_SLOT: u64 = 1;
@@ -296,9 +297,9 @@ pub(super) struct HarnessOptions {
     /// SSV fork the store's `ForkSchedule` reports as active. Defaults to `Boole`; tests that
     /// exercise pre-Boole behaviour supply an earlier fork.
     pub(super) active_fork: Fork,
-    /// Proposer delay wired into the store. Defaults to zero so most tests assert timing-free
-    /// behaviour.
-    pub(super) proposer_delay: Duration,
+    /// Proposer delays wired into the store. Both default to zero so most tests assert
+    /// timing-free behaviour.
+    pub(super) proposer_delays: ProposerDelays,
 }
 
 impl Default for HarnessOptions {
@@ -313,7 +314,7 @@ impl Default for HarnessOptions {
             spec: Arc::new(ChainSpec::mainnet()),
             forced_gloas_index: None,
             active_fork: Fork::Boole,
-            proposer_delay: Duration::ZERO,
+            proposer_delays: ProposerDelays::default(),
         }
     }
 }
@@ -385,21 +386,6 @@ impl ValidatorStoreTestHarness {
             our_operator_id,
             HarnessOptions {
                 active_fork,
-                ..Default::default()
-            },
-        )
-    }
-
-    pub(super) fn new_with_proposer_delay(
-        committee_setups: Vec<CommitteeSetup>,
-        our_operator_id: OperatorId,
-        proposer_delay: Duration,
-    ) -> Self {
-        Self::new_with_options(
-            committee_setups,
-            our_operator_id,
-            HarnessOptions {
-                proposer_delay,
                 ..Default::default()
             },
         )
@@ -532,7 +518,7 @@ impl ValidatorStoreTestHarness {
             30_000_000,
             None,
             false,
-            options.proposer_delay,
+            options.proposer_delays,
             false,
             is_synced_rx,
             executor,

--- a/anchor/validator_store/src/testing/proposer_delay.rs
+++ b/anchor/validator_store/src/testing/proposer_delay.rs
@@ -9,17 +9,17 @@
 //! delay of 300ms (safely under both config bounds: the 1000ms acknowledgement gate and the
 //! 4000ms hard cap) leaves a 200ms remainder.
 
-use std::time::Duration;
+use std::{sync::Arc, time::Duration};
 
 use bls::PublicKeyBytes;
 use slot_clock::ManualSlotClock;
 use ssv_types::OperatorId;
 use tokio::time::Instant;
-use types::Epoch;
+use types::{ChainSpec, Epoch, EthSpec, MainnetEthSpec};
 use validator_store::ValidatorStore;
 
 use super::common::*;
-use crate::Error;
+use crate::{Error, ProposerDelays};
 
 const OUR_OPERATOR_ID: OperatorId = OperatorId(1);
 const OPERATOR_IDS: [OperatorId; 4] = [OperatorId(1), OperatorId(2), OperatorId(3), OperatorId(4)];
@@ -33,26 +33,46 @@ const ELAPSED_IN_SLOT_AT_CALL: Duration = Duration::from_millis(100);
 /// The floor minus the elapsed time: 300ms - 100ms.
 const EXPECTED_REMAINING_WAIT: Duration = Duration::from_millis(200);
 
+/// A `--proposer-delay-epbs-ms` value distinct from [`PROPOSER_DELAY`], so which knob applied is
+/// observable from the wait alone. Under the 1000ms hard cap.
+const GLOAS_PROPOSER_DELAY: Duration = Duration::from_millis(500);
+/// The Gloas-side floor minus the elapsed time: 500ms - 100ms.
+const EXPECTED_GLOAS_REMAINING_WAIT: Duration = Duration::from_millis(400);
+
 /// Epoch of `TEST_SLOT` (slot 1) on the mainnet spec.
 const SIGNING_EPOCH: Epoch = Epoch::new(0);
 
-/// Places the shared clock `ELAPSED_IN_SLOT_AT_CALL` into `TEST_SLOT`, replacing the harness
-/// default of 5s in, which the 300ms floor could never reach.
-fn reposition_clock_early_in_test_slot(slot_clock: &ManualSlotClock) {
-    slot_clock.set_current_time(
-        Duration::from_secs(TEST_SLOT * SLOT_DURATION_SECS) + ELAPSED_IN_SLOT_AT_CALL,
+/// Places the shared clock `ELAPSED_IN_SLOT_AT_CALL` into `slot`, replacing the harness default
+/// of 5s into `TEST_SLOT`, which the sub-second floors could never reach.
+fn reposition_clock_early_in_slot(slot_clock: &ManualSlotClock, slot: u64) {
+    slot_clock
+        .set_current_time(Duration::from_secs(slot * SLOT_DURATION_SECS) + ELAPSED_IN_SLOT_AT_CALL);
+}
+
+/// Builds a harness with the given spec and delays, with the clock early in `TEST_SLOT`.
+fn harness(spec: Arc<ChainSpec>, proposer_delays: ProposerDelays) -> ValidatorStoreTestHarness {
+    let committee = create_committee_setup(&OPERATOR_IDS, 1, 0);
+    let harness = ValidatorStoreTestHarness::new_with_options(
+        vec![committee],
+        OUR_OPERATOR_ID,
+        HarnessOptions {
+            spec,
+            proposer_delays,
+            ..Default::default()
+        },
     );
+    reposition_clock_early_in_slot(&harness.slot_clock, TEST_SLOT);
+    harness
 }
 
 fn harness_with_proposer_delay() -> ValidatorStoreTestHarness {
-    let committee = create_committee_setup(&OPERATOR_IDS, 1, 0);
-    let harness = ValidatorStoreTestHarness::new_with_proposer_delay(
-        vec![committee],
-        OUR_OPERATOR_ID,
-        PROPOSER_DELAY,
-    );
-    reposition_clock_early_in_test_slot(&harness.slot_clock);
-    harness
+    harness(
+        Arc::new(ChainSpec::mainnet()),
+        ProposerDelays {
+            pre_gloas: PROPOSER_DELAY,
+            gloas: Duration::ZERO,
+        },
+    )
 }
 
 /// The delay is a floor from slot start, applied *after* signature collection: with the clock
@@ -105,5 +125,86 @@ async fn randao_reveal_unknown_pubkey_fails_without_waiting() {
         started.elapsed(),
         Duration::ZERO,
         "error path must not apply the proposer delay"
+    );
+}
+
+/// Builds a harness with both delay knobs set to distinct values, under the given spec.
+fn harness_with_both_delays(spec: Arc<ChainSpec>) -> ValidatorStoreTestHarness {
+    harness(
+        spec,
+        ProposerDelays {
+            pre_gloas: PROPOSER_DELAY,
+            gloas: GLOAS_PROPOSER_DELAY,
+        },
+    )
+}
+
+/// From the Gloas fork on, the ePBS value is the floor: with Gloas active at genesis, `TEST_SLOT`
+/// is post-fork, so the 500ms ePBS floor sleeps its 400ms remainder rather than the 200ms the
+/// pre-Gloas value would have.
+#[tokio::test(flavor = "current_thread", start_paused = true)]
+async fn randao_reveal_in_gloas_waits_the_gloas_floor_remainder() {
+    let harness = harness_with_both_delays(gloas_at_genesis_spec());
+    let validator = harness.validator_metadata(COMMITTEE_INDEX, VALIDATOR_INDEX);
+    let started = Instant::now();
+
+    let result = harness
+        .validator_store
+        .randao_reveal(validator.public_key, SIGNING_EPOCH)
+        .await;
+
+    result.expect("randao reveal should succeed");
+    assert_eq!(
+        started.elapsed(),
+        EXPECTED_GLOAS_REMAINING_WAIT,
+        "a post-Gloas duty must apply the ePBS delay, not the pre-Gloas one"
+    );
+}
+
+/// Before Gloas the ePBS value must be inert: the values are independent, with no fallback in
+/// either direction, so a pre-fork duty waits the pre-Gloas remainder even with the ePBS knob set.
+#[tokio::test(flavor = "current_thread", start_paused = true)]
+async fn randao_reveal_pre_gloas_ignores_the_gloas_delay() {
+    // Mainnet default spec: Gloas is unscheduled, so `TEST_SLOT` is pre-fork.
+    let harness = harness_with_both_delays(Arc::new(ChainSpec::mainnet()));
+    let validator = harness.validator_metadata(COMMITTEE_INDEX, VALIDATOR_INDEX);
+    let started = Instant::now();
+
+    let result = harness
+        .validator_store
+        .randao_reveal(validator.public_key, SIGNING_EPOCH)
+        .await;
+
+    result.expect("randao reveal should succeed");
+    assert_eq!(
+        started.elapsed(),
+        EXPECTED_REMAINING_WAIT,
+        "a pre-Gloas duty must apply the pre-Gloas delay, ignoring the ePBS value"
+    );
+}
+
+/// With Gloas scheduled mid-chain rather than at genesis, a duty in the activation epoch must
+/// still pick the ePBS value. This pins that the selection is driven by the duty's actual epoch,
+/// not by a genesis-relative constant that the two fork-uniform tests above could not distinguish.
+#[tokio::test(flavor = "current_thread", start_paused = true)]
+async fn randao_reveal_at_mid_schedule_gloas_activation_waits_the_gloas_floor_remainder() {
+    let gloas_epoch = Epoch::new(1);
+    let harness = harness_with_both_delays(gloas_at_epoch_spec(gloas_epoch));
+    // Reposition to the first slot of the activation epoch, the same 100ms in.
+    let first_gloas_slot = gloas_epoch.start_slot(MainnetEthSpec::slots_per_epoch());
+    reposition_clock_early_in_slot(&harness.slot_clock, first_gloas_slot.as_u64());
+    let validator = harness.validator_metadata(COMMITTEE_INDEX, VALIDATOR_INDEX);
+    let started = Instant::now();
+
+    let result = harness
+        .validator_store
+        .randao_reveal(validator.public_key, gloas_epoch)
+        .await;
+
+    result.expect("randao reveal should succeed");
+    assert_eq!(
+        started.elapsed(),
+        EXPECTED_GLOAS_REMAINING_WAIT,
+        "a duty in the Gloas activation epoch must apply the ePBS delay"
     );
 }

--- a/docs/docs/generated/cli-node-options.mdx
+++ b/docs/docs/generated/cli-node-options.mdx
@@ -314,7 +314,8 @@ Payload Building Options:
                fork onward: each proposer duty uses whichever value matches the
                fork at its slot, with no fallback between them. Post-ePBS slots
                leave less headroom after the block request, so this value has a
-               hard cap that --allow-dangerous-proposer-delay does not raise.
+               hard 1000ms cap that --allow-dangerous-proposer-delay does not
+               raise.
                
                [default: 0]
 

--- a/docs/docs/generated/cli-node-options.mdx
+++ b/docs/docs/generated/cli-node-options.mdx
@@ -267,7 +267,9 @@ Payload Building Options:
          --allow-dangerous-proposer-delay
                Permit a --proposer-delay-ms above the safety threshold. Delays
                this large significantly increase the risk of missed block
-               proposals. Only set this if you understand the trade-off.
+               proposals. Only set this if you understand the trade-off. Does
+               not apply to --proposer-delay-epbs-ms, which has a hard cap
+               instead.
 
          --builder-boost-factor <UINT64>
                Defines the boost factor, a percentage multiplier to apply to
@@ -307,6 +309,15 @@ Payload Building Options:
                If this flag is set, Anchor will always prefer blocks
                constructed by builders, regardless of payload value.
 
+         --proposer-delay-epbs-ms <MILLISECONDS>
+               Counterpart of --proposer-delay-ms applied from the Gloas (ePBS)
+               fork onward: each proposer duty uses whichever value matches the
+               fork at its slot, with no fallback between them. Post-ePBS slots
+               leave less headroom after the block request, so this value has a
+               hard cap that --allow-dangerous-proposer-delay does not raise.
+               
+               [default: 0]
+
          --proposer-delay-ms <MILLISECONDS>
                Wait until this many milliseconds into the slot before
                requesting a block for a proposer duty, giving builders longer
@@ -314,7 +325,9 @@ Payload Building Options:
                slot, not extra latency: if the RANDAO pre-consensus round
                already finished later than this, no additional wait happens. A
                recommended starting value is 300. Higher values increase the
-               risk of missing the block proposal.
+               risk of missing the block proposal. Applies to slots before the
+               Gloas (ePBS) fork; from that fork on, --proposer-delay-epbs-ms
+               applies instead.
                
                [default: 0]
 

--- a/docs/docs/pages/mev_configuration.mdx
+++ b/docs/docs/pages/mev_configuration.mdx
@@ -7,6 +7,10 @@ your beacon node.
 `--proposer-delay-ms` tunes *when* Anchor asks for a block. Asking later gives builders more time to
 bid, at the cost of leaving less of the slot for everything that follows.
 
+From the Gloas (ePBS) fork onward, `--proposer-delay-epbs-ms` takes over: each proposer duty uses
+whichever value matches the fork at its slot. The two values are independent, with no fallback
+between them, and the ePBS value also defaults to `0` (off).
+
 ## How the delay works
 
 The value is an **offset from the start of the slot, not added latency**. Set `300` and Anchor
@@ -21,7 +25,14 @@ tell you.
 In a cluster, **every** operator holding a share requests its own candidate block and consensus
 picks between them, so set and monitor this fleet-wide rather than on a single node.
 
+Which value applies is decided per duty by the Ethereum fork at the duty's slot: before Gloas,
+`--proposer-delay-ms`; from Gloas onward, `--proposer-delay-epbs-ms`. An existing
+`--proposer-delay-ms` setting therefore stops applying at the fork unless you also set the ePBS
+value.
+
 ## Choosing a value
+
+### `--proposer-delay-ms` (before Gloas)
 
 | Value | Behaviour |
 | --- | --- |
@@ -30,8 +41,16 @@ picks between them, so set and monitor this fleet-wide rather than on a single n
 | above `1000` | Refused unless you also pass `--allow-dangerous-proposer-delay`. |
 | above `4000` | Refused outright. The acknowledgement flag does not override it. |
 
+### `--proposer-delay-epbs-ms` (from Gloas onward)
+
+| Value | Behaviour |
+| --- | --- |
+| `0` | Disabled. The default. |
+| up to `1000` | Applied from the first slot of the Gloas fork epoch. |
+| above `1000` | Refused outright. `--allow-dangerous-proposer-delay` does not override it; there is no escape hatch, matching the SSV node. |
+
 ```bash
-anchor node --proposer-delay-ms 300
+anchor node --proposer-delay-ms 300 --proposer-delay-epbs-ms 300
 ```
 
 **The higher the value, the higher the chance of missing a block proposal**, since consensus,
@@ -46,9 +65,16 @@ safe maximum; both are guard rails.
 - `anchor_proposer_delay_applied_seconds` is the wait actually applied, labelled `disabled`,
   `target_passed`, `waited`, or `clock_unavailable`. Non-waiting outcomes record zero, so a flat
   zero line means the delay is not biting rather than that the metric is missing.
+- From Gloas onward, a flat zero with only `--proposer-delay-ms` configured means the fork switched
+  which value applies, not that the delay is broken. The duty's span records which knob applied as
+  `proposer_delay_source` (`pre_gloas` or `gloas`).
 
 ## Coming from an SSV node
 
 Same semantics as the SSV node's `ProposerDelay`, so an existing value carries over directly. The
 SSV node reads it from a config file or the `PROPOSER_DELAY` environment variable; Anchor takes a
 command line flag in milliseconds, so `ProposerDelay: 300ms` becomes `--proposer-delay-ms 300`.
+
+The ePBS value maps the same way from the SSV node's `ProposerDelayEPBS` key or the
+`PROPOSER_DELAY_EPBS` environment variable: `ProposerDelayEPBS: 300ms` becomes
+`--proposer-delay-epbs-ms 300`. Both clients hard-cap it at one second.


### PR DESCRIPTION
## Problem, Evidence, and Context

`--proposer-delay-ms` (#1213) is a single, fork-agnostic knob. go-ssv splits the setting because ePBS retimes the proposal deadline, so the safe ranges differ: `ProposerDelay` before Gloas, `ProposerDelayEPBS` from it on, the latter hard-capped at 1s with deliberately no override. Without the split, an operator migrating from an SSV node loses a setting at Gloas, and a value tuned pre-Gloas silently keeps applying under a tighter deadline.

Closes #1212.

## Change Overview

- New `--proposer-delay-epbs-ms` (default 0), independent of `--proposer-delay-ms` with no fallback in either direction. Refused above 1000ms at startup regardless of `--allow-dangerous-proposer-delay`, matching go-ssv.
- The two values travel as one `ProposerDelays` pair from config into the validator store. Each proposer duty selects the value by the fork at its slot, and the duty span records which value applied so a post-fork flat-zero metric is diagnosable.
- Reading order: the validator store (pair + selection + the one call site in the RANDAO seam), then config validation, then tests and docs; the CLI and client wiring are mechanical.
- Unchanged: the delay's floor-from-slot-start semantics, metric names and outcome labels, and the ValidatorStore trait.
- One deliberate deviation from the issue's Note: selection keys on `signing_epoch` rather than the captured clock slot. Lighthouse passes the duty slot's epoch there, and `fork_name_at_slot` is defined as `fork_name_at_epoch(slot.epoch())`, so this is exactly "the fork at the duty slot" while removing clock-vs-duty skew at the boundary. Still no trait change.

## Risks, Trade-offs, and Mitigations

- An operator running only `--proposer-delay-ms` loses the delay at Gloas by design (parity). Mitigated by a startup warning on networks where Gloas is scheduled, the span's `proposer_delay_source` field, and the docs' migration mapping.
- The 1000ms cap is go-ssv's policy value, not an Anchor-measured ceiling; the docs keep presenting the limits as guard rails, not safe maxima.

## Validation

- Unit tests: selection either side of the Gloas activation epoch, unscheduled Gloas, and zero-on-the-selected-side pins for the no-fallback semantic; config tests cover both defaults, the cap boundary, and refusal with the acknowledgement flag set.
- Virtual-time integration tests: Gloas-at-genesis applies the ePBS value, pre-Gloas ignores it, and a mid-schedule activation pins that the duty's real epoch drives selection.
- Full workspace suite (825 tests), clippy, fmt, and the docgen check all pass. go-ssv semantics verified against its `epbs-gloas` branch (key names, env var, cap boundary, flag scoping).

## Rollback

Revert the commit. The flag is additive and defaults to 0, which preserves current behavior; no data or config migration.