### PR TITLE
chore: backmerge stable into unstable after #1247

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -107,17 +107,11 @@ queue_rules:
     batch_max_wait_time: 60 s
     checks_timeout: 10800 s
     merge_method: squash
-    commit_message_template: |
-      {{ title }} (#{{ number }})
-
-        {{ body | get_section("## Issue Addressed", "") }}
-
-
-        {{ body | get_section("## Proposed Changes", "") }}
-      
-      {% for commit in commits | unique(attribute='email_author') %}
-      Co-Authored-By: {{ commit.author }} <{{ commit.email_author }}>
-      {% endfor %}
+    commit_message_format:
+      title: pr-title
+      body: empty
+      trailers:
+        - co-authored-by
     queue_conditions:
       - "#approved-reviews-by >= 1"
       - "check-success=license/cla"

--- a/anchor/validator_store/src/testing/common.rs
+++ b/anchor/validator_store/src/testing/common.rs
@@ -32,6 +32,7 @@ use ssv_types::{
     ValidatorIndex, ValidatorMetadata,
     consensus::{AggregatorCommitteeConsensusData, QbftDataValidator},
 };
+use ssz::Encode;
 use task_executor::TaskExecutor;
 use tempfile::TempDir;
 use tokio::{

--- a/anchor/validator_store/src/testing/sync_contribution.rs
+++ b/anchor/validator_store/src/testing/sync_contribution.rs
@@ -300,17 +300,22 @@ async fn pre_boole_callbacks_use_the_complete_fixed_decided_descriptor() {
         Fork::Alan,
         MockConsensusDecider::fixed_after_barrier(&fixed_value, 2),
     );
-    harness
-        .validator_store
-        .update_aggregation_assignments(AggregationAssignments {
-            slot: Slot::new(TEST_SLOT),
-            aggregator_committees: HashMap::new(),
-            multi_sync_aggregators: HashMap::from([(
-                validator.public_key,
-                ContributionWaiter::new(2),
-            )]),
-            consensus_data_by_ssv_committee: HashMap::new(),
-        });
+    let new_executions =
+        harness
+            .validator_store
+            .update_aggregation_assignments(AggregationAssignments {
+                slot: Slot::new(TEST_SLOT),
+                aggregator_committees: HashMap::new(),
+                multi_sync_aggregators: HashMap::from([(
+                    validator.public_key,
+                    ContributionWaiter::new(2),
+                )]),
+                consensus_data_by_ssv_committee: HashMap::new(),
+            });
+    assert!(
+        new_executions.is_empty(),
+        "pre-Boole assignments without consensus data must not register aggregate executions"
+    );
 
     let stream = harness
         .validator_store


### PR DESCRIPTION
Backmerges `stable` into `unstable` after #1247 so `stable` becomes an ancestor of `unstable` and the Mergify `commit_message_format` migration is present on the development branch.

The branch also repairs test compilation already broken on `unstable` by the merge order of #1245 and #1208:

- Restores the `ssz::Encode` import required by `MockConsensusDecider::fixed_after_barrier`
- Consumes the `#[must_use]` aggregation-update result by asserting that pre-Boole assignments without consensus data register no aggregate executions

Verified candidate:

- Backmerge commit: `f4d8f7fd026a30e9b89c6b09c0e6bb4a4e44065e`
- First parent: `c46211c3f96c412eb4db8306391b94f6e9943a92` (`unstable`)
- Second parent: `782e6fea86f07519949096efbae7e564e11ba630` (`stable`)
- Follow-up CI fix: `87ab4db1997894832b00d032f75e580d6a47c648`
- Diff against `unstable`: `.github/mergify.yml` plus two validator-store test-support files
- Local verification: nightly formatting, validator-store all-target Clippy, and all 79 validator-store tests

**Informational CI gate only. Do not merge this PR on GitHub.**

The branch contains a true two-parent merge commit. This repository only offers squash merges, which would discard the second-parent ancestry. After CI passes and the target tips are rechecked, a maintainer must fast-forward this exact branch onto `unstable` with a direct CLI push under a temporary rules bypass.