### PR TITLE
fix(message_validator): ignore, not reject, messages with an unresolved validator index

### DIFF
--- a/anchor/message_validator/src/lib.rs
+++ b/anchor/message_validator/src/lib.rs
@@ -762,6 +762,22 @@ fn verify_message_signatures(
     Ok(())
 }
 
+/// Returns the single validator index of a non-committee duty message.
+///
+/// The index is absent when the validator is known locally but its beacon metadata has not been
+/// synced yet. That is a gap in the local view, not a fault of the sending peer, so it maps to
+/// [`ValidationFailure::NoShareMetadata`] (Ignore) rather than a Reject.
+fn single_validator_index(
+    validation_context: &ValidationContext<impl SlotClock>,
+) -> Result<ValidatorIndex, ValidationFailure> {
+    validation_context
+        .committee_info
+        .validator_indices
+        .first()
+        .copied()
+        .ok_or(ValidationFailure::NoShareMetadata)
+}
+
 /// Validates if a validator is assigned to a specific duty
 pub(crate) fn validate_beacon_duty(
     validation_context: &ValidationContext<impl SlotClock>,
@@ -792,15 +808,7 @@ pub(crate) fn validate_beacon_duty(
             return Ok(());
         }
 
-        // Non-committee roles always have one validator index
-        let validator_index = validation_context
-            .committee_info
-            .validator_indices
-            .first()
-            .copied()
-            .ok_or(ValidationFailure::UnexpectedFailure {
-                msg: "Unexpected error when getting first validator index".to_string(),
-            })?;
+        let validator_index = single_validator_index(validation_context)?;
 
         if !duty_provider.is_validator_proposer_at_slot(slot, validator_index) {
             return Err(ValidationFailure::NoDuty);
@@ -811,14 +819,7 @@ pub(crate) fn validate_beacon_duty(
     if role == Role::SyncCommittee {
         let period =
             sync_committee_period(epoch, validation_context.epochs_per_sync_committee_period)?;
-        let validator_index = validation_context
-            .committee_info
-            .validator_indices
-            .first()
-            .copied()
-            .ok_or(ValidationFailure::UnexpectedFailure {
-                msg: "Unexpected error when getting first validator index".to_string(),
-            })?;
+        let validator_index = single_validator_index(validation_context)?;
 
         if !duty_provider.is_validator_in_sync_committee(period, validator_index) {
             return Err(ValidationFailure::NoDuty);

--- a/anchor/message_validator/src/lib.rs
+++ b/anchor/message_validator/src/lib.rs
@@ -118,7 +118,6 @@ pub enum ValidationFailure {
     NonExistentCommitteeID,
     RoundTooHigh,
     ValidatorIndexMismatch,
-    TooManyDutiesPerEpoch,
     NoDuty,
     EstimatedRoundNotInAllowedSpread {
         got: String,
@@ -243,7 +242,7 @@ impl From<&ValidationFailure> for MessageAcceptance {
             | ValidationFailure::RoundTooHigh
             | ValidationFailure::RoundOverflow
             | ValidationFailure::ValidatorIndexMismatch
-            | ValidationFailure::TooManyDutiesPerEpoch
+            | ValidationFailure::ExcessiveDutyCount { .. }
             | ValidationFailure::NoDuty
             | ValidationFailure::EstimatedRoundNotInAllowedSpread { .. } => {
                 MessageAcceptance::Ignore

--- a/anchor/message_validator/src/partial_signature.rs
+++ b/anchor/message_validator/src/partial_signature.rs
@@ -351,9 +351,13 @@ mod tests {
     use types::{EthSpec, MainnetEthSpec, Slot};
 
     use super::*;
-    use crate::tests::{
-        FOUR_NODE_COMMITTEE, MockDutiesProvider, assert_validation_error, create_committee_info,
-        create_message_id_for_test, create_operator_pub_keys, generate_random_rsa_public_keys,
+    use crate::{
+        MessageAcceptance,
+        tests::{
+            FOUR_NODE_COMMITTEE, MockDutiesProvider, assert_validation_error,
+            create_committee_info, create_message_id_for_test, create_operator_pub_keys,
+            generate_random_rsa_public_keys,
+        },
     };
 
     // Options for creating test partial signature messages
@@ -856,6 +860,101 @@ mod tests {
             result,
             |failure| matches!(failure, ValidationFailure::ValidatorIndexMismatch),
             "ValidatorIndexMismatch",
+        );
+    }
+
+    /// Runs a single-validator partial signature message through validation with an empty
+    /// `validator_indices` (validator known locally, beacon index not synced yet).
+    fn validate_with_empty_validator_indices(
+        role: Role,
+        kind: PartialSignatureKind,
+    ) -> Result<ValidatedSSVMessage, ValidationFailure> {
+        let mut committee_info = create_committee_info(FOUR_NODE_COMMITTEE);
+        committee_info.validator_indices = vec![];
+
+        let (_, signed_msg) = create_test_partial_signature(
+            role,
+            kind,
+            OperatorId(1),
+            PartialSigTestOptions::default(),
+            None,
+        );
+
+        let binding = generate_random_rsa_public_keys(signed_msg.operator_ids().len());
+        let map = create_operator_pub_keys(committee_info.committee_members.clone(), binding);
+
+        let validation_context = create_test_validation_context(
+            &signed_msg,
+            &committee_info,
+            role,
+            &map,
+            generate_fork_schedule(Fork::Alan),
+        );
+
+        validate_partial_signature_message(
+            validation_context,
+            &mut DutyState::new(2),
+            Arc::new(MockDutiesProvider {
+                voluntary_exit_duty_count: 0,
+            }),
+        )
+    }
+
+    fn assert_no_share_metadata_ignored(result: Result<ValidatedSSVMessage, ValidationFailure>) {
+        assert_validation_error(
+            result,
+            |failure| {
+                matches!(failure, ValidationFailure::NoShareMetadata)
+                    && MessageAcceptance::from(failure) == MessageAcceptance::Ignore
+            },
+            "NoShareMetadata (Ignore)",
+        );
+    }
+
+    #[test]
+    fn test_proposer_missing_validator_index_returns_no_share_metadata() {
+        // PostConsensus, not RANDAO, so the first-slot RANDAO carve-out does not apply
+        let result = validate_with_empty_validator_indices(
+            Role::Proposer,
+            PartialSignatureKind::PostConsensus,
+        );
+
+        assert_no_share_metadata_ignored(result);
+    }
+
+    #[test]
+    fn test_sync_committee_missing_validator_index_returns_no_share_metadata() {
+        let result = validate_with_empty_validator_indices(
+            Role::SyncCommittee,
+            PartialSignatureKind::PostConsensus,
+        );
+
+        assert_no_share_metadata_ignored(result);
+    }
+
+    #[test]
+    fn test_committee_role_missing_validator_index_skips_single_index_lookup() {
+        // Committee roles never look up a single validator index, so validation proceeds past
+        // validate_beacon_duty. With zero known validators the per-slot duty limit is 0, which
+        // is the downstream failure we expect to reach instead of NoShareMetadata.
+        let result = validate_with_empty_validator_indices(
+            Role::Committee,
+            PartialSignatureKind::PostConsensus,
+        );
+
+        assert_validation_error(
+            result,
+            |failure| {
+                matches!(
+                    failure,
+                    ValidationFailure::ExcessiveDutyCount {
+                        limit: 0,
+                        role: Role::Committee,
+                        ..
+                    }
+                )
+            },
+            "ExcessiveDutyCount",
         );
     }
 

--- a/anchor/message_validator/src/partial_signature.rs
+++ b/anchor/message_validator/src/partial_signature.rs
@@ -952,9 +952,9 @@ mod tests {
                         role: Role::Committee,
                         ..
                     }
-                )
+                ) && MessageAcceptance::from(failure) == MessageAcceptance::Ignore
             },
-            "ExcessiveDutyCount",
+            "ExcessiveDutyCount (Ignore)",
         );
     }
 


### PR DESCRIPTION
## Problem, Evidence, and Context (Required)

When a hosted validator is in the local database but its beacon index has not been synced yet (right after startup or activation), `CommitteeInfo::validator_indices` is empty. The `Proposer` and `SyncCommittee` branches of `validate_beacon_duty` then fail with `UnexpectedFailure`, which maps to `MessageAcceptance::Reject`. An honest peer relaying a valid message gets penalized for a gap in our own view.

go-ssv returns `ErrNoShareMetadata` here, a non-reject (Ignore) error. Anchor already has `ValidationFailure::NoShareMetadata` mapped to Ignore, but nothing returned it.

Closes #1259

## Change Overview (Required)

- The two identical index lookups in `validate_beacon_duty` collapse into one helper that returns `NoShareMetadata` when the index is absent.
- Read `lib.rs` first (the helper and its two call sites), then the tests in `partial_signature.rs`.
- Nothing else changes: the Ignore mapping, the duty checks that follow, and every other role's path are untouched. Committee roles never take this lookup (an empty index list only lowers their duty limit, and `TooManyDutiesPerEpoch` is already Ignore).

## Risks, Trade-offs, and Mitigations (Required)

- Blast radius is one verdict on one already-rare path: Reject becomes Ignore. The message is still not forwarded or processed.
- No wire, topic, or scoring-parameter change.

## Validation (Required)

- New tests: Proposer and SyncCommittee with empty `validator_indices` return `NoShareMetadata` and map to `Ignore`; a Committee-role control shows that path never hits the lookup. Both new assertions fail on the pre-fix code with the old `UnexpectedFailure`.
- `cargo test -p message_validator`: 60 passed, 0 failed.
- `make cargo-fmt-check`, `make lint`: clean.

## Rollback (Required for behavior or runtime changes; optional otherwise)

Revert the commit. No config, data, or operational impact.

## Blockers / Dependencies (Optional)

N/A

## Additional Info / Next Steps (Optional)

N/A