### PR TITLE
ci(mergify): migrate to declarative commit_message_format

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -107,17 +107,11 @@ queue_rules:
     batch_max_wait_time: 60 s
     checks_timeout: 10800 s
     merge_method: squash
-    commit_message_template: |
-      {{ title }} (#{{ number }})
-
-        {{ body | get_section("## Issue Addressed", "") }}
-
-
-        {{ body | get_section("## Proposed Changes", "") }}
-      
-      {% for commit in commits | unique(attribute='email_author') %}
-      Co-Authored-By: {{ commit.author }} <{{ commit.email_author }}>
-      {% endfor %}
+    commit_message_format:
+      title: pr-title
+      body: empty
+      trailers:
+        - co-authored-by
     queue_conditions:
       - "#approved-reviews-by >= 1"
       - "check-success=license/cla"


### PR DESCRIPTION
## Problem, Evidence, and Context (Required)

- Mergify has deprecated the Jinja2 `commit_message_template` field; it stops working on **2026-09-30**, after which `.github/mergify.yml` becomes invalid and merge-queue commit messages may break.
- Mergify's auto-migration PR (#1107) was a no-op and has been closed, so the config must be migrated by hand.
- Targets `stable` because Mergify reads the config from the repository default branch; it reaches `unstable` via the release backmerge. Precedent for `stable`-targeted CI config PRs: #1152, #1130, #1042.
- Closes #1108

## Change Overview (Required)

- Replaces the `commit_message_template` block in `queue_rules -> default` with the declarative `commit_message_format`: `title: pr-title` (renders `<PR title> (#<number>)`), `body: empty`, and `co-authored-by` trailers (deduplicated by author email, replacing the Jinja2 loop).
- This is Option B from #1108. It preserves current effective behavior: the `get_section("## Issue Addressed")` / `get_section("## Proposed Changes")` extractions already return nothing since the PR template rewrite in #892, so squash-commit bodies are effectively title + co-authors today.
- Nothing else changed: `pull_request_rules`, queue/merge conditions, batch settings, and `merge_method: squash` are untouched.

## Risks, Trade-offs, and Mitigations (Required)

- `body: empty` means squash commits carry no description body. This is accepted in #1108 (and is the de facto behavior already, see above).
- `target-branch-check` will fail on this PR since it enforces `unstable` as the base; like prior `stable`-targeted CI PRs, this needs a manual maintainer merge rather than the merge queue.

## Validation (Required)

- Mergify's PR check validates the changed configuration on this PR (acceptance criterion from #1108).
- `grep` confirms zero `commit_message_template` occurrences remain; YAML parses cleanly.
- Observable post-merge: the next merge-queue squash commit shows `<PR title> (#<num>)` plus `Co-Authored-By:` trailers and no body.

## Rollback (Required for behavior or runtime changes; optional otherwise)

- Revert the commit; the old template remains functional until 2026-09-30. No data or operational impact.