### PR TITLE
feat(validator_store): sign self-build execution payload envelopes

### DIFF
--- a/anchor/validator_store/src/lib.rs
+++ b/anchor/validator_store/src/lib.rs
@@ -4067,6 +4067,10 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> ValidatorStore
                     builder_index: envelope.builder_index,
                 }));
             }
+            let current_slot = self.slot_clock.now().ok_or(SpecificError::SlotClock)?;
+            if slot > current_slot {
+                return Err(Error::GreaterThanCurrentSlot { slot, current_slot });
+            }
 
             let decided_block_root = self.get_decided_block_root(validator_pubkey, slot)?;
             let local_blinded = BlindedExecutionPayloadEnvelope::from_full(&envelope);

--- a/anchor/validator_store/src/lib.rs
+++ b/anchor/validator_store/src/lib.rs
@@ -30,8 +30,9 @@ use openssl::{
 use parking_lot::Mutex;
 use qbft::Completed;
 use qbft_manager::{
-    AggregatorCommitteeInstanceId, CommitteeInstanceId, ConsensusDecider, ProposerInstanceId,
-    QbftError, QbftManager, TimeoutMode, ValidatorDutyKind,
+    AggregatorCommitteeInstanceId, CommitteeInstanceId, ConsensusDecider,
+    EnvelopeProposerInstanceId, ProposerInstanceId, QbftError, QbftManager, TimeoutMode,
+    ValidatorDutyKind,
 };
 use safe_arith::{ArithError, SafeArith};
 use signature_collector::{
@@ -45,11 +46,12 @@ use ssv_types::{
     OperatorId, ValidatorIndex, ValidatorMetadata,
     consensus::{
         AggregatorCommitteeConsensusData, AggregatorCommitteeDataValidator, BEACON_ROLE_AGGREGATOR,
-        BEACON_ROLE_PROPOSER, BEACON_ROLE_SYNC_COMMITTEE_CONTRIBUTION, BeaconVote,
-        BeaconVoteValidator, Contribution, ContributionWrapper, Contributions, DataVersion,
-        EnvelopeConsensusDataValidator, ForkDecodeError, GloasBeaconVote, GloasBeaconVoteValidator,
-        ProposerConsensusData, ProposerConsensusDataValidator, QbftData, SelectionProofBatchId,
-        ValidatorDuty,
+        BEACON_ROLE_ENVELOPE_PROPOSER, BEACON_ROLE_PROPOSER,
+        BEACON_ROLE_SYNC_COMMITTEE_CONTRIBUTION, BeaconVote, BeaconVoteValidator,
+        BlindedExecutionPayloadEnvelope, Contribution, ContributionWrapper, Contributions,
+        DataVersion, EnvelopeConsensusData, EnvelopeConsensusDataValidator, ForkDecodeError,
+        GloasBeaconVote, GloasBeaconVoteValidator, ProposerConsensusData,
+        ProposerConsensusDataValidator, QbftData, SelectionProofBatchId, ValidatorDuty,
     },
     msgid::Role,
     partial_sig::PartialSignatureKind,
@@ -64,6 +66,7 @@ use tokio::{
     time::{Instant, sleep},
 };
 use tracing::{Instrument, Span, debug, error, field, info, info_span, trace, warn};
+use tree_hash::TreeHash;
 use types::{
     AbstractExecPayload, Address, AggregateAndProof, Attestation, BeaconBlock, BeaconBlockRef,
     BlindedPayload, ChainSpec, Checkpoint, ContributionAndProof, Domain, Epoch, EthSpec,
@@ -74,6 +77,7 @@ use types::{
     SignedValidatorRegistrationData, SignedVoluntaryExit, SingleAttestation, Slot, SlotData,
     SyncAggregatorSelectionData, SyncCommitteeContribution, SyncCommitteeMessage,
     SyncSelectionProof, SyncSubnetId, ValidatorRegistrationData, VoluntaryExit,
+    consts::gloas::BUILDER_INDEX_SELF_BUILD,
 };
 use validator_metrics::IntCounterVec;
 use validator_store::{
@@ -945,7 +949,6 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> AnchorValidator
     /// with no later insert, an old entry stays in the map.
     ///
     /// Reads are non-destructive and return the root by value.
-    #[cfg_attr(not(test), expect(dead_code))] // no non-test caller yet
     fn get_decided_block_root(
         &self,
         validator_pubkey: PublicKeyBytes,
@@ -1369,7 +1372,6 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> AnchorValidator
     }
 
     /// Constructs the QBFT data validator for envelope-signing duties.
-    #[cfg_attr(not(test), expect(dead_code))] // no non-test caller yet
     fn create_envelope_consensus_data_validator(
         &self,
         validator_pubkey: PublicKeyBytes,
@@ -3052,7 +3054,7 @@ pub enum SpecificError {
         builder_index: u64,
     },
     /// Consensus decided an envelope another operator built. This is an intentional
-    /// non-publish, not a failure: the partial signature was already contributed.
+    /// non-publish, not a failure.
     EnvelopeNotBuiltLocally {
         local_root: Hash256,
         decided_root: Hash256,
@@ -4033,11 +4035,163 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> ValidatorStore
 
     async fn sign_execution_payload_envelope(
         &self,
-        _validator_pubkey: PublicKeyBytes,
-        _envelope: ExecutionPayloadEnvelope<E>,
+        validator_pubkey: PublicKeyBytes,
+        envelope: ExecutionPayloadEnvelope<E>,
     ) -> Result<SignedExecutionPayloadEnvelope<E>, Error> {
-        // TODO(gloas)
-        Err(Error::SpecificError(SpecificError::Unsupported))
+        let slot = envelope.slot();
+        let span = info_span!(
+            "sign_execution_payload_envelope",
+            slot = slot.as_u64(),
+            %validator_pubkey,
+            validator_index = field::Empty,
+            outcome = field::Empty,
+        );
+
+        async move {
+            if !*self.is_synced.borrow() {
+                return Err(Error::SpecificError(SpecificError::NotSynced));
+            }
+            let (validator, cluster) = self.get_validator_and_cluster(validator_pubkey)?;
+            let validator_index = validator.index.ok_or(SpecificError::MissingIndex)?;
+            Span::current().record("validator_index", *validator_index);
+
+            let fork = self.spec.fork_name_at_slot::<E>(slot);
+            if !fork.gloas_enabled() {
+                return Err(Error::SpecificError(SpecificError::EnvelopeBeforeGloas {
+                    slot,
+                    fork,
+                }));
+            }
+            if envelope.builder_index != BUILDER_INDEX_SELF_BUILD {
+                return Err(Error::SpecificError(SpecificError::EnvelopeNotSelfBuild {
+                    builder_index: envelope.builder_index,
+                }));
+            }
+
+            let decided_block_root = self.get_decided_block_root(validator_pubkey, slot)?;
+            let local_blinded = BlindedExecutionPayloadEnvelope::from_full(&envelope);
+
+            let record_outcome = |outcome: &str| {
+                metrics::inc_counter_vec(&metrics::ENVELOPE_SIGNING_OUTCOMES, &[outcome]);
+                Span::current().record("outcome", outcome);
+            };
+
+            let consensus_data = EnvelopeConsensusData {
+                duty: ValidatorDuty {
+                    r#type: BEACON_ROLE_ENVELOPE_PROPOSER,
+                    pub_key: validator.public_key,
+                    slot,
+                    validator_index,
+                    committee_index: 0,
+                    committee_length: 0,
+                    committees_at_slot: 0,
+                    validator_committee_index: 0,
+                    validator_sync_committee_indices: Default::default(),
+                },
+                // The version participates in the QBFT value hash, so every operator must
+                // derive it from the slot.
+                version: DataVersion::from(fork),
+                data_ssz: try_to_variable_list(local_blinded.as_ssz_bytes(), |provided, max| {
+                    Error::SpecificError(SpecificError::DataTooLarge(format!(
+                        "Envelope data too large for consensus: {provided} > {max}"
+                    )))
+                })?,
+            };
+
+            let data_validator = self.create_envelope_consensus_data_validator(
+                validator.public_key,
+                validator_index,
+                slot,
+                decided_block_root,
+            );
+            let instance_id = EnvelopeProposerInstanceId {
+                validator: validator.public_key,
+                instance_height: slot.as_usize().into(),
+            };
+            let timeout_mode = TimeoutMode::Relative {
+                current_round_start_time: self.get_instant_in_slot(slot, Duration::ZERO)?,
+            };
+
+            let timer = metrics::start_timer_vec(&metrics::CONSENSUS_TIMES, &[metrics::ENVELOPE]);
+            let completed = self
+                .consensus
+                .decide_instance(
+                    instance_id,
+                    consensus_data,
+                    data_validator,
+                    timeout_mode,
+                    &cluster.cluster_members,
+                )
+                .await;
+            drop(timer);
+
+            let decided = match completed {
+                Ok(Completed::Success(decided)) => decided,
+                Ok(Completed::TimedOut) => {
+                    warn!("Envelope consensus timed out");
+                    record_outcome(metrics::ENVELOPE_OUTCOME_FAILED);
+                    return Err(Error::SpecificError(SpecificError::Timeout));
+                }
+                Err(err) => {
+                    warn!(?err, "Envelope consensus failed");
+                    record_outcome(metrics::ENVELOPE_OUTCOME_FAILED);
+                    return Err(Error::SpecificError(SpecificError::from(err)));
+                }
+            };
+            let decided_blinded = decided.decode_blinded_envelope::<E>().map_err(|err| {
+                warn!(?err, "Failed to decode decided envelope");
+                record_outcome(metrics::ENVELOPE_OUTCOME_FAILED);
+                Error::SpecificError(SpecificError::InvalidQbftData(err))
+            })?;
+
+            // Sign before the content gate so every operator contributes its share and the
+            // builder can reconstruct the threshold signature.
+            let epoch = slot.epoch(E::slots_per_epoch());
+            let domain_hash = self.get_domain(epoch, Domain::BeaconBuilder);
+            let signing_root = decided_blinded.signing_root(domain_hash);
+            let signature = self
+                .collect_signature(
+                    PartialSignatureKind::PostConsensus,
+                    Role::EnvelopeProposer,
+                    CollectionMode::SingleValidator,
+                    &validator,
+                    &cluster,
+                    signing_root,
+                    slot,
+                )
+                .await
+                .inspect_err(|err| {
+                    warn!(?err, "Envelope signature collection failed");
+                    record_outcome(metrics::ENVELOPE_OUTCOME_FAILED);
+                })?;
+
+            // Publish gate: the caller publishes every `Ok`, so only the operator whose local
+            // envelope matches the decided value may return one.
+            if local_blinded != decided_blinded {
+                let local_root = local_blinded.tree_hash_root();
+                let decided_root = decided_blinded.tree_hash_root();
+                info!(
+                    ?local_root,
+                    ?decided_root,
+                    "Cluster decided another operator's envelope, skipping publish (expected)"
+                );
+                record_outcome(metrics::ENVELOPE_OUTCOME_NOT_BUILT_LOCALLY);
+                return Err(Error::SpecificError(
+                    SpecificError::EnvelopeNotBuiltLocally {
+                        local_root,
+                        decided_root,
+                    },
+                ));
+            }
+
+            record_outcome(metrics::ENVELOPE_OUTCOME_PUBLISHED);
+            Ok(SignedExecutionPayloadEnvelope {
+                message: envelope,
+                signature,
+            })
+        }
+        .instrument(span)
+        .await
     }
 
     async fn sign_payload_attestation(

--- a/anchor/validator_store/src/metrics.rs
+++ b/anchor/validator_store/src/metrics.rs
@@ -6,6 +6,7 @@ pub const AGGREGATE_AND_PROOF: &str = "aggregate_and_proof";
 pub const BLOCK: &str = "block";
 pub const BEACON_VOTE: &str = "beacon_vote";
 pub const SYNC_CONTRIBUTION_AND_PROOF: &str = "sync_contribution_and_proof";
+pub const ENVELOPE: &str = "envelope";
 pub const TIMEOUT: &str = "timeout";
 pub const OTHER_ERROR: &str = "other_error";
 pub const TRIGGER_HEAD_EVENT: &str = "head_event";
@@ -226,3 +227,20 @@ pub static PROPOSER_PREFERENCES_RECONSTRUCTION_FAILURES: LazyLock<Result<IntCoun
             &["reason"],
         )
     });
+
+/// Consensus, signing, and content match all succeeded; the envelope is returned for
+/// publication.
+pub const ENVELOPE_OUTCOME_PUBLISHED: &str = "published";
+/// Consensus decided an envelope another operator built. Intentional non-publish,
+/// never a failure.
+pub const ENVELOPE_OUTCOME_NOT_BUILT_LOCALLY: &str = "not_built_locally";
+/// QBFT, decode, or signature collection failed.
+pub const ENVELOPE_OUTCOME_FAILED: &str = "failed";
+
+pub static ENVELOPE_SIGNING_OUTCOMES: LazyLock<Result<IntCounterVec>> = LazyLock::new(|| {
+    try_create_int_counter_vec(
+        "anchor_envelope_signing_outcomes_total",
+        "Envelope signing duty outcomes",
+        &["outcome"],
+    )
+});

--- a/anchor/validator_store/src/testing/common.rs
+++ b/anchor/validator_store/src/testing/common.rs
@@ -77,6 +77,14 @@ pub(super) struct CapturedDecideCall {
     pub(super) data_type: &'static str,
 }
 
+/// Forced outcome for `EnvelopeConsensusData` decide calls.
+pub(super) enum ForcedEnvelopeFailure {
+    /// Complete with `Completed::TimedOut`.
+    Timeout,
+    /// Fail with this error.
+    Error(QbftError),
+}
+
 /// Mock that instantly returns `Completed::Success(initial)`, echoing back the proposed data.
 /// Removes the need for `QbftManager` infrastructure and lets the signing pipeline run fully.
 ///
@@ -87,10 +95,12 @@ pub(super) struct CapturedDecideCall {
 /// unchanged, since their decided value carries no index.
 ///
 /// When `forced_envelope_decision` is `Some`, it replaces the echo for `EnvelopeConsensusData`
-/// seeds. Every `decide_instance` call is captured, regardless of the configured behavior.
+/// seeds; when `forced_envelope_failure` is `Some`, envelope seeds time out or fail instead.
+/// Every `decide_instance` call is captured, regardless of the configured behavior.
 pub(super) struct MockConsensusDecider {
     forced_gloas_index: Option<u64>,
     forced_envelope_decision: Option<EnvelopeConsensusData>,
+    forced_envelope_failure: Option<ForcedEnvelopeFailure>,
     captured: CapturedDecides,
 }
 
@@ -100,6 +110,7 @@ impl MockConsensusDecider {
         Self {
             forced_gloas_index: None,
             forced_envelope_decision: None,
+            forced_envelope_failure: None,
             captured: Arc::new(Mutex::new(Vec::new())),
         }
     }
@@ -109,8 +120,7 @@ impl MockConsensusDecider {
     pub(super) fn forcing_gloas_index(index: u64) -> Self {
         Self {
             forced_gloas_index: Some(index),
-            forced_envelope_decision: None,
-            captured: Arc::new(Mutex::new(Vec::new())),
+            ..Self::echoing()
         }
     }
 
@@ -118,9 +128,17 @@ impl MockConsensusDecider {
     /// decided another operator's envelope. Non-envelope seeds keep the echo behavior.
     pub(super) fn deciding_envelope(decided: EnvelopeConsensusData) -> Self {
         Self {
-            forced_gloas_index: None,
             forced_envelope_decision: Some(decided),
-            captured: Arc::new(Mutex::new(Vec::new())),
+            ..Self::echoing()
+        }
+    }
+
+    /// Fails every `EnvelopeConsensusData` decide call with `failure`, modeling envelope
+    /// consensus that times out or errors. Non-envelope seeds keep the echo behavior.
+    pub(super) fn failing_envelope(failure: ForcedEnvelopeFailure) -> Self {
+        Self {
+            forced_envelope_failure: Some(failure),
+            ..Self::echoing()
         }
     }
 
@@ -148,6 +166,25 @@ impl<E: EthSpec> ConsensusDecider<E> for MockConsensusDecider {
             let decided_any: Box<dyn Any> = Box::new(decided);
             if let Ok(decided_envelope) = decided_any.downcast::<D>() {
                 return Ok(Completed::Success(*decided_envelope));
+            }
+        }
+        if let Some(failure) = &self.forced_envelope_failure {
+            // Same soundness argument as below: `D: 'static`. Only an `EnvelopeConsensusData`
+            // seed triggers the forced failure; every other seed echoes back unchanged.
+            let boxed: Box<dyn Any> = Box::new(initial);
+            match boxed.downcast::<EnvelopeConsensusData>() {
+                Ok(_envelope_seed) => {
+                    return match failure {
+                        ForcedEnvelopeFailure::Timeout => Ok(Completed::TimedOut),
+                        ForcedEnvelopeFailure::Error(err) => Err(err.clone()),
+                    };
+                }
+                Err(original) => {
+                    let echoed = original
+                        .downcast::<D>()
+                        .expect("downcast back to original D always succeeds");
+                    return Ok(Completed::Success(*echoed));
+                }
             }
         }
         // `D: QbftDecidable<E>` requires `'static`, so this downcast is sound. Only the Gloas
@@ -341,6 +378,9 @@ pub(super) struct HarnessOptions {
     /// When `Some`, the mock decides every `EnvelopeConsensusData` seed as this value,
     /// modeling a cluster that decided another operator's envelope.
     pub(super) forced_envelope_decision: Option<EnvelopeConsensusData>,
+    /// When `Some`, the mock fails every `EnvelopeConsensusData` decide call with this outcome,
+    /// modeling envelope consensus that times out or errors.
+    pub(super) forced_envelope_failure: Option<ForcedEnvelopeFailure>,
     /// SSV fork the store's `ForkSchedule` reports as active. Defaults to `Boole`; tests that
     /// exercise pre-Boole behaviour supply an earlier fork.
     pub(super) active_fork: Fork,
@@ -361,6 +401,7 @@ impl Default for HarnessOptions {
             spec: Arc::new(ChainSpec::mainnet()),
             forced_gloas_index: None,
             forced_envelope_decision: None,
+            forced_envelope_failure: None,
             active_fork: Fork::Boole,
             proposer_delays: ProposerDelays::default(),
         }
@@ -545,13 +586,16 @@ impl ValidatorStoreTestHarness {
 
         let (is_synced_tx, is_synced_rx) = watch::channel(true);
 
-        let decider = match (options.forced_gloas_index, options.forced_envelope_decision) {
-            (Some(index), None) => MockConsensusDecider::forcing_gloas_index(index),
-            (None, Some(decided)) => MockConsensusDecider::deciding_envelope(decided),
-            (None, None) => MockConsensusDecider::echoing(),
-            (Some(_), Some(_)) => {
-                panic!("harness options must not force both a Gloas index and an envelope decision")
-            }
+        let decider = match (
+            options.forced_gloas_index,
+            options.forced_envelope_decision,
+            options.forced_envelope_failure,
+        ) {
+            (Some(index), None, None) => MockConsensusDecider::forcing_gloas_index(index),
+            (None, Some(decided), None) => MockConsensusDecider::deciding_envelope(decided),
+            (None, None, Some(failure)) => MockConsensusDecider::failing_envelope(failure),
+            (None, None, None) => MockConsensusDecider::echoing(),
+            _ => panic!("harness options must not force more than one consensus behavior"),
         };
         let captured_decides = decider.captured_decides();
 

--- a/anchor/validator_store/src/testing/common.rs
+++ b/anchor/validator_store/src/testing/common.rs
@@ -402,8 +402,6 @@ pub(super) struct ValidatorStoreTestHarness {
         Arc<AnchorValidatorStore<ManualSlotClock, MainnetEthSpec, MockConsensusDecider>>,
     committee_setups: Vec<CommitteeSetup>,
     pub(super) captured_calls: CapturedCalls,
-    /// Not yet read by any harness-driven test; the envelope-signing e2e tests will consume it.
-    #[expect(dead_code)]
     pub(super) captured_decides: CapturedDecides,
     /// Shares `current_time` with the clone held by the store, so tests can reposition the clock
     /// after construction.

--- a/anchor/validator_store/src/testing/envelope_signing.rs
+++ b/anchor/validator_store/src/testing/envelope_signing.rs
@@ -1,27 +1,43 @@
 //! Envelope-signing duty tests (SIP-94).
 
+use std::sync::LazyLock;
+
 use bls::{FixedBytesExtended, PublicKeyBytes};
+use eth2::types::FullBlockContents;
 use qbft::Completed;
 use qbft_manager::{ConsensusDecider, EnvelopeProposerInstanceId, TimeoutMode};
+use signature_collector::CollectionError;
+use slashing_protection::Safe;
 use ssv_types::{
     IndexSet, OperatorId, ValidatorIndex,
     consensus::{
         BEACON_ROLE_ENVELOPE_PROPOSER, BlindedExecutionPayloadEnvelope, DataVersion,
         EnvelopeConsensusData, EnvelopeConsensusDataValidator, QbftDataValidator, ValidatorDuty,
     },
+    msgid::Role,
+    partial_sig::PartialSignatureKind,
 };
 use ssz::Encode;
 use ssz_types::VariableList;
 use tokio::time::Instant;
 use types::{
-    ExecutionPayloadEnvelope, ExecutionPayloadGloas, ExecutionRequestsGloas, ForkName, Hash256,
-    MainnetEthSpec, Slot, consts::gloas::BUILDER_INDEX_SELF_BUILD,
+    BeaconBlock, BeaconBlockGloas, Domain, EmptyBlock, EthSpec, ExecutionPayloadEnvelope,
+    ExecutionPayloadGloas, ExecutionRequestsGloas, ForkName, Hash256, MainnetEthSpec, SignedRoot,
+    Slot, consts::gloas::BUILDER_INDEX_SELF_BUILD,
 };
+use validator_store::{UnsignedBlock, ValidatorStore};
 
 use super::common::*;
+use crate::{Error, SpecificError};
 
 /// Validator index the single-validator committee starts at.
 const STARTING_VALIDATOR_INDEX: usize = 5;
+
+/// Serializes every test that records an envelope outcome: the labels live in the global
+/// prometheus registry, so concurrent recordings would race the delta assertions. Tokio mutex
+/// because the guard is held across awaits.
+static METRIC_TEST_LOCK: LazyLock<tokio::sync::Mutex<()>> =
+    LazyLock::new(|| tokio::sync::Mutex::new(()));
 
 fn test_operator_ids() -> [OperatorId; 4] {
     [OperatorId(1), OperatorId(2), OperatorId(3), OperatorId(4)]
@@ -63,6 +79,23 @@ fn envelope_consensus_value(
         data_ssz: VariableList::new(blinded.as_ssz_bytes())
             .expect("blinded envelope bytes should fit in the consensus data list"),
     }
+}
+
+/// The `(published, not_built_locally, failed)` outcome counters the metric tests assert
+/// deltas on; each test takes its own before-reads under `METRIC_TEST_LOCK`.
+fn envelope_outcome_counters() -> (
+    crate::metrics::IntCounter,
+    crate::metrics::IntCounter,
+    crate::metrics::IntCounter,
+) {
+    let metric = crate::metrics::ENVELOPE_SIGNING_OUTCOMES
+        .as_ref()
+        .expect("metric should be created");
+    (
+        metric.with_label_values(&[crate::metrics::ENVELOPE_OUTCOME_PUBLISHED]),
+        metric.with_label_values(&[crate::metrics::ENVELOPE_OUTCOME_NOT_BUILT_LOCALLY]),
+        metric.with_label_values(&[crate::metrics::ENVELOPE_OUTCOME_FAILED]),
+    )
 }
 
 /// Drives one envelope decide call against the mock and unwraps the decided value.
@@ -191,5 +224,566 @@ async fn factory_wires_duty_metadata_into_the_value_check() {
     assert!(
         !validator.validate(&wrong_slot, &value),
         "a value with the wrong slot must fail the factory-built value check"
+    );
+}
+
+/// A Gloas self-build envelope signs and returns the original message unchanged.
+#[tokio::test(flavor = "multi_thread")]
+async fn gloas_self_build_envelope_signs_and_returns_the_original_message() {
+    let _guard = METRIC_TEST_LOCK.lock().await;
+    let committee = create_committee_setup(&test_operator_ids(), 1, STARTING_VALIDATOR_INDEX);
+    let pubkey = committee.validators[0].public_key;
+    let harness = ValidatorStoreTestHarness::new_with_options(
+        vec![committee],
+        OperatorId(1),
+        HarnessOptions {
+            spec: gloas_at_genesis_spec(),
+            disable_slashing_protection: true,
+            ..Default::default()
+        },
+    );
+    let decided_root = Hash256::from_low_u64_be(0xdec1);
+    harness
+        .validator_store
+        .record_decided_block_root(pubkey, Slot::new(TEST_SLOT), decided_root)
+        .expect("seeding the decided root must succeed");
+    let envelope = self_build_envelope(decided_root);
+
+    let signed = harness
+        .validator_store
+        .sign_execution_payload_envelope(pubkey, envelope.clone())
+        .await
+        .expect("a matched Gloas self-build envelope must sign successfully");
+
+    assert_eq!(
+        signed.message, envelope,
+        "the returned message must be the input envelope unchanged"
+    );
+}
+
+/// Exactly one post-consensus collection happens, over the blinded envelope root under
+/// `Domain::BeaconBuilder`.
+#[tokio::test(flavor = "multi_thread")]
+async fn signing_root_is_the_blinded_envelope_root_under_beacon_builder_domain() {
+    let _guard = METRIC_TEST_LOCK.lock().await;
+    let committee = create_committee_setup(&test_operator_ids(), 1, STARTING_VALIDATOR_INDEX);
+    let pubkey = committee.validators[0].public_key;
+    let harness = ValidatorStoreTestHarness::new_with_options(
+        vec![committee],
+        OperatorId(1),
+        HarnessOptions {
+            spec: gloas_at_genesis_spec(),
+            disable_slashing_protection: true,
+            ..Default::default()
+        },
+    );
+    let decided_root = Hash256::from_low_u64_be(0xdec1);
+    harness
+        .validator_store
+        .record_decided_block_root(pubkey, Slot::new(TEST_SLOT), decided_root)
+        .expect("seeding the decided root must succeed");
+    let envelope = self_build_envelope(decided_root);
+
+    let spec = &harness.spec;
+    let epoch = Slot::new(TEST_SLOT).epoch(MainnetEthSpec::slots_per_epoch());
+    let domain_hash = spec.get_domain(
+        epoch,
+        Domain::BeaconBuilder,
+        &spec.fork_at_epoch(epoch),
+        harness.genesis_validators_root,
+    );
+    let expected_root =
+        BlindedExecutionPayloadEnvelope::from_full(&envelope).signing_root(domain_hash);
+
+    harness
+        .validator_store
+        .sign_execution_payload_envelope(pubkey, envelope)
+        .await
+        .expect("the envelope duty must sign successfully");
+
+    let captured = harness.captured_calls.lock();
+    assert_eq!(
+        captured.len(),
+        1,
+        "exactly one signature collection must happen"
+    );
+    assert_eq!(
+        captured[0].signing_root, expected_root,
+        "the signing root must be the blinded envelope root under Domain::BeaconBuilder"
+    );
+    assert_eq!(
+        captured[0].metadata.kind,
+        PartialSignatureKind::PostConsensus,
+        "the partial signature kind must be post-consensus"
+    );
+    assert_eq!(
+        captured[0].metadata.role,
+        Role::EnvelopeProposer,
+        "the collection role must be EnvelopeProposer"
+    );
+}
+
+/// A pre-Gloas slot is rejected before consensus starts and before any signing.
+#[tokio::test(flavor = "multi_thread")]
+async fn pre_gloas_slot_is_rejected_before_consensus() {
+    let committee = create_committee_setup(&test_operator_ids(), 1, STARTING_VALIDATOR_INDEX);
+    let pubkey = committee.validators[0].public_key;
+    let harness = ValidatorStoreTestHarness::new_with_options(
+        vec![committee],
+        OperatorId(1),
+        HarnessOptions {
+            spec: electra_at_genesis_spec(),
+            disable_slashing_protection: true,
+            ..Default::default()
+        },
+    );
+    let envelope = self_build_envelope(Hash256::from_low_u64_be(0xdec1));
+
+    let result = harness
+        .validator_store
+        .sign_execution_payload_envelope(pubkey, envelope)
+        .await;
+
+    assert!(
+        matches!(
+            result,
+            Err(Error::SpecificError(
+                SpecificError::EnvelopeBeforeGloas { .. }
+            ))
+        ),
+        "a pre-Gloas envelope must be rejected with the dedicated error, got {result:?}"
+    );
+    assert!(
+        harness.captured_decides.lock().is_empty(),
+        "no consensus instance may start for a pre-Gloas envelope"
+    );
+    assert!(
+        harness.captured_calls.lock().is_empty(),
+        "no signature collection may happen for a pre-Gloas envelope"
+    );
+}
+
+/// A non-self-build envelope is rejected before consensus starts and before any signing.
+#[tokio::test(flavor = "multi_thread")]
+async fn non_self_build_envelope_is_rejected_before_consensus() {
+    let committee = create_committee_setup(&test_operator_ids(), 1, STARTING_VALIDATOR_INDEX);
+    let pubkey = committee.validators[0].public_key;
+    let harness = ValidatorStoreTestHarness::new_with_options(
+        vec![committee],
+        OperatorId(1),
+        HarnessOptions {
+            spec: gloas_at_genesis_spec(),
+            disable_slashing_protection: true,
+            ..Default::default()
+        },
+    );
+    let mut envelope = self_build_envelope(Hash256::from_low_u64_be(0xdec1));
+    envelope.builder_index = 7;
+
+    let result = harness
+        .validator_store
+        .sign_execution_payload_envelope(pubkey, envelope)
+        .await;
+
+    assert!(
+        matches!(
+            result,
+            Err(Error::SpecificError(SpecificError::EnvelopeNotSelfBuild {
+                builder_index: 7
+            }))
+        ),
+        "a non-self-build envelope must be rejected with the dedicated error, got {result:?}"
+    );
+    assert!(
+        harness.captured_decides.lock().is_empty(),
+        "no consensus instance may start for a non-self-build envelope"
+    );
+    assert!(
+        harness.captured_calls.lock().is_empty(),
+        "no signature collection may happen for a non-self-build envelope"
+    );
+}
+
+/// An envelope without a recorded decided block root is rejected before consensus.
+#[tokio::test(flavor = "multi_thread")]
+async fn missing_decided_root_is_rejected_before_consensus() {
+    let committee = create_committee_setup(&test_operator_ids(), 1, STARTING_VALIDATOR_INDEX);
+    let pubkey = committee.validators[0].public_key;
+    let harness = ValidatorStoreTestHarness::new_with_options(
+        vec![committee],
+        OperatorId(1),
+        HarnessOptions {
+            spec: gloas_at_genesis_spec(),
+            disable_slashing_protection: true,
+            ..Default::default()
+        },
+    );
+    let envelope = self_build_envelope(Hash256::from_low_u64_be(0xdec1));
+
+    let result = harness
+        .validator_store
+        .sign_execution_payload_envelope(pubkey, envelope)
+        .await;
+
+    assert!(
+        matches!(
+            result,
+            Err(Error::SpecificError(
+                SpecificError::DecidedRootUnavailable { .. }
+            ))
+        ),
+        "an envelope without a decided root must be rejected with the dedicated error, got {result:?}"
+    );
+    assert!(
+        harness.captured_decides.lock().is_empty(),
+        "no consensus instance may start without a decided root"
+    );
+    assert!(
+        harness.captured_calls.lock().is_empty(),
+        "no signature collection may happen without a decided root"
+    );
+}
+
+/// A decided envelope that differs from the local one returns the sentinel error, and the
+/// partial signature was still contributed before the gate.
+#[tokio::test(flavor = "multi_thread")]
+async fn decided_envelope_differing_from_local_returns_the_sentinel_after_signing() {
+    let _guard = METRIC_TEST_LOCK.lock().await;
+    let committee = create_committee_setup(&test_operator_ids(), 1, STARTING_VALIDATOR_INDEX);
+    let pubkey = committee.validators[0].public_key;
+    let decided_root = Hash256::from_low_u64_be(0xdec1);
+    let envelope = self_build_envelope(decided_root);
+    let mut other_envelope = envelope.clone();
+    other_envelope.payload.block_number = 1;
+    let forced = envelope_consensus_value(pubkey, &other_envelope);
+    let harness = ValidatorStoreTestHarness::new_with_options(
+        vec![committee],
+        OperatorId(1),
+        HarnessOptions {
+            spec: gloas_at_genesis_spec(),
+            disable_slashing_protection: true,
+            forced_envelope_decision: Some(forced),
+            ..Default::default()
+        },
+    );
+    harness
+        .validator_store
+        .record_decided_block_root(pubkey, Slot::new(TEST_SLOT), decided_root)
+        .expect("seeding the decided root must succeed");
+
+    let result = harness
+        .validator_store
+        .sign_execution_payload_envelope(pubkey, envelope)
+        .await;
+
+    assert!(
+        matches!(
+            result,
+            Err(Error::SpecificError(
+                SpecificError::EnvelopeNotBuiltLocally { .. }
+            ))
+        ),
+        "a decided envelope built elsewhere must return the sentinel error, got {result:?}"
+    );
+    assert_eq!(
+        harness.captured_calls.lock().len(),
+        1,
+        "the partial signature must be contributed before the content gate"
+    );
+}
+
+/// A decided envelope with the same payload root but different metadata still returns the
+/// sentinel.
+#[tokio::test(flavor = "multi_thread")]
+async fn decided_envelope_with_same_payload_root_still_returns_the_sentinel() {
+    let _guard = METRIC_TEST_LOCK.lock().await;
+    let committee = create_committee_setup(&test_operator_ids(), 1, STARTING_VALIDATOR_INDEX);
+    let pubkey = committee.validators[0].public_key;
+    let decided_root = Hash256::from_low_u64_be(0xdec1);
+    let envelope = self_build_envelope(decided_root);
+    let mut other_envelope = envelope.clone();
+    other_envelope.parent_beacon_block_root = Hash256::from_low_u64_be(0x9999);
+    let forced = envelope_consensus_value(pubkey, &other_envelope);
+    let harness = ValidatorStoreTestHarness::new_with_options(
+        vec![committee],
+        OperatorId(1),
+        HarnessOptions {
+            spec: gloas_at_genesis_spec(),
+            disable_slashing_protection: true,
+            forced_envelope_decision: Some(forced),
+            ..Default::default()
+        },
+    );
+    harness
+        .validator_store
+        .record_decided_block_root(pubkey, Slot::new(TEST_SLOT), decided_root)
+        .expect("seeding the decided root must succeed");
+
+    let result = harness
+        .validator_store
+        .sign_execution_payload_envelope(pubkey, envelope)
+        .await;
+
+    assert!(
+        matches!(
+            result,
+            Err(Error::SpecificError(
+                SpecificError::EnvelopeNotBuiltLocally { .. }
+            ))
+        ),
+        "the gate must compare the full blinded value, not just the payload root, got {result:?}"
+    );
+    assert_eq!(
+        harness.captured_calls.lock().len(),
+        1,
+        "the partial signature must be contributed before the content gate"
+    );
+}
+
+/// The envelope path succeeds with slashing protection enabled and writes no block-proposal
+/// record at the duty slot: a first-time probe insertion afterwards is still accepted as safe.
+#[tokio::test(flavor = "multi_thread")]
+async fn envelope_signing_does_not_touch_the_slashing_db() {
+    let _guard = METRIC_TEST_LOCK.lock().await;
+    let committee = create_committee_setup(&test_operator_ids(), 1, STARTING_VALIDATOR_INDEX);
+    let pubkey = committee.validators[0].public_key;
+    let harness = ValidatorStoreTestHarness::new_with_options(
+        vec![committee],
+        OperatorId(1),
+        HarnessOptions {
+            spec: gloas_at_genesis_spec(),
+            disable_slashing_protection: false,
+            ..Default::default()
+        },
+    );
+    let decided_root = Hash256::from_low_u64_be(0xdec1);
+    harness
+        .validator_store
+        .record_decided_block_root(pubkey, Slot::new(TEST_SLOT), decided_root)
+        .expect("seeding the decided root must succeed");
+    let envelope = self_build_envelope(decided_root);
+
+    let signed = harness
+        .validator_store
+        .sign_execution_payload_envelope(pubkey, envelope.clone())
+        .await
+        .expect("the envelope duty must succeed despite slashing protection being enabled");
+
+    assert_eq!(
+        signed.message, envelope,
+        "the returned message must be the input envelope unchanged"
+    );
+    // Any record left by the envelope path would surface here as `SameData` or a
+    // double-proposal error instead of `Valid`.
+    let first_time_probe = harness
+        .slashing_protection
+        .check_and_insert_block_signing_root(
+            &pubkey,
+            Slot::new(TEST_SLOT),
+            Hash256::repeat_byte(0xEE).into(),
+        );
+    assert!(
+        matches!(first_time_probe, Ok(Safe::Valid)),
+        "no block-proposal record may exist at the duty slot after envelope signing, got {first_time_probe:?}"
+    );
+}
+
+/// A published outcome increments only the `published` label.
+#[tokio::test(flavor = "multi_thread")]
+async fn published_outcome_increments_only_the_published_label() {
+    let _guard = METRIC_TEST_LOCK.lock().await;
+    let committee = create_committee_setup(&test_operator_ids(), 1, STARTING_VALIDATOR_INDEX);
+    let pubkey = committee.validators[0].public_key;
+    let harness = ValidatorStoreTestHarness::new_with_options(
+        vec![committee],
+        OperatorId(1),
+        HarnessOptions {
+            spec: gloas_at_genesis_spec(),
+            disable_slashing_protection: true,
+            ..Default::default()
+        },
+    );
+    let decided_root = Hash256::from_low_u64_be(0xdec1);
+    harness
+        .validator_store
+        .record_decided_block_root(pubkey, Slot::new(TEST_SLOT), decided_root)
+        .expect("seeding the decided root must succeed");
+    let envelope = self_build_envelope(decided_root);
+    let (published, not_built_locally, failed) = envelope_outcome_counters();
+    let published_before = published.get();
+    let not_built_locally_before = not_built_locally.get();
+    let failed_before = failed.get();
+
+    harness
+        .validator_store
+        .sign_execution_payload_envelope(pubkey, envelope)
+        .await
+        .expect("the happy-path envelope duty must sign successfully");
+
+    assert_eq!(
+        published.get() - published_before,
+        1,
+        "a published envelope must increment the published label once"
+    );
+    assert_eq!(
+        not_built_locally.get() - not_built_locally_before,
+        0,
+        "a published envelope must not touch the not_built_locally label"
+    );
+    assert_eq!(
+        failed.get() - failed_before,
+        0,
+        "a published envelope must not touch the failed label"
+    );
+}
+
+/// The sentinel outcome increments `not_built_locally` and never `failed`.
+#[tokio::test(flavor = "multi_thread")]
+async fn sentinel_outcome_increments_not_built_locally_and_never_failed() {
+    let _guard = METRIC_TEST_LOCK.lock().await;
+    let committee = create_committee_setup(&test_operator_ids(), 1, STARTING_VALIDATOR_INDEX);
+    let pubkey = committee.validators[0].public_key;
+    let decided_root = Hash256::from_low_u64_be(0xdec1);
+    let envelope = self_build_envelope(decided_root);
+    let mut other_envelope = envelope.clone();
+    other_envelope.payload.block_number = 1;
+    let forced = envelope_consensus_value(pubkey, &other_envelope);
+    let harness = ValidatorStoreTestHarness::new_with_options(
+        vec![committee],
+        OperatorId(1),
+        HarnessOptions {
+            spec: gloas_at_genesis_spec(),
+            disable_slashing_protection: true,
+            forced_envelope_decision: Some(forced),
+            ..Default::default()
+        },
+    );
+    harness
+        .validator_store
+        .record_decided_block_root(pubkey, Slot::new(TEST_SLOT), decided_root)
+        .expect("seeding the decided root must succeed");
+    let (_, not_built_locally, failed) = envelope_outcome_counters();
+    let not_built_locally_before = not_built_locally.get();
+    let failed_before = failed.get();
+
+    let result = harness
+        .validator_store
+        .sign_execution_payload_envelope(pubkey, envelope)
+        .await;
+
+    assert!(
+        result.is_err(),
+        "a decided envelope built elsewhere must not return a publishable envelope"
+    );
+    assert_eq!(
+        not_built_locally.get() - not_built_locally_before,
+        1,
+        "the sentinel outcome must increment the not_built_locally label once"
+    );
+    assert_eq!(
+        failed.get() - failed_before,
+        0,
+        "the sentinel outcome must never count as a failure"
+    );
+}
+
+/// A signature-collection failure increments the `failed` label.
+#[tokio::test(flavor = "multi_thread")]
+async fn collection_failure_increments_the_failed_label() {
+    let _guard = METRIC_TEST_LOCK.lock().await;
+    let committee = create_committee_setup(&test_operator_ids(), 1, STARTING_VALIDATOR_INDEX);
+    let pubkey = committee.validators[0].public_key;
+    let harness = ValidatorStoreTestHarness::new_with_options(
+        vec![committee],
+        OperatorId(1),
+        HarnessOptions {
+            spec: gloas_at_genesis_spec(),
+            disable_slashing_protection: true,
+            collector_failure: Some(CollectionError::EmptySignature),
+            ..Default::default()
+        },
+    );
+    let decided_root = Hash256::from_low_u64_be(0xdec1);
+    harness
+        .validator_store
+        .record_decided_block_root(pubkey, Slot::new(TEST_SLOT), decided_root)
+        .expect("seeding the decided root must succeed");
+    let envelope = self_build_envelope(decided_root);
+    let (published, not_built_locally, failed) = envelope_outcome_counters();
+    let published_before = published.get();
+    let not_built_locally_before = not_built_locally.get();
+    let failed_before = failed.get();
+
+    let result = harness
+        .validator_store
+        .sign_execution_payload_envelope(pubkey, envelope)
+        .await;
+
+    assert!(
+        matches!(
+            result,
+            Err(Error::SpecificError(
+                SpecificError::SignatureCollectionFailed(CollectionError::EmptySignature)
+            ))
+        ),
+        "a collection failure must surface as SignatureCollectionFailed, got {result:?}"
+    );
+    assert_eq!(
+        failed.get() - failed_before,
+        1,
+        "a collection failure must increment the failed label once"
+    );
+    assert_eq!(
+        published.get() - published_before,
+        0,
+        "a collection failure must not touch the published label"
+    );
+    assert_eq!(
+        not_built_locally.get() - not_built_locally_before,
+        0,
+        "a collection failure must not touch the not_built_locally label"
+    );
+}
+
+/// End to end: `sign_block` records the decided root, then a matching envelope signs.
+#[tokio::test(flavor = "multi_thread")]
+async fn sign_block_then_matching_envelope_succeeds() {
+    let _guard = METRIC_TEST_LOCK.lock().await;
+    let committee = create_committee_setup(&test_operator_ids(), 1, STARTING_VALIDATOR_INDEX);
+    let pubkey = committee.validators[0].public_key;
+    let harness = ValidatorStoreTestHarness::new_with_options(
+        vec![committee],
+        OperatorId(1),
+        HarnessOptions {
+            spec: gloas_at_genesis_spec(),
+            disable_slashing_protection: true,
+            ..Default::default()
+        },
+    );
+    // `EmptyBlock::empty` fixes the slot to `spec.genesis_slot`, so the slot is set on the
+    // inner struct before wrapping.
+    let mut gloas_block = BeaconBlockGloas::<MainnetEthSpec>::empty(&harness.spec);
+    gloas_block.slot = Slot::new(TEST_SLOT);
+    let block = BeaconBlock::Gloas(gloas_block);
+    let envelope = self_build_envelope(block.canonical_root());
+
+    harness
+        .validator_store
+        .sign_block(
+            pubkey,
+            UnsignedBlock::Full(FullBlockContents::Block(block)),
+            Slot::new(TEST_SLOT),
+        )
+        .await
+        .expect("the Gloas block duty must sign successfully");
+    let signed = harness
+        .validator_store
+        .sign_execution_payload_envelope(pubkey, envelope.clone())
+        .await
+        .expect("an envelope matching the block-recorded root must sign successfully");
+
+    assert_eq!(
+        signed.message, envelope,
+        "the returned message must be the input envelope unchanged"
     );
 }

--- a/anchor/validator_store/src/testing/envelope_signing.rs
+++ b/anchor/validator_store/src/testing/envelope_signing.rs
@@ -5,7 +5,7 @@ use std::sync::LazyLock;
 use bls::{FixedBytesExtended, PublicKeyBytes};
 use eth2::types::FullBlockContents;
 use qbft::Completed;
-use qbft_manager::{ConsensusDecider, EnvelopeProposerInstanceId, TimeoutMode};
+use qbft_manager::{ConsensusDecider, EnvelopeProposerInstanceId, QbftError, TimeoutMode};
 use signature_collector::CollectionError;
 use slashing_protection::Safe;
 use ssv_types::{
@@ -22,8 +22,8 @@ use ssz_types::VariableList;
 use tokio::time::Instant;
 use types::{
     BeaconBlock, BeaconBlockGloas, Domain, EmptyBlock, EthSpec, ExecutionPayloadEnvelope,
-    ExecutionPayloadGloas, ExecutionRequestsGloas, ForkName, Hash256, MainnetEthSpec, SignedRoot,
-    Slot, consts::gloas::BUILDER_INDEX_SELF_BUILD,
+    ExecutionPayloadGloas, ExecutionRequestsGloas, ForkName, Hash256, MainnetEthSpec,
+    SignedExecutionPayloadEnvelope, SignedRoot, Slot, consts::gloas::BUILDER_INDEX_SELF_BUILD,
 };
 use validator_store::{UnsignedBlock, ValidatorStore};
 
@@ -39,8 +39,15 @@ const STARTING_VALIDATOR_INDEX: usize = 5;
 static METRIC_TEST_LOCK: LazyLock<tokio::sync::Mutex<()>> =
     LazyLock::new(|| tokio::sync::Mutex::new(()));
 
+// ==================== Fixtures and helpers ====================
+
 fn test_operator_ids() -> [OperatorId; 4] {
     [OperatorId(1), OperatorId(2), OperatorId(3), OperatorId(4)]
+}
+
+/// The block root envelope tests bind envelopes to; `seed_decided_root` records this value.
+fn test_decided_root() -> Hash256 {
+    Hash256::from_low_u64_be(0xdec1)
 }
 
 /// Builds a Gloas self-build envelope at `TEST_SLOT` bound to `beacon_block_root`.
@@ -81,21 +88,141 @@ fn envelope_consensus_value(
     }
 }
 
-/// The `(published, not_built_locally, failed)` outcome counters the metric tests assert
-/// deltas on; each test takes its own before-reads under `METRIC_TEST_LOCK`.
-fn envelope_outcome_counters() -> (
-    crate::metrics::IntCounter,
-    crate::metrics::IntCounter,
-    crate::metrics::IntCounter,
+/// A single-validator committee over `test_operator_ids()` and its validator's public key.
+fn single_validator_committee() -> (CommitteeSetup, PublicKeyBytes) {
+    let committee = create_committee_setup(&test_operator_ids(), 1, STARTING_VALIDATOR_INDEX);
+    let pubkey = committee.validators[0].public_key;
+    (committee, pubkey)
+}
+
+/// Default envelope-test options: Gloas at genesis, slashing protection disabled.
+fn gloas_options() -> HarnessOptions {
+    HarnessOptions {
+        spec: gloas_at_genesis_spec(),
+        disable_slashing_protection: true,
+        ..Default::default()
+    }
+}
+
+/// Builds a single-validator harness owned by `OperatorId(1)` with the given options.
+fn harness_with_options(options: HarnessOptions) -> (ValidatorStoreTestHarness, PublicKeyBytes) {
+    let (committee, pubkey) = single_validator_committee();
+    let harness =
+        ValidatorStoreTestHarness::new_with_options(vec![committee], OperatorId(1), options);
+    (harness, pubkey)
+}
+
+/// Builds the default Gloas harness most envelope tests use.
+fn gloas_harness() -> (ValidatorStoreTestHarness, PublicKeyBytes) {
+    harness_with_options(gloas_options())
+}
+
+/// Drives the envelope duty under test against the store.
+async fn sign_envelope(
+    harness: &ValidatorStoreTestHarness,
+    pubkey: PublicKeyBytes,
+    envelope: ExecutionPayloadEnvelope<MainnetEthSpec>,
+) -> Result<SignedExecutionPayloadEnvelope<MainnetEthSpec>, Error> {
+    harness
+        .validator_store
+        .sign_execution_payload_envelope(pubkey, envelope)
+        .await
+}
+
+/// Records `test_decided_root()` for the validator at `TEST_SLOT` and returns it.
+fn seed_decided_root(harness: &ValidatorStoreTestHarness, pubkey: PublicKeyBytes) -> Hash256 {
+    let decided_root = test_decided_root();
+    harness
+        .validator_store
+        .record_decided_block_root(pubkey, Slot::new(TEST_SLOT), decided_root)
+        .expect("seeding the decided root must succeed");
+    decided_root
+}
+
+/// Builds a Gloas harness whose mock decides a mutated copy of the local envelope, with the
+/// decided root already seeded. Returns the harness, the pubkey, and the local envelope.
+fn forced_decision_harness(
+    mutate_decided: impl FnOnce(&mut ExecutionPayloadEnvelope<MainnetEthSpec>),
+) -> (
+    ValidatorStoreTestHarness,
+    PublicKeyBytes,
+    ExecutionPayloadEnvelope<MainnetEthSpec>,
 ) {
-    let metric = crate::metrics::ENVELOPE_SIGNING_OUTCOMES
-        .as_ref()
-        .expect("metric should be created");
-    (
-        metric.with_label_values(&[crate::metrics::ENVELOPE_OUTCOME_PUBLISHED]),
-        metric.with_label_values(&[crate::metrics::ENVELOPE_OUTCOME_NOT_BUILT_LOCALLY]),
-        metric.with_label_values(&[crate::metrics::ENVELOPE_OUTCOME_FAILED]),
-    )
+    let (committee, pubkey) = single_validator_committee();
+    let envelope = self_build_envelope(test_decided_root());
+    let mut decided_envelope = envelope.clone();
+    mutate_decided(&mut decided_envelope);
+    let harness = ValidatorStoreTestHarness::new_with_options(
+        vec![committee],
+        OperatorId(1),
+        HarnessOptions {
+            forced_envelope_decision: Some(envelope_consensus_value(pubkey, &decided_envelope)),
+            ..gloas_options()
+        },
+    );
+    seed_decided_root(&harness, pubkey);
+    (harness, pubkey, envelope)
+}
+
+/// Before-values of the three envelope outcome labels, taken under `METRIC_TEST_LOCK`.
+struct OutcomeCounters {
+    published: crate::metrics::IntCounter,
+    not_built_locally: crate::metrics::IntCounter,
+    failed: crate::metrics::IntCounter,
+    published_before: u64,
+    not_built_locally_before: u64,
+    failed_before: u64,
+}
+
+impl OutcomeCounters {
+    fn snapshot() -> Self {
+        let metric = crate::metrics::ENVELOPE_SIGNING_OUTCOMES
+            .as_ref()
+            .expect("metric should be created");
+        let published = metric.with_label_values(&[crate::metrics::ENVELOPE_OUTCOME_PUBLISHED]);
+        let not_built_locally =
+            metric.with_label_values(&[crate::metrics::ENVELOPE_OUTCOME_NOT_BUILT_LOCALLY]);
+        let failed = metric.with_label_values(&[crate::metrics::ENVELOPE_OUTCOME_FAILED]);
+        Self {
+            published_before: published.get(),
+            not_built_locally_before: not_built_locally.get(),
+            failed_before: failed.get(),
+            published,
+            not_built_locally,
+            failed,
+        }
+    }
+
+    /// Asserts the delta of every outcome label since the snapshot.
+    fn assert_deltas(&self, published: u64, not_built_locally: u64, failed: u64) {
+        assert_eq!(
+            self.published.get() - self.published_before,
+            published,
+            "unexpected delta on the published outcome label"
+        );
+        assert_eq!(
+            self.not_built_locally.get() - self.not_built_locally_before,
+            not_built_locally,
+            "unexpected delta on the not_built_locally outcome label"
+        );
+        assert_eq!(
+            self.failed.get() - self.failed_before,
+            failed,
+            "unexpected delta on the failed outcome label"
+        );
+    }
+}
+
+/// Asserts that the duty rejected before consensus: no decide call and no signature collection.
+fn assert_rejected_before_consensus(harness: &ValidatorStoreTestHarness, context: &str) {
+    assert!(
+        harness.captured_decides.lock().is_empty(),
+        "no consensus instance may start {context}"
+    );
+    assert!(
+        harness.captured_calls.lock().is_empty(),
+        "no signature collection may happen {context}"
+    );
 }
 
 /// Drives one envelope decide call against the mock and unwraps the decided value.
@@ -129,6 +256,8 @@ async fn decide_envelope_seed(
         Completed::TimedOut => panic!("the mock decider must not time out"),
     }
 }
+
+// ==================== Mock and factory tests ====================
 
 /// A forced envelope decision replaces the echo for envelope seeds.
 #[tokio::test(flavor = "multi_thread")]
@@ -191,18 +320,8 @@ async fn mock_captures_envelope_decide_calls() {
 /// The factory passes pubkey, index, slot, and decided root into the value check.
 #[tokio::test(flavor = "multi_thread")]
 async fn factory_wires_duty_metadata_into_the_value_check() {
-    let committee = create_committee_setup(&test_operator_ids(), 1, STARTING_VALIDATOR_INDEX);
-    let pubkey = committee.validators[0].public_key;
-    let harness = ValidatorStoreTestHarness::new_with_options(
-        vec![committee],
-        OperatorId(1),
-        HarnessOptions {
-            spec: gloas_at_genesis_spec(),
-            disable_slashing_protection: true,
-            ..Default::default()
-        },
-    );
-    let envelope = self_build_envelope(Hash256::from_low_u64_be(0xdec1));
+    let (harness, pubkey) = gloas_harness();
+    let envelope = self_build_envelope(test_decided_root());
     let value = envelope_consensus_value(pubkey, &envelope);
 
     let validator = harness
@@ -227,31 +346,16 @@ async fn factory_wires_duty_metadata_into_the_value_check() {
     );
 }
 
+// ==================== Signing path tests ====================
+
 /// A Gloas self-build envelope signs and returns the original message unchanged.
 #[tokio::test(flavor = "multi_thread")]
 async fn gloas_self_build_envelope_signs_and_returns_the_original_message() {
     let _guard = METRIC_TEST_LOCK.lock().await;
-    let committee = create_committee_setup(&test_operator_ids(), 1, STARTING_VALIDATOR_INDEX);
-    let pubkey = committee.validators[0].public_key;
-    let harness = ValidatorStoreTestHarness::new_with_options(
-        vec![committee],
-        OperatorId(1),
-        HarnessOptions {
-            spec: gloas_at_genesis_spec(),
-            disable_slashing_protection: true,
-            ..Default::default()
-        },
-    );
-    let decided_root = Hash256::from_low_u64_be(0xdec1);
-    harness
-        .validator_store
-        .record_decided_block_root(pubkey, Slot::new(TEST_SLOT), decided_root)
-        .expect("seeding the decided root must succeed");
-    let envelope = self_build_envelope(decided_root);
+    let (harness, pubkey) = gloas_harness();
+    let envelope = self_build_envelope(seed_decided_root(&harness, pubkey));
 
-    let signed = harness
-        .validator_store
-        .sign_execution_payload_envelope(pubkey, envelope.clone())
+    let signed = sign_envelope(&harness, pubkey, envelope.clone())
         .await
         .expect("a matched Gloas self-build envelope must sign successfully");
 
@@ -266,23 +370,8 @@ async fn gloas_self_build_envelope_signs_and_returns_the_original_message() {
 #[tokio::test(flavor = "multi_thread")]
 async fn signing_root_is_the_blinded_envelope_root_under_beacon_builder_domain() {
     let _guard = METRIC_TEST_LOCK.lock().await;
-    let committee = create_committee_setup(&test_operator_ids(), 1, STARTING_VALIDATOR_INDEX);
-    let pubkey = committee.validators[0].public_key;
-    let harness = ValidatorStoreTestHarness::new_with_options(
-        vec![committee],
-        OperatorId(1),
-        HarnessOptions {
-            spec: gloas_at_genesis_spec(),
-            disable_slashing_protection: true,
-            ..Default::default()
-        },
-    );
-    let decided_root = Hash256::from_low_u64_be(0xdec1);
-    harness
-        .validator_store
-        .record_decided_block_root(pubkey, Slot::new(TEST_SLOT), decided_root)
-        .expect("seeding the decided root must succeed");
-    let envelope = self_build_envelope(decided_root);
+    let (harness, pubkey) = gloas_harness();
+    let envelope = self_build_envelope(seed_decided_root(&harness, pubkey));
 
     let spec = &harness.spec;
     let epoch = Slot::new(TEST_SLOT).epoch(MainnetEthSpec::slots_per_epoch());
@@ -295,9 +384,7 @@ async fn signing_root_is_the_blinded_envelope_root_under_beacon_builder_domain()
     let expected_root =
         BlindedExecutionPayloadEnvelope::from_full(&envelope).signing_root(domain_hash);
 
-    harness
-        .validator_store
-        .sign_execution_payload_envelope(pubkey, envelope)
+    sign_envelope(&harness, pubkey, envelope)
         .await
         .expect("the envelope duty must sign successfully");
 
@@ -323,249 +410,18 @@ async fn signing_root_is_the_blinded_envelope_root_under_beacon_builder_domain()
     );
 }
 
-/// A pre-Gloas slot is rejected before consensus starts and before any signing.
-#[tokio::test(flavor = "multi_thread")]
-async fn pre_gloas_slot_is_rejected_before_consensus() {
-    let committee = create_committee_setup(&test_operator_ids(), 1, STARTING_VALIDATOR_INDEX);
-    let pubkey = committee.validators[0].public_key;
-    let harness = ValidatorStoreTestHarness::new_with_options(
-        vec![committee],
-        OperatorId(1),
-        HarnessOptions {
-            spec: electra_at_genesis_spec(),
-            disable_slashing_protection: true,
-            ..Default::default()
-        },
-    );
-    let envelope = self_build_envelope(Hash256::from_low_u64_be(0xdec1));
-
-    let result = harness
-        .validator_store
-        .sign_execution_payload_envelope(pubkey, envelope)
-        .await;
-
-    assert!(
-        matches!(
-            result,
-            Err(Error::SpecificError(
-                SpecificError::EnvelopeBeforeGloas { .. }
-            ))
-        ),
-        "a pre-Gloas envelope must be rejected with the dedicated error, got {result:?}"
-    );
-    assert!(
-        harness.captured_decides.lock().is_empty(),
-        "no consensus instance may start for a pre-Gloas envelope"
-    );
-    assert!(
-        harness.captured_calls.lock().is_empty(),
-        "no signature collection may happen for a pre-Gloas envelope"
-    );
-}
-
-/// A non-self-build envelope is rejected before consensus starts and before any signing.
-#[tokio::test(flavor = "multi_thread")]
-async fn non_self_build_envelope_is_rejected_before_consensus() {
-    let committee = create_committee_setup(&test_operator_ids(), 1, STARTING_VALIDATOR_INDEX);
-    let pubkey = committee.validators[0].public_key;
-    let harness = ValidatorStoreTestHarness::new_with_options(
-        vec![committee],
-        OperatorId(1),
-        HarnessOptions {
-            spec: gloas_at_genesis_spec(),
-            disable_slashing_protection: true,
-            ..Default::default()
-        },
-    );
-    let mut envelope = self_build_envelope(Hash256::from_low_u64_be(0xdec1));
-    envelope.builder_index = 7;
-
-    let result = harness
-        .validator_store
-        .sign_execution_payload_envelope(pubkey, envelope)
-        .await;
-
-    assert!(
-        matches!(
-            result,
-            Err(Error::SpecificError(SpecificError::EnvelopeNotSelfBuild {
-                builder_index: 7
-            }))
-        ),
-        "a non-self-build envelope must be rejected with the dedicated error, got {result:?}"
-    );
-    assert!(
-        harness.captured_decides.lock().is_empty(),
-        "no consensus instance may start for a non-self-build envelope"
-    );
-    assert!(
-        harness.captured_calls.lock().is_empty(),
-        "no signature collection may happen for a non-self-build envelope"
-    );
-}
-
-/// An envelope without a recorded decided block root is rejected before consensus.
-#[tokio::test(flavor = "multi_thread")]
-async fn missing_decided_root_is_rejected_before_consensus() {
-    let committee = create_committee_setup(&test_operator_ids(), 1, STARTING_VALIDATOR_INDEX);
-    let pubkey = committee.validators[0].public_key;
-    let harness = ValidatorStoreTestHarness::new_with_options(
-        vec![committee],
-        OperatorId(1),
-        HarnessOptions {
-            spec: gloas_at_genesis_spec(),
-            disable_slashing_protection: true,
-            ..Default::default()
-        },
-    );
-    let envelope = self_build_envelope(Hash256::from_low_u64_be(0xdec1));
-
-    let result = harness
-        .validator_store
-        .sign_execution_payload_envelope(pubkey, envelope)
-        .await;
-
-    assert!(
-        matches!(
-            result,
-            Err(Error::SpecificError(
-                SpecificError::DecidedRootUnavailable { .. }
-            ))
-        ),
-        "an envelope without a decided root must be rejected with the dedicated error, got {result:?}"
-    );
-    assert!(
-        harness.captured_decides.lock().is_empty(),
-        "no consensus instance may start without a decided root"
-    );
-    assert!(
-        harness.captured_calls.lock().is_empty(),
-        "no signature collection may happen without a decided root"
-    );
-}
-
-/// A decided envelope that differs from the local one returns the sentinel error, and the
-/// partial signature was still contributed before the gate.
-#[tokio::test(flavor = "multi_thread")]
-async fn decided_envelope_differing_from_local_returns_the_sentinel_after_signing() {
-    let _guard = METRIC_TEST_LOCK.lock().await;
-    let committee = create_committee_setup(&test_operator_ids(), 1, STARTING_VALIDATOR_INDEX);
-    let pubkey = committee.validators[0].public_key;
-    let decided_root = Hash256::from_low_u64_be(0xdec1);
-    let envelope = self_build_envelope(decided_root);
-    let mut other_envelope = envelope.clone();
-    other_envelope.payload.block_number = 1;
-    let forced = envelope_consensus_value(pubkey, &other_envelope);
-    let harness = ValidatorStoreTestHarness::new_with_options(
-        vec![committee],
-        OperatorId(1),
-        HarnessOptions {
-            spec: gloas_at_genesis_spec(),
-            disable_slashing_protection: true,
-            forced_envelope_decision: Some(forced),
-            ..Default::default()
-        },
-    );
-    harness
-        .validator_store
-        .record_decided_block_root(pubkey, Slot::new(TEST_SLOT), decided_root)
-        .expect("seeding the decided root must succeed");
-
-    let result = harness
-        .validator_store
-        .sign_execution_payload_envelope(pubkey, envelope)
-        .await;
-
-    assert!(
-        matches!(
-            result,
-            Err(Error::SpecificError(
-                SpecificError::EnvelopeNotBuiltLocally { .. }
-            ))
-        ),
-        "a decided envelope built elsewhere must return the sentinel error, got {result:?}"
-    );
-    assert_eq!(
-        harness.captured_calls.lock().len(),
-        1,
-        "the partial signature must be contributed before the content gate"
-    );
-}
-
-/// A decided envelope with the same payload root but different metadata still returns the
-/// sentinel.
-#[tokio::test(flavor = "multi_thread")]
-async fn decided_envelope_with_same_payload_root_still_returns_the_sentinel() {
-    let _guard = METRIC_TEST_LOCK.lock().await;
-    let committee = create_committee_setup(&test_operator_ids(), 1, STARTING_VALIDATOR_INDEX);
-    let pubkey = committee.validators[0].public_key;
-    let decided_root = Hash256::from_low_u64_be(0xdec1);
-    let envelope = self_build_envelope(decided_root);
-    let mut other_envelope = envelope.clone();
-    other_envelope.parent_beacon_block_root = Hash256::from_low_u64_be(0x9999);
-    let forced = envelope_consensus_value(pubkey, &other_envelope);
-    let harness = ValidatorStoreTestHarness::new_with_options(
-        vec![committee],
-        OperatorId(1),
-        HarnessOptions {
-            spec: gloas_at_genesis_spec(),
-            disable_slashing_protection: true,
-            forced_envelope_decision: Some(forced),
-            ..Default::default()
-        },
-    );
-    harness
-        .validator_store
-        .record_decided_block_root(pubkey, Slot::new(TEST_SLOT), decided_root)
-        .expect("seeding the decided root must succeed");
-
-    let result = harness
-        .validator_store
-        .sign_execution_payload_envelope(pubkey, envelope)
-        .await;
-
-    assert!(
-        matches!(
-            result,
-            Err(Error::SpecificError(
-                SpecificError::EnvelopeNotBuiltLocally { .. }
-            ))
-        ),
-        "the gate must compare the full blinded value, not just the payload root, got {result:?}"
-    );
-    assert_eq!(
-        harness.captured_calls.lock().len(),
-        1,
-        "the partial signature must be contributed before the content gate"
-    );
-}
-
 /// The envelope path succeeds with slashing protection enabled and writes no block-proposal
 /// record at the duty slot: a first-time probe insertion afterwards is still accepted as safe.
 #[tokio::test(flavor = "multi_thread")]
 async fn envelope_signing_does_not_touch_the_slashing_db() {
     let _guard = METRIC_TEST_LOCK.lock().await;
-    let committee = create_committee_setup(&test_operator_ids(), 1, STARTING_VALIDATOR_INDEX);
-    let pubkey = committee.validators[0].public_key;
-    let harness = ValidatorStoreTestHarness::new_with_options(
-        vec![committee],
-        OperatorId(1),
-        HarnessOptions {
-            spec: gloas_at_genesis_spec(),
-            disable_slashing_protection: false,
-            ..Default::default()
-        },
-    );
-    let decided_root = Hash256::from_low_u64_be(0xdec1);
-    harness
-        .validator_store
-        .record_decided_block_root(pubkey, Slot::new(TEST_SLOT), decided_root)
-        .expect("seeding the decided root must succeed");
-    let envelope = self_build_envelope(decided_root);
+    let (harness, pubkey) = harness_with_options(HarnessOptions {
+        disable_slashing_protection: false,
+        ..gloas_options()
+    });
+    let envelope = self_build_envelope(seed_decided_root(&harness, pubkey));
 
-    let signed = harness
-        .validator_store
-        .sign_execution_payload_envelope(pubkey, envelope.clone())
+    let signed = sign_envelope(&harness, pubkey, envelope.clone())
         .await
         .expect("the envelope duty must succeed despite slashing protection being enabled");
 
@@ -588,136 +444,189 @@ async fn envelope_signing_does_not_touch_the_slashing_db() {
     );
 }
 
+// ==================== Gate tests ====================
+
+/// A pre-Gloas slot is rejected before consensus starts and before any signing.
+#[tokio::test(flavor = "multi_thread")]
+async fn pre_gloas_slot_is_rejected_before_consensus() {
+    let (harness, pubkey) = harness_with_options(HarnessOptions {
+        spec: electra_at_genesis_spec(),
+        ..Default::default()
+    });
+    let envelope = self_build_envelope(test_decided_root());
+
+    let result = sign_envelope(&harness, pubkey, envelope).await;
+
+    assert!(
+        matches!(
+            result,
+            Err(Error::SpecificError(
+                SpecificError::EnvelopeBeforeGloas { .. }
+            ))
+        ),
+        "a pre-Gloas envelope must be rejected with the dedicated error, got {result:?}"
+    );
+    assert_rejected_before_consensus(&harness, "for a pre-Gloas envelope");
+}
+
+/// A non-self-build envelope is rejected before consensus starts and before any signing.
+#[tokio::test(flavor = "multi_thread")]
+async fn non_self_build_envelope_is_rejected_before_consensus() {
+    let (harness, pubkey) = gloas_harness();
+    let mut envelope = self_build_envelope(test_decided_root());
+    envelope.builder_index = 7;
+
+    let result = sign_envelope(&harness, pubkey, envelope).await;
+
+    assert!(
+        matches!(
+            result,
+            Err(Error::SpecificError(SpecificError::EnvelopeNotSelfBuild {
+                builder_index: 7
+            }))
+        ),
+        "a non-self-build envelope must be rejected with the dedicated error, got {result:?}"
+    );
+    assert_rejected_before_consensus(&harness, "for a non-self-build envelope");
+}
+
+/// A future-slot envelope is rejected before consensus starts and before any signing.
+#[tokio::test(flavor = "multi_thread")]
+async fn future_slot_envelope_is_rejected_before_consensus() {
+    let (harness, pubkey) = gloas_harness();
+    let mut envelope = self_build_envelope(test_decided_root());
+    envelope.payload.slot_number = Slot::new(TEST_SLOT + 1);
+
+    let result = sign_envelope(&harness, pubkey, envelope).await;
+
+    assert!(
+        matches!(result, Err(Error::GreaterThanCurrentSlot { .. })),
+        "a future-slot envelope must be rejected with the dedicated error, got {result:?}"
+    );
+    assert_rejected_before_consensus(&harness, "for a future-slot envelope");
+}
+
+/// An envelope without a recorded decided block root is rejected before consensus.
+#[tokio::test(flavor = "multi_thread")]
+async fn missing_decided_root_is_rejected_before_consensus() {
+    let (harness, pubkey) = gloas_harness();
+    let envelope = self_build_envelope(test_decided_root());
+
+    let result = sign_envelope(&harness, pubkey, envelope).await;
+
+    assert!(
+        matches!(
+            result,
+            Err(Error::SpecificError(
+                SpecificError::DecidedRootUnavailable { .. }
+            ))
+        ),
+        "an envelope without a decided root must be rejected with the dedicated error, got {result:?}"
+    );
+    assert_rejected_before_consensus(&harness, "without a decided root");
+}
+
+// ==================== Content gate tests ====================
+
+/// A decided envelope that differs from the local one returns the sentinel error, and the
+/// partial signature was still contributed before the gate.
+#[tokio::test(flavor = "multi_thread")]
+async fn decided_envelope_differing_from_local_returns_the_sentinel_after_signing() {
+    let _guard = METRIC_TEST_LOCK.lock().await;
+    let (harness, pubkey, envelope) =
+        forced_decision_harness(|decided| decided.payload.block_number = 1);
+
+    let result = sign_envelope(&harness, pubkey, envelope).await;
+
+    assert!(
+        matches!(
+            result,
+            Err(Error::SpecificError(
+                SpecificError::EnvelopeNotBuiltLocally { .. }
+            ))
+        ),
+        "a decided envelope built elsewhere must return the sentinel error, got {result:?}"
+    );
+    assert_eq!(
+        harness.captured_calls.lock().len(),
+        1,
+        "the partial signature must be contributed before the content gate"
+    );
+}
+
+/// A decided envelope with the same payload root but different metadata still returns the
+/// sentinel.
+#[tokio::test(flavor = "multi_thread")]
+async fn decided_envelope_with_same_payload_root_still_returns_the_sentinel() {
+    let _guard = METRIC_TEST_LOCK.lock().await;
+    let (harness, pubkey, envelope) = forced_decision_harness(|decided| {
+        decided.parent_beacon_block_root = Hash256::from_low_u64_be(0x9999)
+    });
+
+    let result = sign_envelope(&harness, pubkey, envelope).await;
+
+    assert!(
+        matches!(
+            result,
+            Err(Error::SpecificError(
+                SpecificError::EnvelopeNotBuiltLocally { .. }
+            ))
+        ),
+        "the gate must compare the full blinded value, not just the payload root, got {result:?}"
+    );
+    assert_eq!(
+        harness.captured_calls.lock().len(),
+        1,
+        "the partial signature must be contributed before the content gate"
+    );
+}
+
+// ==================== Outcome metric tests ====================
+
 /// A published outcome increments only the `published` label.
 #[tokio::test(flavor = "multi_thread")]
 async fn published_outcome_increments_only_the_published_label() {
     let _guard = METRIC_TEST_LOCK.lock().await;
-    let committee = create_committee_setup(&test_operator_ids(), 1, STARTING_VALIDATOR_INDEX);
-    let pubkey = committee.validators[0].public_key;
-    let harness = ValidatorStoreTestHarness::new_with_options(
-        vec![committee],
-        OperatorId(1),
-        HarnessOptions {
-            spec: gloas_at_genesis_spec(),
-            disable_slashing_protection: true,
-            ..Default::default()
-        },
-    );
-    let decided_root = Hash256::from_low_u64_be(0xdec1);
-    harness
-        .validator_store
-        .record_decided_block_root(pubkey, Slot::new(TEST_SLOT), decided_root)
-        .expect("seeding the decided root must succeed");
-    let envelope = self_build_envelope(decided_root);
-    let (published, not_built_locally, failed) = envelope_outcome_counters();
-    let published_before = published.get();
-    let not_built_locally_before = not_built_locally.get();
-    let failed_before = failed.get();
+    let (harness, pubkey) = gloas_harness();
+    let envelope = self_build_envelope(seed_decided_root(&harness, pubkey));
+    let counters = OutcomeCounters::snapshot();
 
-    harness
-        .validator_store
-        .sign_execution_payload_envelope(pubkey, envelope)
+    sign_envelope(&harness, pubkey, envelope)
         .await
         .expect("the happy-path envelope duty must sign successfully");
 
-    assert_eq!(
-        published.get() - published_before,
-        1,
-        "a published envelope must increment the published label once"
-    );
-    assert_eq!(
-        not_built_locally.get() - not_built_locally_before,
-        0,
-        "a published envelope must not touch the not_built_locally label"
-    );
-    assert_eq!(
-        failed.get() - failed_before,
-        0,
-        "a published envelope must not touch the failed label"
-    );
+    counters.assert_deltas(1, 0, 0);
 }
 
 /// The sentinel outcome increments `not_built_locally` and never `failed`.
 #[tokio::test(flavor = "multi_thread")]
 async fn sentinel_outcome_increments_not_built_locally_and_never_failed() {
     let _guard = METRIC_TEST_LOCK.lock().await;
-    let committee = create_committee_setup(&test_operator_ids(), 1, STARTING_VALIDATOR_INDEX);
-    let pubkey = committee.validators[0].public_key;
-    let decided_root = Hash256::from_low_u64_be(0xdec1);
-    let envelope = self_build_envelope(decided_root);
-    let mut other_envelope = envelope.clone();
-    other_envelope.payload.block_number = 1;
-    let forced = envelope_consensus_value(pubkey, &other_envelope);
-    let harness = ValidatorStoreTestHarness::new_with_options(
-        vec![committee],
-        OperatorId(1),
-        HarnessOptions {
-            spec: gloas_at_genesis_spec(),
-            disable_slashing_protection: true,
-            forced_envelope_decision: Some(forced),
-            ..Default::default()
-        },
-    );
-    harness
-        .validator_store
-        .record_decided_block_root(pubkey, Slot::new(TEST_SLOT), decided_root)
-        .expect("seeding the decided root must succeed");
-    let (_, not_built_locally, failed) = envelope_outcome_counters();
-    let not_built_locally_before = not_built_locally.get();
-    let failed_before = failed.get();
+    let (harness, pubkey, envelope) =
+        forced_decision_harness(|decided| decided.payload.block_number = 1);
+    let counters = OutcomeCounters::snapshot();
 
-    let result = harness
-        .validator_store
-        .sign_execution_payload_envelope(pubkey, envelope)
-        .await;
+    let result = sign_envelope(&harness, pubkey, envelope).await;
 
     assert!(
         result.is_err(),
         "a decided envelope built elsewhere must not return a publishable envelope"
     );
-    assert_eq!(
-        not_built_locally.get() - not_built_locally_before,
-        1,
-        "the sentinel outcome must increment the not_built_locally label once"
-    );
-    assert_eq!(
-        failed.get() - failed_before,
-        0,
-        "the sentinel outcome must never count as a failure"
-    );
+    counters.assert_deltas(0, 1, 0);
 }
 
 /// A signature-collection failure increments the `failed` label.
 #[tokio::test(flavor = "multi_thread")]
 async fn collection_failure_increments_the_failed_label() {
     let _guard = METRIC_TEST_LOCK.lock().await;
-    let committee = create_committee_setup(&test_operator_ids(), 1, STARTING_VALIDATOR_INDEX);
-    let pubkey = committee.validators[0].public_key;
-    let harness = ValidatorStoreTestHarness::new_with_options(
-        vec![committee],
-        OperatorId(1),
-        HarnessOptions {
-            spec: gloas_at_genesis_spec(),
-            disable_slashing_protection: true,
-            collector_failure: Some(CollectionError::EmptySignature),
-            ..Default::default()
-        },
-    );
-    let decided_root = Hash256::from_low_u64_be(0xdec1);
-    harness
-        .validator_store
-        .record_decided_block_root(pubkey, Slot::new(TEST_SLOT), decided_root)
-        .expect("seeding the decided root must succeed");
-    let envelope = self_build_envelope(decided_root);
-    let (published, not_built_locally, failed) = envelope_outcome_counters();
-    let published_before = published.get();
-    let not_built_locally_before = not_built_locally.get();
-    let failed_before = failed.get();
+    let (harness, pubkey) = harness_with_options(HarnessOptions {
+        collector_failure: Some(CollectionError::EmptySignature),
+        ..gloas_options()
+    });
+    let envelope = self_build_envelope(seed_decided_root(&harness, pubkey));
+    let counters = OutcomeCounters::snapshot();
 
-    let result = harness
-        .validator_store
-        .sign_execution_payload_envelope(pubkey, envelope)
-        .await;
+    let result = sign_envelope(&harness, pubkey, envelope).await;
 
     assert!(
         matches!(
@@ -728,38 +637,121 @@ async fn collection_failure_increments_the_failed_label() {
         ),
         "a collection failure must surface as SignatureCollectionFailed, got {result:?}"
     );
+    counters.assert_deltas(0, 0, 1);
+}
+
+// ==================== Consensus failure tests ====================
+
+/// A decided envelope that fails SSZ decoding counts as failed and signs nothing.
+#[tokio::test(flavor = "multi_thread")]
+async fn undecodable_decided_envelope_counts_as_failed_and_signs_nothing() {
+    let _guard = METRIC_TEST_LOCK.lock().await;
+    let (committee, pubkey) = single_validator_committee();
+    let envelope = self_build_envelope(test_decided_root());
+    let mut forced = envelope_consensus_value(pubkey, &envelope);
+    forced.data_ssz = VariableList::new(vec![0xFF; 3]).expect("garbage bytes should fit");
+    let harness = ValidatorStoreTestHarness::new_with_options(
+        vec![committee],
+        OperatorId(1),
+        HarnessOptions {
+            forced_envelope_decision: Some(forced),
+            ..gloas_options()
+        },
+    );
+    seed_decided_root(&harness, pubkey);
+    let counters = OutcomeCounters::snapshot();
+
+    let result = sign_envelope(&harness, pubkey, envelope).await;
+
+    assert!(
+        matches!(
+            result,
+            Err(Error::SpecificError(SpecificError::InvalidQbftData(_)))
+        ),
+        "an undecodable decided envelope must surface as InvalidQbftData, got {result:?}"
+    );
+    counters.assert_deltas(0, 0, 1);
     assert_eq!(
-        failed.get() - failed_before,
+        harness.captured_decides.lock().len(),
         1,
-        "a collection failure must increment the failed label once"
+        "exactly one decide call must reach consensus for an undecodable decided envelope"
     );
-    assert_eq!(
-        published.get() - published_before,
-        0,
-        "a collection failure must not touch the published label"
-    );
-    assert_eq!(
-        not_built_locally.get() - not_built_locally_before,
-        0,
-        "a collection failure must not touch the not_built_locally label"
+    assert!(
+        harness.captured_calls.lock().is_empty(),
+        "no signature collection may happen for an undecodable decided envelope"
     );
 }
+
+/// A consensus timeout counts as failed and signs nothing.
+#[tokio::test(flavor = "multi_thread")]
+async fn consensus_timeout_counts_as_failed_and_signs_nothing() {
+    let _guard = METRIC_TEST_LOCK.lock().await;
+    let (harness, pubkey) = harness_with_options(HarnessOptions {
+        forced_envelope_failure: Some(ForcedEnvelopeFailure::Timeout),
+        ..gloas_options()
+    });
+    let envelope = self_build_envelope(seed_decided_root(&harness, pubkey));
+    let counters = OutcomeCounters::snapshot();
+
+    let result = sign_envelope(&harness, pubkey, envelope).await;
+
+    assert!(
+        matches!(result, Err(Error::SpecificError(SpecificError::Timeout))),
+        "a consensus timeout must surface as Timeout, got {result:?}"
+    );
+    counters.assert_deltas(0, 0, 1);
+    assert_eq!(
+        harness.captured_decides.lock().len(),
+        1,
+        "exactly one decide call must reach consensus before a consensus timeout"
+    );
+    assert!(
+        harness.captured_calls.lock().is_empty(),
+        "no signature collection may happen after a consensus timeout"
+    );
+}
+
+/// A consensus error counts as failed and signs nothing.
+#[tokio::test(flavor = "multi_thread")]
+async fn consensus_error_counts_as_failed_and_signs_nothing() {
+    let _guard = METRIC_TEST_LOCK.lock().await;
+    let (harness, pubkey) = harness_with_options(HarnessOptions {
+        forced_envelope_failure: Some(ForcedEnvelopeFailure::Error(QbftError::QueueClosedError)),
+        ..gloas_options()
+    });
+    let envelope = self_build_envelope(seed_decided_root(&harness, pubkey));
+    let counters = OutcomeCounters::snapshot();
+
+    let result = sign_envelope(&harness, pubkey, envelope).await;
+
+    assert!(
+        matches!(
+            result,
+            Err(Error::SpecificError(SpecificError::QbftError(
+                QbftError::QueueClosedError
+            )))
+        ),
+        "a consensus error must surface as the wrapped QbftError, got {result:?}"
+    );
+    counters.assert_deltas(0, 0, 1);
+    assert_eq!(
+        harness.captured_decides.lock().len(),
+        1,
+        "exactly one decide call must reach consensus before a consensus error"
+    );
+    assert!(
+        harness.captured_calls.lock().is_empty(),
+        "no signature collection may happen after a consensus error"
+    );
+}
+
+// ==================== End-to-end tests ====================
 
 /// End to end: `sign_block` records the decided root, then a matching envelope signs.
 #[tokio::test(flavor = "multi_thread")]
 async fn sign_block_then_matching_envelope_succeeds() {
     let _guard = METRIC_TEST_LOCK.lock().await;
-    let committee = create_committee_setup(&test_operator_ids(), 1, STARTING_VALIDATOR_INDEX);
-    let pubkey = committee.validators[0].public_key;
-    let harness = ValidatorStoreTestHarness::new_with_options(
-        vec![committee],
-        OperatorId(1),
-        HarnessOptions {
-            spec: gloas_at_genesis_spec(),
-            disable_slashing_protection: true,
-            ..Default::default()
-        },
-    );
+    let (harness, pubkey) = gloas_harness();
     // `EmptyBlock::empty` fixes the slot to `spec.genesis_slot`, so the slot is set on the
     // inner struct before wrapping.
     let mut gloas_block = BeaconBlockGloas::<MainnetEthSpec>::empty(&harness.spec);
@@ -776,9 +768,7 @@ async fn sign_block_then_matching_envelope_succeeds() {
         )
         .await
         .expect("the Gloas block duty must sign successfully");
-    let signed = harness
-        .validator_store
-        .sign_execution_payload_envelope(pubkey, envelope.clone())
+    let signed = sign_envelope(&harness, pubkey, envelope.clone())
         .await
         .expect("an envelope matching the block-recorded root must sign successfully");
 


### PR DESCRIPTION
## Problem, Evidence, and Context (Required)

- After the Gloas fork, a self-build proposer must sign and publish an execution payload envelope (EIP-7732 / SIP-94).
- Anchor's validator store rejected this duty as unsupported, so a self-build proposal could not complete after the block was published.
- PR #1248 added the groundwork: typed errors, consensus value validation, and test fixtures. This PR completes the self-build envelope proposer duty path.
- Closes #1126.

## Change Overview (Required)

- The duty follows the same shape as the other consensus duties. The store blinds the local envelope, reaches QBFT consensus over it, and signs the decided envelope under the builder domain.
- Every operator signs first, so the builder can reconstruct the threshold signature. Only the operator whose local envelope matches the decided value returns it for publication. All other operators return a typed sentinel error, because the caller publishes every success result.
- A new counter classifies each completed attempt as published, not built locally, or failed. Tracing mirrors the sibling duties: a span per duty, warnings on failures, and an info line for the expected non-publish.
- Read the duty body first, then the metrics, then the tests.
- What did not change: pre-consensus rejections (not synced, pre-Gloas slot, external builder, missing decided block root) stay typed errors and never touch the counter. No other duty path changed.

## Risks, Trade-offs, and Mitigations (Required)

- The blast radius is the envelope duty only, and the path is active only after the Gloas fork.
- The beacon node logs the sentinel at error level on every operator that did not build the decided envelope. Anchor logs the same event at info level with both roots and marks it as expected. The outcome metric separates this case from real failures.
- Trade-off: signing before the content gate spends a signature share on envelopes the operator will not publish. This is required so the builder can reconstruct the threshold signature.

## Validation (Required)

- Format and workspace lint are clean.
- `cargo test -p anchor_validator_store`: 130 passed, 0 failed, with 12 new envelope tests.
- The new tests cover the happy path, the signing root and domain, the pre-consensus gates, content mismatches, per-label metric deltas, a slashing-database probe, and an end-to-end block-then-envelope flow.
- The full workspace test suite passes.

## Rollback (Required for behavior or runtime changes; optional otherwise)

- Revert the single commit. The duty returns to the unsupported stub.
- No configuration, data, or migration impact. The new metric stops being exported.

## Blockers / Dependencies (Optional)

- None.

## Additional Info / Next Steps (Optional)

- Devnet validation of the duty is deferred indefinitely. Coverage limited to unit tests against the mocked consensus and collection layers.
- Follow-up candidates: bound the signature collection await to the duty slot end, and pin the consensus value version inside the shared value validator.