### PR TITLE
feat(validator_store): add envelope-signing groundwork

### DIFF
--- a/anchor/validator_store/src/lib.rs
+++ b/anchor/validator_store/src/lib.rs
@@ -47,8 +47,9 @@ use ssv_types::{
         AggregatorCommitteeConsensusData, AggregatorCommitteeDataValidator, BEACON_ROLE_AGGREGATOR,
         BEACON_ROLE_PROPOSER, BEACON_ROLE_SYNC_COMMITTEE_CONTRIBUTION, BeaconVote,
         BeaconVoteValidator, Contribution, ContributionWrapper, Contributions, DataVersion,
-        ForkDecodeError, GloasBeaconVote, GloasBeaconVoteValidator, ProposerConsensusData,
-        ProposerConsensusDataValidator, QbftData, SelectionProofBatchId, ValidatorDuty,
+        EnvelopeConsensusDataValidator, ForkDecodeError, GloasBeaconVote, GloasBeaconVoteValidator,
+        ProposerConsensusData, ProposerConsensusDataValidator, QbftData, SelectionProofBatchId,
+        ValidatorDuty,
     },
     msgid::Role,
     partial_sig::PartialSignatureKind,
@@ -1306,6 +1307,23 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> AnchorValidator
             validator_attestation_committees,
             self.genesis_validators_root,
             self.strict_mfp,
+        ))
+    }
+
+    /// Constructs the QBFT data validator for envelope-signing duties.
+    #[cfg_attr(not(test), expect(dead_code))] // no non-test caller yet
+    fn create_envelope_consensus_data_validator(
+        &self,
+        validator_pubkey: PublicKeyBytes,
+        validator_index: ValidatorIndex,
+        slot: Slot,
+        decided_block_root: Hash256,
+    ) -> Box<EnvelopeConsensusDataValidator<E>> {
+        Box::new(EnvelopeConsensusDataValidator::new(
+            validator_pubkey,
+            validator_index,
+            slot,
+            decided_block_root,
         ))
     }
 
@@ -2959,6 +2977,21 @@ pub enum SpecificError {
         validator_pubkey: PublicKeyBytes,
         slot: Slot,
         current_slot: Slot,
+    },
+    /// The envelope slot is before the Gloas fork.
+    EnvelopeBeforeGloas {
+        slot: Slot,
+        fork: ForkName,
+    },
+    /// The envelope was built externally; only self-build envelopes are signed.
+    EnvelopeNotSelfBuild {
+        builder_index: u64,
+    },
+    /// Consensus decided an envelope another operator built. This is an intentional
+    /// non-publish, not a failure: the partial signature was already contributed.
+    EnvelopeNotBuiltLocally {
+        local_root: Hash256,
+        decided_root: Hash256,
     },
 }
 

--- a/anchor/validator_store/src/testing/common.rs
+++ b/anchor/validator_store/src/testing/common.rs
@@ -23,7 +23,7 @@ use ssv_types::{
     ValidatorIndex, ValidatorMetadata,
     consensus::{
         AggregatorCommitteeConsensusData, AssignedAggregator, BeaconVote, DataVersion,
-        GloasBeaconVote, QbftDataValidator,
+        EnvelopeConsensusData, GloasBeaconVote, QbftDataValidator,
     },
 };
 use ssz::Encode;
@@ -65,6 +65,15 @@ pub(super) async fn run_sign_attestations(
 
 // ==================== Mock consensus decider ====================
 
+/// Shared storage for captured `decide_instance` calls.
+pub(super) type CapturedDecides = Arc<Mutex<Vec<CapturedDecideCall>>>;
+
+/// One captured `decide_instance` call.
+pub(super) struct CapturedDecideCall {
+    /// Type name of the proposed consensus data, identifying which duty started consensus.
+    pub(super) data_type: &'static str,
+}
+
 /// Mock that instantly returns `Completed::Success(initial)`, echoing back the proposed data.
 /// Removes the need for `QbftManager` infrastructure and lets the signing pipeline run fully.
 ///
@@ -73,8 +82,13 @@ pub(super) async fn run_sign_attestations(
 /// tests exercise "the cluster-decided index differs from this operator's local seed", which is
 /// exactly the case `#1027` must apply. Non-Gloas seeds (`BeaconVote`) are always echoed back
 /// unchanged, since their decided value carries no index.
+///
+/// When `forced_envelope_decision` is `Some`, it replaces the echo for `EnvelopeConsensusData`
+/// seeds. Every `decide_instance` call is captured, regardless of the configured behavior.
 pub(super) struct MockConsensusDecider {
     forced_gloas_index: Option<u64>,
+    forced_envelope_decision: Option<EnvelopeConsensusData>,
+    captured: CapturedDecides,
 }
 
 impl MockConsensusDecider {
@@ -82,6 +96,8 @@ impl MockConsensusDecider {
     pub(super) fn echoing() -> Self {
         Self {
             forced_gloas_index: None,
+            forced_envelope_decision: None,
+            captured: Arc::new(Mutex::new(Vec::new())),
         }
     }
 
@@ -90,7 +106,24 @@ impl MockConsensusDecider {
     pub(super) fn forcing_gloas_index(index: u64) -> Self {
         Self {
             forced_gloas_index: Some(index),
+            forced_envelope_decision: None,
+            captured: Arc::new(Mutex::new(Vec::new())),
         }
+    }
+
+    /// Decides every `EnvelopeConsensusData` seed as `decided`, modeling a cluster that
+    /// decided another operator's envelope. Non-envelope seeds keep the echo behavior.
+    pub(super) fn deciding_envelope(decided: EnvelopeConsensusData) -> Self {
+        Self {
+            forced_gloas_index: None,
+            forced_envelope_decision: Some(decided),
+            captured: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+
+    /// Handle to the captured `decide_instance` calls.
+    pub(super) fn captured_decides(&self) -> CapturedDecides {
+        Arc::clone(&self.captured)
     }
 }
 
@@ -103,6 +136,17 @@ impl<E: EthSpec> ConsensusDecider<E> for MockConsensusDecider {
         _timeout_mode: TimeoutMode,
         _committee_members: &IndexSet<OperatorId>,
     ) -> Result<Completed<D>, QbftError> {
+        self.captured.lock().push(CapturedDecideCall {
+            data_type: std::any::type_name::<D>(),
+        });
+        if let Some(decided) = self.forced_envelope_decision.clone() {
+            // Same soundness argument as below: `D: 'static`. Only an `EnvelopeConsensusData`
+            // seed downcasts; every other `D` falls through to the existing behavior.
+            let decided_any: Box<dyn Any> = Box::new(decided);
+            if let Ok(decided_envelope) = decided_any.downcast::<D>() {
+                return Ok(Completed::Success(*decided_envelope));
+            }
+        }
         // `D: QbftDecidable<E>` requires `'static`, so this downcast is sound. Only the Gloas
         // seed type carries `attestation_data_index`; every other `D` falls through to the echo.
         if let Some(index) = self.forced_gloas_index {
@@ -291,6 +335,9 @@ pub(super) struct HarnessOptions {
     /// When `Some`, the mock decides every `GloasBeaconVote` with this `attestation_data_index`,
     /// modeling a cluster-decided index that may differ from each operator's local seed.
     pub(super) forced_gloas_index: Option<u64>,
+    /// When `Some`, the mock decides every `EnvelopeConsensusData` seed as this value,
+    /// modeling a cluster that decided another operator's envelope.
+    pub(super) forced_envelope_decision: Option<EnvelopeConsensusData>,
     /// SSV fork the store's `ForkSchedule` reports as active. Defaults to `Boole`; tests that
     /// exercise pre-Boole behaviour supply an earlier fork.
     pub(super) active_fork: Fork,
@@ -310,6 +357,7 @@ impl Default for HarnessOptions {
             disable_slashing_protection: true,
             spec: Arc::new(ChainSpec::mainnet()),
             forced_gloas_index: None,
+            forced_envelope_decision: None,
             active_fork: Fork::Boole,
             proposer_delay: Duration::ZERO,
         }
@@ -351,6 +399,9 @@ pub(super) struct ValidatorStoreTestHarness {
         Arc<AnchorValidatorStore<ManualSlotClock, MainnetEthSpec, MockConsensusDecider>>,
     committee_setups: Vec<CommitteeSetup>,
     pub(super) captured_calls: CapturedCalls,
+    /// Not yet read by any harness-driven test; the envelope-signing e2e tests will consume it.
+    #[expect(dead_code)]
+    pub(super) captured_decides: CapturedDecides,
     /// Shares `current_time` with the clone held by the store, so tests can reposition the clock
     /// after construction.
     pub(super) slot_clock: ManualSlotClock,
@@ -506,10 +557,15 @@ impl ValidatorStoreTestHarness {
 
         let (is_synced_tx, is_synced_rx) = watch::channel(true);
 
-        let decider = match options.forced_gloas_index {
-            Some(index) => MockConsensusDecider::forcing_gloas_index(index),
-            None => MockConsensusDecider::echoing(),
+        let decider = match (options.forced_gloas_index, options.forced_envelope_decision) {
+            (Some(index), None) => MockConsensusDecider::forcing_gloas_index(index),
+            (None, Some(decided)) => MockConsensusDecider::deciding_envelope(decided),
+            (None, None) => MockConsensusDecider::echoing(),
+            (Some(_), Some(_)) => {
+                panic!("harness options must not force both a Gloas index and an envelope decision")
+            }
         };
+        let captured_decides = decider.captured_decides();
 
         let spec = Arc::clone(&options.spec);
         let genesis_validators_root = Hash256::zero();
@@ -538,6 +594,7 @@ impl ValidatorStoreTestHarness {
             validator_store,
             committee_setups,
             captured_calls,
+            captured_decides,
             slot_clock,
             is_synced_tx,
             spec,

--- a/anchor/validator_store/src/testing/envelope_signing.rs
+++ b/anchor/validator_store/src/testing/envelope_signing.rs
@@ -1,0 +1,195 @@
+//! Envelope-signing duty tests (SIP-94).
+
+use bls::{FixedBytesExtended, PublicKeyBytes};
+use qbft::Completed;
+use qbft_manager::{ConsensusDecider, EnvelopeProposerInstanceId, TimeoutMode};
+use ssv_types::{
+    IndexSet, OperatorId, ValidatorIndex,
+    consensus::{
+        BEACON_ROLE_ENVELOPE_PROPOSER, BlindedExecutionPayloadEnvelope, DataVersion,
+        EnvelopeConsensusData, EnvelopeConsensusDataValidator, QbftDataValidator, ValidatorDuty,
+    },
+};
+use ssz::Encode;
+use ssz_types::VariableList;
+use tokio::time::Instant;
+use types::{
+    ExecutionPayloadEnvelope, ExecutionPayloadGloas, ExecutionRequestsGloas, ForkName, Hash256,
+    MainnetEthSpec, Slot, consts::gloas::BUILDER_INDEX_SELF_BUILD,
+};
+
+use super::common::*;
+
+/// Validator index the single-validator committee starts at.
+const STARTING_VALIDATOR_INDEX: usize = 5;
+
+fn test_operator_ids() -> [OperatorId; 4] {
+    [OperatorId(1), OperatorId(2), OperatorId(3), OperatorId(4)]
+}
+
+/// Builds a Gloas self-build envelope at `TEST_SLOT` bound to `beacon_block_root`.
+fn self_build_envelope(beacon_block_root: Hash256) -> ExecutionPayloadEnvelope<MainnetEthSpec> {
+    ExecutionPayloadEnvelope {
+        payload: ExecutionPayloadGloas::<MainnetEthSpec> {
+            slot_number: Slot::new(TEST_SLOT),
+            ..Default::default()
+        },
+        execution_requests: ExecutionRequestsGloas::<MainnetEthSpec>::default(),
+        builder_index: BUILDER_INDEX_SELF_BUILD,
+        beacon_block_root,
+        parent_beacon_block_root: Hash256::from_low_u64_be(0x1111),
+    }
+}
+
+/// Wraps a full envelope into the consensus value the store proposes for it.
+fn envelope_consensus_value(
+    pubkey: PublicKeyBytes,
+    envelope: &ExecutionPayloadEnvelope<MainnetEthSpec>,
+) -> EnvelopeConsensusData {
+    let blinded = BlindedExecutionPayloadEnvelope::from_full(envelope);
+    EnvelopeConsensusData {
+        duty: ValidatorDuty {
+            r#type: BEACON_ROLE_ENVELOPE_PROPOSER,
+            pub_key: pubkey,
+            slot: Slot::new(TEST_SLOT),
+            validator_index: ValidatorIndex(STARTING_VALIDATOR_INDEX),
+            committee_index: 0,
+            committee_length: 0,
+            committees_at_slot: 0,
+            validator_committee_index: 0,
+            validator_sync_committee_indices: Default::default(),
+        },
+        version: DataVersion::from(ForkName::Gloas),
+        data_ssz: VariableList::new(blinded.as_ssz_bytes())
+            .expect("blinded envelope bytes should fit in the consensus data list"),
+    }
+}
+
+/// Drives one envelope decide call against the mock and unwraps the decided value.
+async fn decide_envelope_seed(
+    decider: &MockConsensusDecider,
+    pubkey: PublicKeyBytes,
+    seed: EnvelopeConsensusData,
+) -> EnvelopeConsensusData {
+    let result = ConsensusDecider::<MainnetEthSpec>::decide_instance(
+        decider,
+        EnvelopeProposerInstanceId {
+            validator: pubkey,
+            instance_height: (TEST_SLOT as usize).into(),
+        },
+        seed,
+        Box::new(EnvelopeConsensusDataValidator::<MainnetEthSpec>::new(
+            pubkey,
+            ValidatorIndex(STARTING_VALIDATOR_INDEX),
+            Slot::new(TEST_SLOT),
+            Hash256::zero(),
+        )),
+        TimeoutMode::Relative {
+            current_round_start_time: Instant::now(),
+        },
+        &IndexSet::from(test_operator_ids()),
+    )
+    .await
+    .expect("the mock decider must not fail");
+    match result {
+        Completed::Success(decided) => decided,
+        Completed::TimedOut => panic!("the mock decider must not time out"),
+    }
+}
+
+/// A forced envelope decision replaces the echo for envelope seeds.
+#[tokio::test(flavor = "multi_thread")]
+async fn mock_deciding_envelope_returns_the_forced_value() {
+    let pubkey = PublicKeyBytes::empty();
+    let seed_envelope = self_build_envelope(Hash256::from_low_u64_be(0xaaaa));
+    let mut forced_envelope = seed_envelope.clone();
+    forced_envelope.parent_beacon_block_root = Hash256::from_low_u64_be(0xbbbb);
+    let seed = envelope_consensus_value(pubkey, &seed_envelope);
+    let forced = envelope_consensus_value(pubkey, &forced_envelope);
+
+    let decider = MockConsensusDecider::deciding_envelope(forced.clone());
+    let decided = decide_envelope_seed(&decider, pubkey, seed).await;
+
+    assert_eq!(
+        decided, forced,
+        "an envelope seed must decide as the forced value, not the echo"
+    );
+}
+
+/// Without a forced decision, an envelope seed echoes back unchanged.
+#[tokio::test(flavor = "multi_thread")]
+async fn mock_echoes_envelope_seed_without_a_forced_decision() {
+    let pubkey = PublicKeyBytes::empty();
+    let seed = envelope_consensus_value(
+        pubkey,
+        &self_build_envelope(Hash256::from_low_u64_be(0xaaaa)),
+    );
+
+    let decider = MockConsensusDecider::echoing();
+    let decided = decide_envelope_seed(&decider, pubkey, seed.clone()).await;
+
+    assert_eq!(
+        decided, seed,
+        "the echoing mock must return the seed unchanged"
+    );
+}
+
+/// Every decide call lands in the capture, tagged with the seed type.
+#[tokio::test(flavor = "multi_thread")]
+async fn mock_captures_envelope_decide_calls() {
+    let pubkey = PublicKeyBytes::empty();
+    let seed = envelope_consensus_value(
+        pubkey,
+        &self_build_envelope(Hash256::from_low_u64_be(0xaaaa)),
+    );
+
+    let decider = MockConsensusDecider::echoing();
+    let captured = decider.captured_decides();
+    decide_envelope_seed(&decider, pubkey, seed).await;
+
+    let calls = captured.lock();
+    assert_eq!(calls.len(), 1, "one decide call must be captured");
+    assert!(
+        calls[0].data_type.contains("EnvelopeConsensusData"),
+        "the captured call must be tagged with the envelope seed type"
+    );
+}
+
+/// The factory passes pubkey, index, slot, and decided root into the value check.
+#[tokio::test(flavor = "multi_thread")]
+async fn factory_wires_duty_metadata_into_the_value_check() {
+    let committee = create_committee_setup(&test_operator_ids(), 1, STARTING_VALIDATOR_INDEX);
+    let pubkey = committee.validators[0].public_key;
+    let harness = ValidatorStoreTestHarness::new_with_options(
+        vec![committee],
+        OperatorId(1),
+        HarnessOptions {
+            spec: gloas_at_genesis_spec(),
+            disable_slashing_protection: true,
+            ..Default::default()
+        },
+    );
+    let envelope = self_build_envelope(Hash256::from_low_u64_be(0xdec1));
+    let value = envelope_consensus_value(pubkey, &envelope);
+
+    let validator = harness
+        .validator_store
+        .create_envelope_consensus_data_validator(
+            pubkey,
+            ValidatorIndex(STARTING_VALIDATOR_INDEX),
+            Slot::new(TEST_SLOT),
+            envelope.beacon_block_root,
+        );
+
+    assert!(
+        validator.validate(&value, &value),
+        "a matched envelope value must pass the factory-built value check"
+    );
+
+    let mut wrong_slot = value.clone();
+    wrong_slot.duty.slot = Slot::new(TEST_SLOT + 1);
+    assert!(
+        !validator.validate(&wrong_slot, &value),
+        "a value with the wrong slot must fail the factory-built value check"
+    );
+}

--- a/anchor/validator_store/src/testing/mod.rs
+++ b/anchor/validator_store/src/testing/mod.rs
@@ -6,6 +6,7 @@ mod committee_attestation_gloas;
 mod committee_attestation_slashing;
 mod decided_block_root;
 mod decided_block_root_e2e;
+mod envelope_signing;
 mod payload_attestation;
 mod proposer_delay;
 mod proposer_preferences;


### PR DESCRIPTION
Lands the shared groundwork for the SIP-94 envelope-signing duty, ahead of the duty implementation.

## Problem, Evidence, and Context

- The envelope-signing duty method is still an `Unsupported` stub. The duty implementation needs error variants, a QBFT value-check factory, and test-harness support first.
- Landing the groundwork separately keeps both PRs small and independently reviewable.
- Part of #1126 (PR 1 of 2).

## Change Overview

- Three new duty error variants: a pre-Gloas rejection, a non-self-build rejection, and a sentinel for consensus deciding an envelope that another operator built.
- A factory that builds the QBFT value check for envelope consensus data, staged behind a dead-code expectation until the duty wires it in.
- Test harness: the mock consensus decider can now force a decided envelope value and records every decide call. A new envelope test module adds the shared fixtures and four tests.
- Suggested reading order: the error variants and the factory, then the harness extensions, then the new test module.
- No behavior changed: the duty stub still returns `Unsupported`, and no production path uses the additions yet.

## Risks, Trade-offs, and Mitigations

- Blast radius is minimal: every addition is either test-only or unused by production code.
- The staged dead-code expectations are lint-enforced, so the follow-up PR cannot forget to remove them.
- The sentinel variant models an intentional non-publish as an error because the caller publishes every `Ok`. The follow-up PR classifies it separately in logs and metrics.

## Validation

- `cargo test -p anchor_validator_store`: 108 tests pass (104 existing + 4 new).
- Format check and clippy with `-D warnings` are clean.
- The new tests pin the mock's forced-decision and capture behavior and the factory's parameter wiring. The value-check rejection matrix is already covered by `ssv_types` tests.

## Rollback

- Revert the commit. No config, data, or operational impact.

## Blockers / Dependencies

- The follow-up PR (the duty implementation) depends on this PR.