### PR TITLE
fix(validator_store): publish decided AggregatorCommittee aggregates from the metadata service

### DIFF
--- a/anchor/validator_store/src/aggregator_post_consensus.rs
+++ b/anchor/validator_store/src/aggregator_post_consensus.rs
@@ -141,7 +141,9 @@ async fn publish_one_root<E: EthSpec, F, Fut>(
             metrics::inc_publish_result(metrics::NO_SIGNATURES);
             return;
         }
-        // Deadline expired before this root's quorum; only this root is withheld.
+        // Deadline expired before this root's quorum; only this root is withheld. Labelled
+        // `timeout` to match the committee-level join arm, now that expiry is distinguishable
+        // from a collection failure.
         Err(_) => {
             warn!(
                 pubkey = ?root.request.validator.public_key,
@@ -150,7 +152,7 @@ async fn publish_one_root<E: EthSpec, F, Fut>(
             );
             validator_metrics::inc_counter_vec(
                 &validator_metrics::SIGNED_AGGREGATES_TOTAL,
-                &[metrics::OTHER_ERROR],
+                &[metrics::TIMEOUT],
             );
             metrics::inc_publish_result(metrics::NO_SIGNATURES);
             return;

--- a/anchor/validator_store/src/aggregator_post_consensus.rs
+++ b/anchor/validator_store/src/aggregator_post_consensus.rs
@@ -2,11 +2,14 @@
 //!
 //! One QBFT decision carries both attestation aggregates and sync contributions for an SSV
 //! committee, and the operator must emit exactly one committee partial-signature message per
-//! `(committee, slot)` covering everything it can sign. No consumer can own that message:
-//! contributions are returned through a Lighthouse callback that may or may not fire (issue
-//! #1227), and aggregates are published by the metadata service's publisher because Lighthouse's
-//! duty snapshot is cloned before slot-start selection proofs finish and would silently skip
-//! them.
+//! `(committee, slot)` covering everything it can sign. The decided value drives both what gets
+//! signed and what gets published: Anchor owns Boole+ aggregate publication outright, through
+//! the metadata service's publisher, because the protocol's unit of agreement is the decided
+//! value and no local Lighthouse view is part of it. (Lighthouse's duty snapshot in particular
+//! is cloned before slot-start selection proofs finish, so routing publication through it would
+//! silently skip late-installed proofs.) Contributions are returned through a Lighthouse
+//! callback that may or may not fire (issue #1227), so no callback can own the committee
+//! message either.
 //!
 //! The signing set is therefore a property of the duty, not of any consumer. The slot pipeline
 //! starts one execution per committee when it publishes the decided value at 2/3 slot; the
@@ -74,6 +77,10 @@ pub(crate) struct PreparedRoot<M> {
 /// identity: validator index for aggregates (read by the aggregate publisher),
 /// `(validator index, subcommittee index)` for contributions (read by the Lighthouse callback).
 pub(crate) struct AggregatorPostConsensusOutcome<E: EthSpec> {
+    /// Fork the decided value's SSZ payloads were decoded under (its `DataVersion`). The
+    /// publisher derives its HTTP endpoint choice and fork header from this, so they cannot
+    /// diverge from the payload variant actually in the batch.
+    pub(crate) fork_name: ForkName,
     pub(crate) aggregates: HashMap<ValidatorIndex, PreparedRoot<AggregateAndProof<E>>>,
     pub(crate) contributions: HashMap<(ValidatorIndex, u64), PreparedRoot<ContributionAndProof<E>>>,
 }
@@ -88,8 +95,15 @@ pub(crate) enum ResolvedAggregates<E: EthSpec> {
     ConsensusFailed,
     /// The decided worklist legitimately holds contributions only.
     NoAggregates,
-    /// Signature draining finished; empty when no decided root reached quorum in time.
-    Batch(Vec<SignedAggregateAndProof<E>>),
+    /// Aggregates were decided, but no root reached signature quorum before the deadline.
+    NoSignatures,
+    /// At least one decided aggregate reached quorum. `fork_name` is the fork the decided
+    /// value's payloads were decoded under, carried with the batch so the publish endpoint
+    /// always matches the payload variant.
+    Batch {
+        fork_name: ForkName,
+        aggregates: Vec<SignedAggregateAndProof<E>>,
+    },
 }
 
 /// The signing worklist derived from one decided `AggregatorCommitteeConsensusData`.
@@ -128,7 +142,9 @@ impl<T: SlotClock + 'static, E: EthSpec, C: ConsensusDecider<E> + 'static>
     /// The returned handles feed the metadata service's aggregate publisher. Returning only the
     /// vacant insertions gives the publisher the same exactly-once property as the executions
     /// themselves: a repeated call for one `(committee, slot)` registers nothing and therefore
-    /// publishes nothing twice.
+    /// publishes nothing twice. Both properties are scoped to the process lifetime and to the
+    /// retention window below: after an entry is pruned, only a slot clock stepping backwards
+    /// past the window could present its `(committee, slot)` again, and that would re-register.
     ///
     /// Pre-Boole there is no consensus data and this is a no-op returning no executions.
     #[must_use = "dropping the returned executions disables Boole+ aggregate publication"]
@@ -197,8 +213,8 @@ impl<T: SlotClock + 'static, E: EthSpec, C: ConsensusDecider<E> + 'static>
     /// publication does not depend on Lighthouse's snapshot timing.
     ///
     /// Takes the execution handle directly rather than re-entering the assignments watch channel,
-    /// so a late-polled publisher cannot observe `MetadataSlotPassed` for an execution that still
-    /// exists in the retention map.
+    /// so a late-polled publisher cannot observe `AggregatorInfoSlotPassed` for an execution that
+    /// still exists in the retention map.
     pub(crate) async fn resolve_decided_aggregates(
         &self,
         committee_id: CommitteeId,
@@ -278,7 +294,14 @@ impl<T: SlotClock + 'static, E: EthSpec, C: ConsensusDecider<E> + 'static>
             ));
         }
 
-        ResolvedAggregates::Batch(results)
+        if results.is_empty() {
+            return ResolvedAggregates::NoSignatures;
+        }
+
+        ResolvedAggregates::Batch {
+            fork_name: outcome.fork_name,
+            aggregates: results,
+        }
     }
 
     /// Resolve each committee's decided aggregates and hand every non-empty batch to `publish`.
@@ -295,14 +318,15 @@ impl<T: SlotClock + 'static, E: EthSpec, C: ConsensusDecider<E> + 'static>
     /// below.
     ///
     /// A batch always holds exactly one committee's aggregates, all decoded from one decided
-    /// `DataVersion`; the publish closure may rely on that uniformity when selecting an endpoint.
+    /// `DataVersion`; the fork that version names travels with the batch, so the publish
+    /// closure's endpoint choice always matches the payload variant.
     pub(crate) async fn publish_decided_aggregates<F, Fut>(
         &self,
         slot: Slot,
         executions: Vec<(CommitteeId, AggregatorPostConsensusShared<E>)>,
         publish: F,
     ) where
-        F: Fn(Arc<Vec<SignedAggregateAndProof<E>>>) -> Fut,
+        F: Fn(ForkName, Arc<Vec<SignedAggregateAndProof<E>>>) -> Fut,
         Fut: Future<Output = Result<(), String>>,
     {
         let publish = &publish;
@@ -319,7 +343,7 @@ impl<T: SlotClock + 'static, E: EthSpec, C: ConsensusDecider<E> + 'static>
                     ResolvedAggregates::NoAggregates => {
                         metrics::inc_publish_result(metrics::NO_AGGREGATES);
                     }
-                    ResolvedAggregates::Batch(batch) if batch.is_empty() => {
+                    ResolvedAggregates::NoSignatures => {
                         warn!(
                             ?committee_id,
                             %slot,
@@ -327,9 +351,12 @@ impl<T: SlotClock + 'static, E: EthSpec, C: ConsensusDecider<E> + 'static>
                         );
                         metrics::inc_publish_result(metrics::NO_SIGNATURES);
                     }
-                    ResolvedAggregates::Batch(batch) => {
-                        let signed = Arc::new(batch);
-                        let result = publish(Arc::clone(&signed))
+                    ResolvedAggregates::Batch {
+                        fork_name,
+                        aggregates,
+                    } => {
+                        let signed = Arc::new(aggregates);
+                        let result = publish(fork_name, Arc::clone(&signed))
                             .instrument(info_span!("publish_aggregates", count = signed.len()))
                             .await;
                         // Both arms reproduce the per-aggregate log Lighthouse emits on its
@@ -424,6 +451,7 @@ impl<T: SlotClock + 'static, E: EthSpec, C: ConsensusDecider<E> + 'static>
                 "No active cluster for committee, skipping aggregator post-consensus"
             );
             return Ok(Arc::new(AggregatorPostConsensusOutcome {
+                fork_name: ForkName::from(our_consensus_data.version),
                 aggregates: HashMap::new(),
                 contributions: HashMap::new(),
             }));
@@ -454,6 +482,7 @@ impl<T: SlotClock + 'static, E: EthSpec, C: ConsensusDecider<E> + 'static>
         };
 
         Ok(Arc::new(AggregatorPostConsensusOutcome {
+            fork_name: ForkName::from(decided_data.version),
             aggregates: self.prepare_roots(worklist.aggregates, &collection_mode, &cluster, slot),
             contributions: self.prepare_roots(
                 worklist.contributions,

--- a/anchor/validator_store/src/aggregator_post_consensus.rs
+++ b/anchor/validator_store/src/aggregator_post_consensus.rs
@@ -2,14 +2,17 @@
 //!
 //! One QBFT decision carries both attestation aggregates and sync contributions for an SSV
 //! committee, and the operator must emit exactly one committee partial-signature message per
-//! `(committee, slot)` covering everything it can sign. Lighthouse asks for signatures through two
-//! independent callbacks, one per object class, so neither callback can own that message: whichever
-//! one fires, the other class still has to be signed (issue #1227).
+//! `(committee, slot)` covering everything it can sign. No consumer can own that message:
+//! contributions are returned through a Lighthouse callback that may or may not fire (issue
+//! #1227), and aggregates are published by the metadata service's publisher because Lighthouse's
+//! duty snapshot is cloned before slot-start selection proofs finish and would silently skip
+//! them.
 //!
-//! The signing set is therefore a property of the duty, not of any callback. The slot pipeline
-//! starts one execution per committee when it publishes the decided value at 2/3 slot, and the
-//! callbacks only look up their own results. This is the ssv-spec-normative shape, where the
-//! decided value drives what gets signed and local state only filters.
+//! The signing set is therefore a property of the duty, not of any consumer. The slot pipeline
+//! starts one execution per committee when it publishes the decided value at 2/3 slot; the
+//! contributions callback and the aggregate publisher only look up their own results. This is
+//! the ssv-spec-normative shape, where the decided value drives what gets signed and local state
+//! only filters.
 
 use std::{
     collections::{HashMap, HashSet, hash_map::Entry},
@@ -20,8 +23,9 @@ use std::{
 use bls::Signature;
 use database::{NonUniqueIndex, UniqueIndex};
 use futures::{
-    FutureExt,
+    FutureExt, StreamExt,
     future::{BoxFuture, Shared},
+    stream::FuturesUnordered,
 };
 use qbft_manager::ConsensusDecider;
 use slot_clock::SlotClock;
@@ -33,15 +37,15 @@ use ssv_types::{
 };
 use ssz::Decode;
 use tokio::time::Instant;
-use tracing::{debug, error, warn};
+use tracing::{Instrument, debug, error, info, info_span, warn};
 use types::{
     AggregateAndProof, Attestation, AttestationBase, AttestationElectra, ContributionAndProof,
-    Domain, EthSpec, ForkName, Hash256, SelectionProof, SignedRoot, Slot,
+    Domain, EthSpec, ForkName, Hash256, SelectionProof, SignedAggregateAndProof, SignedRoot, Slot,
 };
 
 use crate::{
     AggregationAssignments, AnchorValidatorStore, CollectionMode, Error, SigningRequest,
-    SpecificError,
+    SpecificError, drain_signatures, metrics,
 };
 
 /// Epochs to retain finished `AggregatorCommittee` post-consensus executions.
@@ -66,12 +70,26 @@ pub(crate) struct PreparedRoot<M> {
     pub(crate) signature: SharedResult<Signature>,
 }
 
-/// Everything this operator signs for one decided `AggregatorCommittee` round, keyed by the
-/// identities the Lighthouse callbacks look up: validator index for aggregates,
-/// `(validator index, subcommittee index)` for contributions.
+/// Everything this operator signs for one decided `AggregatorCommittee` round, keyed by signing
+/// identity: validator index for aggregates (read by the aggregate publisher),
+/// `(validator index, subcommittee index)` for contributions (read by the Lighthouse callback).
 pub(crate) struct AggregatorPostConsensusOutcome<E: EthSpec> {
     pub(crate) aggregates: HashMap<ValidatorIndex, PreparedRoot<AggregateAndProof<E>>>,
     pub(crate) contributions: HashMap<(ValidatorIndex, u64), PreparedRoot<ContributionAndProof<E>>>,
+}
+
+/// Outcome of resolving one committee's decided aggregates for publication.
+///
+/// Returned instead of a bare vec so [`AnchorValidatorStore::publish_decided_aggregates`] can
+/// emit every `AGGREGATOR_COMMITTEE_PUBLISH_TOTAL` label from one `match`, keeping the metric's
+/// partition over processed committees checkable in one place.
+pub(crate) enum ResolvedAggregates<E: EthSpec> {
+    /// Consensus failed, timed out, or the deadline could not be computed (logged at the site).
+    ConsensusFailed,
+    /// The decided worklist legitimately holds contributions only.
+    NoAggregates,
+    /// Signature draining finished; empty when no decided root reached quorum in time.
+    Batch(Vec<SignedAggregateAndProof<E>>),
 }
 
 /// The signing worklist derived from one decided `AggregatorCommitteeConsensusData`.
@@ -99,18 +117,25 @@ async fn join_detached_task<R>(
 impl<T: SlotClock + 'static, E: EthSpec, C: ConsensusDecider<E> + 'static>
     AnchorValidatorStore<T, E, C>
 {
-    /// Start one post-consensus execution per committee in freshly built assignments.
+    /// Start one post-consensus execution per committee in freshly built assignments, returning
+    /// the executions newly registered by this call.
     ///
     /// This is the only place executions are created. Callbacks look results up and never start
     /// work, so exactly one committee message per `(committee, slot)` holds by construction rather
     /// than by locking. Called from `update_aggregation_assignments` before the watch channel is
     /// published, so any consumer that can observe the assignments can also observe the execution.
     ///
-    /// Pre-Boole there is no consensus data and this is a no-op.
+    /// The returned handles feed the metadata service's aggregate publisher. Returning only the
+    /// vacant insertions gives the publisher the same exactly-once property as the executions
+    /// themselves: a repeated call for one `(committee, slot)` registers nothing and therefore
+    /// publishes nothing twice.
+    ///
+    /// Pre-Boole there is no consensus data and this is a no-op returning no executions.
+    #[must_use = "dropping the returned executions disables Boole+ aggregate publication"]
     pub(crate) fn start_aggregator_post_consensus(
         self: &Arc<Self>,
         assignments: &AggregationAssignments<E>,
-    ) {
+    ) -> Vec<(CommitteeId, AggregatorPostConsensusShared<E>)> {
         let slot = assignments.slot;
         let mut executions = self.aggregator_post_consensus.lock();
 
@@ -118,6 +143,7 @@ impl<T: SlotClock + 'static, E: EthSpec, C: ConsensusDecider<E> + 'static>
             slot.saturating_sub(AGGREGATOR_POST_CONSENSUS_RETAIN_EPOCHS * E::slots_per_epoch());
         executions.retain(|(_, execution_slot), _| *execution_slot >= cutoff);
 
+        let mut new_executions = Vec::new();
         for (&committee_id, decided_data) in &assignments.consensus_data_by_ssv_committee {
             // Vacant-only, so registration is idempotent. Overwriting would spawn a second QBFT
             // round and a second set of detached signing tasks while the first set kept running,
@@ -128,22 +154,228 @@ impl<T: SlotClock + 'static, E: EthSpec, C: ConsensusDecider<E> + 'static>
             if let Entry::Vacant(vacant) = executions.entry((committee_id, slot)) {
                 let store = Arc::clone(self);
                 let decided_data = Arc::clone(decided_data);
-                vacant.insert(self.spawn_shared("aggregator_post_consensus", async move {
+                let execution = self.spawn_shared("aggregator_post_consensus", async move {
                     store
                         .run_aggregator_post_consensus(committee_id, slot, decided_data)
                         .await
-                }));
+                });
+                vacant.insert(execution.clone());
+                new_executions.push((committee_id, execution));
             }
         }
+        new_executions
     }
 
-    /// Join the post-consensus execution for `(committee, slot)`, returning the outcome and the
-    /// deadline that bounded the join, for the caller to reuse when draining its own roots.
+    /// Join one committee's execution under the shared deadline, returning the outcome and the
+    /// deadline for the caller to reuse when draining its own roots.
     ///
     /// The single deadline (one slot past the duty slot's end) is an anti-hang backstop, not a
     /// duty-freshness bound: QBFT `SlotTime` rounds legitimately decide after the slot ends and
     /// reconstruction needs a network round trip after that, so bounding at slot end would discard
     /// results decided in contended rounds.
+    async fn join_execution(
+        &self,
+        slot: Slot,
+        execution: AggregatorPostConsensusShared<E>,
+    ) -> Result<(Instant, Arc<AggregatorPostConsensusOutcome<E>>), Error> {
+        let deadline = self.get_instant_in_slot(slot, self.spec.get_slot_duration() * 2)?;
+        let outcome = tokio::time::timeout_at(deadline, execution)
+            .await
+            .map_err(|_| Error::SpecificError(SpecificError::Timeout))?
+            .map_err(|e| (*e).clone())?;
+
+        Ok((deadline, outcome))
+    }
+
+    /// Join one committee's post-consensus execution and assemble every decided aggregate this
+    /// operator signed into publishable [`SignedAggregateAndProof`]s.
+    ///
+    /// This backs [`Self::publish_decided_aggregates`], which owns Boole+ aggregate publication:
+    /// Lighthouse's aggregate callback returns an empty batch at Boole+, because its duty
+    /// snapshot is cloned before slot-start selection proofs finish, silently skipping any proof
+    /// installed after the clone. The publisher works from the decided value instead, so
+    /// publication does not depend on Lighthouse's snapshot timing.
+    ///
+    /// Takes the execution handle directly rather than re-entering the assignments watch channel,
+    /// so a late-polled publisher cannot observe `MetadataSlotPassed` for an execution that still
+    /// exists in the retention map.
+    pub(crate) async fn resolve_decided_aggregates(
+        &self,
+        committee_id: CommitteeId,
+        slot: Slot,
+        execution: AggregatorPostConsensusShared<E>,
+    ) -> ResolvedAggregates<E> {
+        let (deadline, outcome) = match self.join_execution(slot, execution).await {
+            Ok(joined) => joined,
+            Err(e) => {
+                warn!(
+                    ?committee_id,
+                    %slot,
+                    error = ?e,
+                    "Aggregator post-consensus failed, no aggregates to publish"
+                );
+                // Keeps the Lighthouse-era signing counter alive for dashboards keyed on it. The
+                // per-aggregate count is unknowable before the outcome resolves, so failures
+                // count once per committee, an undercount but not silence.
+                let label = match e {
+                    Error::SpecificError(SpecificError::Timeout) => metrics::TIMEOUT,
+                    _ => metrics::OTHER_ERROR,
+                };
+                validator_metrics::inc_counter_vec(
+                    &validator_metrics::SIGNED_AGGREGATES_TOTAL,
+                    &[label],
+                );
+                return ResolvedAggregates::ConsensusFailed;
+            }
+        };
+
+        // A decided value can legitimately hold contributions only; nothing to publish then.
+        if outcome.aggregates.is_empty() {
+            debug!(?committee_id, %slot, "Decided worklist holds no aggregates");
+            return ResolvedAggregates::NoAggregates;
+        }
+
+        // Drain every aggregate root's signature concurrently under the deadline, so a root that
+        // never reaches quorum withholds only itself.
+        let pending = FuturesUnordered::new();
+        for (&index, root) in &outcome.aggregates {
+            let signing_root = root.request.signing_root;
+            let signature = root.signature.clone();
+            pending.push(async move { (index, signing_root, signature.await) });
+        }
+        let signatures = drain_signatures(pending, Some(deadline)).await;
+
+        let mut results = Vec::with_capacity(outcome.aggregates.len());
+        for (index, root) in &outcome.aggregates {
+            // Clone the decided message only on a signature hit; misses need just the pubkey.
+            let Some(signature) = signatures.get(&(*index, root.request.signing_root)) else {
+                warn!(
+                    pubkey = ?root.request.validator.public_key,
+                    %slot,
+                    "Missing signature, skipping aggregate"
+                );
+                validator_metrics::inc_counter_vec(
+                    &validator_metrics::SIGNED_AGGREGATES_TOTAL,
+                    &[metrics::OTHER_ERROR],
+                );
+                continue;
+            };
+            let message = root.request.duty_data.clone();
+
+            debug!(
+                aggregator_index = message.aggregator_index(),
+                data = ?message.aggregate().data(),
+                num_set_aggregation_bits = message.aggregate().num_set_aggregation_bits(),
+                "Signed AggregateAndProof (Boole+ committee consensus)"
+            );
+            validator_metrics::inc_counter_vec(
+                &validator_metrics::SIGNED_AGGREGATES_TOTAL,
+                &[validator_metrics::SUCCESS],
+            );
+            results.push(SignedAggregateAndProof::from_aggregate_and_proof(
+                message,
+                signature.clone(),
+            ));
+        }
+
+        ResolvedAggregates::Batch(results)
+    }
+
+    /// Resolve each committee's decided aggregates and hand every non-empty batch to `publish`.
+    ///
+    /// This is the authoritative Boole+ aggregate publication driver, spawned per slot by the
+    /// metadata service with the executions its assignment update newly registered. Generic over
+    /// the publish operation so tests (in `testing/aggregator_post_consensus.rs`) can inject a
+    /// recorder instead of an HTTP client. Each committee runs resolve-and-publish as one
+    /// `FuturesUnordered` entry, so a contended QBFT round or a slow POST in one committee does
+    /// not delay another committee's publication.
+    ///
+    /// Owns every `AGGREGATOR_COMMITTEE_PUBLISH_TOTAL` increment: the labels partition the
+    /// processed committees by outcome, and that partition is checkable in the single `match`
+    /// below.
+    ///
+    /// A batch always holds exactly one committee's aggregates, all decoded from one decided
+    /// `DataVersion`; the publish closure may rely on that uniformity when selecting an endpoint.
+    pub(crate) async fn publish_decided_aggregates<F, Fut>(
+        &self,
+        slot: Slot,
+        executions: Vec<(CommitteeId, AggregatorPostConsensusShared<E>)>,
+        publish: F,
+    ) where
+        F: Fn(Arc<Vec<SignedAggregateAndProof<E>>>) -> Fut,
+        Fut: Future<Output = Result<(), String>>,
+    {
+        let publish = &publish;
+        let mut pending: FuturesUnordered<_> = executions
+            .into_iter()
+            .map(|(committee_id, execution)| async move {
+                match self
+                    .resolve_decided_aggregates(committee_id, slot, execution)
+                    .await
+                {
+                    ResolvedAggregates::ConsensusFailed => {
+                        metrics::inc_publish_result(metrics::CONSENSUS_ERROR);
+                    }
+                    ResolvedAggregates::NoAggregates => {
+                        metrics::inc_publish_result(metrics::NO_AGGREGATES);
+                    }
+                    ResolvedAggregates::Batch(batch) if batch.is_empty() => {
+                        warn!(
+                            ?committee_id,
+                            %slot,
+                            "No decided aggregate reached signature quorum, nothing to publish"
+                        );
+                        metrics::inc_publish_result(metrics::NO_SIGNATURES);
+                    }
+                    ResolvedAggregates::Batch(batch) => {
+                        let signed = Arc::new(batch);
+                        let result = publish(Arc::clone(&signed))
+                            .instrument(info_span!("publish_aggregates", count = signed.len()))
+                            .await;
+                        // Both arms reproduce the per-aggregate log Lighthouse emits on its
+                        // pre-Boole path; operator pipelines key on `type="aggregated"`.
+                        match result {
+                            Ok(()) => {
+                                for signed in signed.iter() {
+                                    let attestation = signed.message().aggregate();
+                                    info!(
+                                        aggregator = signed.message().aggregator_index(),
+                                        signatures = attestation.num_set_aggregation_bits(),
+                                        head_block =
+                                            format!("{:?}", attestation.data().beacon_block_root),
+                                        committee_index = attestation.committee_index(),
+                                        slot = slot.as_u64(),
+                                        "type" = "aggregated",
+                                        "Successfully published attestation"
+                                    );
+                                }
+                                metrics::inc_publish_result(validator_metrics::SUCCESS);
+                            }
+                            Err(e) => {
+                                for signed in signed.iter() {
+                                    let attestation = signed.message().aggregate();
+                                    error!(
+                                        error = %e,
+                                        aggregator = signed.message().aggregator_index(),
+                                        committee_index = attestation.committee_index(),
+                                        slot = slot.as_u64(),
+                                        "type" = "aggregated",
+                                        "Failed to publish attestation"
+                                    );
+                                }
+                                metrics::inc_publish_result(metrics::HTTP_ERROR);
+                            }
+                        }
+                    }
+                }
+            })
+            .collect();
+
+        while pending.next().await.is_some() {}
+    }
+
+    /// Join the post-consensus execution for `(committee, slot)`, returning the outcome and the
+    /// deadline that bounded the join, for the caller to reuse when draining its own roots.
     pub(crate) async fn post_consensus_outcome(
         &self,
         committee_id: CommitteeId,
@@ -160,13 +392,7 @@ impl<T: SlotClock + 'static, E: EthSpec, C: ConsensusDecider<E> + 'static>
             .cloned()
             .ok_or(Error::SpecificError(SpecificError::ConsensusDataNotFound))?;
 
-        let deadline = self.get_instant_in_slot(slot, self.spec.get_slot_duration() * 2)?;
-        let outcome = tokio::time::timeout_at(deadline, execution)
-            .await
-            .map_err(|_| Error::SpecificError(SpecificError::Timeout))?
-            .map_err(|e| (*e).clone())?;
-
-        Ok((deadline, outcome))
+        self.join_execution(slot, execution).await
     }
 
     /// Spawn `fut` detached and hand out a `Shared` view of its result.

--- a/anchor/validator_store/src/aggregator_post_consensus.rs
+++ b/anchor/validator_store/src/aggregator_post_consensus.rs
@@ -48,7 +48,7 @@ use types::{
 
 use crate::{
     AggregationAssignments, AnchorValidatorStore, CollectionMode, Error, SigningRequest,
-    SpecificError, drain_signatures, metrics,
+    SpecificError, metrics,
 };
 
 /// Epochs to retain finished `AggregatorCommittee` post-consensus executions.
@@ -79,31 +79,10 @@ pub(crate) struct PreparedRoot<M> {
 pub(crate) struct AggregatorPostConsensusOutcome<E: EthSpec> {
     /// Fork the decided value's SSZ payloads were decoded under (its `DataVersion`). The
     /// publisher derives its HTTP endpoint choice and fork header from this, so they cannot
-    /// diverge from the payload variant actually in the batch.
+    /// diverge from the payload variant of the decided aggregates.
     pub(crate) fork_name: ForkName,
     pub(crate) aggregates: HashMap<ValidatorIndex, PreparedRoot<AggregateAndProof<E>>>,
     pub(crate) contributions: HashMap<(ValidatorIndex, u64), PreparedRoot<ContributionAndProof<E>>>,
-}
-
-/// Outcome of resolving one committee's decided aggregates for publication.
-///
-/// Returned instead of a bare vec so [`AnchorValidatorStore::publish_decided_aggregates`] can
-/// emit every `AGGREGATOR_COMMITTEE_PUBLISH_TOTAL` label from one `match`, keeping the metric's
-/// partition over processed committees checkable in one place.
-pub(crate) enum ResolvedAggregates<E: EthSpec> {
-    /// Consensus failed, timed out, or the deadline could not be computed (logged at the site).
-    ConsensusFailed,
-    /// The decided worklist legitimately holds contributions only.
-    NoAggregates,
-    /// Aggregates were decided, but no root reached signature quorum before the deadline.
-    NoSignatures,
-    /// At least one decided aggregate reached quorum. `fork_name` is the fork the decided
-    /// value's payloads were decoded under, carried with the batch so the publish endpoint
-    /// always matches the payload variant.
-    Batch {
-        fork_name: ForkName,
-        aggregates: Vec<SignedAggregateAndProof<E>>,
-    },
 }
 
 /// The signing worklist derived from one decided `AggregatorCommitteeConsensusData`.
@@ -126,6 +105,105 @@ async fn join_detached_task<R>(
         None => None,
     }
     .ok_or_else(post_consensus_aborted)
+}
+
+/// Await one decided root's threshold signature under the deadline and publish it on quorum,
+/// one publish call per aggregate.
+///
+/// Both publish arms reproduce the per-aggregate log Lighthouse emits on its pre-Boole path;
+/// operator pipelines key on `type="aggregated"`.
+async fn publish_one_root<E: EthSpec, F, Fut>(
+    slot: Slot,
+    fork_name: ForkName,
+    deadline: Instant,
+    root: &PreparedRoot<AggregateAndProof<E>>,
+    publish: &F,
+) where
+    F: Fn(ForkName, SignedAggregateAndProof<E>) -> Fut,
+    Fut: Future<Output = Result<(), String>>,
+{
+    let signature = match tokio::time::timeout_at(deadline, root.signature.clone()).await {
+        Ok(Ok(signature)) => signature,
+        // `collect_signature` failures are also logged by the detached signing task, but a task
+        // that died without a result (spawn refused, executor exit, panic) is only visible here,
+        // so carry the error into the warn.
+        Ok(Err(e)) => {
+            warn!(
+                pubkey = ?root.request.validator.public_key,
+                %slot,
+                error = ?e,
+                "Missing signature, skipping aggregate"
+            );
+            validator_metrics::inc_counter_vec(
+                &validator_metrics::SIGNED_AGGREGATES_TOTAL,
+                &[metrics::OTHER_ERROR],
+            );
+            metrics::inc_publish_result(metrics::NO_SIGNATURES);
+            return;
+        }
+        // Deadline expired before this root's quorum; only this root is withheld.
+        Err(_) => {
+            warn!(
+                pubkey = ?root.request.validator.public_key,
+                %slot,
+                "Missing signature, skipping aggregate"
+            );
+            validator_metrics::inc_counter_vec(
+                &validator_metrics::SIGNED_AGGREGATES_TOTAL,
+                &[metrics::OTHER_ERROR],
+            );
+            metrics::inc_publish_result(metrics::NO_SIGNATURES);
+            return;
+        }
+    };
+
+    let message = root.request.duty_data.clone();
+    debug!(
+        aggregator_index = message.aggregator_index(),
+        data = ?message.aggregate().data(),
+        num_set_aggregation_bits = message.aggregate().num_set_aggregation_bits(),
+        "Signed AggregateAndProof (Boole+ committee consensus)"
+    );
+    validator_metrics::inc_counter_vec(
+        &validator_metrics::SIGNED_AGGREGATES_TOTAL,
+        &[validator_metrics::SUCCESS],
+    );
+    let signed = SignedAggregateAndProof::from_aggregate_and_proof(message, signature);
+
+    let aggregator = signed.message().aggregator_index();
+    let attestation = signed.message().aggregate();
+    let signatures = attestation.num_set_aggregation_bits();
+    let head_block = format!("{:?}", attestation.data().beacon_block_root);
+    let committee_index = attestation.committee_index();
+
+    let result = publish(fork_name, signed)
+        .instrument(info_span!("publish_aggregate", aggregator))
+        .await;
+    match result {
+        Ok(()) => {
+            info!(
+                aggregator,
+                signatures,
+                head_block,
+                committee_index,
+                slot = slot.as_u64(),
+                "type" = "aggregated",
+                "Successfully published attestation"
+            );
+            metrics::inc_publish_result(validator_metrics::SUCCESS);
+        }
+        Err(e) => {
+            error!(
+                error = %e,
+                aggregator,
+                committee_index,
+                slot = slot.as_u64(),
+                "type" = "aggregated",
+                "Failed to publish attestation"
+            );
+            metrics::inc_publish_result(metrics::HTTP_ERROR);
+        }
+    }
 }
 
 impl<T: SlotClock + 'static, E: EthSpec, C: ConsensusDecider<E> + 'static>
@@ -203,8 +281,8 @@ impl<T: SlotClock + 'static, E: EthSpec, C: ConsensusDecider<E> + 'static>
         Ok((deadline, outcome))
     }
 
-    /// Join one committee's post-consensus execution and assemble every decided aggregate this
-    /// operator signed into publishable [`SignedAggregateAndProof`]s.
+    /// Join one committee's post-consensus execution and publish each decided aggregate this
+    /// operator signed as soon as its threshold signature reconstructs.
     ///
     /// This backs [`Self::publish_decided_aggregates`], which owns Boole+ aggregate publication:
     /// Lighthouse's aggregate callback returns an empty batch at Boole+, because its duty
@@ -215,12 +293,16 @@ impl<T: SlotClock + 'static, E: EthSpec, C: ConsensusDecider<E> + 'static>
     /// Takes the execution handle directly rather than re-entering the assignments watch channel,
     /// so a late-polled publisher cannot observe `AggregatorInfoSlotPassed` for an execution that
     /// still exists in the retention map.
-    pub(crate) async fn resolve_decided_aggregates(
+    async fn publish_committee_aggregates<F, Fut>(
         &self,
         committee_id: CommitteeId,
         slot: Slot,
         execution: AggregatorPostConsensusShared<E>,
-    ) -> ResolvedAggregates<E> {
+        publish: &F,
+    ) where
+        F: Fn(ForkName, SignedAggregateAndProof<E>) -> Fut,
+        Fut: Future<Output = Result<(), String>>,
+    {
         let (deadline, outcome) = match self.join_execution(slot, execution).await {
             Ok(joined) => joined,
             Err(e) => {
@@ -241,160 +323,61 @@ impl<T: SlotClock + 'static, E: EthSpec, C: ConsensusDecider<E> + 'static>
                     &validator_metrics::SIGNED_AGGREGATES_TOTAL,
                     &[label],
                 );
-                return ResolvedAggregates::ConsensusFailed;
+                metrics::inc_publish_result(metrics::CONSENSUS_ERROR);
+                return;
             }
         };
 
         // A decided value can legitimately hold contributions only; nothing to publish then.
         if outcome.aggregates.is_empty() {
             debug!(?committee_id, %slot, "Decided worklist holds no aggregates");
-            return ResolvedAggregates::NoAggregates;
+            metrics::inc_publish_result(metrics::NO_AGGREGATES);
+            return;
         }
 
-        // Drain every aggregate root's signature concurrently under the deadline, so a root that
-        // never reaches quorum withholds only itself.
-        let pending = FuturesUnordered::new();
-        for (&index, root) in &outcome.aggregates {
-            let signing_root = root.request.signing_root;
-            let signature = root.signature.clone();
-            pending.push(async move { (index, signing_root, signature.await) });
-        }
-        let signatures = drain_signatures(pending, Some(deadline)).await;
-
-        let mut results = Vec::with_capacity(outcome.aggregates.len());
-        for (index, root) in &outcome.aggregates {
-            // Clone the decided message only on a signature hit; misses need just the pubkey.
-            let Some(signature) = signatures.get(&(*index, root.request.signing_root)) else {
-                warn!(
-                    pubkey = ?root.request.validator.public_key,
-                    %slot,
-                    "Missing signature, skipping aggregate"
-                );
-                validator_metrics::inc_counter_vec(
-                    &validator_metrics::SIGNED_AGGREGATES_TOTAL,
-                    &[metrics::OTHER_ERROR],
-                );
-                continue;
-            };
-            let message = root.request.duty_data.clone();
-
-            debug!(
-                aggregator_index = message.aggregator_index(),
-                data = ?message.aggregate().data(),
-                num_set_aggregation_bits = message.aggregate().num_set_aggregation_bits(),
-                "Signed AggregateAndProof (Boole+ committee consensus)"
-            );
-            validator_metrics::inc_counter_vec(
-                &validator_metrics::SIGNED_AGGREGATES_TOTAL,
-                &[validator_metrics::SUCCESS],
-            );
-            results.push(SignedAggregateAndProof::from_aggregate_and_proof(
-                message,
-                signature.clone(),
-            ));
-        }
-
-        if results.is_empty() {
-            return ResolvedAggregates::NoSignatures;
-        }
-
-        ResolvedAggregates::Batch {
-            fork_name: outcome.fork_name,
-            aggregates: results,
-        }
+        // Each root publishes independently under the shared deadline, so a root that never
+        // reaches quorum withholds only itself and never delays a sibling's POST.
+        let mut roots: FuturesUnordered<_> = outcome
+            .aggregates
+            .values()
+            .map(|root| publish_one_root(slot, outcome.fork_name, deadline, root, publish))
+            .collect();
+        while roots.next().await.is_some() {}
     }
 
-    /// Resolve each committee's decided aggregates and hand every non-empty batch to `publish`.
+    /// Resolve each committee's decided aggregates and hand each signed aggregate to `publish`
+    /// the moment its threshold signature reconstructs, one publish call per aggregate. This is
+    /// go-ssv's publication shape at the reference pin: a bad aggregate cannot fail a sibling's
+    /// POST, and a no-quorum root cannot delay its committee's other aggregates.
     ///
     /// This is the authoritative Boole+ aggregate publication driver, spawned per slot by the
     /// metadata service with the executions its assignment update newly registered. Generic over
     /// the publish operation so tests (in `testing/aggregator_post_consensus.rs`) can inject a
-    /// recorder instead of an HTTP client. Each committee runs resolve-and-publish as one
-    /// `FuturesUnordered` entry, so a contended QBFT round or a slow POST in one committee does
-    /// not delay another committee's publication.
+    /// recorder instead of an HTTP client. Each committee runs as one `FuturesUnordered` entry
+    /// and each of its roots as another inside it, so committees and roots are all mutually
+    /// independent.
     ///
-    /// Owns every `AGGREGATOR_COMMITTEE_PUBLISH_TOTAL` increment: the labels partition the
-    /// processed committees by outcome, and that partition is checkable in the single `match`
-    /// below.
+    /// Owns every `AGGREGATOR_COMMITTEE_PUBLISH_TOTAL` increment, together with
+    /// [`publish_one_root`]: `consensus_error` and `no_aggregates` count committees (those
+    /// failures occur before per-root work exists), while `success`, `http_error`, and
+    /// `no_signatures` count individual aggregates.
     ///
-    /// A batch always holds exactly one committee's aggregates, all decoded from one decided
-    /// `DataVersion`; the fork that version names travels with the batch, so the publish
-    /// closure's endpoint choice always matches the payload variant.
+    /// The fork handed to `publish` is the one the decided value's payloads were decoded under,
+    /// so the closure's endpoint choice always matches the payload variant.
     pub(crate) async fn publish_decided_aggregates<F, Fut>(
         &self,
         slot: Slot,
         executions: Vec<(CommitteeId, AggregatorPostConsensusShared<E>)>,
         publish: F,
     ) where
-        F: Fn(ForkName, Arc<Vec<SignedAggregateAndProof<E>>>) -> Fut,
+        F: Fn(ForkName, SignedAggregateAndProof<E>) -> Fut,
         Fut: Future<Output = Result<(), String>>,
     {
         let publish = &publish;
         let mut pending: FuturesUnordered<_> = executions
             .into_iter()
-            .map(|(committee_id, execution)| async move {
-                match self
-                    .resolve_decided_aggregates(committee_id, slot, execution)
-                    .await
-                {
-                    ResolvedAggregates::ConsensusFailed => {
-                        metrics::inc_publish_result(metrics::CONSENSUS_ERROR);
-                    }
-                    ResolvedAggregates::NoAggregates => {
-                        metrics::inc_publish_result(metrics::NO_AGGREGATES);
-                    }
-                    ResolvedAggregates::NoSignatures => {
-                        warn!(
-                            ?committee_id,
-                            %slot,
-                            "No decided aggregate reached signature quorum, nothing to publish"
-                        );
-                        metrics::inc_publish_result(metrics::NO_SIGNATURES);
-                    }
-                    ResolvedAggregates::Batch {
-                        fork_name,
-                        aggregates,
-                    } => {
-                        let signed = Arc::new(aggregates);
-                        let result = publish(fork_name, Arc::clone(&signed))
-                            .instrument(info_span!("publish_aggregates", count = signed.len()))
-                            .await;
-                        // Both arms reproduce the per-aggregate log Lighthouse emits on its
-                        // pre-Boole path; operator pipelines key on `type="aggregated"`.
-                        match result {
-                            Ok(()) => {
-                                for signed in signed.iter() {
-                                    let attestation = signed.message().aggregate();
-                                    info!(
-                                        aggregator = signed.message().aggregator_index(),
-                                        signatures = attestation.num_set_aggregation_bits(),
-                                        head_block =
-                                            format!("{:?}", attestation.data().beacon_block_root),
-                                        committee_index = attestation.committee_index(),
-                                        slot = slot.as_u64(),
-                                        "type" = "aggregated",
-                                        "Successfully published attestation"
-                                    );
-                                }
-                                metrics::inc_publish_result(validator_metrics::SUCCESS);
-                            }
-                            Err(e) => {
-                                for signed in signed.iter() {
-                                    let attestation = signed.message().aggregate();
-                                    error!(
-                                        error = %e,
-                                        aggregator = signed.message().aggregator_index(),
-                                        committee_index = attestation.committee_index(),
-                                        slot = slot.as_u64(),
-                                        "type" = "aggregated",
-                                        "Failed to publish attestation"
-                                    );
-                                }
-                                metrics::inc_publish_result(metrics::HTTP_ERROR);
-                            }
-                        }
-                    }
-                }
+            .map(|(committee_id, execution)| {
+                self.publish_committee_aggregates(committee_id, slot, execution, publish)
             })
             .collect();
 

--- a/anchor/validator_store/src/lib.rs
+++ b/anchor/validator_store/src/lib.rs
@@ -2629,31 +2629,45 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> ValidatorStore
         self: &Arc<Self>,
         aggregates: Vec<AggregateToSign<E>>,
     ) -> impl Stream<Item = Result<Vec<SignedAggregateAndProof<E>>, Error>> + Send {
-        let publish_via_lighthouse = aggregates.first().is_some_and(|first| {
-            self.fork_schedule
-                .active_fork(first.aggregate.data().target.epoch)
-                < Fork::Boole
-        });
+        let this = Arc::clone(self);
+        stream::once(async move {
+            let publish_via_lighthouse = aggregates.first().is_some_and(|first| {
+                this.fork_schedule
+                    .active_fork(first.aggregate.data().target.epoch)
+                    < Fork::Boole
+            });
 
-        if publish_via_lighthouse {
+            if !publish_via_lighthouse {
+                // Boole+ (or empty input): hand Lighthouse an empty batch, which its publish loop
+                // drops silently. Publication ownership lives with the metadata service's
+                // aggregate publisher, which signs and publishes the decided worklist regardless
+                // of whether Lighthouse's duty snapshot saw the selection proofs in time. See
+                // [`crate::aggregator_post_consensus`].
+                if let Some(first) = aggregates.first() {
+                    // Lighthouse's request set is its snapshot's view of who aggregates; the
+                    // publisher only ever sees the decided view. Logging the request set here
+                    // keeps divergent operator views diagnosable by comparing the two.
+                    debug!(
+                        slot = %first.aggregate.data().slot,
+                        requested = aggregates.len(),
+                        aggregators = ?aggregates
+                            .iter()
+                            .map(|agg| agg.aggregator_index)
+                            .collect::<Vec<_>>(),
+                        "Deferring Lighthouse-requested aggregates to the decided-value publisher"
+                    );
+                }
+                return Ok(Vec::new());
+            }
+
             // Pre-Boole: per-validator processing, Lighthouse publishes the results
-            let this = Arc::clone(self);
-            Either::Left(stream::once(async move {
-                let futures = aggregates.into_iter().map(|agg| {
-                    let this = Arc::clone(&this);
-                    async move { this.sign_single_aggregate_and_proof(agg).await }
-                });
-                let results = join_all(futures).await;
-                Ok(results.into_iter().filter_map(|r| r.ok()).collect())
-            }))
-        } else {
-            // Boole+ (or empty input): hand Lighthouse an empty batch, which its publish loop
-            // drops silently. Publication ownership lives with the metadata service's aggregate
-            // publisher, which signs and publishes the decided worklist regardless of whether
-            // Lighthouse's duty snapshot saw the selection proofs in time. See
-            // [`crate::aggregator_post_consensus`].
-            Either::Right(stream::once(async { Ok(Vec::new()) }))
-        }
+            let futures = aggregates.into_iter().map(|agg| {
+                let this = Arc::clone(&this);
+                async move { this.sign_single_aggregate_and_proof(agg).await }
+            });
+            let results = join_all(futures).await;
+            Ok(results.into_iter().filter_map(|r| r.ok()).collect())
+        })
     }
 
     async fn produce_selection_proof(

--- a/anchor/validator_store/src/lib.rs
+++ b/anchor/validator_store/src/lib.rs
@@ -248,9 +248,10 @@ pub struct AnchorValidatorStore<
     /// One entry per `(committee, slot)`, registered by the slot pipeline in
     /// [`Self::update_aggregation_assignments`] before those assignments are published, and only
     /// when the entry is vacant. That registration is the single writer, so the complete decided
-    /// worklist is signed and batched exactly once no matter which Lighthouse callbacks fire, in
-    /// what order, or whether their futures are dropped. Callbacks only read this map as a
-    /// detached `Shared` future; they never start work.
+    /// worklist is signed and batched exactly once no matter which consumers run, in what order,
+    /// or whether their futures are dropped. Consumers (the contributions callback via this map,
+    /// the aggregate publisher via the handles registration returns) only read detached `Shared`
+    /// futures; they never start work.
     aggregator_post_consensus:
         Mutex<HashMap<(CommitteeId, Slot), AggregatorPostConsensusShared<E>>>,
 }
@@ -996,10 +997,19 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> AnchorValidator
     /// It also starts each Boole+ committee's post-consensus signing execution, before publishing,
     /// so that every consumer able to observe these assignments can also observe the execution they
     /// belong to. See [`crate::aggregator_post_consensus`].
-    pub fn update_aggregation_assignments(self: &Arc<Self>, info: AggregationAssignments<E>) {
-        self.start_aggregator_post_consensus(&info);
+    ///
+    /// Returns the executions newly registered by this call, for the caller to hand to the
+    /// aggregate publisher. Only vacant insertions are returned, so repeated calls for one slot
+    /// cannot register a second publisher for the same `(committee, slot)`.
+    #[must_use = "dropping the returned executions disables Boole+ aggregate publication"]
+    pub(crate) fn update_aggregation_assignments(
+        self: &Arc<Self>,
+        info: AggregationAssignments<E>,
+    ) -> Vec<(CommitteeId, AggregatorPostConsensusShared<E>)> {
+        let new_executions = self.start_aggregator_post_consensus(&info);
         self.aggregation_assignments_tx
             .send_replace(Some(Arc::new(info)));
+        new_executions
     }
 
     /// Return [`SpecificError::Timeout`] if the given future does not complete at `delay` into the
@@ -1725,85 +1735,6 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> AnchorValidator
             }
 
             results.push((validator_index, attestation, pubkey));
-        }
-
-        Ok(results)
-    }
-
-    /// Boole+ committee-based aggregate signing: join the per-`(committee, slot)`
-    /// post-consensus execution and return the requested aggregates from its outcome.
-    ///
-    /// The execution signs the complete decided worklist (both object classes) regardless of
-    /// which Lighthouse callbacks fire; this callback only filters. See
-    /// [`crate::aggregator_post_consensus`].
-    async fn sign_committee_aggregate_and_proofs(
-        &self,
-        committee_id: CommitteeId,
-        aggregates: Vec<(ValidatorMetadata, AggregateToSign<E>)>,
-    ) -> Result<Vec<SignedAggregateAndProof<E>>, Error> {
-        let Some((_, first)) = aggregates.first() else {
-            warn!("sign_committee_aggregate_and_proofs called with empty aggregates");
-            return Ok(vec![]);
-        };
-        let slot = first.aggregate.data().slot;
-
-        let (deadline, outcome) = self.post_consensus_outcome(committee_id, slot).await?;
-
-        // Select this callback's own identities out of the shared outcome. The execution signs the
-        // whole decided value, so anything missing here is an entry the cluster did not decide on.
-        let mut prepared = Vec::with_capacity(aggregates.len());
-        let pending = FuturesUnordered::new();
-        for (validator, agg) in &aggregates {
-            let root = validator
-                .index
-                .and_then(|index| outcome.aggregates.get(&index).map(|root| (index, root)));
-            let Some((index, root)) = root else {
-                debug!(
-                    pubkey = ?agg.pubkey,
-                    "Requested aggregate not in the decided worklist, skipping due to divergent \
-                     operator views"
-                );
-                validator_metrics::inc_counter_vec(
-                    &validator_metrics::SIGNED_AGGREGATES_TOTAL,
-                    &[metrics::OTHER_ERROR],
-                );
-                continue;
-            };
-            let signing_root = root.request.signing_root;
-            let signature = root.signature.clone();
-            pending.push(async move { (index, signing_root, signature.await) });
-            prepared.push(root.request.clone());
-        }
-
-        let signatures = drain_signatures(pending, Some(deadline)).await;
-
-        let mut results = Vec::with_capacity(prepared.len());
-        for request in prepared {
-            let (message, signature) = match request.resolve(&signatures) {
-                Ok(resolved) => resolved,
-                Err(pubkey) => {
-                    warn!(?pubkey, "Missing signature, skipping aggregate");
-                    validator_metrics::inc_counter_vec(
-                        &validator_metrics::SIGNED_AGGREGATES_TOTAL,
-                        &[metrics::OTHER_ERROR],
-                    );
-                    continue;
-                }
-            };
-
-            debug!(
-                aggregator_index = message.aggregator_index(),
-                data = ?message.aggregate().data(),
-                num_set_aggregation_bits = message.aggregate().num_set_aggregation_bits(),
-                "Signed AggregateAndProof (Boole+ committee consensus)"
-            );
-            validator_metrics::inc_counter_vec(
-                &validator_metrics::SIGNED_AGGREGATES_TOTAL,
-                &[validator_metrics::SUCCESS],
-            );
-            results.push(SignedAggregateAndProof::from_aggregate_and_proof(
-                message, signature,
-            ));
         }
 
         Ok(results)
@@ -2698,39 +2629,14 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> ValidatorStore
         self: &Arc<Self>,
         aggregates: Vec<AggregateToSign<E>>,
     ) -> impl Stream<Item = Result<Vec<SignedAggregateAndProof<E>>, Error>> + Send {
-        // Early return for empty input — no fork to determine, nothing to sign
-        let Some(first) = aggregates.first() else {
-            return Either::Right(FuturesUnordered::new());
-        };
+        let publish_via_lighthouse = aggregates.first().is_some_and(|first| {
+            self.fork_schedule
+                .active_fork(first.aggregate.data().target.epoch)
+                < Fork::Boole
+        });
 
-        if self
-            .fork_schedule
-            .active_fork(first.aggregate.data().target.epoch)
-            >= Fork::Boole
-        {
-            // Boole+: group by committee, stream per committee via FuturesUnordered
-            let _span = info_span!("sign_aggregate_and_proofs").entered();
-            let committee_mapping = self.group_by_committee(aggregates, |a| a.pubkey);
-
-            let committee_futures: FuturesUnordered<_> = committee_mapping
-                .into_iter()
-                .map(|(committee_id, (_cluster, aggregates))| {
-                    let this = Arc::clone(self);
-                    async move {
-                        run_committee_signing(
-                            committee_id,
-                            aggregates.len(),
-                            &validator_metrics::SIGNED_AGGREGATES_TOTAL,
-                            this.sign_committee_aggregate_and_proofs(committee_id, aggregates),
-                        )
-                        .await
-                    }
-                })
-                .collect();
-
-            Either::Right(committee_futures)
-        } else {
-            // Pre-Boole: per-validator processing, no committee grouping needed
+        if publish_via_lighthouse {
+            // Pre-Boole: per-validator processing, Lighthouse publishes the results
             let this = Arc::clone(self);
             Either::Left(stream::once(async move {
                 let futures = aggregates.into_iter().map(|agg| {
@@ -2740,6 +2646,13 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> ValidatorStore
                 let results = join_all(futures).await;
                 Ok(results.into_iter().filter_map(|r| r.ok()).collect())
             }))
+        } else {
+            // Boole+ (or empty input): hand Lighthouse an empty batch, which its publish loop
+            // drops silently. Publication ownership lives with the metadata service's aggregate
+            // publisher, which signs and publishes the decided worklist regardless of whether
+            // Lighthouse's duty snapshot saw the selection proofs in time. See
+            // [`crate::aggregator_post_consensus`].
+            Either::Right(stream::once(async { Ok(Vec::new()) }))
         }
     }
 

--- a/anchor/validator_store/src/metadata_service.rs
+++ b/anchor/validator_store/src/metadata_service.rs
@@ -27,14 +27,14 @@ use tokio::{
 use tracing::{Instrument, debug, error, info, info_span, trace, warn};
 use tree_hash::TreeHash;
 use types::{
-    Attestation, AttestationData, ChainSpec, EthSpec, ForkName, Hash256, Slot,
-    SyncCommitteeContribution, SyncSelectionProof, SyncSubnetId,
+    Attestation, AttestationData, AttestationRef, ChainSpec, EthSpec, ForkName, Hash256,
+    SignedAggregateAndProof, Slot, SyncCommitteeContribution, SyncSelectionProof, SyncSubnetId,
 };
 use validator_services::duties_service::{DutiesService, DutyAndProof};
 
 use crate::{
     AggregationAssignments, AnchorValidatorStore, ContributionWaiter, VotingAssignments,
-    VotingContext, metrics,
+    VotingContext, aggregator_post_consensus::AggregatorPostConsensusShared, metrics,
 };
 
 /// Data for sync committee aggregators.
@@ -640,11 +640,53 @@ impl<E: EthSpec, T: SlotClock + 'static> MetadataService<E, T> {
             consensus_data_by_ssv_committee,
         };
 
-        self.validator_store
+        let new_executions = self
+            .validator_store
             .update_aggregation_assignments(aggregator_info);
+        self.spawn_aggregate_publisher(slot, new_executions);
 
         trace!(%slot, "Published AggregationAssignments at 2/3 slot");
         Ok(())
+    }
+
+    /// Spawn the detached publisher for this slot's newly registered post-consensus executions.
+    ///
+    /// The publisher owns Boole+ aggregate publication: the Lighthouse aggregate callback returns
+    /// an empty batch at Boole+ because its duty snapshot is cloned before slot-start selection
+    /// proofs finish, so aggregates the snapshot never saw would otherwise be silently dropped.
+    /// Contributions are unaffected (sync selection proofs are precomputed a slot ahead) and stay
+    /// on the Lighthouse publish path.
+    ///
+    /// Exactly-once: `new_executions` holds only vacant registrations, so a repeated Phase 3 run
+    /// for one slot cannot spawn a second publisher for the same `(committee, slot)`.
+    ///
+    /// The publisher is implicitly Boole-gated (consensus data exists only for Boole+ slots),
+    /// while the empty Lighthouse callback gates on the aggregate's target epoch. The two agree
+    /// because `attestation.data.target.epoch` equals the slot's own epoch by construction, which
+    /// is what rules out both paths publishing for one duty.
+    fn spawn_aggregate_publisher(
+        &self,
+        slot: Slot,
+        new_executions: Vec<(CommitteeId, AggregatorPostConsensusShared<E>)>,
+    ) {
+        if new_executions.is_empty() {
+            return;
+        }
+
+        let validator_store = self.validator_store.clone();
+        let beacon_nodes = self.beacon_nodes.clone();
+        let fork_name = self.spec.fork_name_at_slot::<E>(slot);
+
+        self.executor.spawn(
+            async move {
+                validator_store
+                    .publish_decided_aggregates(slot, new_executions, |signed| {
+                        post_aggregates(&beacon_nodes, fork_name, signed)
+                    })
+                    .await;
+            },
+            "aggregator_committee_publisher",
+        );
     }
 
     /// Build `AggregatorCommitteeConsensusData` for each committee that has aggregators.
@@ -1379,6 +1421,44 @@ pub fn filter_contributors_with_contributions<E: EthSpec>(
     contributors_with_roots.retain(|(_, contrib)| {
         sync_contributions.contains_key(&SyncSubnetId::new(contrib.committee_index))
     });
+}
+
+/// POST one committee's signed aggregates, mirroring Lighthouse's own aggregate publication
+/// policy at the pin: plain `first_success`, v2 with the fork header for Electra-shaped batches,
+/// v1 otherwise.
+///
+/// The v1/v2 choice sniffs the reconstructed variant, which follows the decided value's
+/// `DataVersion` rather than a recomputed fork; the batch is variant-uniform because it holds
+/// exactly one committee's aggregates decoded from one decided value.
+async fn post_aggregates<T: SlotClock + 'static, E: EthSpec>(
+    beacon_nodes: &BeaconNodeFallback<T>,
+    fork_name: ForkName,
+    signed: Arc<Vec<SignedAggregateAndProof<E>>>,
+) -> Result<(), String> {
+    beacon_nodes
+        .first_success(|beacon_node| {
+            let signed = signed.as_slice();
+            async move {
+                let _timer = validator_metrics::start_timer_vec(
+                    &validator_metrics::ATTESTATION_SERVICE_TIMES,
+                    &[validator_metrics::AGGREGATES_HTTP_POST],
+                );
+                let base = signed
+                    .first()
+                    .is_some_and(|s| matches!(s.message().aggregate(), AttestationRef::Base(_)));
+                if base {
+                    beacon_node
+                        .post_validator_aggregate_and_proof_v1(signed)
+                        .await
+                } else {
+                    beacon_node
+                        .post_validator_aggregate_and_proof_v2(signed, fork_name)
+                        .await
+                }
+            }
+        })
+        .await
+        .map_err(|e| format!("{e}"))
 }
 
 #[cfg(test)]

--- a/anchor/validator_store/src/metadata_service.rs
+++ b/anchor/validator_store/src/metadata_service.rs
@@ -27,8 +27,8 @@ use tokio::{
 use tracing::{Instrument, debug, error, info, info_span, trace, warn};
 use tree_hash::TreeHash;
 use types::{
-    Attestation, AttestationData, AttestationRef, ChainSpec, EthSpec, ForkName, Hash256,
-    SignedAggregateAndProof, Slot, SyncCommitteeContribution, SyncSelectionProof, SyncSubnetId,
+    Attestation, AttestationData, ChainSpec, EthSpec, ForkName, Hash256, SignedAggregateAndProof,
+    Slot, SyncCommitteeContribution, SyncSelectionProof, SyncSubnetId,
 };
 use validator_services::duties_service::{DutiesService, DutyAndProof};
 
@@ -675,12 +675,11 @@ impl<E: EthSpec, T: SlotClock + 'static> MetadataService<E, T> {
 
         let validator_store = self.validator_store.clone();
         let beacon_nodes = self.beacon_nodes.clone();
-        let fork_name = self.spec.fork_name_at_slot::<E>(slot);
 
         self.executor.spawn(
             async move {
                 validator_store
-                    .publish_decided_aggregates(slot, new_executions, |signed| {
+                    .publish_decided_aggregates(slot, new_executions, |fork_name, signed| {
                         post_aggregates(&beacon_nodes, fork_name, signed)
                     })
                     .await;
@@ -1424,12 +1423,12 @@ pub fn filter_contributors_with_contributions<E: EthSpec>(
 }
 
 /// POST one committee's signed aggregates, mirroring Lighthouse's own aggregate publication
-/// policy at the pin: plain `first_success`, v2 with the fork header for Electra-shaped batches,
-/// v1 otherwise.
+/// policy at the pin: `first_success` across the beacon nodes (which makes two passes over the
+/// candidate list before giving up), v2 with the fork header for Electra+ batches, v1 otherwise.
 ///
-/// The v1/v2 choice sniffs the reconstructed variant, which follows the decided value's
-/// `DataVersion` rather than a recomputed fork; the batch is variant-uniform because it holds
-/// exactly one committee's aggregates decoded from one decided value.
+/// `fork_name` is the fork the batch's payloads were decoded under (the decided value's
+/// `DataVersion`), carried with the batch so the endpoint and fork header cannot diverge from
+/// the payload variant.
 async fn post_aggregates<T: SlotClock + 'static, E: EthSpec>(
     beacon_nodes: &BeaconNodeFallback<T>,
     fork_name: ForkName,
@@ -1443,16 +1442,13 @@ async fn post_aggregates<T: SlotClock + 'static, E: EthSpec>(
                     &validator_metrics::ATTESTATION_SERVICE_TIMES,
                     &[validator_metrics::AGGREGATES_HTTP_POST],
                 );
-                let base = signed
-                    .first()
-                    .is_some_and(|s| matches!(s.message().aggregate(), AttestationRef::Base(_)));
-                if base {
+                if fork_name.electra_enabled() {
                     beacon_node
-                        .post_validator_aggregate_and_proof_v1(signed)
+                        .post_validator_aggregate_and_proof_v2(signed, fork_name)
                         .await
                 } else {
                     beacon_node
-                        .post_validator_aggregate_and_proof_v2(signed, fork_name)
+                        .post_validator_aggregate_and_proof_v1(signed)
                         .await
                 }
             }

--- a/anchor/validator_store/src/metadata_service.rs
+++ b/anchor/validator_store/src/metadata_service.rs
@@ -680,7 +680,7 @@ impl<E: EthSpec, T: SlotClock + 'static> MetadataService<E, T> {
             async move {
                 validator_store
                     .publish_decided_aggregates(slot, new_executions, |fork_name, signed| {
-                        post_aggregates(&beacon_nodes, fork_name, signed)
+                        post_aggregate(&beacon_nodes, fork_name, signed)
                     })
                     .await;
             },
@@ -1422,21 +1422,22 @@ pub fn filter_contributors_with_contributions<E: EthSpec>(
     });
 }
 
-/// POST one committee's signed aggregates, mirroring Lighthouse's own aggregate publication
-/// policy at the pin: `first_success` across the beacon nodes (which makes two passes over the
-/// candidate list before giving up), v2 with the fork header for Electra+ batches, v1 otherwise.
+/// POST one signed aggregate, matching go-ssv's publication shape at the reference pin (one
+/// aggregate per request, published as soon as its quorum lands). Endpoint policy mirrors
+/// Lighthouse's at the pin: `first_success` across the beacon nodes (which makes two passes
+/// over the candidate list before giving up), v2 with the fork header for Electra+ aggregates,
+/// v1 otherwise.
 ///
-/// `fork_name` is the fork the batch's payloads were decoded under (the decided value's
-/// `DataVersion`), carried with the batch so the endpoint and fork header cannot diverge from
-/// the payload variant.
-async fn post_aggregates<T: SlotClock + 'static, E: EthSpec>(
+/// `fork_name` is the fork the aggregate's payload was decoded under (the decided value's
+/// `DataVersion`), so the endpoint and fork header cannot diverge from the payload variant.
+async fn post_aggregate<T: SlotClock + 'static, E: EthSpec>(
     beacon_nodes: &BeaconNodeFallback<T>,
     fork_name: ForkName,
-    signed: Arc<Vec<SignedAggregateAndProof<E>>>,
+    signed: SignedAggregateAndProof<E>,
 ) -> Result<(), String> {
     beacon_nodes
         .first_success(|beacon_node| {
-            let signed = signed.as_slice();
+            let signed = std::slice::from_ref(&signed);
             async move {
                 let _timer = validator_metrics::start_timer_vec(
                     &validator_metrics::ATTESTATION_SERVICE_TIMES,

--- a/anchor/validator_store/src/metrics.rs
+++ b/anchor/validator_store/src/metrics.rs
@@ -142,6 +142,31 @@ pub static AGGREGATOR_COMMITTEE_FETCH_SUCCESS: LazyLock<Result<IntCounterVec>> =
         )
     });
 
+// Labels for `AGGREGATOR_COMMITTEE_PUBLISH_TOTAL` (`success` is `validator_metrics::SUCCESS`).
+pub const CONSENSUS_ERROR: &str = "consensus_error";
+pub const HTTP_ERROR: &str = "http_error";
+pub const NO_AGGREGATES: &str = "no_aggregates";
+pub const NO_SIGNATURES: &str = "no_signatures";
+
+/// Outcomes of the Boole+ aggregate publisher, one increment per committee per slot. The labels
+/// partition every committee the publisher processed: `success` and `http_error` from the publish
+/// attempt, `consensus_error` when the outcome failed or timed out, `no_aggregates` when the
+/// decided worklist held contributions only, `no_signatures` when aggregates were decided but no
+/// root reached signature quorum in time. All increments live in
+/// `AnchorValidatorStore::publish_decided_aggregates`.
+pub static AGGREGATOR_COMMITTEE_PUBLISH_TOTAL: LazyLock<Result<IntCounterVec>> =
+    LazyLock::new(|| {
+        try_create_int_counter_vec(
+            "anchor_aggregator_committee_publish_total",
+            "Committees processed by the Boole+ aggregate publisher, by outcome",
+            &["result"],
+        )
+    });
+
+pub fn inc_publish_result(result: &str) {
+    inc_counter_vec(&AGGREGATOR_COMMITTEE_PUBLISH_TOTAL, &[result]);
+}
+
 // ═══════════════════════════════════════════════════════════════════════════════
 // Weighted Attestation Data (WAD) metrics
 // ═══════════════════════════════════════════════════════════════════════════════

--- a/anchor/validator_store/src/metrics.rs
+++ b/anchor/validator_store/src/metrics.rs
@@ -148,17 +148,18 @@ pub const HTTP_ERROR: &str = "http_error";
 pub const NO_AGGREGATES: &str = "no_aggregates";
 pub const NO_SIGNATURES: &str = "no_signatures";
 
-/// Outcomes of the Boole+ aggregate publisher, one increment per committee per slot. The labels
-/// partition every committee the publisher processed: `success` and `http_error` from the publish
-/// attempt, `consensus_error` when the outcome failed or timed out, `no_aggregates` when the
-/// decided worklist held contributions only, `no_signatures` when aggregates were decided but no
-/// root reached signature quorum in time. All increments live in
-/// `AnchorValidatorStore::publish_decided_aggregates`.
+/// Outcomes of the Boole+ aggregate publisher. `consensus_error` (outcome failed or timed out)
+/// and `no_aggregates` (decided worklist held contributions only) count committees, since those
+/// failures occur before any per-root work exists. `success` and `http_error` (per publish
+/// attempt) and `no_signatures` (root missed signature quorum in time) count individual
+/// aggregates, matching go-ssv's one-POST-per-aggregate accounting. All increments live in
+/// `AnchorValidatorStore::publish_decided_aggregates` and its per-committee/per-root helpers in
+/// `aggregator_post_consensus.rs`.
 pub static AGGREGATOR_COMMITTEE_PUBLISH_TOTAL: LazyLock<Result<IntCounterVec>> =
     LazyLock::new(|| {
         try_create_int_counter_vec(
             "anchor_aggregator_committee_publish_total",
-            "Committees processed by the Boole+ aggregate publisher, by outcome",
+            "Boole+ aggregate publisher outcomes (committee-level errors, per-aggregate results)",
             &["result"],
         )
     });

--- a/anchor/validator_store/src/testing/aggregator_post_consensus.rs
+++ b/anchor/validator_store/src/testing/aggregator_post_consensus.rs
@@ -2,10 +2,14 @@
 //!
 //! One QBFT decision carries both attestation aggregates and sync contributions. The
 //! per-`(committee, slot)` execution signs the complete decided worklist regardless of which
-//! Lighthouse callbacks fire; the callbacks only filter the shared outcome down to their own
-//! requested items. These tests pin the regression from issue #1227: a callback of one class
-//! must still produce the partial signatures for the other class, so the shared committee
+//! Lighthouse callbacks fire. These tests pin the regression from issue #1227: a callback of one
+//! class must still produce the partial signatures for the other class, so the shared committee
 //! batch never stalls below its expected size.
+//!
+//! The two classes are read out differently. Contributions still go back through the Lighthouse
+//! callback, which filters the shared outcome down to its own requested items. Aggregates do not:
+//! Anchor publishes them itself from the decided value, so `resolve_decided_aggregates` and
+//! `publish_decided_aggregates` are the readers, and the aggregate callback returns nothing.
 //!
 //! The worklist tasks are detached, so captured `sign_and_collect` calls arrive
 //! asynchronously; assertions on capture counts poll with a deadline and then let the
@@ -18,7 +22,8 @@ use std::{
 };
 
 use bls::{AggregateSignature, FixedBytesExtended, PublicKeyBytes, Signature};
-use futures::StreamExt;
+use futures::{FutureExt, StreamExt};
+use parking_lot::Mutex;
 use signature_collector::SignatureRequester;
 use ssv_types::{
     CommitteeId, OperatorId, ValidatorIndex, ValidatorMetadata,
@@ -30,15 +35,21 @@ use ssz::Encode;
 use ssz_types::VariableList;
 use types::{
     AttestationBase, AttestationData, Checkpoint, Epoch, ForkName, Hash256, MainnetEthSpec,
-    SignedAggregateAndProof, SignedContributionAndProof, Slot, SyncCommitteeContribution,
-    SyncSelectionProof,
+    SignedContributionAndProof, Slot, SyncCommitteeContribution, SyncSelectionProof,
 };
 use validator_store::{ContributionToSign, ValidatorStore};
 
 use super::common::*;
-use crate::{AggregationAssignments, Error};
+use crate::{
+    Error, SpecificError,
+    aggregator_post_consensus::{AggregatorPostConsensusShared, ResolvedAggregates},
+};
 
-type SignAggregatesResult = Vec<Result<Vec<SignedAggregateAndProof<MainnetEthSpec>>, Error>>;
+/// One committee's decided value, as the slot pipeline publishes it.
+type DecidedData = AggregatorCommitteeConsensusData<MainnetEthSpec>;
+/// A handle on one `(committee, slot)` post-consensus execution, as handed to the publisher.
+type Execution = AggregatorPostConsensusShared<MainnetEthSpec>;
+
 type SignContributionsResult = Vec<Result<Vec<SignedContributionAndProof<MainnetEthSpec>>, Error>>;
 
 const COMMITTEE_OPERATOR_IDS: [OperatorId; 4] =
@@ -68,11 +79,14 @@ const FOREIGN_CONTRIBUTOR_INDEX: usize = 901;
 /// decided value.
 const MIXED_WORKLIST_SIZE: usize = 1 + CONTRIBUTION_SUBCOMMITTEES.len();
 
+/// A clock position past the publisher's deadline for `TEST_SLOT` (one slot past that slot's end),
+/// so deadline tests reach the timeout without sleeping two real slots.
+const PAST_PUBLISH_DEADLINE_SECS: u64 = (TEST_SLOT + 3) * SLOT_DURATION_SECS;
+
 const CAPTURE_TIMEOUT: Duration = Duration::from_secs(2);
 const CAPTURE_POLL_INTERVAL: Duration = Duration::from_millis(10);
 /// Extra wait after the expected capture count is reached, to catch spurious extra captures.
 const SETTLE_DELAY: Duration = Duration::from_millis(200);
-const STREAM_TIMEOUT: Duration = Duration::from_secs(5);
 
 // ==================== Fixture ====================
 
@@ -116,50 +130,81 @@ impl AggregatorCommitteeFixture {
 
     /// Seeds `AggregationAssignments` at `TEST_SLOT` with the given consensus data for this
     /// committee. The mock decider echoes the proposal, so this is also the decided value.
-    fn seed_decided_value(
-        &self,
-        data: AggregatorCommitteeConsensusData<MainnetEthSpec>,
-    ) -> Arc<AggregatorCommitteeConsensusData<MainnetEthSpec>> {
+    fn seed_decided_value(&self, data: DecidedData) -> Arc<DecidedData> {
         let data = Arc::new(data);
-        self.harness
-            .validator_store
-            .update_aggregation_assignments(AggregationAssignments {
-                slot: Slot::new(TEST_SLOT),
-                aggregator_committees: HashMap::new(),
-                multi_sync_aggregators: HashMap::new(),
-                consensus_data_by_ssv_committee: HashMap::from([(
-                    self.committee_id,
-                    Arc::clone(&data),
-                )]),
-            });
+        self.publish_decided_value(Arc::clone(&data));
         data
     }
 
-    /// Seeds `AggregationAssignments` at `TEST_SLOT` without consensus data for any committee, so
-    /// no execution is registered and the callbacks fail with `ConsensusDataNotFound`.
-    fn seed_assignments_without_consensus_data(&self) {
+    /// Publishes `data` as this committee's decided value at `TEST_SLOT`, returning the executions
+    /// newly registered by the publish. This is what the slot pipeline hands to the aggregate
+    /// publisher, so a republish of the same slot returns nothing.
+    fn publish_decided_value(&self, data: Arc<DecidedData>) -> Vec<(CommitteeId, Execution)> {
         self.harness
-            .validator_store
-            .update_aggregation_assignments(AggregationAssignments {
-                slot: Slot::new(TEST_SLOT),
-                aggregator_committees: HashMap::new(),
-                multi_sync_aggregators: HashMap::new(),
-                consensus_data_by_ssv_committee: HashMap::new(),
-            });
+            .publish_decided_values(HashMap::from([(self.committee_id, data)]))
     }
 
-    /// Seeds the standard mixed decided value: one aggregate for the aggregate validator plus
-    /// one contribution per subcommittee in [`CONTRIBUTION_SUBCOMMITTEES`] for the contributor.
-    fn seed_mixed_decided_value(&self) -> Arc<AggregatorCommitteeConsensusData<MainnetEthSpec>> {
+    /// Seeds `AggregationAssignments` at `TEST_SLOT` without consensus data for any committee, so
+    /// no execution is registered and the callbacks fail with `ConsensusDataNotFound`. Returns the
+    /// (empty) set of executions the publish registered.
+    fn seed_assignments_without_consensus_data(&self) -> Vec<(CommitteeId, Execution)> {
+        self.harness.publish_decided_values(HashMap::new())
+    }
+
+    /// The standard mixed decided value: one aggregate for the aggregate validator plus one
+    /// contribution per subcommittee in [`CONTRIBUTION_SUBCOMMITTEES`] for the contributor.
+    fn mixed_decided_data(&self) -> DecidedData {
         let aggregator = self.validator_index(AGGREGATE_VALIDATOR_IDX);
         let contributor = self.validator_index(CONTRIBUTOR_VALIDATOR_IDX);
-        self.seed_decided_value(build_decided_data(
+        build_decided_data(
             &[(aggregator, BEACON_COMMITTEE_INDEX)],
             &[
                 (contributor, CONTRIBUTION_SUBCOMMITTEES[0]),
                 (contributor, CONTRIBUTION_SUBCOMMITTEES[1]),
             ],
-        ))
+        )
+    }
+
+    /// Seeds the standard mixed decided value.
+    fn seed_mixed_decided_value(&self) -> Arc<DecidedData> {
+        self.seed_decided_value(self.mixed_decided_data())
+    }
+
+    /// Seeds the standard mixed decided value and returns the single execution it registers,
+    /// for tests that also read the aggregate side through the publisher.
+    fn seed_mixed_decided_value_with_execution(&self) -> (Arc<DecidedData>, Execution) {
+        self.seed_decided_value_with_execution(self.mixed_decided_data())
+    }
+
+    /// Seeds `data` and returns the single execution it registers.
+    fn seed_decided_value_with_execution(
+        &self,
+        data: DecidedData,
+    ) -> (Arc<DecidedData>, Execution) {
+        let data = Arc::new(data);
+        let mut new_executions = self.publish_decided_value(Arc::clone(&data));
+        assert_eq!(
+            new_executions.len(),
+            1,
+            "seeding one committee should register exactly one execution"
+        );
+        let (committee_id, execution) = new_executions.pop().expect("execution should exist");
+        assert_eq!(committee_id, self.committee_id);
+        (data, execution)
+    }
+
+    /// Resolves this committee's decided aggregates the way the publisher does.
+    async fn resolve_aggregates(&self, execution: Execution) -> ResolvedAggregates<MainnetEthSpec> {
+        self.harness
+            .validator_store
+            .resolve_decided_aggregates(self.committee_id, Slot::new(TEST_SLOT), execution)
+            .await
+    }
+
+    /// The aggregator index the standard mixed decided value publishes.
+    fn expected_aggregator_index(&self) -> u64 {
+        self.harness
+            .aggregator_index(COMMITTEE_INDEX, AGGREGATE_VALIDATOR_IDX)
     }
 
     fn create_contribution(
@@ -189,19 +234,6 @@ impl AggregatorCommitteeFixture {
         tokio::time::timeout(STREAM_TIMEOUT, stream.collect())
             .await
             .expect("contribution callback should complete within the stream timeout")
-    }
-
-    async fn collect_aggregates(
-        &self,
-        aggregates: Vec<validator_store::AggregateToSign<MainnetEthSpec>>,
-    ) -> SignAggregatesResult {
-        let stream = self
-            .harness
-            .validator_store
-            .sign_aggregate_and_proofs(aggregates);
-        tokio::time::timeout(STREAM_TIMEOUT, stream.collect())
-            .await
-            .expect("aggregate callback should complete within the stream timeout")
     }
 }
 
@@ -398,6 +430,33 @@ async fn assert_captured_calls_settle_at(harness: &ValidatorStoreTestHarness, ex
     );
 }
 
+/// Asserts the publisher resolved a batch holding exactly `expected` aggregator indexes.
+///
+/// The non-`Batch` variants are what select the publisher's metric label, so a test that expected
+/// a batch and got one of them is reported as that variant rather than as a length mismatch.
+fn assert_published_aggregators(
+    published: ResolvedAggregates<MainnetEthSpec>,
+    expected: &[u64],
+    context: &str,
+) {
+    match published {
+        ResolvedAggregates::Batch(batch) => assert_eq!(
+            batch
+                .iter()
+                .map(|signed| signed.message().aggregator_index())
+                .collect::<Vec<_>>(),
+            expected,
+            "{context}"
+        ),
+        ResolvedAggregates::ConsensusFailed => {
+            panic!("{context}: the execution failed instead of resolving a batch")
+        }
+        ResolvedAggregates::NoAggregates => {
+            panic!("{context}: the decided worklist held no aggregates")
+        }
+    }
+}
+
 /// Unwraps a single-committee stream result into its signed batch.
 fn single_batch<T>(results: Vec<Result<Vec<T>, Error>>) -> Vec<T> {
     assert_eq!(results.len(), 1, "expected one committee stream item");
@@ -463,28 +522,35 @@ async fn contribution_only_callback_signs_complete_mixed_worklist() {
     );
 }
 
-/// The mirror case: an aggregate-only callback must still trigger signing of both decided
-/// contributions.
+/// The mirror case, read through the publisher: the aggregate callback returns nothing, the
+/// publisher takes the decided aggregate, and the decided contributions are signed anyway.
+///
+/// The aggregate callback no longer joins the execution at all, so this is the test that the
+/// aggregate half of the worklist is complete: only the publisher can observe it.
 #[tokio::test(flavor = "multi_thread")]
-async fn aggregate_only_callback_signs_complete_mixed_worklist() {
+async fn publisher_takes_the_decided_aggregate_while_the_callback_returns_empty() {
     // Arrange
     let fixture = AggregatorCommitteeFixture::new(MIXED_COMMITTEE_VALIDATOR_COUNT);
-    let decided = fixture.seed_mixed_decided_value();
+    let (decided, execution) = fixture.seed_mixed_decided_value_with_execution();
     let aggregates = vec![
         fixture
             .harness
             .create_aggregate(COMMITTEE_INDEX, AGGREGATE_VALIDATOR_IDX),
     ];
 
-    // Act: only the aggregate callback fires.
-    let results = fixture.collect_aggregates(aggregates).await;
+    // Act: only the aggregate callback fires, and the publisher reads the same execution.
+    let results = fixture.harness.collect_aggregates(aggregates).await;
+    let published = fixture.resolve_aggregates(execution).await;
 
-    // Assert: the callback returns exactly its own aggregate.
-    let signed = single_batch(results);
-    assert_eq!(
-        signed.len(),
-        1,
-        "the aggregate callback should return only its requested aggregate"
+    // Assert: Lighthouse gets nothing to publish, Anchor publishes the decided aggregate itself.
+    assert!(
+        single_batch(results).is_empty(),
+        "the aggregate callback must hand Lighthouse an empty batch at Boole+"
+    );
+    assert_published_aggregators(
+        published,
+        &[fixture.expected_aggregator_index()],
+        "the publisher should return the decided aggregate",
     );
 
     // Both contribution roots are signed by detached tasks without a contribution callback.
@@ -552,40 +618,35 @@ async fn republished_assignments_do_not_resubmit() {
     assert_batch_identity(&calls, MIXED_WORKLIST_SIZE, decided.hash());
 }
 
-/// Both callbacks read the same execution: neither re-runs consensus nor duplicates signatures,
-/// and each returns only its own items.
+/// The contribution callback and the publisher read the same execution: neither re-runs consensus
+/// nor duplicates signatures, and each takes only its own class of decided item.
 #[tokio::test(flavor = "multi_thread")]
-async fn both_callbacks_share_one_execution() {
+async fn contribution_callback_and_publisher_share_one_execution() {
     // Arrange
     let fixture = AggregatorCommitteeFixture::new(MIXED_COMMITTEE_VALIDATOR_COUNT);
-    let decided = fixture.seed_mixed_decided_value();
+    let (decided, execution) = fixture.seed_mixed_decided_value_with_execution();
     let contributions = CONTRIBUTION_SUBCOMMITTEES
         .iter()
         .map(|&subcommittee| fixture.create_contribution(CONTRIBUTOR_VALIDATOR_IDX, subcommittee))
         .collect();
-    let aggregates = vec![
-        fixture
-            .harness
-            .create_aggregate(COMMITTEE_INDEX, AGGREGATE_VALIDATOR_IDX),
-    ];
 
-    // Act: contribution callback first, then the aggregate callback joins the cached outcome.
+    // Act: contribution callback first, then the publisher joins the cached outcome.
     let contribution_results = fixture.collect_contributions(contributions).await;
-    let aggregate_results = fixture.collect_aggregates(aggregates).await;
+    let published = fixture.resolve_aggregates(execution).await;
 
-    // Assert: each callback returned only its own items.
+    // Assert: each reader took only its own class.
     assert_eq!(
         single_batch(contribution_results).len(),
         CONTRIBUTION_SUBCOMMITTEES.len(),
         "the contribution callback should return only its contributions"
     );
-    assert_eq!(
-        single_batch(aggregate_results).len(),
-        1,
-        "the aggregate callback should return only its aggregate"
+    assert_published_aggregators(
+        published,
+        &[fixture.expected_aggregator_index()],
+        "the publisher should return only the decided aggregate",
     );
 
-    // The union is signed exactly once: no duplicate captures from the second callback.
+    // The union is signed exactly once: no duplicate captures from the second reader.
     assert_captured_calls_settle_at(&fixture.harness, MIXED_WORKLIST_SIZE).await;
     let calls = committee_calls(&fixture.harness);
     assert_eq!(distinct_roots(&calls).len(), MIXED_WORKLIST_SIZE);
@@ -593,12 +654,12 @@ async fn both_callbacks_share_one_execution() {
 }
 
 /// Dropping a callback future must not cancel the execution it is reading: the complete worklist
-/// is still signed, and a later callback still gets its items from the same execution.
+/// is still signed, and a later reader still gets its items from the same execution.
 #[tokio::test(flavor = "multi_thread")]
 async fn dropped_callback_future_still_completes_worklist() {
     // Arrange
     let fixture = AggregatorCommitteeFixture::new(MIXED_COMMITTEE_VALIDATOR_COUNT);
-    let decided = fixture.seed_mixed_decided_value();
+    let (decided, execution) = fixture.seed_mixed_decided_value_with_execution();
     let contributions: Vec<_> = CONTRIBUTION_SUBCOMMITTEES
         .iter()
         .map(|&subcommittee| fixture.create_contribution(CONTRIBUTOR_VALIDATOR_IDX, subcommittee))
@@ -618,20 +679,15 @@ async fn dropped_callback_future_still_completes_worklist() {
     let calls = committee_calls(&fixture.harness);
     assert_batch_identity(&calls, MIXED_WORKLIST_SIZE, decided.hash());
 
-    // A later aggregate callback joins the finished execution and gets its aggregate.
-    let aggregates = vec![
-        fixture
-            .harness
-            .create_aggregate(COMMITTEE_INDEX, AGGREGATE_VALIDATOR_IDX),
-    ];
-    let signed = single_batch(fixture.collect_aggregates(aggregates).await);
-    assert_eq!(
-        signed.len(),
-        1,
-        "a late aggregate callback should resolve from the cached execution"
+    // A late publisher joins the finished execution and gets the decided aggregate.
+    let published = fixture.resolve_aggregates(execution).await;
+    assert_published_aggregators(
+        published,
+        &[fixture.expected_aggregator_index()],
+        "a late publisher should resolve from the cached execution",
     );
 
-    // Still no duplicate captures after the late callback.
+    // Still no duplicate captures after the late read.
     tokio::time::sleep(SETTLE_DELAY).await;
     assert_eq!(
         fixture.harness.captured_calls.lock().len(),
@@ -802,13 +858,14 @@ async fn conflicting_aggregate_roots_sign_only_the_first() {
 // ==================== Empty and error path tests ====================
 
 /// A decided value naming only validators this operator has no metadata for produces an empty
-/// worklist: the callbacks return empty batches and no signature is ever collected.
+/// worklist: the contribution callback returns an empty batch, the publisher has nothing to
+/// publish, and no signature is ever collected.
 #[tokio::test(flavor = "multi_thread")]
 async fn empty_worklist_returns_empty() {
-    // Arrange: the decided entries reference foreign validator indices, while the callbacks
-    // reference the local validator (required to pass committee grouping).
+    // Arrange: the decided entries reference foreign validator indices, while the callback
+    // references the local validator (required to pass committee grouping).
     let fixture = AggregatorCommitteeFixture::new(SINGLE_VALIDATOR_COUNT);
-    fixture.seed_decided_value(build_decided_data(
+    let (_, execution) = fixture.seed_decided_value_with_execution(build_decided_data(
         &[(
             ValidatorIndex(FOREIGN_AGGREGATOR_INDEX),
             BEACON_COMMITTEE_INDEX,
@@ -818,60 +875,49 @@ async fn empty_worklist_returns_empty() {
             CONTRIBUTION_SUBCOMMITTEES[0],
         )],
     ));
-    let aggregates = vec![
-        fixture
-            .harness
-            .create_aggregate(COMMITTEE_INDEX, AGGREGATE_VALIDATOR_IDX),
-    ];
     let contributions =
         vec![fixture.create_contribution(SOLE_VALIDATOR_IDX, CONTRIBUTION_SUBCOMMITTEES[0])];
 
     // Act
-    let aggregate_results = fixture.collect_aggregates(aggregates).await;
     let contribution_results = fixture.collect_contributions(contributions).await;
+    let published = fixture.resolve_aggregates(execution).await;
 
-    // Assert: both callbacks yield an empty batch and nothing is signed.
-    assert!(
-        single_batch(aggregate_results).is_empty(),
-        "no locally signable decided entry means an empty aggregate batch"
-    );
+    // Assert: nothing to return, nothing to publish, nothing signed.
     assert!(
         single_batch(contribution_results).is_empty(),
         "no locally signable decided entry means an empty contribution batch"
     );
+    assert!(
+        matches!(published, ResolvedAggregates::NoAggregates),
+        "no locally signable decided aggregate means nothing to publish"
+    );
     assert_captured_calls_settle_at(&fixture.harness, 0).await;
 }
 
-/// Missing consensus data for the committee fails the execution; the trait layer swallows the
-/// error into an empty batch (`run_committee_signing`) and nothing is signed.
+/// Missing consensus data for the committee registers no execution: the contribution callback
+/// fails with `ConsensusDataNotFound`, the publisher gets no handle, and nothing is signed.
 #[tokio::test(flavor = "multi_thread")]
 async fn consensus_data_missing_errors() {
     // Arrange: assignments exist for the slot, but carry no consensus data for any committee,
     // so the execution fails with `ConsensusDataNotFound`. (Seeding nothing at all would park
-    // the callbacks on the assignments watch channel instead of erroring.)
+    // the callback on the assignments watch channel instead of erroring.)
     let fixture = AggregatorCommitteeFixture::new(MIXED_COMMITTEE_VALIDATOR_COUNT);
-    fixture.seed_assignments_without_consensus_data();
-    let aggregates = vec![
-        fixture
-            .harness
-            .create_aggregate(COMMITTEE_INDEX, AGGREGATE_VALIDATOR_IDX),
-    ];
+    let executions = fixture.seed_assignments_without_consensus_data();
     let contributions =
         vec![fixture.create_contribution(CONTRIBUTOR_VALIDATOR_IDX, CONTRIBUTION_SUBCOMMITTEES[0])];
 
-    // Act: both callback classes hit the same cached execution error.
-    let aggregate_results = fixture.collect_aggregates(aggregates).await;
+    // Act
     let contribution_results = fixture.collect_contributions(contributions).await;
 
     // Assert: `run_committee_signing` swallows the failure into one empty stream item per
-    // committee, and no signature collection is ever attempted.
-    assert!(
-        single_batch(aggregate_results).is_empty(),
-        "a failed execution should yield an empty aggregate batch"
-    );
+    // committee, nothing is handed to the publisher, and no signature collection is attempted.
     assert!(
         single_batch(contribution_results).is_empty(),
         "a failed execution should yield an empty contribution batch"
+    );
+    assert!(
+        executions.is_empty(),
+        "a committee with no decided value must not register a publisher handle"
     );
     assert_captured_calls_settle_at(&fixture.harness, 0).await;
 }
@@ -921,5 +967,342 @@ async fn slot_mismatched_decided_payloads_are_excluded() {
     assert_eq!(
         calls[0].batch_size, EXPECTED_SURVIVOR_COUNT,
         "the batch size should count only surviving entries"
+    );
+}
+
+// ==================== Publisher registration tests ====================
+
+/// Registration is vacant-only, so a `(committee, slot)` yields its publisher handle exactly once.
+///
+/// The handle is what makes the publisher run, so a second handle for one slot would post the
+/// same aggregates to the beacon node twice.
+#[tokio::test(flavor = "multi_thread")]
+async fn start_aggregator_post_consensus_returns_only_vacant_insertions() {
+    // Arrange
+    let fixture = AggregatorCommitteeFixture::new(MIXED_COMMITTEE_VALIDATOR_COUNT);
+    let decided = Arc::new(fixture.mixed_decided_data());
+
+    // Act: publish the same slot's assignments twice.
+    let first = fixture.publish_decided_value(Arc::clone(&decided));
+    let second = fixture.publish_decided_value(decided);
+
+    // Assert
+    assert_eq!(
+        first.len(),
+        1,
+        "the first publish should register this committee's execution"
+    );
+    assert_eq!(first[0].0, fixture.committee_id);
+    assert!(
+        second.is_empty(),
+        "a republish must not hand out a second publisher handle"
+    );
+    assert_eq!(
+        fixture
+            .harness
+            .validator_store
+            .aggregator_post_consensus
+            .lock()
+            .len(),
+        1,
+        "the retention map should hold exactly one execution for the slot"
+    );
+}
+
+// ==================== resolve_decided_aggregates failure tests ====================
+
+/// A failed execution resolves to `ConsensusFailed` rather than propagating the error, which is
+/// what makes the publisher count it as a consensus error and publish nothing.
+#[tokio::test(flavor = "multi_thread")]
+async fn resolve_decided_aggregates_reports_consensus_failure() {
+    // Arrange: an execution that resolves to an error, as a lost QBFT round would.
+    let fixture = AggregatorCommitteeFixture::new(SINGLE_VALIDATOR_COUNT);
+    let execution: Execution = async {
+        Err(Arc::new(Error::SpecificError(
+            SpecificError::PostConsensusAborted,
+        )))
+    }
+    .boxed()
+    .shared();
+
+    // Act
+    let published = fixture.resolve_aggregates(execution).await;
+
+    // Assert
+    assert!(
+        matches!(published, ResolvedAggregates::ConsensusFailed),
+        "a failed execution should publish nothing"
+    );
+}
+
+/// An execution that never decides is bounded by the two-slot deadline instead of hanging, and the
+/// timeout is reported as a consensus failure.
+///
+/// The harness clock is moved past that deadline first, so the bound is asserted without sleeping
+/// two real slots.
+#[tokio::test(flavor = "multi_thread")]
+async fn resolve_decided_aggregates_reports_consensus_failure_once_the_deadline_passes() {
+    // Arrange
+    let fixture = AggregatorCommitteeFixture::new(SINGLE_VALIDATOR_COUNT);
+    fixture
+        .harness
+        .slot_clock
+        .set_current_time(Duration::from_secs(PAST_PUBLISH_DEADLINE_SECS));
+    let execution: Execution = futures::future::pending().boxed().shared();
+
+    // Act
+    let published = tokio::time::timeout(STREAM_TIMEOUT, fixture.resolve_aggregates(execution))
+        .await
+        .expect("the publisher must not outlive the two-slot deadline");
+
+    // Assert
+    assert!(
+        matches!(published, ResolvedAggregates::ConsensusFailed),
+        "an undecided execution should publish nothing"
+    );
+}
+
+// ==================== Publisher tests ====================
+
+/// Distinct operator sets give distinct `CommitteeId`s, so one harness can hold several committees
+/// with different decided values.
+const PUBLISHER_OPERATOR_SETS: [[OperatorId; 4]; 3] = [
+    [OperatorId(1), OperatorId(2), OperatorId(3), OperatorId(4)],
+    [OperatorId(1), OperatorId(5), OperatorId(6), OperatorId(7)],
+    [OperatorId(1), OperatorId(8), OperatorId(9), OperatorId(10)],
+];
+/// Validator index space per publisher committee, so an aggregator index identifies its committee.
+const PUBLISHER_INDEX_STRIDE: usize = 100;
+/// Committee positions in [`PublisherFixture`], named by the role they play in the tests.
+const FIRST_AGGREGATE_COMMITTEE: usize = 0;
+const CONTRIBUTIONS_ONLY_COMMITTEE: usize = 1;
+const SECOND_AGGREGATE_COMMITTEE: usize = 2;
+
+/// Several single-validator committees in one harness, for the publisher's per-committee fan-out.
+struct PublisherFixture {
+    harness: ValidatorStoreTestHarness,
+    committee_ids: Vec<CommitteeId>,
+}
+
+impl PublisherFixture {
+    fn new() -> Self {
+        let setups: Vec<_> = PUBLISHER_OPERATOR_SETS
+            .iter()
+            .enumerate()
+            .map(|(position, operator_ids)| {
+                create_committee_setup(
+                    operator_ids,
+                    SINGLE_VALIDATOR_COUNT,
+                    (position + 1) * PUBLISHER_INDEX_STRIDE,
+                )
+            })
+            .collect();
+        let committee_ids = setups
+            .iter()
+            .map(|setup| setup.cluster.committee_id())
+            .collect();
+        Self {
+            harness: ValidatorStoreTestHarness::new(setups, OUR_OPERATOR_ID),
+            committee_ids,
+        }
+    }
+
+    fn validator_index(&self, committee: usize) -> ValidatorIndex {
+        self.harness
+            .validator_metadata(committee, SOLE_VALIDATOR_IDX)
+            .index
+            .expect("test validator should have an index")
+    }
+
+    fn aggregator_index(&self, committee: usize) -> u64 {
+        self.harness.aggregator_index(committee, SOLE_VALIDATOR_IDX)
+    }
+
+    /// A decided value holding this committee's single aggregate.
+    fn aggregate_only(&self, committee: usize) -> DecidedData {
+        build_decided_data(
+            &[(self.validator_index(committee), BEACON_COMMITTEE_INDEX)],
+            &[],
+        )
+    }
+
+    /// A decided value holding one contribution and no aggregate, which the publisher must skip.
+    fn contributions_only(&self, committee: usize) -> DecidedData {
+        build_decided_data(
+            &[],
+            &[(
+                self.validator_index(committee),
+                CONTRIBUTION_SUBCOMMITTEES[0],
+            )],
+        )
+    }
+
+    /// Publishes one decided value per named committee at `TEST_SLOT`, returning the executions
+    /// the slot pipeline hands to the publisher.
+    fn publish(
+        &self,
+        decided_by_committee: Vec<(usize, DecidedData)>,
+    ) -> Vec<(CommitteeId, Execution)> {
+        self.harness.publish_decided_values(
+            decided_by_committee
+                .into_iter()
+                .map(|(committee, data)| (self.committee_ids[committee], Arc::new(data)))
+                .collect(),
+        )
+    }
+
+    /// Runs the publisher over `executions` with a recording publish closure, returning the
+    /// aggregator indexes of every batch it was handed.
+    ///
+    /// `outcome` decides each batch's publish result from its contents, so a test can fail one
+    /// committee's publish without depending on the order committees finish in. The returned
+    /// batches are sorted for the same reason.
+    async fn run_publisher(
+        &self,
+        executions: Vec<(CommitteeId, Execution)>,
+        outcome: impl Fn(&[u64]) -> Result<(), String>,
+    ) -> Vec<Vec<u64>> {
+        let recorded: Arc<Mutex<Vec<Vec<u64>>>> = Arc::new(Mutex::new(Vec::new()));
+        self.harness
+            .validator_store
+            .publish_decided_aggregates(Slot::new(TEST_SLOT), executions, |signed| {
+                let recorded = Arc::clone(&recorded);
+                let outcome = &outcome;
+                async move {
+                    let aggregators: Vec<u64> = signed
+                        .iter()
+                        .map(|signed| signed.message().aggregator_index())
+                        .collect();
+                    let result = outcome(&aggregators);
+                    recorded.lock().push(aggregators);
+                    result
+                }
+            })
+            .await;
+
+        let mut recorded = recorded.lock().clone();
+        recorded.sort();
+        recorded
+    }
+}
+
+/// Every committee with decided aggregates is published exactly once, and a committee whose
+/// decided value holds only contributions never reaches the publish call at all.
+///
+/// Contributions stay on Lighthouse's publish path, so handing an empty batch to the beacon node
+/// would be a pointless POST for the contributions-only case.
+#[tokio::test(flavor = "multi_thread")]
+async fn publish_decided_aggregates_publishes_each_committee_with_aggregates_once() {
+    // Arrange
+    let fixture = PublisherFixture::new();
+    let executions = fixture.publish(vec![
+        (
+            FIRST_AGGREGATE_COMMITTEE,
+            fixture.aggregate_only(FIRST_AGGREGATE_COMMITTEE),
+        ),
+        (
+            CONTRIBUTIONS_ONLY_COMMITTEE,
+            fixture.contributions_only(CONTRIBUTIONS_ONLY_COMMITTEE),
+        ),
+        (
+            SECOND_AGGREGATE_COMMITTEE,
+            fixture.aggregate_only(SECOND_AGGREGATE_COMMITTEE),
+        ),
+    ]);
+    assert_eq!(
+        executions.len(),
+        PUBLISHER_OPERATOR_SETS.len(),
+        "each committee should register one execution"
+    );
+
+    // Act
+    let published = fixture.run_publisher(executions, |_| Ok(())).await;
+
+    // Assert: one batch per committee holding aggregates, carrying that committee's aggregator.
+    assert_eq!(
+        published,
+        vec![
+            vec![fixture.aggregator_index(FIRST_AGGREGATE_COMMITTEE)],
+            vec![fixture.aggregator_index(SECOND_AGGREGATE_COMMITTEE)],
+        ],
+        "committees with decided aggregates publish once each, and the contributions-only \
+         committee never reaches the publish call"
+    );
+}
+
+/// A publish failure is contained to its own committee: it neither panics nor stops the other
+/// committees' batches from being published.
+#[tokio::test(flavor = "multi_thread")]
+async fn publish_decided_aggregates_survives_a_failing_publish() {
+    // Arrange: all three committees decide an aggregate.
+    let fixture = PublisherFixture::new();
+    let executions = fixture.publish(
+        (0..PUBLISHER_OPERATOR_SETS.len())
+            .map(|committee| (committee, fixture.aggregate_only(committee)))
+            .collect(),
+    );
+    let failing_aggregator = fixture.aggregator_index(FIRST_AGGREGATE_COMMITTEE);
+
+    // Act: the first committee's POST fails, keyed by batch contents so the outcome does not
+    // depend on which committee resolves first.
+    let published = fixture
+        .run_publisher(executions, |aggregators| {
+            if aggregators.contains(&failing_aggregator) {
+                Err("beacon node unavailable".to_string())
+            } else {
+                Ok(())
+            }
+        })
+        .await;
+
+    // Assert: every committee's batch was still attempted.
+    assert_eq!(
+        published,
+        (0..PUBLISHER_OPERATOR_SETS.len())
+            .map(|committee| vec![fixture.aggregator_index(committee)])
+            .collect::<Vec<_>>(),
+        "a failing publish must not withhold the other committees' batches"
+    );
+}
+
+/// A committee that decided aggregates but whose roots never reached signature quorum resolves to
+/// an empty `Batch`, and the publisher posts nothing.
+///
+/// This is a third outcome, distinct from `ConsensusFailed` (the round itself failed) and
+/// `NoAggregates` (the decided value held none): consensus succeeded and there was something to
+/// sign, but no signature came back. The publisher counts it under its own label, so the three
+/// cases stay separable on a dashboard instead of collapsing into one.
+#[tokio::test(flavor = "multi_thread")]
+async fn publish_decided_aggregates_skips_a_committee_whose_roots_never_reach_quorum() {
+    // Arrange: signature collection fails before the decided value is published, so the
+    // committee's only aggregate root resolves to an error.
+    let fixture = PublisherFixture::new();
+    fixture.harness.fail_signature_collection();
+    let executions = fixture.publish(vec![(
+        FIRST_AGGREGATE_COMMITTEE,
+        fixture.aggregate_only(FIRST_AGGREGATE_COMMITTEE),
+    )]);
+    let (committee_id, execution) = executions
+        .first()
+        .cloned()
+        .expect("the committee should register one execution");
+
+    // Act
+    let resolved = fixture
+        .harness
+        .validator_store
+        .resolve_decided_aggregates(committee_id, Slot::new(TEST_SLOT), execution)
+        .await;
+    let published = fixture.run_publisher(executions, |_| Ok(())).await;
+
+    // Assert: a batch was resolved, it is empty, and nothing was handed to publish.
+    assert!(
+        matches!(&resolved, ResolvedAggregates::Batch(batch) if batch.is_empty()),
+        "a decided aggregate whose signature never arrives should resolve to an empty batch, \
+         not to a consensus failure or an absent worklist"
+    );
+    assert!(
+        published.is_empty(),
+        "the publisher must not POST an empty batch"
     );
 }

--- a/anchor/validator_store/src/testing/aggregator_post_consensus.rs
+++ b/anchor/validator_store/src/testing/aggregator_post_consensus.rs
@@ -34,8 +34,9 @@ use ssv_types::{
 use ssz::Encode;
 use ssz_types::VariableList;
 use types::{
-    AttestationBase, AttestationData, Checkpoint, Epoch, ForkName, Hash256, MainnetEthSpec,
-    SignedContributionAndProof, Slot, SyncCommitteeContribution, SyncSelectionProof,
+    AttestationBase, AttestationData, AttestationElectra, Checkpoint, Epoch, ForkName, Hash256,
+    MainnetEthSpec, SignedContributionAndProof, Slot, SyncCommitteeContribution,
+    SyncSelectionProof,
 };
 use validator_store::{ContributionToSign, ValidatorStore};
 
@@ -43,6 +44,7 @@ use super::common::*;
 use crate::{
     Error, SpecificError,
     aggregator_post_consensus::{AggregatorPostConsensusShared, ResolvedAggregates},
+    metrics,
 };
 
 /// One committee's decided value, as the slot pipeline publishes it.
@@ -247,25 +249,55 @@ fn assigned(validator_index: ValidatorIndex, committee_index: u64) -> AssignedAg
     }
 }
 
-/// An aggregate attestation payload at `TEST_SLOT`. Distinct `committee_index` values produce
-/// distinct signing roots.
+/// The `AttestationData` shared by the aggregate payload builders, at `TEST_SLOT`.
+fn test_attestation_data(index: u64) -> AttestationData {
+    AttestationData {
+        slot: Slot::new(TEST_SLOT),
+        index,
+        beacon_block_root: Hash256::zero(),
+        source: Checkpoint {
+            epoch: Epoch::new(0),
+            root: Hash256::zero(),
+        },
+        target: Checkpoint {
+            epoch: Epoch::new(0),
+            root: Hash256::zero(),
+        },
+    }
+}
+
+/// An aggregate attestation payload at `TEST_SLOT`, in the pre-Electra shape. Distinct
+/// `committee_index` values produce distinct signing roots.
 fn test_aggregate_attestation(committee_index: u64) -> AttestationBase<MainnetEthSpec> {
     AttestationBase {
         aggregation_bits: ssz_types::BitList::with_capacity(128).expect("bitlist should be valid"),
-        data: AttestationData {
-            slot: Slot::new(TEST_SLOT),
-            index: committee_index,
-            beacon_block_root: Hash256::zero(),
-            source: Checkpoint {
-                epoch: Epoch::new(0),
-                root: Hash256::zero(),
-            },
-            target: Checkpoint {
-                epoch: Epoch::new(0),
-                root: Hash256::zero(),
-            },
-        },
+        data: test_attestation_data(committee_index),
         signature: AggregateSignature::infinity(),
+    }
+}
+
+/// An aggregate attestation payload at `TEST_SLOT`, in the Electra+ shape: the committee moves
+/// from `data.index` to `committee_bits`. Distinct `committee_index` values produce distinct
+/// signing roots.
+fn test_aggregate_attestation_electra(committee_index: u64) -> AttestationElectra<MainnetEthSpec> {
+    let mut committee_bits = ssz_types::BitVector::new();
+    committee_bits
+        .set(committee_index as usize, true)
+        .expect("committee bit should be in range");
+    AttestationElectra {
+        aggregation_bits: ssz_types::BitList::with_capacity(128).expect("bitlist should be valid"),
+        data: test_attestation_data(0),
+        signature: AggregateSignature::infinity(),
+        committee_bits,
+    }
+}
+
+/// SSZ payload bytes for one decided aggregate, in the shape `fork` decodes.
+fn aggregate_payload_bytes(fork: ForkName, committee_index: u64) -> Vec<u8> {
+    if fork >= ForkName::Electra {
+        test_aggregate_attestation_electra(committee_index).as_ssz_bytes()
+    } else {
+        test_aggregate_attestation(committee_index).as_ssz_bytes()
     }
 }
 
@@ -281,12 +313,24 @@ fn test_contribution(subcommittee_index: u64) -> SyncCommitteeContribution<Mainn
     }
 }
 
-/// Builds an `AggregatorCommitteeConsensusData` from decided entries.
+/// Fork the standard decided values are built at; [`build_decided_data`] uses it.
+const DEFAULT_DECIDED_FORK: ForkName = ForkName::Deneb;
+
+/// Builds an `AggregatorCommitteeConsensusData` at [`DEFAULT_DECIDED_FORK`] from decided entries.
+fn build_decided_data(
+    aggregators: &[(ValidatorIndex, u64)],
+    contributors: &[(ValidatorIndex, u64)],
+) -> AggregatorCommitteeConsensusData<MainnetEthSpec> {
+    build_decided_data_at_fork(DEFAULT_DECIDED_FORK, aggregators, contributors)
+}
+
+/// Builds an `AggregatorCommitteeConsensusData` decided at `fork` from decided entries.
 ///
 /// `aggregators` and `contributors` are `(validator_index, committee_index)` pairs; the
 /// attestation and contribution payload lists are derived from them (one payload per unique
-/// index).
-fn build_decided_data(
+/// index), with each attestation payload in the shape `fork` decodes.
+fn build_decided_data_at_fork(
+    fork: ForkName,
     aggregators: &[(ValidatorIndex, u64)],
     contributors: &[(ValidatorIndex, u64)],
 ) -> AggregatorCommitteeConsensusData<MainnetEthSpec> {
@@ -310,7 +354,7 @@ fn build_decided_data(
     let aggregated_attestations: Vec<_> = aggregate_committee_indexes
         .iter()
         .map(|&committee_index| {
-            VariableList::new(test_aggregate_attestation(committee_index).as_ssz_bytes())
+            VariableList::new(aggregate_payload_bytes(fork, committee_index))
                 .expect("attestation bytes should fit")
         })
         .collect();
@@ -324,7 +368,7 @@ fn build_decided_data(
         .collect();
 
     AggregatorCommitteeConsensusData {
-        version: DataVersion::from(ForkName::Deneb),
+        version: DataVersion::from(fork),
         aggregators: VariableList::new(aggregators).expect("aggregator list should be valid"),
         aggregator_committee_indexes: VariableList::new(aggregate_committee_indexes)
             .expect("committee indexes should be valid"),
@@ -440,8 +484,8 @@ fn assert_published_aggregators(
     context: &str,
 ) {
     match published {
-        ResolvedAggregates::Batch(batch) => assert_eq!(
-            batch
+        ResolvedAggregates::Batch { aggregates, .. } => assert_eq!(
+            aggregates
                 .iter()
                 .map(|signed| signed.message().aggregator_index())
                 .collect::<Vec<_>>(),
@@ -453,6 +497,9 @@ fn assert_published_aggregators(
         }
         ResolvedAggregates::NoAggregates => {
             panic!("{context}: the decided worklist held no aggregates")
+        }
+        ResolvedAggregates::NoSignatures => {
+            panic!("{context}: no decided root reached signature quorum")
         }
     }
 }
@@ -1078,6 +1125,9 @@ const FIRST_AGGREGATE_COMMITTEE: usize = 0;
 const CONTRIBUTIONS_ONLY_COMMITTEE: usize = 1;
 const SECOND_AGGREGATE_COMMITTEE: usize = 2;
 
+/// Fork and aggregator indexes of one batch handed to the recording publish closure.
+type RecordedBatch = (ForkName, Vec<u64>);
+
 /// Several single-validator committees in one harness, for the publisher's per-committee fan-out.
 struct PublisherFixture {
     harness: ValidatorStoreTestHarness,
@@ -1120,7 +1170,13 @@ impl PublisherFixture {
 
     /// A decided value holding this committee's single aggregate.
     fn aggregate_only(&self, committee: usize) -> DecidedData {
-        build_decided_data(
+        self.aggregate_only_at_fork(committee, DEFAULT_DECIDED_FORK)
+    }
+
+    /// [`Self::aggregate_only`] decided at `fork`, with the payload in that fork's shape.
+    fn aggregate_only_at_fork(&self, committee: usize, fork: ForkName) -> DecidedData {
+        build_decided_data_at_fork(
+            fork,
             &[(self.validator_index(committee), BEACON_COMMITTEE_INDEX)],
             &[],
         )
@@ -1151,21 +1207,23 @@ impl PublisherFixture {
         )
     }
 
-    /// Runs the publisher over `executions` with a recording publish closure, returning the
-    /// aggregator indexes of every batch it was handed.
+    /// Runs the publisher over `executions` with a recording publish closure, returning the fork
+    /// and aggregator indexes of every batch it was handed.
     ///
-    /// `outcome` decides each batch's publish result from its contents, so a test can fail one
-    /// committee's publish without depending on the order committees finish in. The returned
-    /// batches are sorted for the same reason.
+    /// The recorder captures the `ForkName` the closure receives, so tests can pin that it
+    /// matches the decided value's `DataVersion`. `outcome` decides each batch's publish result
+    /// from its contents, so a test can fail one committee's publish without depending on the
+    /// order committees finish in. The returned batches are sorted by their aggregator indexes
+    /// for the same reason.
     async fn run_publisher(
         &self,
         executions: Vec<(CommitteeId, Execution)>,
         outcome: impl Fn(&[u64]) -> Result<(), String>,
-    ) -> Vec<Vec<u64>> {
-        let recorded: Arc<Mutex<Vec<Vec<u64>>>> = Arc::new(Mutex::new(Vec::new()));
+    ) -> Vec<RecordedBatch> {
+        let recorded: Arc<Mutex<Vec<RecordedBatch>>> = Arc::new(Mutex::new(Vec::new()));
         self.harness
             .validator_store
-            .publish_decided_aggregates(Slot::new(TEST_SLOT), executions, |signed| {
+            .publish_decided_aggregates(Slot::new(TEST_SLOT), executions, |fork_name, signed| {
                 let recorded = Arc::clone(&recorded);
                 let outcome = &outcome;
                 async move {
@@ -1174,14 +1232,14 @@ impl PublisherFixture {
                         .map(|signed| signed.message().aggregator_index())
                         .collect();
                     let result = outcome(&aggregators);
-                    recorded.lock().push(aggregators);
+                    recorded.lock().push((fork_name, aggregators));
                     result
                 }
             })
             .await;
 
         let mut recorded = recorded.lock().clone();
-        recorded.sort();
+        recorded.sort_by(|left, right| left.1.cmp(&right.1));
         recorded
     }
 }
@@ -1218,12 +1276,19 @@ async fn publish_decided_aggregates_publishes_each_committee_with_aggregates_onc
     // Act
     let published = fixture.run_publisher(executions, |_| Ok(())).await;
 
-    // Assert: one batch per committee holding aggregates, carrying that committee's aggregator.
+    // Assert: one batch per committee holding aggregates, carrying that committee's aggregator
+    // and the decided value's fork.
     assert_eq!(
         published,
         vec![
-            vec![fixture.aggregator_index(FIRST_AGGREGATE_COMMITTEE)],
-            vec![fixture.aggregator_index(SECOND_AGGREGATE_COMMITTEE)],
+            (
+                DEFAULT_DECIDED_FORK,
+                vec![fixture.aggregator_index(FIRST_AGGREGATE_COMMITTEE)],
+            ),
+            (
+                DEFAULT_DECIDED_FORK,
+                vec![fixture.aggregator_index(SECOND_AGGREGATE_COMMITTEE)],
+            ),
         ],
         "committees with decided aggregates publish once each, and the contributions-only \
          committee never reaches the publish call"
@@ -1259,14 +1324,29 @@ async fn publish_decided_aggregates_survives_a_failing_publish() {
     assert_eq!(
         published,
         (0..PUBLISHER_OPERATOR_SETS.len())
-            .map(|committee| vec![fixture.aggregator_index(committee)])
+            .map(|committee| (
+                DEFAULT_DECIDED_FORK,
+                vec![fixture.aggregator_index(committee)]
+            ))
             .collect::<Vec<_>>(),
         "a failing publish must not withhold the other committees' batches"
     );
 }
 
+/// Current value of the publisher's `no_signatures` outcome counter.
+///
+/// The counter is process-global, but the label is emitted from exactly one production site and
+/// reached by exactly one test, so a before/after delta stays safe under parallel execution.
+fn no_signatures_count() -> u64 {
+    metrics::AGGREGATOR_COMMITTEE_PUBLISH_TOTAL
+        .as_ref()
+        .expect("the publish outcome metric should be created")
+        .with_label_values(&[metrics::NO_SIGNATURES])
+        .get()
+}
+
 /// A committee that decided aggregates but whose roots never reached signature quorum resolves to
-/// an empty `Batch`, and the publisher posts nothing.
+/// `NoSignatures`, and the publisher posts nothing.
 ///
 /// This is a third outcome, distinct from `ConsensusFailed` (the round itself failed) and
 /// `NoAggregates` (the decided value held none): consensus succeeded and there was something to
@@ -1286,6 +1366,7 @@ async fn publish_decided_aggregates_skips_a_committee_whose_roots_never_reach_qu
         .first()
         .cloned()
         .expect("the committee should register one execution");
+    let no_signatures_before = no_signatures_count();
 
     // Act
     let resolved = fixture
@@ -1295,14 +1376,48 @@ async fn publish_decided_aggregates_skips_a_committee_whose_roots_never_reach_qu
         .await;
     let published = fixture.run_publisher(executions, |_| Ok(())).await;
 
-    // Assert: a batch was resolved, it is empty, and nothing was handed to publish.
+    // Assert: the resolution names the missing signatures, the publish closure was never
+    // invoked, and the publisher counted the committee under its own label.
     assert!(
-        matches!(&resolved, ResolvedAggregates::Batch(batch) if batch.is_empty()),
-        "a decided aggregate whose signature never arrives should resolve to an empty batch, \
+        matches!(&resolved, ResolvedAggregates::NoSignatures),
+        "a decided aggregate whose signature never arrives should resolve to `NoSignatures`, \
          not to a consensus failure or an absent worklist"
     );
     assert!(
         published.is_empty(),
-        "the publisher must not POST an empty batch"
+        "the publisher must not invoke the publish closure without a batch"
+    );
+    assert_eq!(
+        no_signatures_count(),
+        no_signatures_before + 1,
+        "the publisher should count the committee under the `no_signatures` label"
+    );
+}
+
+/// The fork handed to the publish closure is the decided value's `DataVersion` fork, not any
+/// local default: an Electra-decided value reaches the closure as `ForkName::Electra`.
+///
+/// The closure derives its publish endpoint and fork header from this argument, so binding it to
+/// the decided version is what keeps the endpoint from diverging from the payload variant.
+#[tokio::test(flavor = "multi_thread")]
+async fn publish_decided_aggregates_hands_the_decided_versions_fork_to_the_closure() {
+    // Arrange: one committee decides an Electra-versioned value with an Electra-shaped payload.
+    let fixture = PublisherFixture::new();
+    let executions = fixture.publish(vec![(
+        FIRST_AGGREGATE_COMMITTEE,
+        fixture.aggregate_only_at_fork(FIRST_AGGREGATE_COMMITTEE, ForkName::Electra),
+    )]);
+
+    // Act
+    let published = fixture.run_publisher(executions, |_| Ok(())).await;
+
+    // Assert
+    assert_eq!(
+        published,
+        vec![(
+            ForkName::Electra,
+            vec![fixture.aggregator_index(FIRST_AGGREGATE_COMMITTEE)],
+        )],
+        "the publish closure must receive the fork named by the decided value's DataVersion"
     );
 }

--- a/anchor/validator_store/src/testing/aggregator_post_consensus.rs
+++ b/anchor/validator_store/src/testing/aggregator_post_consensus.rs
@@ -8,8 +8,8 @@
 //!
 //! The two classes are read out differently. Contributions still go back through the Lighthouse
 //! callback, which filters the shared outcome down to its own requested items. Aggregates do not:
-//! Anchor publishes them itself from the decided value, so `resolve_decided_aggregates` and
-//! `publish_decided_aggregates` are the readers, and the aggregate callback returns nothing.
+//! Anchor publishes them itself from the decided value, one publish call per root, so
+//! `publish_decided_aggregates` is the reader and the aggregate callback returns nothing.
 //!
 //! The worklist tasks are detached, so captured `sign_and_collect` calls arrive
 //! asynchronously; assertions on capture counts poll with a deadline and then let the
@@ -42,9 +42,7 @@ use validator_store::{ContributionToSign, ValidatorStore};
 
 use super::common::*;
 use crate::{
-    Error, SpecificError,
-    aggregator_post_consensus::{AggregatorPostConsensusShared, ResolvedAggregates},
-    metrics,
+    Error, SpecificError, aggregator_post_consensus::AggregatorPostConsensusShared, metrics,
 };
 
 /// One committee's decided value, as the slot pipeline publishes it.
@@ -195,12 +193,13 @@ impl AggregatorCommitteeFixture {
         (data, execution)
     }
 
-    /// Resolves this committee's decided aggregates the way the publisher does.
-    async fn resolve_aggregates(&self, execution: Execution) -> ResolvedAggregates<MainnetEthSpec> {
-        self.harness
-            .validator_store
-            .resolve_decided_aggregates(self.committee_id, Slot::new(TEST_SLOT), execution)
-            .await
+    /// Runs the publisher over this committee's execution with an always-succeeding recording
+    /// closure, returning one `(fork, aggregator index)` entry per publish call.
+    async fn run_publisher(&self, execution: Execution) -> Vec<RecordedPublish> {
+        run_recording_publisher(&self.harness, vec![(self.committee_id, execution)], |_| {
+            Ok(())
+        })
+        .await
     }
 
     /// The aggregator index the standard mixed decided value publishes.
@@ -380,6 +379,61 @@ fn build_decided_data_at_fork(
     }
 }
 
+// ==================== Recording publisher ====================
+
+/// Fork and aggregator index of one publish call made by the recording closure.
+type RecordedPublish = (ForkName, u64);
+
+/// Runs the publisher over `executions` with a recording publish closure, returning one
+/// `(fork, aggregator index)` entry per publish call.
+///
+/// The recorder captures the `ForkName` each call receives, so tests can pin that it matches the
+/// decided value's `DataVersion`. `outcome` decides each call's publish result from its
+/// aggregator index, so a test can fail one aggregate's publish without depending on the order
+/// roots finish in. The returned calls are sorted by aggregator index for the same reason.
+async fn run_recording_publisher(
+    harness: &ValidatorStoreTestHarness,
+    executions: Vec<(CommitteeId, Execution)>,
+    outcome: impl Fn(u64) -> Result<(), String>,
+) -> Vec<RecordedPublish> {
+    let recorded: Arc<Mutex<Vec<RecordedPublish>>> = Arc::new(Mutex::new(Vec::new()));
+    harness
+        .validator_store
+        .publish_decided_aggregates(Slot::new(TEST_SLOT), executions, |fork_name, signed| {
+            let recorded = Arc::clone(&recorded);
+            let outcome = &outcome;
+            async move {
+                let aggregator = signed.message().aggregator_index();
+                let result = outcome(aggregator);
+                recorded.lock().push((fork_name, aggregator));
+                result
+            }
+        })
+        .await;
+
+    let mut recorded = recorded.lock().clone();
+    recorded.sort_by_key(|&(_, aggregator)| aggregator);
+    recorded
+}
+
+/// Serializes the tests that mutate and assert deltas on the `consensus_error`, `no_aggregates`,
+/// and `no_signatures` publish outcome labels, so one test's increments cannot land inside
+/// another's before/after window. `success` and `http_error` have no delta assertions, so tests
+/// touching only those labels stay unserialized.
+static PUBLISH_METRIC_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
+/// Current value of one `AGGREGATOR_COMMITTEE_PUBLISH_TOTAL` label.
+///
+/// The counters are process-global: a test asserting a delta must hold [`PUBLISH_METRIC_LOCK`],
+/// together with every test that increments the same label.
+fn publish_result_count(label: &str) -> u64 {
+    metrics::AGGREGATOR_COMMITTEE_PUBLISH_TOTAL
+        .as_ref()
+        .expect("the publish outcome metric should be created")
+        .with_label_values(&[label])
+        .get()
+}
+
 // ==================== Capture assertions ====================
 
 /// The committee-requester view of one captured `sign_and_collect` call.
@@ -474,34 +528,14 @@ async fn assert_captured_calls_settle_at(harness: &ValidatorStoreTestHarness, ex
     );
 }
 
-/// Asserts the publisher resolved a batch holding exactly `expected` aggregator indexes.
-///
-/// The non-`Batch` variants are what select the publisher's metric label, so a test that expected
-/// a batch and got one of them is reported as that variant rather than as a length mismatch.
-fn assert_published_aggregators(
-    published: ResolvedAggregates<MainnetEthSpec>,
-    expected: &[u64],
-    context: &str,
-) {
-    match published {
-        ResolvedAggregates::Batch { aggregates, .. } => assert_eq!(
-            aggregates
-                .iter()
-                .map(|signed| signed.message().aggregator_index())
-                .collect::<Vec<_>>(),
-            expected,
-            "{context}"
-        ),
-        ResolvedAggregates::ConsensusFailed => {
-            panic!("{context}: the execution failed instead of resolving a batch")
-        }
-        ResolvedAggregates::NoAggregates => {
-            panic!("{context}: the decided worklist held no aggregates")
-        }
-        ResolvedAggregates::NoSignatures => {
-            panic!("{context}: no decided root reached signature quorum")
-        }
-    }
+/// Asserts the recording publisher made exactly one publish call per expected aggregator index,
+/// all at [`DEFAULT_DECIDED_FORK`].
+fn assert_published_aggregators(published: &[RecordedPublish], expected: &[u64], context: &str) {
+    let expected: Vec<RecordedPublish> = expected
+        .iter()
+        .map(|&aggregator| (DEFAULT_DECIDED_FORK, aggregator))
+        .collect();
+    assert_eq!(published, expected.as_slice(), "{context}");
 }
 
 /// Unwraps a single-committee stream result into its signed batch.
@@ -587,7 +621,7 @@ async fn publisher_takes_the_decided_aggregate_while_the_callback_returns_empty(
 
     // Act: only the aggregate callback fires, and the publisher reads the same execution.
     let results = fixture.harness.collect_aggregates(aggregates).await;
-    let published = fixture.resolve_aggregates(execution).await;
+    let published = fixture.run_publisher(execution).await;
 
     // Assert: Lighthouse gets nothing to publish, Anchor publishes the decided aggregate itself.
     assert!(
@@ -595,9 +629,9 @@ async fn publisher_takes_the_decided_aggregate_while_the_callback_returns_empty(
         "the aggregate callback must hand Lighthouse an empty batch at Boole+"
     );
     assert_published_aggregators(
-        published,
+        &published,
         &[fixture.expected_aggregator_index()],
-        "the publisher should return the decided aggregate",
+        "the publisher should publish the decided aggregate",
     );
 
     // Both contribution roots are signed by detached tasks without a contribution callback.
@@ -679,7 +713,7 @@ async fn contribution_callback_and_publisher_share_one_execution() {
 
     // Act: contribution callback first, then the publisher joins the cached outcome.
     let contribution_results = fixture.collect_contributions(contributions).await;
-    let published = fixture.resolve_aggregates(execution).await;
+    let published = fixture.run_publisher(execution).await;
 
     // Assert: each reader took only its own class.
     assert_eq!(
@@ -688,9 +722,9 @@ async fn contribution_callback_and_publisher_share_one_execution() {
         "the contribution callback should return only its contributions"
     );
     assert_published_aggregators(
-        published,
+        &published,
         &[fixture.expected_aggregator_index()],
-        "the publisher should return only the decided aggregate",
+        "the publisher should publish only the decided aggregate",
     );
 
     // The union is signed exactly once: no duplicate captures from the second reader.
@@ -727,11 +761,11 @@ async fn dropped_callback_future_still_completes_worklist() {
     assert_batch_identity(&calls, MIXED_WORKLIST_SIZE, decided.hash());
 
     // A late publisher joins the finished execution and gets the decided aggregate.
-    let published = fixture.resolve_aggregates(execution).await;
+    let published = fixture.run_publisher(execution).await;
     assert_published_aggregators(
-        published,
+        &published,
         &[fixture.expected_aggregator_index()],
-        "a late publisher should resolve from the cached execution",
+        "a late publisher should publish from the cached execution",
     );
 
     // Still no duplicate captures after the late read.
@@ -906,9 +940,10 @@ async fn conflicting_aggregate_roots_sign_only_the_first() {
 
 /// A decided value naming only validators this operator has no metadata for produces an empty
 /// worklist: the contribution callback returns an empty batch, the publisher has nothing to
-/// publish, and no signature is ever collected.
+/// publish and counts the committee under `no_aggregates`, and no signature is ever collected.
 #[tokio::test(flavor = "multi_thread")]
 async fn empty_worklist_returns_empty() {
+    let _metric_guard = PUBLISH_METRIC_LOCK.lock().await;
     // Arrange: the decided entries reference foreign validator indices, while the callback
     // references the local validator (required to pass committee grouping).
     let fixture = AggregatorCommitteeFixture::new(SINGLE_VALIDATOR_COUNT);
@@ -924,10 +959,11 @@ async fn empty_worklist_returns_empty() {
     ));
     let contributions =
         vec![fixture.create_contribution(SOLE_VALIDATOR_IDX, CONTRIBUTION_SUBCOMMITTEES[0])];
+    let no_aggregates_before = publish_result_count(metrics::NO_AGGREGATES);
 
     // Act
     let contribution_results = fixture.collect_contributions(contributions).await;
-    let published = fixture.resolve_aggregates(execution).await;
+    let published = fixture.run_publisher(execution).await;
 
     // Assert: nothing to return, nothing to publish, nothing signed.
     assert!(
@@ -935,8 +971,13 @@ async fn empty_worklist_returns_empty() {
         "no locally signable decided entry means an empty contribution batch"
     );
     assert!(
-        matches!(published, ResolvedAggregates::NoAggregates),
-        "no locally signable decided aggregate means nothing to publish"
+        published.is_empty(),
+        "no locally signable decided aggregate means no publish call"
+    );
+    assert_eq!(
+        publish_result_count(metrics::NO_AGGREGATES),
+        no_aggregates_before + 1,
+        "the publisher should count the aggregate-free committee under `no_aggregates`"
     );
     assert_captured_calls_settle_at(&fixture.harness, 0).await;
 }
@@ -1056,12 +1097,13 @@ async fn start_aggregator_post_consensus_returns_only_vacant_insertions() {
     );
 }
 
-// ==================== resolve_decided_aggregates failure tests ====================
+// ==================== Publisher consensus-failure tests ====================
 
-/// A failed execution resolves to `ConsensusFailed` rather than propagating the error, which is
-/// what makes the publisher count it as a consensus error and publish nothing.
+/// A failed execution publishes nothing and is counted as a consensus error rather than
+/// propagating the error.
 #[tokio::test(flavor = "multi_thread")]
-async fn resolve_decided_aggregates_reports_consensus_failure() {
+async fn publisher_counts_a_failed_execution_as_a_consensus_error() {
+    let _metric_guard = PUBLISH_METRIC_LOCK.lock().await;
     // Arrange: an execution that resolves to an error, as a lost QBFT round would.
     let fixture = AggregatorCommitteeFixture::new(SINGLE_VALIDATOR_COUNT);
     let execution: Execution = async {
@@ -1071,24 +1113,31 @@ async fn resolve_decided_aggregates_reports_consensus_failure() {
     }
     .boxed()
     .shared();
+    let consensus_error_before = publish_result_count(metrics::CONSENSUS_ERROR);
 
     // Act
-    let published = fixture.resolve_aggregates(execution).await;
+    let published = fixture.run_publisher(execution).await;
 
     // Assert
     assert!(
-        matches!(published, ResolvedAggregates::ConsensusFailed),
+        published.is_empty(),
         "a failed execution should publish nothing"
+    );
+    assert_eq!(
+        publish_result_count(metrics::CONSENSUS_ERROR),
+        consensus_error_before + 1,
+        "the publisher should count the failed committee under `consensus_error`"
     );
 }
 
-/// An execution that never decides is bounded by the two-slot deadline instead of hanging, and the
-/// timeout is reported as a consensus failure.
+/// An execution that never decides is bounded by the two-slot deadline instead of hanging, and
+/// the timeout is counted as a consensus error.
 ///
 /// The harness clock is moved past that deadline first, so the bound is asserted without sleeping
 /// two real slots.
 #[tokio::test(flavor = "multi_thread")]
-async fn resolve_decided_aggregates_reports_consensus_failure_once_the_deadline_passes() {
+async fn publisher_counts_a_consensus_error_once_the_deadline_passes() {
+    let _metric_guard = PUBLISH_METRIC_LOCK.lock().await;
     // Arrange
     let fixture = AggregatorCommitteeFixture::new(SINGLE_VALIDATOR_COUNT);
     fixture
@@ -1096,16 +1145,22 @@ async fn resolve_decided_aggregates_reports_consensus_failure_once_the_deadline_
         .slot_clock
         .set_current_time(Duration::from_secs(PAST_PUBLISH_DEADLINE_SECS));
     let execution: Execution = futures::future::pending().boxed().shared();
+    let consensus_error_before = publish_result_count(metrics::CONSENSUS_ERROR);
 
     // Act
-    let published = tokio::time::timeout(STREAM_TIMEOUT, fixture.resolve_aggregates(execution))
+    let published = tokio::time::timeout(STREAM_TIMEOUT, fixture.run_publisher(execution))
         .await
         .expect("the publisher must not outlive the two-slot deadline");
 
     // Assert
     assert!(
-        matches!(published, ResolvedAggregates::ConsensusFailed),
+        published.is_empty(),
         "an undecided execution should publish nothing"
+    );
+    assert_eq!(
+        publish_result_count(metrics::CONSENSUS_ERROR),
+        consensus_error_before + 1,
+        "the publisher should count the timed-out committee under `consensus_error`"
     );
 }
 
@@ -1124,9 +1179,6 @@ const PUBLISHER_INDEX_STRIDE: usize = 100;
 const FIRST_AGGREGATE_COMMITTEE: usize = 0;
 const CONTRIBUTIONS_ONLY_COMMITTEE: usize = 1;
 const SECOND_AGGREGATE_COMMITTEE: usize = 2;
-
-/// Fork and aggregator indexes of one batch handed to the recording publish closure.
-type RecordedBatch = (ForkName, Vec<u64>);
 
 /// Several single-validator committees in one harness, for the publisher's per-committee fan-out.
 struct PublisherFixture {
@@ -1207,50 +1259,24 @@ impl PublisherFixture {
         )
     }
 
-    /// Runs the publisher over `executions` with a recording publish closure, returning the fork
-    /// and aggregator indexes of every batch it was handed.
-    ///
-    /// The recorder captures the `ForkName` the closure receives, so tests can pin that it
-    /// matches the decided value's `DataVersion`. `outcome` decides each batch's publish result
-    /// from its contents, so a test can fail one committee's publish without depending on the
-    /// order committees finish in. The returned batches are sorted by their aggregator indexes
-    /// for the same reason.
+    /// [`run_recording_publisher`] over this fixture's harness.
     async fn run_publisher(
         &self,
         executions: Vec<(CommitteeId, Execution)>,
-        outcome: impl Fn(&[u64]) -> Result<(), String>,
-    ) -> Vec<RecordedBatch> {
-        let recorded: Arc<Mutex<Vec<RecordedBatch>>> = Arc::new(Mutex::new(Vec::new()));
-        self.harness
-            .validator_store
-            .publish_decided_aggregates(Slot::new(TEST_SLOT), executions, |fork_name, signed| {
-                let recorded = Arc::clone(&recorded);
-                let outcome = &outcome;
-                async move {
-                    let aggregators: Vec<u64> = signed
-                        .iter()
-                        .map(|signed| signed.message().aggregator_index())
-                        .collect();
-                    let result = outcome(&aggregators);
-                    recorded.lock().push((fork_name, aggregators));
-                    result
-                }
-            })
-            .await;
-
-        let mut recorded = recorded.lock().clone();
-        recorded.sort_by(|left, right| left.1.cmp(&right.1));
-        recorded
+        outcome: impl Fn(u64) -> Result<(), String>,
+    ) -> Vec<RecordedPublish> {
+        run_recording_publisher(&self.harness, executions, outcome).await
     }
 }
 
-/// Every committee with decided aggregates is published exactly once, and a committee whose
-/// decided value holds only contributions never reaches the publish call at all.
+/// Every decided aggregate is published exactly once, and a committee whose decided value holds
+/// only contributions never reaches the publish call at all.
 ///
-/// Contributions stay on Lighthouse's publish path, so handing an empty batch to the beacon node
-/// would be a pointless POST for the contributions-only case.
+/// Contributions stay on Lighthouse's publish path, so a publish call for the contributions-only
+/// committee would be a pointless POST.
 #[tokio::test(flavor = "multi_thread")]
 async fn publish_decided_aggregates_publishes_each_committee_with_aggregates_once() {
+    let _metric_guard = PUBLISH_METRIC_LOCK.lock().await;
     // Arrange
     let fixture = PublisherFixture::new();
     let executions = fixture.publish(vec![
@@ -1276,18 +1302,18 @@ async fn publish_decided_aggregates_publishes_each_committee_with_aggregates_onc
     // Act
     let published = fixture.run_publisher(executions, |_| Ok(())).await;
 
-    // Assert: one batch per committee holding aggregates, carrying that committee's aggregator
-    // and the decided value's fork.
+    // Assert: one publish call per decided aggregate, carrying its committee's aggregator and
+    // the decided value's fork.
     assert_eq!(
         published,
         vec![
             (
                 DEFAULT_DECIDED_FORK,
-                vec![fixture.aggregator_index(FIRST_AGGREGATE_COMMITTEE)],
+                fixture.aggregator_index(FIRST_AGGREGATE_COMMITTEE),
             ),
             (
                 DEFAULT_DECIDED_FORK,
-                vec![fixture.aggregator_index(SECOND_AGGREGATE_COMMITTEE)],
+                fixture.aggregator_index(SECOND_AGGREGATE_COMMITTEE),
             ),
         ],
         "committees with decided aggregates publish once each, and the contributions-only \
@@ -1295,8 +1321,8 @@ async fn publish_decided_aggregates_publishes_each_committee_with_aggregates_onc
     );
 }
 
-/// A publish failure is contained to its own committee: it neither panics nor stops the other
-/// committees' batches from being published.
+/// A publish failure is contained to its own aggregate: it neither panics nor stops the other
+/// committees' aggregates from being published.
 #[tokio::test(flavor = "multi_thread")]
 async fn publish_decided_aggregates_survives_a_failing_publish() {
     // Arrange: all three committees decide an aggregate.
@@ -1308,11 +1334,11 @@ async fn publish_decided_aggregates_survives_a_failing_publish() {
     );
     let failing_aggregator = fixture.aggregator_index(FIRST_AGGREGATE_COMMITTEE);
 
-    // Act: the first committee's POST fails, keyed by batch contents so the outcome does not
+    // Act: the first committee's POST fails, keyed by aggregator index so the outcome does not
     // depend on which committee resolves first.
     let published = fixture
-        .run_publisher(executions, |aggregators| {
-            if aggregators.contains(&failing_aggregator) {
+        .run_publisher(executions, |aggregator| {
+            if aggregator == failing_aggregator {
                 Err("beacon node unavailable".to_string())
             } else {
                 Ok(())
@@ -1320,40 +1346,26 @@ async fn publish_decided_aggregates_survives_a_failing_publish() {
         })
         .await;
 
-    // Assert: every committee's batch was still attempted.
+    // Assert: every committee's aggregate was still attempted.
     assert_eq!(
         published,
         (0..PUBLISHER_OPERATOR_SETS.len())
-            .map(|committee| (
-                DEFAULT_DECIDED_FORK,
-                vec![fixture.aggregator_index(committee)]
-            ))
+            .map(|committee| (DEFAULT_DECIDED_FORK, fixture.aggregator_index(committee)))
             .collect::<Vec<_>>(),
-        "a failing publish must not withhold the other committees' batches"
+        "a failing publish must not withhold the other committees' aggregates"
     );
 }
 
-/// Current value of the publisher's `no_signatures` outcome counter.
+/// A committee that decided an aggregate whose root never reached signature quorum publishes
+/// nothing, and the root is counted under `no_signatures`.
 ///
-/// The counter is process-global, but the label is emitted from exactly one production site and
-/// reached by exactly one test, so a before/after delta stays safe under parallel execution.
-fn no_signatures_count() -> u64 {
-    metrics::AGGREGATOR_COMMITTEE_PUBLISH_TOTAL
-        .as_ref()
-        .expect("the publish outcome metric should be created")
-        .with_label_values(&[metrics::NO_SIGNATURES])
-        .get()
-}
-
-/// A committee that decided aggregates but whose roots never reached signature quorum resolves to
-/// `NoSignatures`, and the publisher posts nothing.
-///
-/// This is a third outcome, distinct from `ConsensusFailed` (the round itself failed) and
-/// `NoAggregates` (the decided value held none): consensus succeeded and there was something to
-/// sign, but no signature came back. The publisher counts it under its own label, so the three
-/// cases stay separable on a dashboard instead of collapsing into one.
+/// This is a third outcome, distinct from `consensus_error` (the round itself failed) and
+/// `no_aggregates` (the decided value held none): consensus succeeded and there was something to
+/// sign, but no signature came back. The publisher counts each such root under its own label, so
+/// the three cases stay separable on a dashboard instead of collapsing into one.
 #[tokio::test(flavor = "multi_thread")]
 async fn publish_decided_aggregates_skips_a_committee_whose_roots_never_reach_quorum() {
+    let _metric_guard = PUBLISH_METRIC_LOCK.lock().await;
     // Arrange: signature collection fails before the decided value is published, so the
     // committee's only aggregate root resolves to an error.
     let fixture = PublisherFixture::new();
@@ -1362,35 +1374,75 @@ async fn publish_decided_aggregates_skips_a_committee_whose_roots_never_reach_qu
         FIRST_AGGREGATE_COMMITTEE,
         fixture.aggregate_only(FIRST_AGGREGATE_COMMITTEE),
     )]);
-    let (committee_id, execution) = executions
-        .first()
-        .cloned()
-        .expect("the committee should register one execution");
-    let no_signatures_before = no_signatures_count();
+    let no_signatures_before = publish_result_count(metrics::NO_SIGNATURES);
 
     // Act
-    let resolved = fixture
-        .harness
-        .validator_store
-        .resolve_decided_aggregates(committee_id, Slot::new(TEST_SLOT), execution)
-        .await;
     let published = fixture.run_publisher(executions, |_| Ok(())).await;
 
-    // Assert: the resolution names the missing signatures, the publish closure was never
-    // invoked, and the publisher counted the committee under its own label.
-    assert!(
-        matches!(&resolved, ResolvedAggregates::NoSignatures),
-        "a decided aggregate whose signature never arrives should resolve to `NoSignatures`, \
-         not to a consensus failure or an absent worklist"
-    );
+    // Assert: the publish closure was never invoked, and the root was counted under its label.
     assert!(
         published.is_empty(),
-        "the publisher must not invoke the publish closure without a batch"
+        "the publisher must not invoke the publish closure for a root without quorum"
     );
     assert_eq!(
-        no_signatures_count(),
+        publish_result_count(metrics::NO_SIGNATURES),
         no_signatures_before + 1,
-        "the publisher should count the committee under the `no_signatures` label"
+        "each decided root without quorum should count once under `no_signatures`; this \
+         committee decided exactly one root"
+    );
+}
+
+/// Two decided aggregate roots in one committee where exactly one misses signature quorum: the
+/// surviving root is still published, and only the missing root is counted under
+/// `no_signatures`.
+///
+/// This per-root independence is the point of the per-root publisher: under the batch shape a
+/// committee published all-or-nothing, so one quorum miss could withhold a signed sibling.
+#[tokio::test(flavor = "multi_thread")]
+async fn publish_decided_aggregates_publishes_the_surviving_root_when_a_sibling_misses_quorum() {
+    let _metric_guard = PUBLISH_METRIC_LOCK.lock().await;
+    // Arrange: both validators aggregate distinct roots, and signature collection fails only for
+    // the second validator. The fail mode is set before seeding, since the detached worklist
+    // tasks start collecting at publish.
+    const SURVIVING_VALIDATOR_IDX: usize = 0;
+    const FAILING_VALIDATOR_IDX: usize = 1;
+    let fixture = AggregatorCommitteeFixture::new(MIXED_COMMITTEE_VALIDATOR_COUNT);
+    fixture
+        .harness
+        .fail_signature_collection_for(fixture.pubkey(FAILING_VALIDATOR_IDX));
+    let (_, execution) = fixture.seed_decided_value_with_execution(build_decided_data(
+        &[
+            (
+                fixture.validator_index(SURVIVING_VALIDATOR_IDX),
+                BEACON_COMMITTEE_INDEX,
+            ),
+            (
+                fixture.validator_index(FAILING_VALIDATOR_IDX),
+                CONFLICTING_BEACON_COMMITTEE_INDEX,
+            ),
+        ],
+        &[],
+    ));
+    let no_signatures_before = publish_result_count(metrics::NO_SIGNATURES);
+
+    // Act
+    let published = fixture.run_publisher(execution).await;
+
+    // Assert: exactly the surviving root was published, exactly the missing one was counted.
+    assert_eq!(
+        published,
+        vec![(
+            DEFAULT_DECIDED_FORK,
+            fixture
+                .harness
+                .aggregator_index(COMMITTEE_INDEX, SURVIVING_VALIDATOR_IDX),
+        )],
+        "a sibling's quorum miss must not withhold the surviving root's publish call"
+    );
+    assert_eq!(
+        publish_result_count(metrics::NO_SIGNATURES),
+        no_signatures_before + 1,
+        "only the root that missed quorum should count under `no_signatures`"
     );
 }
 
@@ -1416,7 +1468,7 @@ async fn publish_decided_aggregates_hands_the_decided_versions_fork_to_the_closu
         published,
         vec![(
             ForkName::Electra,
-            vec![fixture.aggregator_index(FIRST_AGGREGATE_COMMITTEE)],
+            fixture.aggregator_index(FIRST_AGGREGATE_COMMITTEE),
         )],
         "the publish closure must receive the fork named by the decided value's DataVersion"
     );

--- a/anchor/validator_store/src/testing/committee_aggregate.rs
+++ b/anchor/validator_store/src/testing/committee_aggregate.rs
@@ -1,16 +1,18 @@
-//! Integration tests for committee aggregate signing in `sign_aggregate_and_proofs()`.
-use std::time::Duration;
+//! Integration tests for `sign_aggregate_and_proofs()`.
+//!
+//! At Boole+ this Lighthouse callback is deliberately inert: Anchor is the authoritative publisher
+//! of committee aggregates, signing and posting the decided worklist itself (see
+//! [`crate::aggregator_post_consensus`]). Anything the callback returned would be published a
+//! second time by Lighthouse, so it hands back an empty batch. Pre-Boole is unchanged: the callback
+//! still signs per validator and Lighthouse still publishes the result.
 
-use futures::StreamExt;
+use std::collections::HashSet;
+
+use fork::Fork;
 use signature_collector::SignatureRequester;
-use ssv_types::OperatorId;
-use types::{MainnetEthSpec, SignedAggregateAndProof};
-use validator_store::ValidatorStore;
+use ssv_types::{OperatorId, msgid::Role};
 
 use super::common::*;
-use crate::Error;
-
-type SignAggregatesResult = Vec<Result<Vec<SignedAggregateAndProof<MainnetEthSpec>>, Error>>;
 
 const PRIMARY_COMMITTEE_OPERATOR_IDS: [OperatorId; 4] =
     [OperatorId(1), OperatorId(2), OperatorId(3), OperatorId(4)];
@@ -28,33 +30,50 @@ const SINGLE_VALIDATOR_COUNT: usize = 1;
 const PRIMARY_COMMITTEE_STARTING_VALIDATOR_INDEX: usize = 0;
 const SECONDARY_COMMITTEE_STARTING_VALIDATOR_INDEX: usize = 100;
 
-const NEXT_SLOT: u64 = TEST_SLOT + 1;
-const STREAM_ITEM_TIMEOUT: Duration = Duration::from_secs(5);
-const BLOCKED_STREAM_TIMEOUT: Duration = Duration::from_millis(500);
-
-/// `sign_aggregate_and_proofs` with empty input yields zero stream items.
-#[tokio::test(flavor = "multi_thread")]
-async fn sign_aggregate_and_proofs_empty_input() {
-    let committee = create_primary_committee_setup(SINGLE_VALIDATOR_COUNT);
-    let harness = ValidatorStoreTestHarness::new(vec![committee], OUR_OPERATOR_ID);
-
-    let results: SignAggregatesResult = harness
-        .validator_store
-        .sign_aggregate_and_proofs(vec![])
-        .collect()
-        .await;
-
+/// Asserts the stream yielded exactly one item and that item is an empty batch.
+///
+/// The empty batch is the Boole+ contract: Lighthouse's publish loop drops an empty result
+/// silently, which is what keeps Anchor the single publisher of committee aggregates.
+fn assert_single_empty_batch(results: SignAggregatesResult) {
+    assert_eq!(results.len(), 1, "expected exactly one stream item");
+    let batch = results
+        .into_iter()
+        .next()
+        .expect("stream item should exist")
+        .expect("the aggregate callback should not fail");
     assert!(
-        results.is_empty(),
-        "empty input should yield zero stream items"
+        batch.is_empty(),
+        "Lighthouse must receive nothing to publish at Boole+; the metadata service publishes \
+         committee aggregates from the decided value"
     );
 }
 
-/// `sign_aggregate_and_proofs` groups aggregates by `CommitteeId`, runs consensus once per
-/// committee, collects one signature per validator, and streams one batch per committee.
+// ==================== Boole+ tests ====================
+
+/// Empty input yields the same single empty batch as any other Boole+ call: there is no fork to
+/// determine and nothing to publish either way.
 #[tokio::test(flavor = "multi_thread")]
-async fn sign_aggregate_and_proofs_produces_one_stream_item_per_committee() {
+async fn sign_aggregate_and_proofs_empty_input_yields_one_empty_batch() {
     // Arrange
+    let committee = create_primary_committee_setup(SINGLE_VALIDATOR_COUNT);
+    let harness = ValidatorStoreTestHarness::new(vec![committee], OUR_OPERATOR_ID);
+
+    // Act
+    let results = harness.collect_aggregates(vec![]).await;
+
+    // Assert
+    assert_single_empty_batch(results);
+}
+
+/// Boole+ yields one empty batch however many committees the request spans, without waiting on
+/// `AggregationAssignments` and without collecting any signature of its own.
+///
+/// The single item is the stream's completion signal, not a per-committee result: the callback no
+/// longer groups by committee, because it no longer produces anything Lighthouse could publish. It
+/// also no longer parks on the assignments watch channel, which is why nothing is seeded here.
+#[tokio::test(flavor = "multi_thread")]
+async fn sign_aggregate_and_proofs_boole_yields_one_empty_batch_for_all_committees() {
+    // Arrange: two distinct committees, no assignments published for the slot at all.
     let committee_a = create_primary_committee_setup(PRIMARY_COMMITTEE_VALIDATOR_COUNT);
     let committee_b = create_secondary_committee_setup(SINGLE_VALIDATOR_COUNT);
     assert_ne!(
@@ -62,12 +81,6 @@ async fn sign_aggregate_and_proofs_produces_one_stream_item_per_committee() {
         committee_b.cluster.committee_id(),
     );
     let harness = ValidatorStoreTestHarness::new(vec![committee_a, committee_b], OUR_OPERATOR_ID);
-    // Seed aggregate assignments for both committees at TEST_SLOT so both committee batches can
-    // resolve their decided aggregate data.
-    harness.seed_aggregation_assignments_for_slot(
-        TEST_SLOT,
-        &[PRIMARY_COMMITTEE_INDEX, SECONDARY_COMMITTEE_INDEX],
-    );
     let aggregates = vec![
         harness.create_aggregate(PRIMARY_COMMITTEE_INDEX, FIRST_VALIDATOR_INDEX),
         harness.create_aggregate(PRIMARY_COMMITTEE_INDEX, SECOND_VALIDATOR_INDEX),
@@ -75,110 +88,68 @@ async fn sign_aggregate_and_proofs_produces_one_stream_item_per_committee() {
     ];
 
     // Act
-    let results: SignAggregatesResult = harness
-        .validator_store
-        .sign_aggregate_and_proofs(aggregates)
-        .collect()
-        .await;
+    let results = harness.collect_aggregates(aggregates).await;
 
     // Assert
-    assert_eq!(results.len(), 2, "expected one stream item per committee");
-    let all_signed: Vec<Vec<SignedAggregateAndProof<MainnetEthSpec>>> = results
-        .into_iter()
-        .map(|r| r.expect("each committee batch should succeed"))
-        .collect();
-    let total: usize = all_signed.iter().map(|batch| batch.len()).sum();
-    let expected_total = PRIMARY_COMMITTEE_VALIDATOR_COUNT + SINGLE_VALIDATOR_COUNT;
-    assert_eq!(
-        total, expected_total,
-        "expected {expected_total} total signed aggregates"
-    );
-
-    // We make one `sign_and_collect` call per validator.
-    // The committee requester stores the local batch size for that validator's committee:
-    // committee A has 2 validators, so it produces 2 calls, each with batch size 2;
-    // committee B has 1 validator, so it produces 1 call with batch size 1.
-    let captured = harness.captured_calls.lock();
-    assert_eq!(
-        captured.len(),
-        expected_total,
-        "expected {expected_total} sign_and_collect calls"
-    );
-    let batch_sizes: Vec<_> = captured
-        .iter()
-        .map(|call| match &call.requester {
-            SignatureRequester::Committee {
-                validator_partial_signature_batch_size,
-                ..
-            } => *validator_partial_signature_batch_size,
-            other => panic!("expected SignatureRequester::Committee, got: {other:?}"),
-        })
-        .collect();
-
-    let calls_with_batch_size = |batch_size: usize| {
-        batch_sizes
-            .iter()
-            .filter(|&&size| size == batch_size)
-            .count()
-    };
-    assert_eq!(
-        calls_with_batch_size(PRIMARY_COMMITTEE_VALIDATOR_COUNT),
-        PRIMARY_COMMITTEE_VALIDATOR_COUNT,
-        "committee A should make one call per validator, and each call should have batch size {}",
-        PRIMARY_COMMITTEE_VALIDATOR_COUNT,
-    );
-    assert_eq!(
-        calls_with_batch_size(SINGLE_VALIDATOR_COUNT),
-        SINGLE_VALIDATOR_COUNT,
-        "committee B should make one call for its only validator, and that call should have batch size {}",
-        SINGLE_VALIDATOR_COUNT,
+    assert_single_empty_batch(results);
+    assert!(
+        harness.captured_calls.lock().is_empty(),
+        "the callback must not collect signatures; signing belongs to the post-consensus execution"
     );
 }
 
-/// One committee blocked on missing `AggregationAssignments` must not stop another committee from
-/// producing its aggregate batch. This verifies that committee futures stay isolated.
-#[tokio::test(flavor = "current_thread", start_paused = true)]
-async fn sign_aggregate_and_proofs_failure_isolation() {
+// ==================== Pre-Boole tests ====================
+
+/// Pre-Boole the callback still signs one aggregate per validator and returns them for Lighthouse
+/// to publish. The empty-batch contract is Boole+ only.
+#[tokio::test(flavor = "multi_thread")]
+async fn sign_aggregate_and_proofs_pre_boole_signs_each_validator() {
     // Arrange
-    let committee_a = create_primary_committee_setup(SINGLE_VALIDATOR_COUNT);
-    let committee_b = create_secondary_committee_setup(SINGLE_VALIDATOR_COUNT);
-    let harness = ValidatorStoreTestHarness::new(vec![committee_a, committee_b], OUR_OPERATOR_ID);
-    // Only the primary committee gets aggregate assignments for TEST_SLOT.
-    harness.seed_aggregation_assignments_for_slot(TEST_SLOT, &[PRIMARY_COMMITTEE_INDEX]);
+    let committee = create_primary_committee_setup(PRIMARY_COMMITTEE_VALIDATOR_COUNT);
+    let harness =
+        ValidatorStoreTestHarness::new_with_fork(vec![committee], OUR_OPERATOR_ID, Fork::Alan);
     let aggregates = vec![
-        // Committee A uses TEST_SLOT and should complete.
         harness.create_aggregate(PRIMARY_COMMITTEE_INDEX, FIRST_VALIDATOR_INDEX),
-        // Committee B uses NEXT_SLOT, where no aggregate assignments were seeded, so it should
-        // stay blocked in the aggregate-assignment lookup.
-        harness.create_aggregate_at_slot(
-            SECONDARY_COMMITTEE_INDEX,
-            FIRST_VALIDATOR_INDEX,
-            NEXT_SLOT,
-        ),
+        harness.create_aggregate(PRIMARY_COMMITTEE_INDEX, SECOND_VALIDATOR_INDEX),
     ];
 
     // Act
-    let stream = harness
-        .validator_store
-        .sign_aggregate_and_proofs(aggregates);
-    tokio::pin!(stream);
-    let first = tokio::time::timeout(STREAM_ITEM_TIMEOUT, stream.next()).await;
-    let second = tokio::time::timeout(BLOCKED_STREAM_TIMEOUT, stream.next()).await;
+    let results = harness.collect_aggregates(aggregates).await;
 
-    // Assert
-    let first_item = first
-        .expect("first committee should complete within timeout")
-        .expect("stream should yield an item");
-    let signed = first_item.expect("first committee should succeed");
+    // Assert: one batch holding both validators' signed aggregates.
+    assert_eq!(results.len(), 1, "the pre-Boole path yields one batch");
+    let signed = results
+        .into_iter()
+        .next()
+        .expect("stream item should exist")
+        .expect("pre-Boole signing should succeed");
+    let signed_aggregators: HashSet<u64> = signed
+        .iter()
+        .map(|signed| signed.message().aggregator_index())
+        .collect();
+    let expected_aggregators: HashSet<u64> = [FIRST_VALIDATOR_INDEX, SECOND_VALIDATOR_INDEX]
+        .iter()
+        .map(|&position| harness.aggregator_index(PRIMARY_COMMITTEE_INDEX, position))
+        .collect();
     assert_eq!(
-        signed.len(),
-        1,
-        "successful committee should produce one signed item"
+        signed_aggregators, expected_aggregators,
+        "every requested validator should get a signed aggregate back"
     );
-    assert!(
-        second.is_err(),
-        "stuck committee should not produce a result"
+
+    // Signature collection is per validator, not batched into one committee message.
+    let captured = harness.captured_calls.lock();
+    assert_eq!(
+        captured.len(),
+        PRIMARY_COMMITTEE_VALIDATOR_COUNT,
+        "expected one sign_and_collect call per validator"
     );
+    for call in captured.iter() {
+        assert_eq!(call.metadata.role, Role::Aggregator);
+        assert!(
+            matches!(call.requester, SignatureRequester::SingleValidator { .. }),
+            "pre-Boole aggregates are collected per validator, not as a committee batch"
+        );
+    }
 }
 
 fn create_primary_committee_setup(num_validators: usize) -> CommitteeSetup {

--- a/anchor/validator_store/src/testing/common.rs
+++ b/anchor/validator_store/src/testing/common.rs
@@ -3,11 +3,21 @@
 //! Provides a `ValidatorStoreTestHarness` that wires up a real `AnchorValidatorStore` with
 //! in-memory database, mock consensus, and a mock signature collector.
 
-use std::{collections::HashMap, future::Future, pin::Pin, sync::Arc, time::Duration};
+use std::{
+    collections::HashMap,
+    future::Future,
+    pin::Pin,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
+    time::Duration,
+};
 
 use bls::{AggregateSignature, FixedBytesExtended, PublicKeyBytes, Signature};
 use database::{NetworkDatabase, PendingStateUpdates};
 use fork::{Fork, ForkSchedule};
+use futures::StreamExt;
 use parking_lot::Mutex;
 use qbft::Completed;
 use qbft_manager::{ConsensusDecider, QbftDecidable, QbftError, TimeoutMode};
@@ -18,27 +28,33 @@ use signature_collector::{
 use slashing_protection::SlashingDatabase;
 use slot_clock::{ManualSlotClock, SlotClock};
 use ssv_types::{
-    Cluster, ClusterId, ENCRYPTED_KEY_LENGTH, IndexSet, OperatorId, Share, ValidatorIndex,
-    ValidatorMetadata,
-    consensus::{
-        AggregatorCommitteeConsensusData, AssignedAggregator, DataVersion, QbftDataValidator,
-    },
+    Cluster, ClusterId, CommitteeId, ENCRYPTED_KEY_LENGTH, IndexSet, OperatorId, Share,
+    ValidatorIndex, ValidatorMetadata,
+    consensus::{AggregatorCommitteeConsensusData, QbftDataValidator},
 };
-use ssz::Encode;
-use ssz_types::VariableList;
 use task_executor::TaskExecutor;
 use tempfile::TempDir;
 use tokio::{sync::watch, time::Instant};
 use types::{
     Attestation, AttestationBase, AttestationData, ChainSpec, Checkpoint, Epoch, EthSpec, Graffiti,
-    Hash256, MainnetEthSpec, SelectionProof, Slot, SyncSubnetId,
+    Hash256, MainnetEthSpec, SelectionProof, SignedAggregateAndProof, Slot, SyncSubnetId,
 };
-use validator_store::{AggregateToSign, AttestationToSign};
+use validator_store::{AggregateToSign, AttestationToSign, ValidatorStore};
 
-use crate::{AggregationAssignments, AnchorValidatorStore, VotingAssignments, VotingContext};
+use crate::{
+    AggregationAssignments, AnchorValidatorStore, Error, VotingAssignments, VotingContext,
+    aggregator_post_consensus::AggregatorPostConsensusShared,
+};
 
 pub(super) const TEST_SLOT: u64 = 1;
 pub(super) const SLOT_DURATION_SECS: u64 = 12;
+/// Bound on any Lighthouse callback stream in these tests; a callback that blocks past it is a
+/// failure, not a slow machine.
+pub(super) const STREAM_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// What the Lighthouse aggregate callback yields: one result per stream item.
+pub(super) type SignAggregatesResult =
+    Vec<Result<Vec<SignedAggregateAndProof<MainnetEthSpec>>, Error>>;
 
 // ==================== Mock consensus decider ====================
 
@@ -73,9 +89,11 @@ pub(super) struct CapturedSignatureCall {
     pub(super) captured_at: Instant,
 }
 
-/// Mock that captures calls and returns a canned infinity signature.
+/// Mock that captures calls and returns a canned infinity signature, or a collection timeout once
+/// [`ValidatorStoreTestHarness::fail_signature_collection`] is called.
 struct MockSignatureCollector {
     captured: CapturedCalls,
+    fails: Arc<AtomicBool>,
 }
 
 impl SignatureCollecting for MockSignatureCollector {
@@ -92,18 +110,26 @@ impl SignatureCollecting for MockSignatureCollector {
             signing_root: signing_data.root,
             captured_at: Instant::now(),
         });
+        // Stands in for any root that never reaches quorum; the caller only distinguishes
+        // success from failure.
+        if self.fails.load(Ordering::Relaxed) {
+            return Box::pin(async { Err(CollectionError::CollectionTimeout) });
+        }
         let sig = Signature::infinity().expect("infinity signature");
         Box::pin(async move { Ok(Arc::new(sig)) })
     }
 }
 
-/// Creates a mock signature collector and returns the shared captured calls handle.
-fn create_mock_collector() -> (Box<dyn SignatureCollecting>, CapturedCalls) {
+/// Creates a mock signature collector, returning the shared captured calls and failure-mode
+/// handles.
+fn create_mock_collector() -> (Box<dyn SignatureCollecting>, CapturedCalls, Arc<AtomicBool>) {
     let captured: CapturedCalls = Arc::new(Mutex::new(Vec::new()));
+    let fails = Arc::new(AtomicBool::new(false));
     let mock = MockSignatureCollector {
         captured: Arc::clone(&captured),
+        fails: Arc::clone(&fails),
     };
-    (Box::new(mock), captured)
+    (Box::new(mock), captured, fails)
 }
 
 // ==================== Committee setup ====================
@@ -180,6 +206,8 @@ pub(super) struct ValidatorStoreTestHarness {
         Arc<AnchorValidatorStore<ManualSlotClock, MainnetEthSpec, MockConsensusDecider>>,
     committee_setups: Vec<CommitteeSetup>,
     pub(super) captured_calls: CapturedCalls,
+    /// Set by [`Self::fail_signature_collection`]; read by the mock collector on every call.
+    signature_collection_fails: Arc<AtomicBool>,
     /// Shares `current_time` with the clone held by the store, so tests can reposition the clock
     /// after construction.
     pub(super) slot_clock: ManualSlotClock,
@@ -246,7 +274,7 @@ impl ValidatorStoreTestHarness {
             "test",
         ));
 
-        let (mock_collector, captured_calls) = create_mock_collector();
+        let (mock_collector, captured_calls, signature_collection_fails) = create_mock_collector();
 
         // Database
         let database = Arc::new(
@@ -335,6 +363,7 @@ impl ValidatorStoreTestHarness {
             validator_store,
             committee_setups,
             captured_calls,
+            signature_collection_fails,
             slot_clock,
             is_synced_tx,
             _slashing_db_dir: slashing_db_dir,
@@ -348,6 +377,15 @@ impl ValidatorStoreTestHarness {
         validator_idx: usize,
     ) -> ValidatorMetadata {
         self.committee_setups[committee_idx].validators[validator_idx].clone()
+    }
+
+    /// The beacon-chain validator index of one committee member, as it appears in signed
+    /// aggregates and decided values.
+    pub(super) fn aggregator_index(&self, committee_idx: usize, validator_idx: usize) -> u64 {
+        *self
+            .validator_metadata(committee_idx, validator_idx)
+            .index
+            .expect("test validator should have an index") as u64
     }
 
     pub(super) fn seed_sync_voting_assignments_for_slot(
@@ -406,81 +444,43 @@ impl ValidatorStoreTestHarness {
         });
     }
 
-    /// Seeds `AggregationAssignments` for the given committees at the provided slot.
+    /// Publishes `consensus_data_by_ssv_committee` as the decided values at `TEST_SLOT`, returning
+    /// the executions the publish newly registered.
     ///
-    /// Each validator in the selected committee is treated as an attestation aggregator for a
-    /// single beacon committee index derived from the test committee position.
-    pub(super) fn seed_aggregation_assignments_for_slot(
+    /// This is the slot pipeline's Phase 3 step: registration happens before the assignments reach
+    /// the watch channel, and only vacant registrations come back, so a republish returns nothing.
+    pub(super) fn publish_decided_values(
         &self,
-        slot: u64,
-        committee_indices: &[usize],
-    ) {
-        let mut aggregator_committees = HashMap::new();
-        let mut consensus_data_by_ssv_committee = HashMap::new();
-
-        for &committee_idx in committee_indices {
-            let setup = &self.committee_setups[committee_idx];
-            let beacon_committee_index = committee_idx as u64;
-
-            for validator in &setup.validators {
-                aggregator_committees.insert(validator.public_key, beacon_committee_index);
-            }
-
-            let aggregators: Vec<_> = setup
-                .validators
-                .iter()
-                .map(|validator| AssignedAggregator {
-                    validator_index: validator.index.expect("test validator should have index"),
-                    selection_proof: Signature::empty(),
-                    committee_index: beacon_committee_index,
-                })
-                .collect();
-
-            let aggregated_attestation = AttestationBase::<MainnetEthSpec> {
-                aggregation_bits: ssz_types::BitList::with_capacity(128)
-                    .expect("bitlist should be valid"),
-                data: AttestationData {
-                    slot: Slot::new(slot),
-                    index: beacon_committee_index,
-                    beacon_block_root: Hash256::zero(),
-                    source: Checkpoint {
-                        epoch: Epoch::new(0),
-                        root: Hash256::zero(),
-                    },
-                    target: Checkpoint {
-                        epoch: Epoch::new(0),
-                        root: Hash256::zero(),
-                    },
-                },
-                signature: AggregateSignature::infinity(),
-            };
-
-            let consensus_data = AggregatorCommitteeConsensusData::<MainnetEthSpec> {
-                version: DataVersion::from(types::ForkName::Deneb),
-                aggregators: VariableList::new(aggregators)
-                    .expect("aggregator list should be valid"),
-                aggregator_committee_indexes: VariableList::new(vec![beacon_committee_index])
-                    .expect("committee indexes should be valid"),
-                aggregated_attestations: VariableList::new(vec![
-                    VariableList::new(aggregated_attestation.as_ssz_bytes())
-                        .expect("attestation bytes should fit"),
-                ])
-                .expect("aggregated attestations should be valid"),
-                contributors: VariableList::empty(),
-                sync_committee_contributions: VariableList::empty(),
-            };
-
-            consensus_data_by_ssv_committee
-                .insert(setup.cluster.committee_id(), Arc::new(consensus_data));
-        }
-
+        consensus_data_by_ssv_committee: HashMap<
+            CommitteeId,
+            Arc<AggregatorCommitteeConsensusData<MainnetEthSpec>>,
+        >,
+    ) -> Vec<(CommitteeId, AggregatorPostConsensusShared<MainnetEthSpec>)> {
         self.validator_store
             .update_aggregation_assignments(AggregationAssignments {
-                slot: Slot::new(slot),
-                aggregator_committees,
+                slot: Slot::new(TEST_SLOT),
+                aggregator_committees: HashMap::new(),
                 multi_sync_aggregators: HashMap::new(),
                 consensus_data_by_ssv_committee,
-            });
+            })
+    }
+
+    /// Runs the Lighthouse aggregate callback to completion.
+    pub(super) async fn collect_aggregates(
+        &self,
+        aggregates: Vec<AggregateToSign<MainnetEthSpec>>,
+    ) -> SignAggregatesResult {
+        let stream = self.validator_store.sign_aggregate_and_proofs(aggregates);
+        tokio::time::timeout(STREAM_TIMEOUT, stream.collect())
+            .await
+            .expect("the aggregate callback should complete within the stream timeout")
+    }
+
+    /// Makes every subsequent `sign_and_collect` call fail, for tests of the paths a root that
+    /// never reaches quorum takes. Calls are still captured.
+    pub(super) fn fail_signature_collection(&self) {
+        self.signature_collection_fails
+            .store(true, Ordering::Relaxed);
     }
 
     pub(super) fn create_attestation(
@@ -532,15 +532,6 @@ impl ValidatorStoreTestHarness {
         committee_idx: usize,
         validator_idx: usize,
     ) -> AggregateToSign<MainnetEthSpec> {
-        self.create_aggregate_at_slot(committee_idx, validator_idx, TEST_SLOT)
-    }
-
-    pub(super) fn create_aggregate_at_slot(
-        &self,
-        committee_idx: usize,
-        validator_idx: usize,
-        slot: u64,
-    ) -> AggregateToSign<MainnetEthSpec> {
         let validator = &self.committee_setups[committee_idx].validators[validator_idx];
         let validator_index = validator
             .index
@@ -553,7 +544,7 @@ impl ValidatorStoreTestHarness {
                 aggregation_bits: ssz_types::BitList::with_capacity(128)
                     .expect("bitlist should be valid"),
                 data: AttestationData {
-                    slot: Slot::new(slot),
+                    slot: Slot::new(TEST_SLOT),
                     index: committee_idx as u64,
                     beacon_block_root: Hash256::zero(),
                     source: Checkpoint {

--- a/anchor/validator_store/src/testing/common.rs
+++ b/anchor/validator_store/src/testing/common.rs
@@ -4,7 +4,7 @@
 //! in-memory database, mock consensus, and a mock signature collector.
 
 use std::{
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     future::Future,
     pin::Pin,
     sync::{
@@ -89,11 +89,17 @@ pub(super) struct CapturedSignatureCall {
     pub(super) captured_at: Instant,
 }
 
-/// Mock that captures calls and returns a canned infinity signature, or a collection timeout once
-/// [`ValidatorStoreTestHarness::fail_signature_collection`] is called.
+/// Validator pubkeys whose signature collection fails; shared with the harness so tests can fail
+/// a single validator's roots.
+type FailingPubkeys = Arc<Mutex<HashSet<PublicKeyBytes>>>;
+
+/// Mock that captures calls and returns a canned infinity signature, or a collection timeout for
+/// every call once [`ValidatorStoreTestHarness::fail_signature_collection`] is called, or for one
+/// validator's calls once [`ValidatorStoreTestHarness::fail_signature_collection_for`] is.
 struct MockSignatureCollector {
     captured: CapturedCalls,
     fails: Arc<AtomicBool>,
+    failing_pubkeys: FailingPubkeys,
 }
 
 impl SignatureCollecting for MockSignatureCollector {
@@ -112,7 +118,12 @@ impl SignatureCollecting for MockSignatureCollector {
         });
         // Stands in for any root that never reaches quorum; the caller only distinguishes
         // success from failure.
-        if self.fails.load(Ordering::Relaxed) {
+        if self.fails.load(Ordering::Relaxed)
+            || self
+                .failing_pubkeys
+                .lock()
+                .contains(&signing_data.validator_pubkey)
+        {
             return Box::pin(async { Err(CollectionError::CollectionTimeout) });
         }
         let sig = Signature::infinity().expect("infinity signature");
@@ -122,14 +133,21 @@ impl SignatureCollecting for MockSignatureCollector {
 
 /// Creates a mock signature collector, returning the shared captured calls and failure-mode
 /// handles.
-fn create_mock_collector() -> (Box<dyn SignatureCollecting>, CapturedCalls, Arc<AtomicBool>) {
+fn create_mock_collector() -> (
+    Box<dyn SignatureCollecting>,
+    CapturedCalls,
+    Arc<AtomicBool>,
+    FailingPubkeys,
+) {
     let captured: CapturedCalls = Arc::new(Mutex::new(Vec::new()));
     let fails = Arc::new(AtomicBool::new(false));
+    let failing_pubkeys: FailingPubkeys = Arc::new(Mutex::new(HashSet::new()));
     let mock = MockSignatureCollector {
         captured: Arc::clone(&captured),
         fails: Arc::clone(&fails),
+        failing_pubkeys: Arc::clone(&failing_pubkeys),
     };
-    (Box::new(mock), captured, fails)
+    (Box::new(mock), captured, fails, failing_pubkeys)
 }
 
 // ==================== Committee setup ====================
@@ -208,6 +226,9 @@ pub(super) struct ValidatorStoreTestHarness {
     pub(super) captured_calls: CapturedCalls,
     /// Set by [`Self::fail_signature_collection`]; read by the mock collector on every call.
     signature_collection_fails: Arc<AtomicBool>,
+    /// Filled by [`Self::fail_signature_collection_for`]; read by the mock collector on every
+    /// call.
+    failing_pubkeys: FailingPubkeys,
     /// Shares `current_time` with the clone held by the store, so tests can reposition the clock
     /// after construction.
     pub(super) slot_clock: ManualSlotClock,
@@ -274,7 +295,8 @@ impl ValidatorStoreTestHarness {
             "test",
         ));
 
-        let (mock_collector, captured_calls, signature_collection_fails) = create_mock_collector();
+        let (mock_collector, captured_calls, signature_collection_fails, failing_pubkeys) =
+            create_mock_collector();
 
         // Database
         let database = Arc::new(
@@ -364,6 +386,7 @@ impl ValidatorStoreTestHarness {
             committee_setups,
             captured_calls,
             signature_collection_fails,
+            failing_pubkeys,
             slot_clock,
             is_synced_tx,
             _slashing_db_dir: slashing_db_dir,
@@ -481,6 +504,12 @@ impl ValidatorStoreTestHarness {
     pub(super) fn fail_signature_collection(&self) {
         self.signature_collection_fails
             .store(true, Ordering::Relaxed);
+    }
+
+    /// Makes every subsequent `sign_and_collect` call for `pubkey` fail, so one root can miss
+    /// quorum while its siblings still collect. Calls are still captured.
+    pub(super) fn fail_signature_collection_for(&self, pubkey: PublicKeyBytes) {
+        self.failing_pubkeys.lock().insert(pubkey);
     }
 
     pub(super) fn create_attestation(


### PR DESCRIPTION
Rebased on `unstable` (#1229 merged as `c332d6a7`); the three commits here are the full review scope.

## Problem, Evidence, and Context (Required)

Post-Boole, Anchor completes every attestation selection proof but most aggregates are never published. Anchor's selection proofs are distributed signing rounds finishing ~250-500ms into the slot, while embedded Lighthouse's attestation service clones its duty view (including `selection_proof: Option`) when attestation production starts and never re-reads it. All-`None` clones make `produce_and_publish_aggregates` return `Ok` silently. Both Lighthouse trigger paths (head event and timer) share the clone, so delaying the head event cannot close the race.

- Scale-100 ssv-mini evidence: 13/200 expected unique aggregates published (amplified build), 73/200 (PR-1229-only control), while proofs, QBFT, and post-consensus signing all succeeded.
- The failure is silent: no log, no metric, on the skip path.
- go-ssv is not affected: it publishes decided aggregates from the SSV node itself with no validator-client snapshot in its path.

## Change Overview (Required)

Make Anchor the single authoritative Boole+ aggregate publisher, working from the decided value instead of Lighthouse's snapshot:

- The Boole+ branch of `sign_aggregate_and_proofs` now yields one empty `Ok` batch (Lighthouse's publish loop drops empty batches silently, verified at pin b263df5) and logs the discarded request set, and `sign_committee_aggregate_and_proofs` is deleted.
- `start_aggregator_post_consensus` returns its vacant-only insertions; the metadata service spawns one detached publisher per slot that joins each new execution under the existing two-slot deadline and publishes **each decided aggregate the moment its threshold signature reconstructs, one POST per aggregate** (go-ssv's publication shape): a beacon-node-rejected aggregate cannot fail a sibling's POST, and a no-quorum root cannot delay its committee's other aggregates.
- The v1/v2 endpoint and fork header derive from the decided value's `DataVersion` (the fork its payloads were decoded under), so they can never diverge from the payload variant.
- New `anchor_aggregator_committee_publish_total{result}` metric: `consensus_error`/`no_aggregates` count committees, `success`/`http_error`/`no_signatures` count aggregates; per-aggregate publish logs reproduce Lighthouse's field set (`type="aggregated"`).

Reading order: `aggregator_post_consensus.rs` (registration, per-committee join, per-root publish), then `metadata_service.rs` (spawn + POST), then the `lib.rs` deletion, then tests.

Did not change: pre-Boole per-validator aggregate signing (Lighthouse still publishes), the contributions callback, PR #1229's exactly-once registration and detached signing, and all head-event/timer plumbing.

## Risks, Trade-offs, and Mitigations (Required)

- Publication logic for one object class moves into Anchor. Accepted deliberately for go-ssv parity: the decided value, reconstructed signature, and submission now live in one place, and correctness no longer depends on Lighthouse's internal scheduling at each pin.
- All four operators publish the same reconstructed aggregate (as in go-ssv); duplicate POSTs to shared beacon nodes were exercised in two mixed-client runs with zero errors, including with per-aggregate POSTs on both clients.
- One POST per aggregate raises request count (~3-16 per committee-slot vs 1); exercised at 250-validator load (~8 aggregates per slot per node) with zero publish failures.
- The empty-batch behavior of Lighthouse's publish loop is a pin-specific fact; re-verify on pin bumps (tripwire noted in the code comment).
- Cold Boole-only code path; zero lines and zero latency on attestation production.

## Validation (Required)

- 74 crate tests (was 66), including recorder-based per-root publisher tests, fork-propagation from the decided `DataVersion`, vacant-only registration, quorum-failure, deadline, and partial-quorum paths (one root misses quorum, the sibling still publishes), and the previously uncovered pre-Boole per-validator path. `make cargo-fmt-check`, `make lint` clean.
- Seven ssv-mini campaigns (evidence and per-run verdicts recorded in the campaign notes). Batch-shape build (runs 1-4):
  - Scale-100 all-Anchor: **200/200** unique aggregates (control: 73/200) with the underlying race still firing (48-52 of 62 proof batches after Lighthouse's snapshot start).
  - Mixed 2 Anchor + 2 go-ssv: **200/200** under a harsher race (63/64 late batches); publishes from go-led decided values; duplicate POSTs harmless.
  - Fault matrix: single-operator restarts x3 (continuous publication on 3/4), two-operator quorum loss (correct null result, no hangs, instant recovery), hung-BN pause (zero publish failures, instant resume).
  - 250 validators, 513-slot soak: every decided aggregate published, zero publish failures, flat resources; a ~3% eligible-assignment shortfall traced to selection-proof collection timeouts under load (upstream signing pipeline, pre-existing class).
- Final per-root build (runs 5-7; pre-rebase commits `32534555` + `c2e886c4`, now `9233cf56` + `c8c291bb`):
  - Scale-100 all-Anchor: **200/200**, zero publish failures.
  - Mixed 2 Anchor + 2 go-ssv: unique **200/200** under the harshest race profile (63/64 late batches), per-aggregate duplicate POSTs on both clients, zero Anchor publish failures.
  - 250 validators, two 64-slot windows: **500/500 in both**, zero publish failures, zero missed-signature roots.
- Known limitation: the `no_signatures` outcome (a decided root that never reaches quorum) is covered by unit tests including the partial-quorum case, but was not reproducible live (local reconstruction outruns slot-precise fault injection).

## Rollback (Required for behavior or runtime changes; optional otherwise)

Three commits that revert together; reverting restores the Lighthouse callback path (and its snapshot race). No config, schema, or wire-format changes; the new metric disappears on revert.

## Blockers / Dependencies (Optional)

- None: #1229 merged (`c332d6a7`) and this branch is rebased on it.

## Additional Info / Next Steps (Optional)

- Follow-up to be filed: `AggregatorCommitteeDataValidator` version-vs-duty-slot-fork validation (mirrors b6809645; bounds the decided `DataVersion` the publish fork is derived from). An upstream Lighthouse report of the duty-snapshot race may follow separately; it no longer affects Anchor.
- Alternatives considered and rejected: head-event readiness gate (structurally partial: the timer path shares the snapshot; couples attestation liveness to aggregate readiness), fixed post-fork head-event delay (constant-dependent), Lighthouse fork (pin cadence). A redundant dual-publisher rollout was debated and declined: it forfeits the callback-path deletion and makes the publish metric unmeasurable under races. Batch-per-committee publication was implemented first and validated (runs 1-4), then replaced by per-root publication for exact go-ssv parity and failure isolation (runs 5-7).