### PR TITLE
fix(validator_store): publish decided Boole sync contributions from the metadata service

### DIFF
--- a/anchor/client/src/lib.rs
+++ b/anchor/client/src/lib.rs
@@ -780,7 +780,6 @@ impl Client {
             beacon_nodes.clone(),
             executor.clone(),
             spec.clone(),
-            fork_schedule.clone(),
             config.with_weighted_attestation_data,
         );
 

--- a/anchor/validator_store/src/aggregator_post_consensus.rs
+++ b/anchor/validator_store/src/aggregator_post_consensus.rs
@@ -3,31 +3,30 @@
 //! One QBFT decision carries both attestation aggregates and sync contributions for an SSV
 //! committee, and the operator must emit exactly one committee partial-signature message per
 //! `(committee, slot)` covering everything it can sign. The decided value drives both what gets
-//! signed and what gets published: Anchor owns Boole+ aggregate publication outright, through
-//! the metadata service's publisher, because the protocol's unit of agreement is the decided
-//! value and no local Lighthouse view is part of it. (Lighthouse's duty snapshot in particular
-//! is cloned before slot-start selection proofs finish, so routing publication through it would
-//! silently skip late-installed proofs.) Contributions are returned through a Lighthouse
-//! callback that may or may not fire (issue #1227), so no callback can own the committee
-//! message either.
+//! signed and what gets published: Anchor owns Boole+ publication of both classes outright,
+//! through the metadata service's publisher, because the protocol's unit of agreement is the
+//! decided value and no local Lighthouse view is part of it. Lighthouse's duty snapshots are
+//! cloned before slot-start selection proofs finish (both classes share one slot-start
+//! partial-signature batch), so routing publication through either callback would silently skip
+//! late-installed proofs, and a callback may not fire at all (issue #1227).
 //!
 //! The signing set is therefore a property of the duty, not of any consumer. The slot pipeline
-//! starts one execution per committee when it publishes the decided value at 2/3 slot; the
-//! contributions callback and the aggregate publisher only look up their own results. This is
-//! the ssv-spec-normative shape, where the decided value drives what gets signed and local state
-//! only filters.
+//! starts one execution per committee when it publishes the decided value at 2/3 slot, and the
+//! publisher drains that execution's roots of both classes itself; the Lighthouse callbacks
+//! return empty batches. This is the ssv-spec-normative shape, where the decided value drives
+//! what gets signed and published, matching go-ssv's runner-owned post-consensus submission.
 
 use std::{
     collections::{HashMap, HashSet, hash_map::Entry},
     future::Future,
-    sync::Arc,
+    sync::{Arc, LazyLock},
 };
 
 use bls::Signature;
 use database::{NonUniqueIndex, UniqueIndex};
 use futures::{
     FutureExt, StreamExt,
-    future::{BoxFuture, Shared},
+    future::{BoxFuture, Either, Shared},
     stream::FuturesUnordered,
 };
 use qbft_manager::ConsensusDecider;
@@ -43,19 +42,21 @@ use tokio::time::Instant;
 use tracing::{Instrument, debug, error, info, info_span, warn};
 use types::{
     AggregateAndProof, Attestation, AttestationBase, AttestationElectra, ContributionAndProof,
-    Domain, EthSpec, ForkName, Hash256, SelectionProof, SignedAggregateAndProof, SignedRoot, Slot,
+    Domain, EthSpec, ForkName, Hash256, SelectionProof, SignedAggregateAndProof,
+    SignedContributionAndProof, SignedRoot, Slot,
 };
+use validator_metrics::IntCounterVec;
 
 use crate::{
     AggregationAssignments, AnchorValidatorStore, CollectionMode, Error, SigningRequest,
     SpecificError, metrics,
 };
 
-/// Epochs to retain finished `AggregatorCommittee` post-consensus executions.
+/// Epochs to retain started `AggregatorCommittee` post-consensus keys.
 ///
-/// Matches the message validator's per-signer duplicate-detection window, so a very late Lighthouse
-/// callback finds the execution it belongs to rather than nothing. Each entry is one small future
-/// per committee-slot.
+/// Matches the message validator's per-signer duplicate-detection window, so a repeated
+/// `(committee, slot)` inside the window finds its registered key rather than starting a second
+/// execution. Each entry is one key, not a handle; the executions live in their detached tasks.
 const AGGREGATOR_POST_CONSENSUS_RETAIN_EPOCHS: u64 = 2;
 
 /// A result shared between the detached task producing it and any number of joiners.
@@ -74,8 +75,8 @@ pub(crate) struct PreparedRoot<M> {
 }
 
 /// Everything this operator signs for one decided `AggregatorCommittee` round, keyed by signing
-/// identity: validator index for aggregates (read by the aggregate publisher),
-/// `(validator index, subcommittee index)` for contributions (read by the Lighthouse callback).
+/// identity: validator index for aggregates, `(validator index, subcommittee index)` for
+/// contributions. Both classes are read by the metadata service's publisher.
 pub(crate) struct AggregatorPostConsensusOutcome<E: EthSpec> {
     /// Fork the decided value's SSZ payloads were decoded under (its `DataVersion`). The
     /// publisher derives its HTTP endpoint choice and fork header from this, so they cannot
@@ -107,6 +108,47 @@ async fn join_detached_task<R>(
     .ok_or_else(post_consensus_aborted)
 }
 
+/// Await one decided root's threshold signature under the deadline, of either class.
+///
+/// Returns `None` after logging the skip and counting the failure on `signed_total` (the
+/// class's Lighthouse-era signing counter): `other_error` when collection failed, `timeout` when
+/// the deadline expired before quorum (matching the committee-level join arm, now that expiry is
+/// distinguishable from a collection failure). `collect_signature` failures are also logged by
+/// the detached signing task, but a task that died without a result (spawn refused, executor
+/// exit, panic) is only visible here, so the collection-failure arm carries the error into its
+/// warn.
+async fn await_root_signature<M>(
+    slot: Slot,
+    deadline: Instant,
+    root: &PreparedRoot<M>,
+    signed_total: &LazyLock<validator_metrics::Result<IntCounterVec>>,
+    skip_message: &'static str,
+) -> Option<Signature> {
+    let label = match tokio::time::timeout_at(deadline, root.signature.clone()).await {
+        Ok(Ok(signature)) => return Some(signature),
+        Ok(Err(e)) => {
+            warn!(
+                pubkey = ?root.request.validator.public_key,
+                %slot,
+                error = ?e,
+                "{skip_message}"
+            );
+            metrics::OTHER_ERROR
+        }
+        // Deadline expired before this root's quorum; only this root is withheld.
+        Err(_) => {
+            warn!(
+                pubkey = ?root.request.validator.public_key,
+                %slot,
+                "{skip_message}"
+            );
+            metrics::TIMEOUT
+        }
+    };
+    validator_metrics::inc_counter_vec(signed_total, &[label]);
+    None
+}
+
 /// Await one decided root's threshold signature under the deadline and publish it on quorum,
 /// one publish call per aggregate.
 ///
@@ -122,41 +164,19 @@ async fn publish_one_root<E: EthSpec, F, Fut>(
     F: Fn(ForkName, SignedAggregateAndProof<E>) -> Fut,
     Fut: Future<Output = Result<(), String>>,
 {
-    let signature = match tokio::time::timeout_at(deadline, root.signature.clone()).await {
-        Ok(Ok(signature)) => signature,
-        // `collect_signature` failures are also logged by the detached signing task, but a task
-        // that died without a result (spawn refused, executor exit, panic) is only visible here,
-        // so carry the error into the warn.
-        Ok(Err(e)) => {
-            warn!(
-                pubkey = ?root.request.validator.public_key,
-                %slot,
-                error = ?e,
-                "Missing signature, skipping aggregate"
-            );
-            validator_metrics::inc_counter_vec(
-                &validator_metrics::SIGNED_AGGREGATES_TOTAL,
-                &[metrics::OTHER_ERROR],
-            );
-            metrics::inc_publish_result(metrics::NO_SIGNATURES);
-            return;
-        }
-        // Deadline expired before this root's quorum; only this root is withheld. Labelled
-        // `timeout` to match the committee-level join arm, now that expiry is distinguishable
-        // from a collection failure.
-        Err(_) => {
-            warn!(
-                pubkey = ?root.request.validator.public_key,
-                %slot,
-                "Missing signature, skipping aggregate"
-            );
-            validator_metrics::inc_counter_vec(
-                &validator_metrics::SIGNED_AGGREGATES_TOTAL,
-                &[metrics::TIMEOUT],
-            );
-            metrics::inc_publish_result(metrics::NO_SIGNATURES);
-            return;
-        }
+    let Some(signature) = await_root_signature(
+        slot,
+        deadline,
+        root,
+        &validator_metrics::SIGNED_AGGREGATES_TOTAL,
+        "Missing signature, skipping aggregate",
+    )
+    .await
+    else {
+        // The publish-outcome counter is aggregate-only; contributions are tracked by their
+        // signing counter and publish logs alone.
+        metrics::inc_publish_result(metrics::NO_SIGNATURES);
+        return;
     };
 
     let message = root.request.duty_data.clone();
@@ -208,26 +228,100 @@ async fn publish_one_root<E: EthSpec, F, Fut>(
     }
 }
 
+/// Await one decided contribution's threshold signature under the deadline and publish it on
+/// quorum, one publish call per contribution.
+///
+/// Signing outcomes keep the Lighthouse-era `SIGNED_SYNC_COMMITTEE_CONTRIBUTIONS_TOTAL`
+/// accounting that used to live in the contribution callback, and the publish arms reproduce the
+/// per-publish logs Lighthouse emits on its pre-Boole path, so operator pipelines keyed on
+/// either keep working. `AGGREGATOR_COMMITTEE_PUBLISH_TOTAL` stays aggregate-only.
+async fn publish_one_contribution<E: EthSpec, F, Fut>(
+    slot: Slot,
+    deadline: Instant,
+    root: &PreparedRoot<ContributionAndProof<E>>,
+    publish: &F,
+) where
+    F: Fn(SignedContributionAndProof<E>) -> Fut,
+    Fut: Future<Output = Result<(), String>>,
+{
+    let Some(signature) = await_root_signature(
+        slot,
+        deadline,
+        root,
+        &validator_metrics::SIGNED_SYNC_COMMITTEE_CONTRIBUTIONS_TOTAL,
+        "Missing signature, skipping sync committee contribution",
+    )
+    .await
+    else {
+        return;
+    };
+
+    let message = root.request.duty_data.clone();
+    debug!(
+        aggregator_index = message.aggregator_index,
+        slot = %message.contribution.slot,
+        block_root = ?message.contribution.beacon_block_root,
+        subcommittee_index = message.contribution.subcommittee_index,
+        num_set_aggregation_bits = message.contribution.aggregation_bits.num_set_bits(),
+        "Signed ContributionAndProof (Boole+ committee consensus)"
+    );
+    validator_metrics::inc_counter_vec(
+        &validator_metrics::SIGNED_SYNC_COMMITTEE_CONTRIBUTIONS_TOTAL,
+        &[validator_metrics::SUCCESS],
+    );
+
+    let aggregator_index = message.aggregator_index;
+    let subnet = message.contribution.subcommittee_index;
+    let beacon_block_root = message.contribution.beacon_block_root;
+    let num_signers = message.contribution.aggregation_bits.num_set_bits();
+    let signed = SignedContributionAndProof { message, signature };
+
+    let result = publish(signed)
+        .instrument(info_span!("publish_contribution", aggregator_index))
+        .await;
+    match result {
+        Ok(()) => {
+            info!(
+                aggregator_index,
+                subnet,
+                beacon_block_root = ?beacon_block_root,
+                num_signers,
+                slot = slot.as_u64(),
+                "Successfully published sync contributions"
+            );
+        }
+        Err(e) => {
+            error!(
+                error = %e,
+                aggregator_index,
+                subnet,
+                slot = slot.as_u64(),
+                "Unable to publish signed contributions and proofs"
+            );
+        }
+    }
+}
+
 impl<T: SlotClock + 'static, E: EthSpec, C: ConsensusDecider<E> + 'static>
     AnchorValidatorStore<T, E, C>
 {
     /// Start one post-consensus execution per committee in freshly built assignments, returning
     /// the executions newly registered by this call.
     ///
-    /// This is the only place executions are created. Callbacks look results up and never start
-    /// work, so exactly one committee message per `(committee, slot)` holds by construction rather
-    /// than by locking. Called from `update_aggregation_assignments` before the watch channel is
-    /// published, so any consumer that can observe the assignments can also observe the execution.
+    /// This is the only place executions are created, so exactly one committee message per
+    /// `(committee, slot)` holds by construction rather than by locking. Called from
+    /// `update_aggregation_assignments` before the watch channel is published.
     ///
-    /// The returned handles feed the metadata service's aggregate publisher. Returning only the
-    /// vacant insertions gives the publisher the same exactly-once property as the executions
-    /// themselves: a repeated call for one `(committee, slot)` registers nothing and therefore
-    /// publishes nothing twice. Both properties are scoped to the process lifetime and to the
-    /// retention window below: after an entry is pruned, only a slot clock stepping backwards
+    /// The returned handles feed the metadata service's publisher, which is their sole consumer.
+    /// Returning only first-insertions gives the publisher the same exactly-once property as the
+    /// executions themselves: a repeated call for one `(committee, slot)` registers nothing and
+    /// therefore publishes nothing twice. Both properties are scoped to the process lifetime and
+    /// to the retention window below: after a key is pruned, only a slot clock stepping backwards
     /// past the window could present its `(committee, slot)` again, and that would re-register.
     ///
     /// Pre-Boole there is no consensus data and this is a no-op returning no executions.
-    #[must_use = "dropping the returned executions disables Boole+ aggregate publication"]
+    #[must_use = "dropping the returned executions disables Boole+ aggregate and contribution \
+                  publication"]
     pub(crate) fn start_aggregator_post_consensus(
         self: &Arc<Self>,
         assignments: &AggregationAssignments<E>,
@@ -237,17 +331,18 @@ impl<T: SlotClock + 'static, E: EthSpec, C: ConsensusDecider<E> + 'static>
 
         let cutoff =
             slot.saturating_sub(AGGREGATOR_POST_CONSENSUS_RETAIN_EPOCHS * E::slots_per_epoch());
-        executions.retain(|(_, execution_slot), _| *execution_slot >= cutoff);
+        executions.retain(|&(_, execution_slot)| execution_slot >= cutoff);
 
         let mut new_executions = Vec::new();
         for (&committee_id, decided_data) in &assignments.consensus_data_by_ssv_committee {
-            // Vacant-only, so registration is idempotent. Overwriting would spawn a second QBFT
-            // round and a second set of detached signing tasks while the first set kept running,
-            // putting two committee messages on the wire for one slot, which peers reject with a
-            // gossip penalty. The slot pipeline publishes once per slot today, but that is a
-            // property of another module's timing loop; keeping this vacant-only makes
-            // exactly-once hold here regardless of how often it is called.
-            if let Entry::Vacant(vacant) = executions.entry((committee_id, slot)) {
+            // First-insert-only, so registration is idempotent. A second execution for one key
+            // would spawn a second QBFT round and a second set of detached signing tasks while
+            // the first set kept running, putting two committee messages on the wire for one
+            // slot, which peers reject with a gossip penalty. The slot pipeline publishes once
+            // per slot today, but that is a property of another module's timing loop; keeping
+            // this first-insert-only makes exactly-once hold here regardless of how often it is
+            // called.
+            if executions.insert((committee_id, slot)) {
                 let store = Arc::clone(self);
                 let decided_data = Arc::clone(decided_data);
                 let execution = self.spawn_shared("aggregator_post_consensus", async move {
@@ -255,7 +350,6 @@ impl<T: SlotClock + 'static, E: EthSpec, C: ConsensusDecider<E> + 'static>
                         .run_aggregator_post_consensus(committee_id, slot, decided_data)
                         .await
                 });
-                vacant.insert(execution.clone());
                 new_executions.push((committee_id, execution));
             }
         }
@@ -283,27 +377,30 @@ impl<T: SlotClock + 'static, E: EthSpec, C: ConsensusDecider<E> + 'static>
         Ok((deadline, outcome))
     }
 
-    /// Join one committee's post-consensus execution and publish each decided aggregate this
-    /// operator signed as soon as its threshold signature reconstructs.
+    /// Join one committee's post-consensus execution and publish each decided root this operator
+    /// signed, of both classes, as soon as its threshold signature reconstructs.
     ///
-    /// This backs [`Self::publish_decided_aggregates`], which owns Boole+ aggregate publication:
-    /// Lighthouse's aggregate callback returns an empty batch at Boole+, because its duty
-    /// snapshot is cloned before slot-start selection proofs finish, silently skipping any proof
-    /// installed after the clone. The publisher works from the decided value instead, so
-    /// publication does not depend on Lighthouse's snapshot timing.
+    /// This backs [`Self::publish_decided_aggregates`], which owns Boole+ publication of
+    /// aggregates and sync contributions: Lighthouse's callbacks return empty batches at Boole+,
+    /// because their duty snapshots are cloned before slot-start selection proofs finish,
+    /// silently skipping any proof installed after the clone. The publisher works from the
+    /// decided value instead, so publication does not depend on Lighthouse's snapshot timing.
     ///
     /// Takes the execution handle directly rather than re-entering the assignments watch channel,
     /// so a late-polled publisher cannot observe `AggregatorInfoSlotPassed` for an execution that
     /// still exists in the retention map.
-    async fn publish_committee_aggregates<F, Fut>(
+    async fn publish_committee_aggregates<FA, FutA, FC, FutC>(
         &self,
         committee_id: CommitteeId,
         slot: Slot,
         execution: AggregatorPostConsensusShared<E>,
-        publish: &F,
+        publish_aggregate: &FA,
+        publish_contribution: &FC,
     ) where
-        F: Fn(ForkName, SignedAggregateAndProof<E>) -> Fut,
-        Fut: Future<Output = Result<(), String>>,
+        FA: Fn(ForkName, SignedAggregateAndProof<E>) -> FutA,
+        FutA: Future<Output = Result<(), String>>,
+        FC: Fn(SignedContributionAndProof<E>) -> FutC,
+        FutC: Future<Output = Result<(), String>>,
     {
         let (deadline, outcome) = match self.join_execution(slot, execution).await {
             Ok(joined) => joined,
@@ -312,11 +409,13 @@ impl<T: SlotClock + 'static, E: EthSpec, C: ConsensusDecider<E> + 'static>
                     ?committee_id,
                     %slot,
                     error = ?e,
-                    "Aggregator post-consensus failed, no aggregates to publish"
+                    "Aggregator post-consensus failed, nothing to publish"
                 );
-                // Keeps the Lighthouse-era signing counter alive for dashboards keyed on it. The
-                // per-aggregate count is unknowable before the outcome resolves, so failures
-                // count once per committee, an undercount but not silence.
+                // Keeps the Lighthouse-era signing counters alive for dashboards keyed on them.
+                // The per-root counts and class composition are unknowable before the outcome
+                // resolves, so failures count once per committee on both class counters: an
+                // undercount against multiple lost roots, an overcount for a class the committee
+                // had no duties in, but never silence.
                 let label = match e {
                     Error::SpecificError(SpecificError::Timeout) => metrics::TIMEOUT,
                     _ => metrics::OTHER_ERROR,
@@ -325,86 +424,109 @@ impl<T: SlotClock + 'static, E: EthSpec, C: ConsensusDecider<E> + 'static>
                     &validator_metrics::SIGNED_AGGREGATES_TOTAL,
                     &[label],
                 );
+                validator_metrics::inc_counter_vec(
+                    &validator_metrics::SIGNED_SYNC_COMMITTEE_CONTRIBUTIONS_TOTAL,
+                    &[label],
+                );
                 metrics::inc_publish_result(metrics::CONSENSUS_ERROR);
                 return;
             }
         };
 
-        // A decided value can legitimately hold contributions only; nothing to publish then.
+        // A decided value can legitimately hold either class alone; each root publishes
+        // independently, and an empty drain below is a no-op. The aggregate-only publish counter
+        // keeps its committee-level `no_aggregates` outcome.
         if outcome.aggregates.is_empty() {
             debug!(?committee_id, %slot, "Decided worklist holds no aggregates");
             metrics::inc_publish_result(metrics::NO_AGGREGATES);
-            return;
         }
 
-        // Each root publishes independently under the shared deadline, so a root that never
-        // reaches quorum withholds only itself and never delays a sibling's POST.
+        // Beacon nodes accept a contribution only for its own slot (no lookback window, unlike
+        // aggregates' one-epoch tolerance), so a contribution quorum arriving after the slot ends
+        // is unpublishable. Bound that wait at slot end instead of POSTing a guaranteed
+        // rejection; aggregates keep the full deadline.
+        let contribution_deadline = self
+            .get_instant_in_slot(slot, self.spec.get_slot_duration())
+            .unwrap_or(deadline);
+
+        // Each root of either class publishes independently under its class's deadline, so a
+        // root that never reaches quorum withholds only itself and never delays a sibling's
+        // POST, in its own class or the other.
         let mut roots: FuturesUnordered<_> = outcome
             .aggregates
             .values()
-            .map(|root| publish_one_root(slot, outcome.fork_name, deadline, root, publish))
+            .map(|root| {
+                Either::Left(publish_one_root(
+                    slot,
+                    outcome.fork_name,
+                    deadline,
+                    root,
+                    publish_aggregate,
+                ))
+            })
+            .chain(outcome.contributions.values().map(|root| {
+                Either::Right(publish_one_contribution(
+                    slot,
+                    contribution_deadline,
+                    root,
+                    publish_contribution,
+                ))
+            }))
             .collect();
         while roots.next().await.is_some() {}
     }
 
-    /// Resolve each committee's decided aggregates and hand each signed aggregate to `publish`
-    /// the moment its threshold signature reconstructs, one publish call per aggregate. This is
-    /// go-ssv's publication shape at the reference pin: a bad aggregate cannot fail a sibling's
-    /// POST, and a no-quorum root cannot delay its committee's other aggregates.
+    /// Resolve each committee's decided roots and hand each signed aggregate or contribution to
+    /// its publish operation the moment its threshold signature reconstructs, one publish call
+    /// per root. This is go-ssv's publication shape at the reference pin: a bad root cannot fail
+    /// a sibling's POST, and a no-quorum root cannot delay its committee's other roots.
     ///
-    /// This is the authoritative Boole+ aggregate publication driver, spawned per slot by the
-    /// metadata service with the executions its assignment update newly registered. Generic over
-    /// the publish operation so tests (in `testing/aggregator_post_consensus.rs`) can inject a
-    /// recorder instead of an HTTP client. Each committee runs as one `FuturesUnordered` entry
-    /// and each of its roots as another inside it, so committees and roots are all mutually
+    /// This is the authoritative Boole+ publication driver for both classes, spawned per slot by
+    /// the metadata service with the executions its assignment update newly registered. Generic
+    /// over the publish operations so tests (in `testing/aggregator_post_consensus.rs`) can
+    /// inject recorders instead of an HTTP client. Each committee runs as one `FuturesUnordered`
+    /// entry and each of its roots as another inside it, so committees and roots are all mutually
     /// independent.
     ///
     /// Owns every `AGGREGATOR_COMMITTEE_PUBLISH_TOTAL` increment, together with
     /// [`publish_one_root`]: `consensus_error` and `no_aggregates` count committees (those
     /// failures occur before per-root work exists), while `success`, `http_error`, and
-    /// `no_signatures` count individual aggregates.
+    /// `no_signatures` count individual aggregates. Contribution outcomes are tracked by
+    /// `SIGNED_SYNC_COMMITTEE_CONTRIBUTIONS_TOTAL` and per-publish logs instead (see
+    /// [`publish_one_contribution`]).
     ///
-    /// The fork handed to `publish` is the one the decided value's payloads were decoded under,
-    /// so the closure's endpoint choice always matches the payload variant.
-    pub(crate) async fn publish_decided_aggregates<F, Fut>(
+    /// The fork handed to `publish_aggregate` is the one the decided value's payloads were
+    /// decoded under, so the closure's endpoint choice always matches the payload variant. The
+    /// contribution endpoint is fork-independent at the pin, so `publish_contribution` takes
+    /// none.
+    pub(crate) async fn publish_decided_aggregates<FA, FutA, FC, FutC>(
         &self,
         slot: Slot,
         executions: Vec<(CommitteeId, AggregatorPostConsensusShared<E>)>,
-        publish: F,
+        publish_aggregate: FA,
+        publish_contribution: FC,
     ) where
-        F: Fn(ForkName, SignedAggregateAndProof<E>) -> Fut,
-        Fut: Future<Output = Result<(), String>>,
+        FA: Fn(ForkName, SignedAggregateAndProof<E>) -> FutA,
+        FutA: Future<Output = Result<(), String>>,
+        FC: Fn(SignedContributionAndProof<E>) -> FutC,
+        FutC: Future<Output = Result<(), String>>,
     {
-        let publish = &publish;
+        let publish_aggregate = &publish_aggregate;
+        let publish_contribution = &publish_contribution;
         let mut pending: FuturesUnordered<_> = executions
             .into_iter()
             .map(|(committee_id, execution)| {
-                self.publish_committee_aggregates(committee_id, slot, execution, publish)
+                self.publish_committee_aggregates(
+                    committee_id,
+                    slot,
+                    execution,
+                    publish_aggregate,
+                    publish_contribution,
+                )
             })
             .collect();
 
         while pending.next().await.is_some() {}
-    }
-
-    /// Join the post-consensus execution for `(committee, slot)`, returning the outcome and the
-    /// deadline that bounded the join, for the caller to reuse when draining its own roots.
-    pub(crate) async fn post_consensus_outcome(
-        &self,
-        committee_id: CommitteeId,
-        slot: Slot,
-    ) -> Result<(Instant, Arc<AggregatorPostConsensusOutcome<E>>), Error> {
-        // Waiting on the assignments is what makes the lookup below race-free: the execution was
-        // registered before this slot's assignments were published.
-        self.get_aggregation_assignments(slot).await?;
-
-        let execution = self
-            .aggregator_post_consensus
-            .lock()
-            .get(&(committee_id, slot))
-            .cloned()
-            .ok_or(Error::SpecificError(SpecificError::ConsensusDataNotFound))?;
-
-        self.join_execution(slot, execution).await
     }
 
     /// Spawn `fut` detached and hand out a `Shared` view of its result.

--- a/anchor/validator_store/src/lib.rs
+++ b/anchor/validator_store/src/lib.rs
@@ -136,43 +136,24 @@ type CollectedSignatures = HashMap<(ValidatorIndex, Hash256), Signature>;
 /// Drive signature collection to completion, keeping each result as it resolves.
 ///
 /// Results are taken one at a time rather than as a group so that a root which never reaches
-/// quorum withholds only itself. `deadline`, when set, bounds the wait and leaves the roots still
-/// outstanding out of the returned map; callers surface those through `SigningRequest::resolve`
-/// failing for the affected request.
-async fn drain_signatures<F, E>(
-    mut pending: FuturesUnordered<F>,
-    deadline: Option<Instant>,
-) -> CollectedSignatures
+/// quorum withholds only itself; callers surface missing roots through
+/// `SigningRequest::resolve` failing for the affected request.
+async fn drain_signatures<F, E>(mut pending: FuturesUnordered<F>) -> CollectedSignatures
 where
     F: Future<Output = (ValidatorIndex, Hash256, Result<Signature, E>)>,
     E: Debug,
 {
     let mut signatures = HashMap::with_capacity(pending.len());
-    let collect = async {
-        while let Some((index, signing_root, result)) = pending.next().await {
-            match result {
-                Ok(signature) => {
-                    signatures.insert((index, signing_root), signature);
-                }
-                Err(e) => {
-                    error!(?index, ?signing_root, error = ?e, "Failed to collect signature");
-                }
+    while let Some((index, signing_root, result)) = pending.next().await {
+        match result {
+            Ok(signature) => {
+                signatures.insert((index, signing_root), signature);
+            }
+            Err(e) => {
+                error!(?index, ?signing_root, error = ?e, "Failed to collect signature");
             }
         }
-    };
-
-    match deadline {
-        Some(deadline) => {
-            if tokio::time::timeout_at(deadline, collect).await.is_err() {
-                warn!(
-                    unresolved = pending.len(),
-                    "Deadline passed before every signature resolved"
-                );
-            }
-        }
-        None => collect.await,
     }
-
     signatures
 }
 
@@ -243,17 +224,16 @@ pub struct AnchorValidatorStore<
     strict_mfp: bool,
     is_synced: watch::Receiver<bool>,
     task_executor: TaskExecutor,
-    /// Once-only post-consensus signing executions for `AggregatorCommittee` duties (Boole+).
+    /// `(committee, slot)` keys whose Boole+ `AggregatorCommittee` post-consensus execution has
+    /// already been started.
     ///
-    /// One entry per `(committee, slot)`, registered by the slot pipeline in
-    /// [`Self::update_aggregation_assignments`] before those assignments are published, and only
-    /// when the entry is vacant. That registration is the single writer, so the complete decided
-    /// worklist is signed and batched exactly once no matter which consumers run, in what order,
-    /// or whether their futures are dropped. Consumers (the contributions callback via this map,
-    /// the aggregate publisher via the handles registration returns) only read detached `Shared`
-    /// futures; they never start work.
-    aggregator_post_consensus:
-        Mutex<HashMap<(CommitteeId, Slot), AggregatorPostConsensusShared<E>>>,
+    /// Registered by the slot pipeline in [`Self::update_aggregation_assignments`] before those
+    /// assignments are published, first-insert-only. That registration is the single writer, so
+    /// the complete decided worklist is signed and batched exactly once no matter how often the
+    /// pipeline runs. The execution handles themselves travel to their sole consumer (the
+    /// metadata service's publisher) through the registration's return value; this set only
+    /// provides registration idempotence across the retention window.
+    aggregator_post_consensus: Mutex<HashSet<(CommitteeId, Slot)>>,
 }
 
 /// How far into `slot` the clock currently is, or `None` if the clock cannot answer.
@@ -413,7 +393,7 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> AnchorValidator
             strict_mfp,
             is_synced,
             task_executor,
-            aggregator_post_consensus: Mutex::new(HashMap::new()),
+            aggregator_post_consensus: Mutex::new(HashSet::new()),
         })
     }
 
@@ -551,7 +531,7 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> AnchorValidator
             })
             .collect();
 
-        Ok(drain_signatures(pending, None).await)
+        Ok(drain_signatures(pending).await)
     }
 
     /// Run `AggregatorCommittee` QBFT consensus for a committee at 2/3 slot.
@@ -1422,90 +1402,16 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> AnchorValidator
         .await
     }
 
-    /// Boole+ committee-based contribution signing: join the per-`(committee, slot)`
-    /// post-consensus execution and return the requested contributions from its outcome.
+    /// Whether Lighthouse's callbacks own publication of aggregator-committee duties at `epoch`.
     ///
-    /// The execution signs the complete decided worklist (both object classes) regardless of
-    /// which Lighthouse callbacks fire; this callback only filters. See
-    /// [`crate::aggregator_post_consensus`].
-    async fn sign_committee_sync_committee_contributions(
-        &self,
-        committee_id: CommitteeId,
-        contributions: Vec<(ValidatorMetadata, ContributionToSign<E>)>,
-    ) -> Result<Vec<SignedContributionAndProof<E>>, Error> {
-        let Some((_, first)) = contributions.first() else {
-            warn!("sign_committee_sync_committee_contributions called with empty contributions");
-            return Ok(vec![]);
-        };
-        let slot = first.contribution.slot;
-
-        let (deadline, outcome) = self.post_consensus_outcome(committee_id, slot).await?;
-
-        // Select this callback's own identities out of the shared outcome. The execution signs the
-        // whole decided value, so anything missing here is an entry the cluster did not decide on.
-        let mut prepared = Vec::with_capacity(contributions.len());
-        let pending = FuturesUnordered::new();
-        for (validator, contrib) in &contributions {
-            let root = validator.index.and_then(|index| {
-                outcome
-                    .contributions
-                    .get(&(index, contrib.contribution.subcommittee_index))
-                    .map(|root| (index, root))
-            });
-            let Some((index, root)) = root else {
-                debug!(
-                    pubkey = ?contrib.aggregator_pubkey,
-                    subcommittee_index = contrib.contribution.subcommittee_index,
-                    "Requested contribution not in the decided worklist, skipping due to \
-                     divergent operator views"
-                );
-                validator_metrics::inc_counter_vec(
-                    &validator_metrics::SIGNED_SYNC_COMMITTEE_CONTRIBUTIONS_TOTAL,
-                    &[metrics::OTHER_ERROR],
-                );
-                continue;
-            };
-            let signing_root = root.request.signing_root;
-            let signature = root.signature.clone();
-            pending.push(async move { (index, signing_root, signature.await) });
-            prepared.push(root.request.clone());
-        }
-
-        let signatures = drain_signatures(pending, Some(deadline)).await;
-
-        let mut results = Vec::with_capacity(prepared.len());
-        for request in prepared {
-            let (message, signature) = match request.resolve(&signatures) {
-                Ok(resolved) => resolved,
-                Err(pubkey) => {
-                    warn!(
-                        ?pubkey,
-                        "Missing signature, skipping sync committee contribution"
-                    );
-                    validator_metrics::inc_counter_vec(
-                        &validator_metrics::SIGNED_SYNC_COMMITTEE_CONTRIBUTIONS_TOTAL,
-                        &[metrics::OTHER_ERROR],
-                    );
-                    continue;
-                }
-            };
-
-            debug!(
-                aggregator_index = ?message.aggregator_index,
-                slot = %message.contribution.slot,
-                block_root = ?message.contribution.beacon_block_root,
-                subcommittee_index = message.contribution.subcommittee_index,
-                num_set_aggregation_bits = message.contribution.aggregation_bits.num_set_bits(),
-                "Signed ContributionAndProof (Boole+ committee consensus)"
-            );
-            validator_metrics::inc_counter_vec(
-                &validator_metrics::SIGNED_SYNC_COMMITTEE_CONTRIBUTIONS_TOTAL,
-                &[validator_metrics::SUCCESS],
-            );
-            results.push(SignedContributionAndProof { message, signature });
-        }
-
-        Ok(results)
+    /// Pre-Boole they do; from Boole the metadata service's publisher owns both classes
+    /// (aggregates and sync contributions) and the callbacks return empty batches. This is the
+    /// exact complement of the publisher's registration gate (consensus data is only built for
+    /// Boole+ slots), so exactly one path publishes for any duty. Both callbacks derive `epoch`
+    /// from the duty's own payload (the aggregate's target epoch, the contribution's slot),
+    /// which equal the duty slot's epoch by construction.
+    pub(crate) fn lighthouse_owns_publication(&self, epoch: Epoch) -> bool {
+        self.fork_schedule.active_fork(epoch) < Fork::Boole
     }
 
     /// Sign sync committee messages for all validators in a single SSV committee.
@@ -2242,8 +2148,6 @@ pub enum SpecificError {
         slot: Slot,
         reason: SyncSelectionProofAssignmentError,
     },
-    /// Pre-built consensus data not found for this committee (Boole+)
-    ConsensusDataNotFound,
     /// This committee's aggregate not found in consensus data (Boole+)
     AggregateNotInConsensus(u64),
     /// This subcommittee's contribution not found in consensus data (Boole+)
@@ -2710,32 +2614,30 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> ValidatorStore
     ) -> impl Stream<Item = Result<Vec<SignedAggregateAndProof<E>>, Error>> + Send {
         let this = Arc::clone(self);
         stream::once(async move {
-            let publish_via_lighthouse = aggregates.first().is_some_and(|first| {
-                this.fork_schedule
-                    .active_fork(first.aggregate.data().target.epoch)
-                    < Fork::Boole
-            });
+            // Empty input: nothing to sign and no fork to determine.
+            let Some(first) = aggregates.first() else {
+                return Ok(Vec::new());
+            };
 
-            if !publish_via_lighthouse {
-                // Boole+ (or empty input): hand Lighthouse an empty batch, which its publish loop
-                // drops silently. Publication ownership lives with the metadata service's
-                // aggregate publisher, which signs and publishes the decided worklist regardless
-                // of whether Lighthouse's duty snapshot saw the selection proofs in time. See
+            if !this.lighthouse_owns_publication(first.aggregate.data().target.epoch) {
+                // Boole+: hand Lighthouse an empty batch, which its publish loop drops silently.
+                // Publication ownership lives with the metadata service's publisher, which signs
+                // and publishes the decided worklist regardless of whether Lighthouse's duty
+                // snapshot saw the selection proofs in time. See
                 // [`crate::aggregator_post_consensus`].
-                if let Some(first) = aggregates.first() {
-                    // Lighthouse's request set is its snapshot's view of who aggregates; the
-                    // publisher only ever sees the decided view. Logging the request set here
-                    // keeps divergent operator views diagnosable by comparing the two.
-                    debug!(
-                        slot = %first.aggregate.data().slot,
-                        requested = aggregates.len(),
-                        aggregators = ?aggregates
-                            .iter()
-                            .map(|agg| agg.aggregator_index)
-                            .collect::<Vec<_>>(),
-                        "Deferring Lighthouse-requested aggregates to the decided-value publisher"
-                    );
-                }
+                //
+                // Lighthouse's request set is its snapshot's view of who aggregates; the
+                // publisher only ever sees the decided view. Logging the request set here keeps
+                // divergent operator views diagnosable by comparing the two.
+                debug!(
+                    slot = %first.aggregate.data().slot,
+                    requested = aggregates.len(),
+                    aggregators = ?aggregates
+                        .iter()
+                        .map(|agg| agg.aggregator_index)
+                        .collect::<Vec<_>>(),
+                    "Deferring Lighthouse-requested aggregates to the decided-value publisher"
+                );
                 return Ok(Vec::new());
             }
 
@@ -3024,50 +2926,48 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> ValidatorStore
         self: &Arc<Self>,
         contributions: Vec<ContributionToSign<E>>,
     ) -> impl Stream<Item = Result<Vec<SignedContributionAndProof<E>>, Error>> + Send {
-        // Early return for empty input — no fork to determine, nothing to sign
-        let Some(first) = contributions.first() else {
-            return Either::Right(FuturesUnordered::new());
-        };
+        let this = Arc::clone(self);
+        stream::once(async move {
+            // Empty input: nothing to sign and no fork to determine.
+            let Some(first) = contributions.first() else {
+                return Ok(Vec::new());
+            };
 
-        let epoch = first.contribution.slot.epoch(E::slots_per_epoch());
+            if !this
+                .lighthouse_owns_publication(first.contribution.slot.epoch(E::slots_per_epoch()))
+            {
+                // Boole+: hand Lighthouse an empty batch, which its publish loop drops silently.
+                // Publication ownership lives with the metadata service's publisher, which signs
+                // and publishes the decided worklist regardless of whether Lighthouse's duty
+                // snapshot saw the sync selection proofs in time. See
+                // [`crate::aggregator_post_consensus`].
+                //
+                // Lighthouse's request set is its snapshot's view of who aggregates; the
+                // publisher only ever sees the decided view. Logging the request set here keeps
+                // divergent operator views diagnosable by comparing the two.
+                debug!(
+                    slot = %first.contribution.slot,
+                    // Lighthouse requests contributions per subnet, so one call is one subnet;
+                    // the publisher's logs key on subcommittee index, and this field is the join.
+                    subnet = first.contribution.subcommittee_index,
+                    requested = contributions.len(),
+                    aggregators = ?contributions
+                        .iter()
+                        .map(|contrib| contrib.aggregator_index)
+                        .collect::<Vec<_>>(),
+                    "Deferring Lighthouse-requested contributions to the decided-value publisher"
+                );
+                return Ok(Vec::new());
+            }
 
-        if self.fork_schedule.active_fork(epoch) >= Fork::Boole {
-            // Boole+: group by committee, stream per committee via FuturesUnordered
-            let _span = info_span!("sign_sync_committee_contributions").entered();
-            let committee_mapping = self.group_by_committee(contributions, |c| c.aggregator_pubkey);
-
-            let committee_futures: FuturesUnordered<_> = committee_mapping
-                .into_iter()
-                .map(|(committee_id, (_cluster, contributions))| {
-                    let this = Arc::clone(self);
-                    async move {
-                        run_committee_signing(
-                            committee_id,
-                            contributions.len(),
-                            &validator_metrics::SIGNED_SYNC_COMMITTEE_CONTRIBUTIONS_TOTAL,
-                            this.sign_committee_sync_committee_contributions(
-                                committee_id,
-                                contributions,
-                            ),
-                        )
-                        .await
-                    }
-                })
-                .collect();
-
-            Either::Right(committee_futures)
-        } else {
-            // Pre-Boole: per-validator processing, no committee grouping needed
-            let this = Arc::clone(self);
-            Either::Left(stream::once(async move {
-                let futures = contributions.into_iter().map(|contrib| {
-                    let this = Arc::clone(&this);
-                    async move { this.sign_single_sync_committee_contribution(contrib).await }
-                });
-                let results = join_all(futures).await;
-                Ok(results.into_iter().filter_map(|r| r.ok()).collect())
-            }))
-        }
+            // Pre-Boole: per-validator processing, Lighthouse publishes the results
+            let futures = contributions.into_iter().map(|contrib| {
+                let this = Arc::clone(&this);
+                async move { this.sign_single_sync_committee_contribution(contrib).await }
+            });
+            let results = join_all(futures).await;
+            Ok(results.into_iter().filter_map(|r| r.ok()).collect())
+        })
     }
 
     // stolen from lighthouse

--- a/anchor/validator_store/src/metadata_service.rs
+++ b/anchor/validator_store/src/metadata_service.rs
@@ -10,7 +10,6 @@ use eth2::{
     BeaconNodeHttpClient,
     types::{BlockId, SyncContributionData},
 };
-use fork::{Fork, ForkSchedule};
 use futures::stream::{FuturesUnordered, StreamExt};
 use slot_clock::SlotClock;
 use ssv_types::{
@@ -28,7 +27,7 @@ use tracing::{Instrument, debug, error, info, info_span, trace, warn};
 use tree_hash::TreeHash;
 use types::{
     Attestation, AttestationData, ChainSpec, EthSpec, ForkName, Hash256, SignedAggregateAndProof,
-    Slot, SyncCommitteeContribution, SyncSelectionProof, SyncSubnetId,
+    SignedContributionAndProof, Slot, SyncCommitteeContribution, SyncSelectionProof, SyncSubnetId,
 };
 use validator_services::duties_service::{DutiesService, DutyAndProof};
 
@@ -178,7 +177,6 @@ pub struct MetadataService<E: EthSpec, T: SlotClock + 'static> {
     beacon_nodes: Arc<BeaconNodeFallback<T>>,
     executor: TaskExecutor,
     spec: Arc<ChainSpec>,
-    fork_schedule: Arc<ForkSchedule>,
     weighted_attestation_data: bool,
 }
 
@@ -226,7 +224,6 @@ async fn run_slot_start_publisher<T: SlotClock>(slot_clock: T, mut publish: impl
 }
 
 impl<E: EthSpec, T: SlotClock + 'static> MetadataService<E, T> {
-    #[expect(clippy::too_many_arguments)]
     pub fn new(
         duties_service: Arc<DutiesService<AnchorValidatorStore<T, E>, T>>,
         validator_store: Arc<AnchorValidatorStore<T, E>>,
@@ -234,7 +231,6 @@ impl<E: EthSpec, T: SlotClock + 'static> MetadataService<E, T> {
         beacon_nodes: Arc<BeaconNodeFallback<T>>,
         executor: TaskExecutor,
         spec: Arc<ChainSpec>,
-        fork_schedule: Arc<ForkSchedule>,
         weighted_attestation_data: bool,
     ) -> Self {
         Self {
@@ -244,7 +240,6 @@ impl<E: EthSpec, T: SlotClock + 'static> MetadataService<E, T> {
             beacon_nodes,
             executor,
             spec,
-            fork_schedule,
             weighted_attestation_data,
         }
     }
@@ -642,8 +637,13 @@ impl<E: EthSpec, T: SlotClock + 'static> MetadataService<E, T> {
         // ═══════════════════════════════════════════════════════════════════════
         let epoch = slot.epoch(E::slots_per_epoch());
 
+        // The exact complement of the Lighthouse callback gates by construction: consensus data
+        // (and therefore the publisher) exists precisely when Lighthouse does not own
+        // publication.
         let consensus_data_by_ssv_committee =
-            if self.fork_schedule.active_fork(epoch) >= Fork::Boole {
+            if self.validator_store.lighthouse_owns_publication(epoch) {
+                HashMap::new()
+            } else {
                 self.build_consensus_data_for_all_committees(
                     slot,
                     attesters_by_ssv_committee,
@@ -652,8 +652,6 @@ impl<E: EthSpec, T: SlotClock + 'static> MetadataService<E, T> {
                     all_subnet_ids,
                 )
                 .await?
-            } else {
-                HashMap::new()
             };
 
         let aggregator_info = AggregationAssignments {
@@ -674,19 +672,20 @@ impl<E: EthSpec, T: SlotClock + 'static> MetadataService<E, T> {
 
     /// Spawn the detached publisher for this slot's newly registered post-consensus executions.
     ///
-    /// The publisher owns Boole+ aggregate publication: the Lighthouse aggregate callback returns
-    /// an empty batch at Boole+ because its duty snapshot is cloned before slot-start selection
-    /// proofs finish, so aggregates the snapshot never saw would otherwise be silently dropped.
-    /// Contributions are unaffected (sync selection proofs are precomputed a slot ahead) and stay
-    /// on the Lighthouse publish path.
+    /// The publisher owns Boole+ publication of aggregates and sync contributions: the Lighthouse
+    /// callbacks return empty batches at Boole+ because their duty snapshots are cloned before
+    /// slot-start selection proofs finish, so roots the snapshots never saw would otherwise be
+    /// silently dropped. (Anchor's sync selection proofs are NOT precomputed a slot ahead: its
+    /// one-slot Lighthouse lookahead config starts slot N's proof signing at slot N's boundary,
+    /// in the same slot-start partial-signature batch as the attestation proofs.)
     ///
     /// Exactly-once: `new_executions` holds only vacant registrations, so a repeated Phase 3 run
     /// for one slot cannot spawn a second publisher for the same `(committee, slot)`.
     ///
     /// The publisher is implicitly Boole-gated (consensus data exists only for Boole+ slots),
-    /// while the empty Lighthouse callback gates on the aggregate's target epoch. The two agree
-    /// because `attestation.data.target.epoch` equals the slot's own epoch by construction, which
-    /// is what rules out both paths publishing for one duty.
+    /// while the empty Lighthouse callbacks gate on the duty's epoch. The two agree because
+    /// `attestation.data.target.epoch` and `contribution.slot`'s epoch equal the slot's own epoch
+    /// by construction, which is what rules out both paths publishing for one duty.
     fn spawn_aggregate_publisher(
         &self,
         slot: Slot,
@@ -702,9 +701,12 @@ impl<E: EthSpec, T: SlotClock + 'static> MetadataService<E, T> {
         self.executor.spawn(
             async move {
                 validator_store
-                    .publish_decided_aggregates(slot, new_executions, |fork_name, signed| {
-                        post_aggregate(&beacon_nodes, fork_name, signed)
-                    })
+                    .publish_decided_aggregates(
+                        slot,
+                        new_executions,
+                        |fork_name, signed| post_aggregate(&beacon_nodes, fork_name, signed),
+                        |signed| post_contribution(&beacon_nodes, signed),
+                    )
                     .await;
             },
             "aggregator_committee_publisher",
@@ -1475,6 +1477,27 @@ async fn post_aggregate<T: SlotClock + 'static, E: EthSpec>(
                         .post_validator_aggregate_and_proof_v1(signed)
                         .await
                 }
+            }
+        })
+        .await
+        .map_err(|e| format!("{e}"))
+}
+
+/// POST one signed sync contribution, matching go-ssv's publication shape at the reference pin
+/// (one contribution per request, published as soon as its quorum lands). Endpoint policy mirrors
+/// Lighthouse's at the pin: `first_success` across the beacon nodes; the endpoint takes no fork
+/// header.
+async fn post_contribution<T: SlotClock + 'static, E: EthSpec>(
+    beacon_nodes: &BeaconNodeFallback<T>,
+    signed: SignedContributionAndProof<E>,
+) -> Result<(), String> {
+    beacon_nodes
+        .first_success(|beacon_node| {
+            let signed = std::slice::from_ref(&signed);
+            async move {
+                beacon_node
+                    .post_validator_contribution_and_proofs(signed)
+                    .await
             }
         })
         .await

--- a/anchor/validator_store/src/metrics.rs
+++ b/anchor/validator_store/src/metrics.rs
@@ -148,13 +148,15 @@ pub const HTTP_ERROR: &str = "http_error";
 pub const NO_AGGREGATES: &str = "no_aggregates";
 pub const NO_SIGNATURES: &str = "no_signatures";
 
-/// Outcomes of the Boole+ aggregate publisher. `consensus_error` (outcome failed or timed out)
-/// and `no_aggregates` (decided worklist held contributions only) count committees, since those
+/// Aggregate-class outcomes of the Boole+ publisher. `consensus_error` (outcome failed or timed
+/// out) and `no_aggregates` (decided worklist held no aggregates) count committees, since those
 /// failures occur before any per-root work exists. `success` and `http_error` (per publish
 /// attempt) and `no_signatures` (root missed signature quorum in time) count individual
-/// aggregates, matching go-ssv's one-POST-per-aggregate accounting. All increments live in
-/// `AnchorValidatorStore::publish_decided_aggregates` and its per-committee/per-root helpers in
-/// `aggregator_post_consensus.rs`.
+/// aggregates, matching go-ssv's one-POST-per-aggregate accounting. The publisher's sync
+/// contribution outcomes are deliberately excluded: they keep the Lighthouse-era
+/// `SIGNED_SYNC_COMMITTEE_CONTRIBUTIONS_TOTAL` accounting and per-publish logs instead. All
+/// increments live in `AnchorValidatorStore::publish_decided_aggregates` and its
+/// per-committee/per-root helpers in `aggregator_post_consensus.rs`.
 pub static AGGREGATOR_COMMITTEE_PUBLISH_TOTAL: LazyLock<Result<IntCounterVec>> =
     LazyLock::new(|| {
         try_create_int_counter_vec(

--- a/anchor/validator_store/src/testing/aggregator_post_consensus.rs
+++ b/anchor/validator_store/src/testing/aggregator_post_consensus.rs
@@ -78,6 +78,16 @@ const MIXED_WORKLIST_SIZE: usize = 1 + CONTRIBUTION_SUBCOMMITTEES.len();
 /// so deadline tests reach the timeout without sleeping two real slots.
 const PAST_PUBLISH_DEADLINE_SECS: u64 = (TEST_SLOT + 3) * SLOT_DURATION_SECS;
 
+/// A clock position strictly between the two per-root deadlines for `TEST_SLOT`: past the
+/// contribution deadline (that slot's end) and before the aggregate deadline (one slot later).
+/// Tests of the per-class asymmetry sit here, where the two classes must behave differently.
+const BETWEEN_CLASS_DEADLINES_SECS: u64 =
+    (TEST_SLOT + 1) * SLOT_DURATION_SECS + SLOT_DURATION_SECS / 2;
+
+/// Long enough that a publisher which is going to finish has finished, short enough to keep the
+/// asymmetry test fast. Only used to prove a publisher is still waiting.
+const STILL_WAITING_PROBE: Duration = Duration::from_millis(500);
+
 const CAPTURE_TIMEOUT: Duration = Duration::from_secs(2);
 const CAPTURE_POLL_INTERVAL: Duration = Duration::from_millis(10);
 /// Extra wait after the expected capture count is reached, to catch spurious extra captures.
@@ -672,9 +682,9 @@ async fn republished_assignments_do_not_resubmit() {
 }
 
 /// A publisher that joins after the worklist has already been signed still publishes both
-/// classes from the cached execution, without re-running consensus or duplicating signatures.
+/// classes from the resolved execution, without re-running consensus or duplicating signatures.
 #[tokio::test(flavor = "multi_thread")]
-async fn a_late_publisher_publishes_both_classes_from_the_cached_execution() {
+async fn a_late_publisher_publishes_both_classes_from_the_resolved_execution() {
     // Arrange: let the detached execution finish the complete worklist first.
     let fixture = AggregatorCommitteeFixture::new(MIXED_COMMITTEE_VALIDATOR_COUNT);
     let (decided, execution) = fixture.seed_mixed_decided_value_with_execution();
@@ -696,7 +706,7 @@ async fn a_late_publisher_publishes_both_classes_from_the_cached_execution() {
                 (contributor, CONTRIBUTION_SUBCOMMITTEES[1]),
             ],
         },
-        "a late publisher should publish from the cached execution"
+        "a late publisher should publish from the resolved execution"
     );
 
     // Still no duplicate captures after the late read.
@@ -943,12 +953,13 @@ async fn slot_mismatched_decided_payloads_are_excluded() {
 
 // ==================== Publisher registration tests ====================
 
-/// Registration is vacant-only, so a `(committee, slot)` yields its publisher handle exactly once.
+/// Registration is first-insert-only, so a `(committee, slot)` yields its publisher handle
+/// exactly once.
 ///
 /// The handle is what makes the publisher run, so a second handle for one slot would post the
 /// same aggregates to the beacon node twice.
 #[tokio::test(flavor = "multi_thread")]
-async fn start_aggregator_post_consensus_returns_only_vacant_insertions() {
+async fn start_aggregator_post_consensus_returns_only_first_insertions() {
     // Arrange
     let fixture = AggregatorCommitteeFixture::new(MIXED_COMMITTEE_VALIDATOR_COUNT);
     let decided = Arc::new(fixture.mixed_decided_data());
@@ -1376,6 +1387,94 @@ async fn publish_decided_aggregates_hands_the_decided_versions_fork_to_the_closu
             fixture.aggregator_index(FIRST_AGGREGATE_COMMITTEE),
         )],
         "the publish closure must receive the fork named by the decided value's DataVersion"
+    );
+}
+
+/// The two classes carry different deadlines, and the difference is load-bearing: a beacon node
+/// accepts a contribution only during its own slot, while aggregates stay acceptable for about an
+/// epoch. So contributions stop waiting for quorum at slot end and aggregates keep waiting.
+///
+/// The clock sits between the two deadlines and signature collection never resolves, so the two
+/// classes must diverge: the contribution roots give up immediately and count `timeout`, while the
+/// aggregate root is still waiting when the probe expires. A refactor that collapsed both classes
+/// onto one deadline would fail this test in one direction or the other.
+#[tokio::test(flavor = "multi_thread")]
+async fn contributions_stop_at_slot_end_while_aggregates_keep_waiting() {
+    let _metric_guard = PUBLISH_METRIC_LOCK.lock().await;
+    // Arrange: a mixed decided value whose roots never reach quorum, with the clock past the
+    // contribution deadline (this slot's end) but before the aggregate deadline (a slot later).
+    let fixture = AggregatorCommitteeFixture::new(MIXED_COMMITTEE_VALIDATOR_COUNT);
+    fixture.harness.hang_signature_collection();
+    let (_, execution) = fixture.seed_mixed_decided_value_with_execution();
+    fixture
+        .harness
+        .slot_clock
+        .set_current_time(Duration::from_secs(BETWEEN_CLASS_DEADLINES_SECS));
+    let contribution_timeouts_before = contribution_signing_count(metrics::TIMEOUT);
+    let no_signatures_before = publish_result_count(metrics::NO_SIGNATURES);
+
+    // Act: the publisher cannot finish while the aggregate root is still within its deadline.
+    let outcome = tokio::time::timeout(STILL_WAITING_PROBE, fixture.run_publisher(execution)).await;
+
+    // Assert: the aggregate is still waiting past this slot's end.
+    assert!(
+        outcome.is_err(),
+        "the aggregate root must keep waiting past slot end; it stays publishable for about an \
+         epoch, so bounding it here would discard a recoverable duty"
+    );
+
+    // The contributions already gave up, counted under the class's own signing counter.
+    assert_eq!(
+        contribution_signing_count(metrics::TIMEOUT),
+        contribution_timeouts_before + CONTRIBUTION_SUBCOMMITTEES.len() as u64,
+        "each contribution root past slot end should count once under `timeout`"
+    );
+    assert_eq!(
+        publish_result_count(metrics::NO_SIGNATURES),
+        no_signatures_before,
+        "contribution outcomes must stay out of the aggregate-only publish counter"
+    );
+}
+
+/// A failing contribution POST is contained to its own root: the sibling aggregate still
+/// publishes and the drain still completes.
+///
+/// The aggregate side of this is covered by `publish_decided_aggregates_survives_a_failing_publish`;
+/// this is the contribution half, which the two-class publisher made reachable.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_failing_contribution_post_does_not_withhold_the_sibling_aggregate() {
+    // Arrange: every contribution POST fails, keyed by the contributor's aggregator index so the
+    // outcome does not depend on which root resolves first.
+    let fixture = AggregatorCommitteeFixture::new(MIXED_COMMITTEE_VALIDATOR_COUNT);
+    let (_, execution) = fixture.seed_mixed_decided_value_with_execution();
+    let failing_contributor = *fixture.validator_index(CONTRIBUTOR_VALIDATOR_IDX) as u64;
+
+    // Act
+    let published = run_recording_publisher(
+        &fixture.harness,
+        vec![(fixture.committee_id, execution)],
+        |aggregator| {
+            if aggregator == failing_contributor {
+                Err("beacon node rejected the contribution".to_string())
+            } else {
+                Ok(())
+            }
+        },
+    )
+    .await;
+
+    // Assert: both contributions were still attempted, and the aggregate published regardless.
+    assert_eq!(
+        published,
+        RecordedPublishes {
+            aggregates: vec![(DEFAULT_DECIDED_FORK, fixture.expected_aggregator_index())],
+            contributions: vec![
+                (failing_contributor, CONTRIBUTION_SUBCOMMITTEES[0]),
+                (failing_contributor, CONTRIBUTION_SUBCOMMITTEES[1]),
+            ],
+        },
+        "a failing contribution POST must not withhold its sibling aggregate or its own sibling \
+         contribution"
     );
 }
 

--- a/anchor/validator_store/src/testing/aggregator_post_consensus.rs
+++ b/anchor/validator_store/src/testing/aggregator_post_consensus.rs
@@ -1439,8 +1439,9 @@ async fn contributions_stop_at_slot_end_while_aggregates_keep_waiting() {
 /// A failing contribution POST is contained to its own root: the sibling aggregate still
 /// publishes and the drain still completes.
 ///
-/// The aggregate side of this is covered by `publish_decided_aggregates_survives_a_failing_publish`;
-/// this is the contribution half, which the two-class publisher made reachable.
+/// The aggregate side of this is covered by
+/// `publish_decided_aggregates_survives_a_failing_publish`; this is the contribution half, which
+/// the two-class publisher made reachable.
 #[tokio::test(flavor = "multi_thread")]
 async fn a_failing_contribution_post_does_not_withhold_the_sibling_aggregate() {
     // Arrange: every contribution POST fails, keyed by the contributor's aggregator index so the

--- a/anchor/validator_store/src/testing/aggregator_post_consensus.rs
+++ b/anchor/validator_store/src/testing/aggregator_post_consensus.rs
@@ -6,10 +6,10 @@
 //! class must still produce the partial signatures for the other class, so the shared committee
 //! batch never stalls below its expected size.
 //!
-//! The two classes are read out differently. Contributions still go back through the Lighthouse
-//! callback, which filters the shared outcome down to its own requested items. Aggregates do not:
-//! Anchor publishes them itself from the decided value, one publish call per root, so
-//! `publish_decided_aggregates` is the reader and the aggregate callback returns nothing.
+//! Both classes are read out the same way: Anchor publishes aggregates and contributions itself
+//! from the decided value, one publish call per root, so `publish_decided_aggregates` is the
+//! only reader and both Lighthouse callbacks return nothing (see `testing/committee_aggregate.rs`
+//! and `testing/committee_contribution.rs` for the callback contract).
 //!
 //! The worklist tasks are detached, so captured `sign_and_collect` calls arrive
 //! asynchronously; assertions on capture counts poll with a deadline and then let the
@@ -22,7 +22,7 @@ use std::{
 };
 
 use bls::{AggregateSignature, FixedBytesExtended, PublicKeyBytes, Signature};
-use futures::{FutureExt, StreamExt};
+use futures::FutureExt;
 use parking_lot::Mutex;
 use signature_collector::SignatureRequester;
 use ssv_types::{
@@ -35,10 +35,8 @@ use ssz::Encode;
 use ssz_types::VariableList;
 use types::{
     AttestationBase, AttestationData, AttestationElectra, Checkpoint, Epoch, ForkName, Hash256,
-    MainnetEthSpec, SignedContributionAndProof, Slot, SyncCommitteeContribution,
-    SyncSelectionProof,
+    MainnetEthSpec, Slot, SyncCommitteeContribution,
 };
-use validator_store::{ContributionToSign, ValidatorStore};
 
 use super::common::*;
 use crate::{
@@ -49,8 +47,6 @@ use crate::{
 type DecidedData = AggregatorCommitteeConsensusData<MainnetEthSpec>;
 /// A handle on one `(committee, slot)` post-consensus execution, as handed to the publisher.
 type Execution = AggregatorPostConsensusShared<MainnetEthSpec>;
-
-type SignContributionsResult = Vec<Result<Vec<SignedContributionAndProof<MainnetEthSpec>>, Error>>;
 
 const COMMITTEE_OPERATOR_IDS: [OperatorId; 4] =
     [OperatorId(1), OperatorId(2), OperatorId(3), OperatorId(4)];
@@ -69,7 +65,6 @@ const BEACON_COMMITTEE_INDEX: u64 = 0;
 const CONFLICTING_BEACON_COMMITTEE_INDEX: u64 = 1;
 const CONTRIBUTION_SUBCOMMITTEES: [u64; 2] = [0, 1];
 const ALL_SUBCOMMITTEES: [u64; 4] = [0, 1, 2, 3];
-const MISSING_SUBCOMMITTEE_INDEX: u64 = 2;
 
 /// Decided validator indices with no local metadata, so the worklist filters them out.
 const FOREIGN_AGGREGATOR_INDEX: usize = 900;
@@ -145,8 +140,7 @@ impl AggregatorCommitteeFixture {
     }
 
     /// Seeds `AggregationAssignments` at `TEST_SLOT` without consensus data for any committee, so
-    /// no execution is registered and the callbacks fail with `ConsensusDataNotFound`. Returns the
-    /// (empty) set of executions the publish registered.
+    /// no execution is registered. Returns the (empty) set of executions the publish registered.
     fn seed_assignments_without_consensus_data(&self) -> Vec<(CommitteeId, Execution)> {
         self.harness.publish_decided_values(HashMap::new())
     }
@@ -193,9 +187,9 @@ impl AggregatorCommitteeFixture {
         (data, execution)
     }
 
-    /// Runs the publisher over this committee's execution with an always-succeeding recording
-    /// closure, returning one `(fork, aggregator index)` entry per publish call.
-    async fn run_publisher(&self, execution: Execution) -> Vec<RecordedPublish> {
+    /// Runs the publisher over this committee's execution with always-succeeding recording
+    /// closures, returning one entry per publish call of either class.
+    async fn run_publisher(&self, execution: Execution) -> RecordedPublishes {
         run_recording_publisher(&self.harness, vec![(self.committee_id, execution)], |_| {
             Ok(())
         })
@@ -206,35 +200,6 @@ impl AggregatorCommitteeFixture {
     fn expected_aggregator_index(&self) -> u64 {
         self.harness
             .aggregator_index(COMMITTEE_INDEX, AGGREGATE_VALIDATOR_IDX)
-    }
-
-    fn create_contribution(
-        &self,
-        position: usize,
-        subcommittee_index: u64,
-    ) -> ContributionToSign<MainnetEthSpec> {
-        let validator = self.validator_metadata(position);
-        ContributionToSign {
-            aggregator_index: *validator
-                .index
-                .expect("test validator should have an index") as u64,
-            aggregator_pubkey: validator.public_key,
-            contribution: test_contribution(subcommittee_index),
-            selection_proof: SyncSelectionProof::from(Signature::empty()),
-        }
-    }
-
-    async fn collect_contributions(
-        &self,
-        contributions: Vec<ContributionToSign<MainnetEthSpec>>,
-    ) -> SignContributionsResult {
-        let stream = self
-            .harness
-            .validator_store
-            .sign_sync_committee_contributions(contributions);
-        tokio::time::timeout(STREAM_TIMEOUT, stream.collect())
-            .await
-            .expect("contribution callback should complete within the stream timeout")
     }
 }
 
@@ -381,39 +346,69 @@ fn build_decided_data_at_fork(
 
 // ==================== Recording publisher ====================
 
-/// Fork and aggregator index of one publish call made by the recording closure.
+/// Fork and aggregator index of one aggregate publish call made by the recording closure.
 type RecordedPublish = (ForkName, u64);
+/// Aggregator index and subcommittee index of one contribution publish call.
+type RecordedContribution = (u64, u64);
 
-/// Runs the publisher over `executions` with a recording publish closure, returning one
-/// `(fork, aggregator index)` entry per publish call.
+/// Every publish call the recording publisher made, one entry per call, by class.
+#[derive(Debug, Default, PartialEq)]
+struct RecordedPublishes {
+    aggregates: Vec<RecordedPublish>,
+    contributions: Vec<RecordedContribution>,
+}
+
+/// Runs the publisher over `executions` with recording publish closures, returning one entry per
+/// publish call of either class.
 ///
-/// The recorder captures the `ForkName` each call receives, so tests can pin that it matches the
-/// decided value's `DataVersion`. `outcome` decides each call's publish result from its
-/// aggregator index, so a test can fail one aggregate's publish without depending on the order
-/// roots finish in. The returned calls are sorted by aggregator index for the same reason.
+/// The aggregate recorder captures the `ForkName` each call receives, so tests can pin that it
+/// matches the decided value's `DataVersion`. `outcome` decides each call's publish result from
+/// its aggregator index (for both classes), so a test can fail one root's publish without
+/// depending on the order roots finish in. The returned calls are sorted for the same reason.
 async fn run_recording_publisher(
     harness: &ValidatorStoreTestHarness,
     executions: Vec<(CommitteeId, Execution)>,
     outcome: impl Fn(u64) -> Result<(), String>,
-) -> Vec<RecordedPublish> {
-    let recorded: Arc<Mutex<Vec<RecordedPublish>>> = Arc::new(Mutex::new(Vec::new()));
+) -> RecordedPublishes {
+    let aggregates: Arc<Mutex<Vec<RecordedPublish>>> = Arc::new(Mutex::new(Vec::new()));
+    let contributions: Arc<Mutex<Vec<RecordedContribution>>> = Arc::new(Mutex::new(Vec::new()));
+    let outcome = &outcome;
     harness
         .validator_store
-        .publish_decided_aggregates(Slot::new(TEST_SLOT), executions, |fork_name, signed| {
-            let recorded = Arc::clone(&recorded);
-            let outcome = &outcome;
-            async move {
-                let aggregator = signed.message().aggregator_index();
-                let result = outcome(aggregator);
-                recorded.lock().push((fork_name, aggregator));
-                result
-            }
-        })
+        .publish_decided_aggregates(
+            Slot::new(TEST_SLOT),
+            executions,
+            |fork_name, signed| {
+                let aggregates = Arc::clone(&aggregates);
+                async move {
+                    let aggregator = signed.message().aggregator_index();
+                    let result = outcome(aggregator);
+                    aggregates.lock().push((fork_name, aggregator));
+                    result
+                }
+            },
+            |signed| {
+                let contributions = Arc::clone(&contributions);
+                async move {
+                    let aggregator = signed.message.aggregator_index;
+                    let result = outcome(aggregator);
+                    contributions
+                        .lock()
+                        .push((aggregator, signed.message.contribution.subcommittee_index));
+                    result
+                }
+            },
+        )
         .await;
 
-    let mut recorded = recorded.lock().clone();
-    recorded.sort_by_key(|&(_, aggregator)| aggregator);
-    recorded
+    let mut aggregates = aggregates.lock().clone();
+    aggregates.sort_by_key(|&(_, aggregator)| aggregator);
+    let mut contributions = contributions.lock().clone();
+    contributions.sort_unstable();
+    RecordedPublishes {
+        aggregates,
+        contributions,
+    }
 }
 
 /// Serializes the tests that mutate and assert deltas on the `consensus_error`, `no_aggregates`,
@@ -430,6 +425,16 @@ fn publish_result_count(label: &str) -> u64 {
     metrics::AGGREGATOR_COMMITTEE_PUBLISH_TOTAL
         .as_ref()
         .expect("the publish outcome metric should be created")
+        .with_label_values(&[label])
+        .get()
+}
+
+/// Current value of one `SIGNED_SYNC_COMMITTEE_CONTRIBUTIONS_TOTAL` label, under the same
+/// [`PUBLISH_METRIC_LOCK`] discipline as [`publish_result_count`].
+fn contribution_signing_count(label: &str) -> u64 {
+    validator_metrics::SIGNED_SYNC_COMMITTEE_CONTRIBUTIONS_TOTAL
+        .as_ref()
+        .expect("the contribution signing metric should be created")
         .with_label_values(&[label])
         .get()
 }
@@ -528,16 +533,6 @@ async fn assert_captured_calls_settle_at(harness: &ValidatorStoreTestHarness, ex
     );
 }
 
-/// Asserts the recording publisher made exactly one publish call per expected aggregator index,
-/// all at [`DEFAULT_DECIDED_FORK`].
-fn assert_published_aggregators(published: &[RecordedPublish], expected: &[u64], context: &str) {
-    let expected: Vec<RecordedPublish> = expected
-        .iter()
-        .map(|&aggregator| (DEFAULT_DECIDED_FORK, aggregator))
-        .collect();
-    assert_eq!(published, expected.as_slice(), "{context}");
-}
-
 /// Unwraps a single-committee stream result into its signed batch.
 fn single_batch<T>(results: Vec<Result<Vec<T>, Error>>) -> Vec<T> {
     assert_eq!(results.len(), 1, "expected one committee stream item");
@@ -550,39 +545,63 @@ fn single_batch<T>(results: Vec<Result<Vec<T>, Error>>) -> Vec<T> {
 
 // ==================== Complete-worklist tests ====================
 
-/// A contribution-only Lighthouse callback must still trigger signing of the decided
-/// aggregate: the detached execution signs the complete mixed worklist, and every root joins
-/// one three-entry committee batch keyed by the decided-value hash.
+/// The publisher takes both classes from the decided value while both Lighthouse callbacks
+/// return empty batches.
+///
+/// This pins the design the module rests on: which callbacks fire has no influence on what is
+/// signed or published. The execution signs the complete mixed worklist into one committee
+/// batch, and the publisher is the single POSTer for aggregates and contributions alike.
 #[tokio::test(flavor = "multi_thread")]
-async fn contribution_only_callback_signs_complete_mixed_worklist() {
+async fn publisher_takes_both_classes_while_the_callbacks_return_empty() {
     // Arrange
     let fixture = AggregatorCommitteeFixture::new(MIXED_COMMITTEE_VALIDATOR_COUNT);
-    let decided = fixture.seed_mixed_decided_value();
+    let (decided, execution) = fixture.seed_mixed_decided_value_with_execution();
+    let aggregates = vec![
+        fixture
+            .harness
+            .create_aggregate(COMMITTEE_INDEX, AGGREGATE_VALIDATOR_IDX),
+    ];
     let contributions = CONTRIBUTION_SUBCOMMITTEES
         .iter()
-        .map(|&subcommittee| fixture.create_contribution(CONTRIBUTOR_VALIDATOR_IDX, subcommittee))
+        .map(|&subcommittee| {
+            fixture.harness.create_contribution(
+                COMMITTEE_INDEX,
+                CONTRIBUTOR_VALIDATOR_IDX,
+                subcommittee,
+            )
+        })
         .collect();
 
-    // Act: only the contribution callback fires.
-    let results = fixture.collect_contributions(contributions).await;
+    // Act: both callbacks fire, then the publisher reads the same execution.
+    let aggregate_results = fixture.harness.collect_aggregates(aggregates).await;
+    let contribution_results = fixture.harness.collect_contributions(contributions).await;
+    let published = fixture.run_publisher(execution).await;
 
-    // Assert: the callback returns exactly its own two contributions.
-    let mut signed = single_batch(results);
-    signed.sort_by_key(|item| item.message.contribution.subcommittee_index);
-    assert_eq!(
-        signed.len(),
-        CONTRIBUTION_SUBCOMMITTEES.len(),
-        "the contribution callback should return only its requested contributions"
+    // Assert: Lighthouse gets nothing to publish on either path.
+    assert!(
+        single_batch(aggregate_results).is_empty(),
+        "the aggregate callback must hand Lighthouse an empty batch at Boole+"
     );
-    for (item, &subcommittee) in signed.iter().zip(CONTRIBUTION_SUBCOMMITTEES.iter()) {
-        assert_eq!(item.message.contribution.subcommittee_index, subcommittee);
-        assert_eq!(
-            item.message.aggregator_index,
-            *fixture.validator_index(CONTRIBUTOR_VALIDATOR_IDX) as u64
-        );
-    }
+    assert!(
+        single_batch(contribution_results).is_empty(),
+        "the contribution callback must hand Lighthouse an empty batch at Boole+"
+    );
 
-    // The aggregate root is signed by a detached task even though no aggregate callback fired.
+    // Anchor publishes the full decided worklist itself.
+    let contributor = *fixture.validator_index(CONTRIBUTOR_VALIDATOR_IDX) as u64;
+    assert_eq!(
+        published,
+        RecordedPublishes {
+            aggregates: vec![(DEFAULT_DECIDED_FORK, fixture.expected_aggregator_index())],
+            contributions: vec![
+                (contributor, CONTRIBUTION_SUBCOMMITTEES[0]),
+                (contributor, CONTRIBUTION_SUBCOMMITTEES[1]),
+            ],
+        },
+        "the publisher should publish the decided aggregate and both decided contributions"
+    );
+
+    // The worklist was signed exactly once, into one committee batch.
     assert_captured_calls_settle_at(&fixture.harness, MIXED_WORKLIST_SIZE).await;
     let calls = committee_calls(&fixture.harness);
     assert_eq!(
@@ -600,53 +619,6 @@ async fn contribution_only_callback_signs_complete_mixed_worklist() {
         calls_for_pubkey(&calls, fixture.pubkey(CONTRIBUTOR_VALIDATOR_IDX)),
         CONTRIBUTION_SUBCOMMITTEES.len(),
         "the contributor must sign one root per subcommittee"
-    );
-}
-
-/// The mirror case, read through the publisher: the aggregate callback returns nothing, the
-/// publisher takes the decided aggregate, and the decided contributions are signed anyway.
-///
-/// The aggregate callback no longer joins the execution at all, so this is the test that the
-/// aggregate half of the worklist is complete: only the publisher can observe it.
-#[tokio::test(flavor = "multi_thread")]
-async fn publisher_takes_the_decided_aggregate_while_the_callback_returns_empty() {
-    // Arrange
-    let fixture = AggregatorCommitteeFixture::new(MIXED_COMMITTEE_VALIDATOR_COUNT);
-    let (decided, execution) = fixture.seed_mixed_decided_value_with_execution();
-    let aggregates = vec![
-        fixture
-            .harness
-            .create_aggregate(COMMITTEE_INDEX, AGGREGATE_VALIDATOR_IDX),
-    ];
-
-    // Act: only the aggregate callback fires, and the publisher reads the same execution.
-    let results = fixture.harness.collect_aggregates(aggregates).await;
-    let published = fixture.run_publisher(execution).await;
-
-    // Assert: Lighthouse gets nothing to publish, Anchor publishes the decided aggregate itself.
-    assert!(
-        single_batch(results).is_empty(),
-        "the aggregate callback must hand Lighthouse an empty batch at Boole+"
-    );
-    assert_published_aggregators(
-        &published,
-        &[fixture.expected_aggregator_index()],
-        "the publisher should publish the decided aggregate",
-    );
-
-    // Both contribution roots are signed by detached tasks without a contribution callback.
-    assert_captured_calls_settle_at(&fixture.harness, MIXED_WORKLIST_SIZE).await;
-    let calls = committee_calls(&fixture.harness);
-    assert_eq!(distinct_roots(&calls).len(), MIXED_WORKLIST_SIZE);
-    assert_batch_identity(&calls, MIXED_WORKLIST_SIZE, decided.hash());
-    assert_eq!(
-        calls_for_pubkey(&calls, fixture.pubkey(AGGREGATE_VALIDATOR_IDX)),
-        1
-    );
-    assert_eq!(
-        calls_for_pubkey(&calls, fixture.pubkey(CONTRIBUTOR_VALIDATOR_IDX)),
-        CONTRIBUTION_SUBCOMMITTEES.len(),
-        "the decided contributions must be signed without a contribution callback"
     );
 }
 
@@ -699,73 +671,32 @@ async fn republished_assignments_do_not_resubmit() {
     assert_batch_identity(&calls, MIXED_WORKLIST_SIZE, decided.hash());
 }
 
-/// The contribution callback and the publisher read the same execution: neither re-runs consensus
-/// nor duplicates signatures, and each takes only its own class of decided item.
+/// A publisher that joins after the worklist has already been signed still publishes both
+/// classes from the cached execution, without re-running consensus or duplicating signatures.
 #[tokio::test(flavor = "multi_thread")]
-async fn contribution_callback_and_publisher_share_one_execution() {
-    // Arrange
+async fn a_late_publisher_publishes_both_classes_from_the_cached_execution() {
+    // Arrange: let the detached execution finish the complete worklist first.
     let fixture = AggregatorCommitteeFixture::new(MIXED_COMMITTEE_VALIDATOR_COUNT);
     let (decided, execution) = fixture.seed_mixed_decided_value_with_execution();
-    let contributions = CONTRIBUTION_SUBCOMMITTEES
-        .iter()
-        .map(|&subcommittee| fixture.create_contribution(CONTRIBUTOR_VALIDATOR_IDX, subcommittee))
-        .collect();
+    assert_captured_calls_settle_at(&fixture.harness, MIXED_WORKLIST_SIZE).await;
+    let calls = committee_calls(&fixture.harness);
+    assert_batch_identity(&calls, MIXED_WORKLIST_SIZE, decided.hash());
 
-    // Act: contribution callback first, then the publisher joins the cached outcome.
-    let contribution_results = fixture.collect_contributions(contributions).await;
+    // Act: the publisher joins the finished execution.
     let published = fixture.run_publisher(execution).await;
 
-    // Assert: each reader took only its own class.
+    // Assert: it publishes the full decided worklist.
+    let contributor = *fixture.validator_index(CONTRIBUTOR_VALIDATOR_IDX) as u64;
     assert_eq!(
-        single_batch(contribution_results).len(),
-        CONTRIBUTION_SUBCOMMITTEES.len(),
-        "the contribution callback should return only its contributions"
-    );
-    assert_published_aggregators(
-        &published,
-        &[fixture.expected_aggregator_index()],
-        "the publisher should publish only the decided aggregate",
-    );
-
-    // The union is signed exactly once: no duplicate captures from the second reader.
-    assert_captured_calls_settle_at(&fixture.harness, MIXED_WORKLIST_SIZE).await;
-    let calls = committee_calls(&fixture.harness);
-    assert_eq!(distinct_roots(&calls).len(), MIXED_WORKLIST_SIZE);
-    assert_batch_identity(&calls, MIXED_WORKLIST_SIZE, decided.hash());
-}
-
-/// Dropping a callback future must not cancel the execution it is reading: the complete worklist
-/// is still signed, and a later reader still gets its items from the same execution.
-#[tokio::test(flavor = "multi_thread")]
-async fn dropped_callback_future_still_completes_worklist() {
-    // Arrange
-    let fixture = AggregatorCommitteeFixture::new(MIXED_COMMITTEE_VALIDATOR_COUNT);
-    let (decided, execution) = fixture.seed_mixed_decided_value_with_execution();
-    let contributions: Vec<_> = CONTRIBUTION_SUBCOMMITTEES
-        .iter()
-        .map(|&subcommittee| fixture.create_contribution(CONTRIBUTOR_VALIDATOR_IDX, subcommittee))
-        .collect();
-
-    // Act: poll the contribution callback once, then drop it. A zero timeout polls the inner
-    // future exactly once before the deadline elapses; if the callback happens to win the race the
-    // scenario degrades to the sequential case.
-    let stream = fixture
-        .harness
-        .validator_store
-        .sign_sync_committee_contributions(contributions);
-    let _ = tokio::time::timeout(Duration::ZERO, stream.collect::<SignContributionsResult>()).await;
-
-    // Assert: the detached execution still signs the complete worklist.
-    assert_captured_calls_settle_at(&fixture.harness, MIXED_WORKLIST_SIZE).await;
-    let calls = committee_calls(&fixture.harness);
-    assert_batch_identity(&calls, MIXED_WORKLIST_SIZE, decided.hash());
-
-    // A late publisher joins the finished execution and gets the decided aggregate.
-    let published = fixture.run_publisher(execution).await;
-    assert_published_aggregators(
-        &published,
-        &[fixture.expected_aggregator_index()],
-        "a late publisher should publish from the cached execution",
+        published,
+        RecordedPublishes {
+            aggregates: vec![(DEFAULT_DECIDED_FORK, fixture.expected_aggregator_index())],
+            contributions: vec![
+                (contributor, CONTRIBUTION_SUBCOMMITTEES[0]),
+                (contributor, CONTRIBUTION_SUBCOMMITTEES[1]),
+            ],
+        },
+        "a late publisher should publish from the cached execution"
     );
 
     // Still no duplicate captures after the late read.
@@ -777,7 +708,8 @@ async fn dropped_callback_future_still_completes_worklist() {
 }
 
 /// One validator owning an aggregate plus contributions in all four subcommittees keeps five
-/// distinct signing roots in one five-entry batch.
+/// distinct signing roots in one five-entry batch, and the publisher assembles one POST per
+/// `(validator, subcommittee)` identity.
 #[tokio::test(flavor = "multi_thread")]
 async fn multi_root_validator_keeps_distinct_roots() {
     // Arrange
@@ -788,20 +720,26 @@ async fn multi_root_validator_keeps_distinct_roots() {
         .iter()
         .map(|&subcommittee| (validator, subcommittee))
         .collect();
-    let decided = fixture.seed_decided_value(build_decided_data(
+    let (decided, execution) = fixture.seed_decided_value_with_execution(build_decided_data(
         &[(validator, BEACON_COMMITTEE_INDEX)],
         &contributors,
     ));
-    let contributions = ALL_SUBCOMMITTEES
-        .iter()
-        .map(|&subcommittee| fixture.create_contribution(SOLE_VALIDATOR_IDX, subcommittee))
-        .collect();
 
     // Act
-    let results = fixture.collect_contributions(contributions).await;
+    let published = fixture.run_publisher(execution).await;
 
-    // Assert
-    assert_eq!(single_batch(results).len(), ALL_SUBCOMMITTEES.len());
+    // Assert: one aggregate POST plus one contribution POST per subcommittee.
+    assert_eq!(
+        published,
+        RecordedPublishes {
+            aggregates: vec![(DEFAULT_DECIDED_FORK, fixture.expected_aggregator_index())],
+            contributions: ALL_SUBCOMMITTEES
+                .iter()
+                .map(|&subcommittee| (*validator as u64, subcommittee))
+                .collect(),
+        },
+        "each (validator, subcommittee) identity should publish its own contribution"
+    );
     assert_captured_calls_settle_at(&fixture.harness, EXPECTED_WORKLIST_SIZE).await;
     let calls = committee_calls(&fixture.harness);
     assert_eq!(
@@ -818,43 +756,8 @@ async fn multi_root_validator_keeps_distinct_roots() {
 
 // ==================== Divergent-view and normalization tests ====================
 
-/// A requested item absent from the decided value is skipped, while the other requested
-/// items succeed and the batch size counts only decided entries.
-#[tokio::test(flavor = "multi_thread")]
-async fn requested_item_missing_from_decided_value() {
-    // Arrange: the decided value covers subcommittees 0 and 1, but the callback also asks
-    // for subcommittee 2.
-    let fixture = AggregatorCommitteeFixture::new(MIXED_COMMITTEE_VALIDATOR_COUNT);
-    let decided = fixture.seed_mixed_decided_value();
-    let contributions = CONTRIBUTION_SUBCOMMITTEES
-        .iter()
-        .chain(std::iter::once(&MISSING_SUBCOMMITTEE_INDEX))
-        .map(|&subcommittee| fixture.create_contribution(CONTRIBUTOR_VALIDATOR_IDX, subcommittee))
-        .collect();
-
-    // Act
-    let results = fixture.collect_contributions(contributions).await;
-
-    // Assert: only the decided subcommittees come back.
-    let signed = single_batch(results);
-    let returned_subcommittees: HashSet<u64> = signed
-        .iter()
-        .map(|item| item.message.contribution.subcommittee_index)
-        .collect();
-    assert_eq!(
-        returned_subcommittees,
-        HashSet::from(CONTRIBUTION_SUBCOMMITTEES),
-        "the undecided subcommittee must be skipped, not signed"
-    );
-
-    // The batch covers the decided union only, without the missing item.
-    assert_captured_calls_settle_at(&fixture.harness, MIXED_WORKLIST_SIZE).await;
-    let calls = committee_calls(&fixture.harness);
-    assert_batch_identity(&calls, MIXED_WORKLIST_SIZE, decided.hash());
-}
-
 /// Exact duplicate decided entries collapse to one worklist entry each, so the batch size
-/// reflects the deduplicated union.
+/// reflects the deduplicated union and each identity publishes once.
 #[tokio::test(flavor = "multi_thread")]
 async fn duplicate_decided_entries_normalized() {
     // Arrange: the same aggregator entry twice and the same contributor entry twice.
@@ -862,7 +765,7 @@ async fn duplicate_decided_entries_normalized() {
     let fixture = AggregatorCommitteeFixture::new(MIXED_COMMITTEE_VALIDATOR_COUNT);
     let aggregator = fixture.validator_index(AGGREGATE_VALIDATOR_IDX);
     let contributor = fixture.validator_index(CONTRIBUTOR_VALIDATOR_IDX);
-    let decided = fixture.seed_decided_value(build_decided_data(
+    let (decided, execution) = fixture.seed_decided_value_with_execution(build_decided_data(
         &[
             (aggregator, BEACON_COMMITTEE_INDEX),
             (aggregator, BEACON_COMMITTEE_INDEX),
@@ -872,14 +775,19 @@ async fn duplicate_decided_entries_normalized() {
             (contributor, CONTRIBUTION_SUBCOMMITTEES[0]),
         ],
     ));
-    let contributions =
-        vec![fixture.create_contribution(CONTRIBUTOR_VALIDATOR_IDX, CONTRIBUTION_SUBCOMMITTEES[0])];
 
     // Act
-    let results = fixture.collect_contributions(contributions).await;
+    let published = fixture.run_publisher(execution).await;
 
     // Assert
-    assert_eq!(single_batch(results).len(), 1);
+    assert_eq!(
+        published,
+        RecordedPublishes {
+            aggregates: vec![(DEFAULT_DECIDED_FORK, fixture.expected_aggregator_index())],
+            contributions: vec![(*contributor as u64, CONTRIBUTION_SUBCOMMITTEES[0])],
+        },
+        "duplicate decided entries must publish once per identity"
+    );
     assert_captured_calls_settle_at(&fixture.harness, EXPECTED_DEDUPED_SIZE).await;
     let calls = committee_calls(&fixture.harness);
     assert_eq!(
@@ -907,15 +815,9 @@ async fn conflicting_aggregate_roots_sign_only_the_first() {
         ],
         &[(contributor, CONTRIBUTION_SUBCOMMITTEES[0])],
     ));
-    let contributions =
-        vec![fixture.create_contribution(CONTRIBUTOR_VALIDATOR_IDX, CONTRIBUTION_SUBCOMMITTEES[0])];
-
-    // Act
-    let results = fixture.collect_contributions(contributions).await;
 
     // Assert: exactly one of the conflicting aggregates is signed, the contribution is
     // unaffected, and the batch counts both.
-    assert_eq!(single_batch(results).len(), 1);
     assert_captured_calls_settle_at(&fixture.harness, EXPECTED_SIGNED_SIZE).await;
     let calls = committee_calls(&fixture.harness);
     assert_eq!(
@@ -939,13 +841,12 @@ async fn conflicting_aggregate_roots_sign_only_the_first() {
 // ==================== Empty and error path tests ====================
 
 /// A decided value naming only validators this operator has no metadata for produces an empty
-/// worklist: the contribution callback returns an empty batch, the publisher has nothing to
-/// publish and counts the committee under `no_aggregates`, and no signature is ever collected.
+/// worklist: the publisher has nothing to publish in either class, counts the committee under
+/// `no_aggregates`, and no signature is ever collected.
 #[tokio::test(flavor = "multi_thread")]
-async fn empty_worklist_returns_empty() {
+async fn empty_worklist_publishes_nothing() {
     let _metric_guard = PUBLISH_METRIC_LOCK.lock().await;
-    // Arrange: the decided entries reference foreign validator indices, while the callback
-    // references the local validator (required to pass committee grouping).
+    // Arrange: the decided entries reference foreign validator indices only.
     let fixture = AggregatorCommitteeFixture::new(SINGLE_VALIDATOR_COUNT);
     let (_, execution) = fixture.seed_decided_value_with_execution(build_decided_data(
         &[(
@@ -957,22 +858,16 @@ async fn empty_worklist_returns_empty() {
             CONTRIBUTION_SUBCOMMITTEES[0],
         )],
     ));
-    let contributions =
-        vec![fixture.create_contribution(SOLE_VALIDATOR_IDX, CONTRIBUTION_SUBCOMMITTEES[0])];
     let no_aggregates_before = publish_result_count(metrics::NO_AGGREGATES);
 
     // Act
-    let contribution_results = fixture.collect_contributions(contributions).await;
     let published = fixture.run_publisher(execution).await;
 
-    // Assert: nothing to return, nothing to publish, nothing signed.
-    assert!(
-        single_batch(contribution_results).is_empty(),
-        "no locally signable decided entry means an empty contribution batch"
-    );
-    assert!(
-        published.is_empty(),
-        "no locally signable decided aggregate means no publish call"
+    // Assert: nothing to publish in either class, nothing signed.
+    assert_eq!(
+        published,
+        RecordedPublishes::default(),
+        "no locally signable decided entry means no publish call of either class"
     );
     assert_eq!(
         publish_result_count(metrics::NO_AGGREGATES),
@@ -982,27 +877,15 @@ async fn empty_worklist_returns_empty() {
     assert_captured_calls_settle_at(&fixture.harness, 0).await;
 }
 
-/// Missing consensus data for the committee registers no execution: the contribution callback
-/// fails with `ConsensusDataNotFound`, the publisher gets no handle, and nothing is signed.
+/// Missing consensus data for the committee registers no execution: the publisher gets no
+/// handle and nothing is signed.
 #[tokio::test(flavor = "multi_thread")]
-async fn consensus_data_missing_errors() {
-    // Arrange: assignments exist for the slot, but carry no consensus data for any committee,
-    // so the execution fails with `ConsensusDataNotFound`. (Seeding nothing at all would park
-    // the callback on the assignments watch channel instead of erroring.)
+async fn consensus_data_missing_registers_no_execution() {
+    // Arrange: assignments exist for the slot, but carry no consensus data for any committee.
     let fixture = AggregatorCommitteeFixture::new(MIXED_COMMITTEE_VALIDATOR_COUNT);
     let executions = fixture.seed_assignments_without_consensus_data();
-    let contributions =
-        vec![fixture.create_contribution(CONTRIBUTOR_VALIDATOR_IDX, CONTRIBUTION_SUBCOMMITTEES[0])];
 
-    // Act
-    let contribution_results = fixture.collect_contributions(contributions).await;
-
-    // Assert: `run_committee_signing` swallows the failure into one empty stream item per
-    // committee, nothing is handed to the publisher, and no signature collection is attempted.
-    assert!(
-        single_batch(contribution_results).is_empty(),
-        "a failed execution should yield an empty contribution batch"
-    );
+    // Assert: nothing is handed to the publisher, and no signature collection is attempted.
     assert!(
         executions.is_empty(),
         "a committee with no decided value must not register a publisher handle"
@@ -1029,20 +912,20 @@ async fn slot_mismatched_decided_payloads_are_excluded() {
     for contribution in decided.sync_committee_contributions.iter_mut() {
         contribution.slot = Slot::new(TEST_SLOT + 1);
     }
-    fixture.seed_decided_value(decided);
-    let contributions = vec![
-        fixture.create_contribution(CONTRIBUTOR_VALIDATOR_IDX, CONTRIBUTION_SUBCOMMITTEES[0]),
-        fixture.create_contribution(CONTRIBUTOR_VALIDATOR_IDX, CONTRIBUTION_SUBCOMMITTEES[1]),
-    ];
+    let (_, execution) = fixture.seed_decided_value_with_execution(decided);
 
     // Act
-    let results = fixture.collect_contributions(contributions).await;
+    let published = fixture.run_publisher(execution).await;
 
-    // Assert: the requested contributions resolve to nothing (their decided payloads were
-    // excluded), while the aggregate still gets signed with a batch sized to the survivors.
-    assert!(
-        single_batch(results).is_empty(),
-        "slot-mismatched contributions should not be returned"
+    // Assert: the mismatched contributions are excluded from the worklist and never published,
+    // while the aggregate still gets signed and published with a batch sized to the survivors.
+    assert_eq!(
+        published,
+        RecordedPublishes {
+            aggregates: vec![(DEFAULT_DECIDED_FORK, fixture.expected_aggregator_index())],
+            contributions: vec![],
+        },
+        "slot-mismatched contributions should not be published"
     );
     const EXPECTED_SURVIVOR_COUNT: usize = 1;
     assert_captured_calls_settle_at(&fixture.harness, EXPECTED_SURVIVOR_COUNT).await;
@@ -1114,19 +997,27 @@ async fn publisher_counts_a_failed_execution_as_a_consensus_error() {
     .boxed()
     .shared();
     let consensus_error_before = publish_result_count(metrics::CONSENSUS_ERROR);
+    let contribution_errors_before = contribution_signing_count(metrics::OTHER_ERROR);
 
     // Act
     let published = fixture.run_publisher(execution).await;
 
     // Assert
-    assert!(
-        published.is_empty(),
+    assert_eq!(
+        published,
+        RecordedPublishes::default(),
         "a failed execution should publish nothing"
     );
     assert_eq!(
         publish_result_count(metrics::CONSENSUS_ERROR),
         consensus_error_before + 1,
         "the publisher should count the failed committee under `consensus_error`"
+    );
+    assert_eq!(
+        contribution_signing_count(metrics::OTHER_ERROR),
+        contribution_errors_before + 1,
+        "a failed committee round should count once on the contribution signing counter too, \
+         keeping the only contribution failure signal non-silent"
     );
 }
 
@@ -1153,8 +1044,9 @@ async fn publisher_counts_a_consensus_error_once_the_deadline_passes() {
         .expect("the publisher must not outlive the two-slot deadline");
 
     // Assert
-    assert!(
-        published.is_empty(),
+    assert_eq!(
+        published,
+        RecordedPublishes::default(),
         "an undecided execution should publish nothing"
     );
     assert_eq!(
@@ -1234,7 +1126,7 @@ impl PublisherFixture {
         )
     }
 
-    /// A decided value holding one contribution and no aggregate, which the publisher must skip.
+    /// A decided value holding one contribution and no aggregate.
     fn contributions_only(&self, committee: usize) -> DecidedData {
         build_decided_data(
             &[],
@@ -1264,18 +1156,19 @@ impl PublisherFixture {
         &self,
         executions: Vec<(CommitteeId, Execution)>,
         outcome: impl Fn(u64) -> Result<(), String>,
-    ) -> Vec<RecordedPublish> {
+    ) -> RecordedPublishes {
         run_recording_publisher(&self.harness, executions, outcome).await
     }
 }
 
-/// Every decided aggregate is published exactly once, and a committee whose decided value holds
-/// only contributions never reaches the publish call at all.
+/// Every decided root is published exactly once, whichever class it belongs to: a
+/// contributions-only committee publishes its contribution rather than being discarded, and it
+/// is the one counted under `no_aggregates`.
 ///
-/// Contributions stay on Lighthouse's publish path, so a publish call for the contributions-only
-/// committee would be a pointless POST.
+/// The discard was the pre-#1260 behavior, when contributions still rode Lighthouse's publish
+/// path; with the Lighthouse callback inert, the publisher is the only POSTer for both classes.
 #[tokio::test(flavor = "multi_thread")]
-async fn publish_decided_aggregates_publishes_each_committee_with_aggregates_once() {
+async fn publish_decided_aggregates_publishes_each_committees_decided_worklist_once() {
     let _metric_guard = PUBLISH_METRIC_LOCK.lock().await;
     // Arrange
     let fixture = PublisherFixture::new();
@@ -1298,26 +1191,37 @@ async fn publish_decided_aggregates_publishes_each_committee_with_aggregates_onc
         PUBLISHER_OPERATOR_SETS.len(),
         "each committee should register one execution"
     );
+    let no_aggregates_before = publish_result_count(metrics::NO_AGGREGATES);
 
     // Act
     let published = fixture.run_publisher(executions, |_| Ok(())).await;
 
-    // Assert: one publish call per decided aggregate, carrying its committee's aggregator and
-    // the decided value's fork.
+    // Assert: one publish call per decided root, each aggregate carrying its committee's
+    // aggregator and the decided value's fork, the contribution carrying its identity.
     assert_eq!(
         published,
-        vec![
-            (
-                DEFAULT_DECIDED_FORK,
-                fixture.aggregator_index(FIRST_AGGREGATE_COMMITTEE),
-            ),
-            (
-                DEFAULT_DECIDED_FORK,
-                fixture.aggregator_index(SECOND_AGGREGATE_COMMITTEE),
-            ),
-        ],
-        "committees with decided aggregates publish once each, and the contributions-only \
-         committee never reaches the publish call"
+        RecordedPublishes {
+            aggregates: vec![
+                (
+                    DEFAULT_DECIDED_FORK,
+                    fixture.aggregator_index(FIRST_AGGREGATE_COMMITTEE),
+                ),
+                (
+                    DEFAULT_DECIDED_FORK,
+                    fixture.aggregator_index(SECOND_AGGREGATE_COMMITTEE),
+                ),
+            ],
+            contributions: vec![(
+                fixture.aggregator_index(CONTRIBUTIONS_ONLY_COMMITTEE),
+                CONTRIBUTION_SUBCOMMITTEES[0],
+            )],
+        },
+        "committees publish their decided roots once each, contributions included"
+    );
+    assert_eq!(
+        publish_result_count(metrics::NO_AGGREGATES),
+        no_aggregates_before + 1,
+        "the contributions-only committee should still count once under `no_aggregates`"
     );
 }
 
@@ -1348,7 +1252,7 @@ async fn publish_decided_aggregates_survives_a_failing_publish() {
 
     // Assert: every committee's aggregate was still attempted.
     assert_eq!(
-        published,
+        published.aggregates,
         (0..PUBLISHER_OPERATOR_SETS.len())
             .map(|committee| (DEFAULT_DECIDED_FORK, fixture.aggregator_index(committee)))
             .collect::<Vec<_>>(),
@@ -1380,8 +1284,9 @@ async fn publish_decided_aggregates_skips_a_committee_whose_roots_never_reach_qu
     let published = fixture.run_publisher(executions, |_| Ok(())).await;
 
     // Assert: the publish closure was never invoked, and the root was counted under its label.
-    assert!(
-        published.is_empty(),
+    assert_eq!(
+        published,
+        RecordedPublishes::default(),
         "the publisher must not invoke the publish closure for a root without quorum"
     );
     assert_eq!(
@@ -1430,7 +1335,7 @@ async fn publish_decided_aggregates_publishes_the_surviving_root_when_a_sibling_
 
     // Assert: exactly the surviving root was published, exactly the missing one was counted.
     assert_eq!(
-        published,
+        published.aggregates,
         vec![(
             DEFAULT_DECIDED_FORK,
             fixture
@@ -1465,11 +1370,41 @@ async fn publish_decided_aggregates_hands_the_decided_versions_fork_to_the_closu
 
     // Assert
     assert_eq!(
-        published,
+        published.aggregates,
         vec![(
             ForkName::Electra,
             fixture.aggregator_index(FIRST_AGGREGATE_COMMITTEE),
         )],
         "the publish closure must receive the fork named by the decided value's DataVersion"
+    );
+}
+
+/// Cross-class independence inside one committee: a contribution root that misses signature
+/// quorum withholds only itself, and the sibling aggregate is still published.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_contributions_quorum_miss_does_not_withhold_the_sibling_aggregate() {
+    // Serialized: the failing contribution roots increment the contribution signing counter's
+    // `other_error` label, which the failed-execution test asserts a delta on.
+    let _metric_guard = PUBLISH_METRIC_LOCK.lock().await;
+    // Arrange: a mixed decided value where only the contributor's signature collection fails.
+    // The fail mode is set before seeding, since the detached worklist tasks start collecting at
+    // publish.
+    let fixture = AggregatorCommitteeFixture::new(MIXED_COMMITTEE_VALIDATOR_COUNT);
+    fixture
+        .harness
+        .fail_signature_collection_for(fixture.pubkey(CONTRIBUTOR_VALIDATOR_IDX));
+    let (_, execution) = fixture.seed_mixed_decided_value_with_execution();
+
+    // Act
+    let published = fixture.run_publisher(execution).await;
+
+    // Assert: the aggregate publishes, the failed contributions publish nothing.
+    assert_eq!(
+        published,
+        RecordedPublishes {
+            aggregates: vec![(DEFAULT_DECIDED_FORK, fixture.expected_aggregator_index())],
+            contributions: vec![],
+        },
+        "a contribution quorum miss must not withhold the sibling aggregate's publish call"
     );
 }

--- a/anchor/validator_store/src/testing/committee_aggregate.rs
+++ b/anchor/validator_store/src/testing/committee_aggregate.rs
@@ -14,11 +14,6 @@ use ssv_types::{OperatorId, msgid::Role};
 
 use super::common::*;
 
-const PRIMARY_COMMITTEE_OPERATOR_IDS: [OperatorId; 4] =
-    [OperatorId(1), OperatorId(2), OperatorId(3), OperatorId(4)];
-const SECONDARY_COMMITTEE_OPERATOR_IDS: [OperatorId; 4] =
-    [OperatorId(1), OperatorId(5), OperatorId(6), OperatorId(7)];
-
 const OUR_OPERATOR_ID: OperatorId = OperatorId(1);
 const PRIMARY_COMMITTEE_INDEX: usize = 0;
 const SECONDARY_COMMITTEE_INDEX: usize = 1;
@@ -27,26 +22,6 @@ const SECOND_VALIDATOR_INDEX: usize = 1;
 
 const PRIMARY_COMMITTEE_VALIDATOR_COUNT: usize = 2;
 const SINGLE_VALIDATOR_COUNT: usize = 1;
-const PRIMARY_COMMITTEE_STARTING_VALIDATOR_INDEX: usize = 0;
-const SECONDARY_COMMITTEE_STARTING_VALIDATOR_INDEX: usize = 100;
-
-/// Asserts the stream yielded exactly one item and that item is an empty batch.
-///
-/// The empty batch is the Boole+ contract: Lighthouse's publish loop drops an empty result
-/// silently, which is what keeps Anchor the single publisher of committee aggregates.
-fn assert_single_empty_batch(results: SignAggregatesResult) {
-    assert_eq!(results.len(), 1, "expected exactly one stream item");
-    let batch = results
-        .into_iter()
-        .next()
-        .expect("stream item should exist")
-        .expect("the aggregate callback should not fail");
-    assert!(
-        batch.is_empty(),
-        "Lighthouse must receive nothing to publish at Boole+; the metadata service publishes \
-         committee aggregates from the decided value"
-    );
-}
 
 // ==================== Boole+ tests ====================
 
@@ -62,7 +37,7 @@ async fn sign_aggregate_and_proofs_empty_input_yields_one_empty_batch() {
     let results = harness.collect_aggregates(vec![]).await;
 
     // Assert
-    assert_single_empty_batch(results);
+    assert_single_empty_batch(results, "aggregates");
 }
 
 /// Boole+ yields one empty batch however many committees the request spans, without waiting on
@@ -91,7 +66,7 @@ async fn sign_aggregate_and_proofs_boole_yields_one_empty_batch_for_all_committe
     let results = harness.collect_aggregates(aggregates).await;
 
     // Assert
-    assert_single_empty_batch(results);
+    assert_single_empty_batch(results, "aggregates");
     assert!(
         harness.captured_calls.lock().is_empty(),
         "the callback must not collect signatures; signing belongs to the post-consensus execution"
@@ -150,20 +125,4 @@ async fn sign_aggregate_and_proofs_pre_boole_signs_each_validator() {
             "pre-Boole aggregates are collected per validator, not as a committee batch"
         );
     }
-}
-
-fn create_primary_committee_setup(num_validators: usize) -> CommitteeSetup {
-    create_committee_setup(
-        &PRIMARY_COMMITTEE_OPERATOR_IDS,
-        num_validators,
-        PRIMARY_COMMITTEE_STARTING_VALIDATOR_INDEX,
-    )
-}
-
-fn create_secondary_committee_setup(num_validators: usize) -> CommitteeSetup {
-    create_committee_setup(
-        &SECONDARY_COMMITTEE_OPERATOR_IDS,
-        num_validators,
-        SECONDARY_COMMITTEE_STARTING_VALIDATOR_INDEX,
-    )
 }

--- a/anchor/validator_store/src/testing/committee_contribution.rs
+++ b/anchor/validator_store/src/testing/committee_contribution.rs
@@ -1,0 +1,83 @@
+//! Integration tests for `sign_sync_committee_contributions()` at Boole+.
+//!
+//! At Boole+ this Lighthouse callback is deliberately inert, exactly like the aggregate one:
+//! Anchor is the authoritative publisher of committee sync contributions, signing and posting the
+//! decided worklist itself (see [`crate::aggregator_post_consensus`]). Anything the callback
+//! returned would be published a second time by Lighthouse, so it hands back an empty batch.
+//! Pre-Boole is unchanged and covered in `testing/sync_contribution.rs`.
+
+use ssv_types::OperatorId;
+
+use super::common::*;
+
+const OUR_OPERATOR_ID: OperatorId = OperatorId(1);
+const PRIMARY_COMMITTEE_INDEX: usize = 0;
+const SECONDARY_COMMITTEE_INDEX: usize = 1;
+const FIRST_VALIDATOR_INDEX: usize = 0;
+const SECOND_VALIDATOR_INDEX: usize = 1;
+
+const PRIMARY_COMMITTEE_VALIDATOR_COUNT: usize = 2;
+const SINGLE_VALIDATOR_COUNT: usize = 1;
+
+const FIRST_SUBCOMMITTEE: u64 = 0;
+const SECOND_SUBCOMMITTEE: u64 = 1;
+
+/// Empty input yields the same single empty batch as any other Boole+ call: there is no fork to
+/// determine and nothing to publish either way.
+#[tokio::test(flavor = "multi_thread")]
+async fn sign_sync_committee_contributions_empty_input_yields_one_empty_batch() {
+    // Arrange
+    let committee = create_primary_committee_setup(SINGLE_VALIDATOR_COUNT);
+    let harness = ValidatorStoreTestHarness::new(vec![committee], OUR_OPERATOR_ID);
+
+    // Act
+    let results = harness.collect_contributions(vec![]).await;
+
+    // Assert
+    assert_single_empty_batch(results, "sync contributions");
+}
+
+/// Boole+ yields one empty batch however many committees the request spans, without waiting on
+/// `AggregationAssignments` and without collecting any signature of its own.
+///
+/// The single item is the stream's completion signal, not a per-committee result: the callback no
+/// longer groups by committee, because it no longer produces anything Lighthouse could publish.
+/// It also no longer parks on the assignments watch channel, which is why nothing is seeded here.
+#[tokio::test(flavor = "multi_thread")]
+async fn sign_sync_committee_contributions_boole_yields_one_empty_batch_for_all_committees() {
+    // Arrange: two distinct committees, no assignments published for the slot at all.
+    let committee_a = create_primary_committee_setup(PRIMARY_COMMITTEE_VALIDATOR_COUNT);
+    let committee_b = create_secondary_committee_setup(SINGLE_VALIDATOR_COUNT);
+    assert_ne!(
+        committee_a.cluster.committee_id(),
+        committee_b.cluster.committee_id(),
+    );
+    let harness = ValidatorStoreTestHarness::new(vec![committee_a, committee_b], OUR_OPERATOR_ID);
+    let contributions = vec![
+        harness.create_contribution(
+            PRIMARY_COMMITTEE_INDEX,
+            FIRST_VALIDATOR_INDEX,
+            FIRST_SUBCOMMITTEE,
+        ),
+        harness.create_contribution(
+            PRIMARY_COMMITTEE_INDEX,
+            SECOND_VALIDATOR_INDEX,
+            SECOND_SUBCOMMITTEE,
+        ),
+        harness.create_contribution(
+            SECONDARY_COMMITTEE_INDEX,
+            FIRST_VALIDATOR_INDEX,
+            FIRST_SUBCOMMITTEE,
+        ),
+    ];
+
+    // Act
+    let results = harness.collect_contributions(contributions).await;
+
+    // Assert
+    assert_single_empty_batch(results, "sync contributions");
+    assert!(
+        harness.captured_calls.lock().is_empty(),
+        "the callback must not collect signatures; signing belongs to the post-consensus execution"
+    );
+}

--- a/anchor/validator_store/src/testing/common.rs
+++ b/anchor/validator_store/src/testing/common.rs
@@ -122,10 +122,16 @@ type FailingPubkeys = Arc<Mutex<HashSet<PublicKeyBytes>>>;
 
 /// Mock that captures calls and returns a canned infinity signature, or a collection timeout for
 /// every call once [`ValidatorStoreTestHarness::fail_signature_collection`] is called, or for one
-/// validator's calls once [`ValidatorStoreTestHarness::fail_signature_collection_for`] is.
+/// validator's calls once [`ValidatorStoreTestHarness::fail_signature_collection_for`] is, or
+/// never resolves at all once [`ValidatorStoreTestHarness::hang_signature_collection`] is.
+///
+/// Failing and hanging are different: a failure resolves to an error, which readers count as
+/// `other_error`, while a hang leaves the root pending so the reader's own deadline decides its
+/// fate. Only the hang mode reaches a per-root deadline-expiry path.
 struct MockSignatureCollector {
     captured: CapturedCalls,
     fails: Arc<AtomicBool>,
+    hangs: Arc<AtomicBool>,
     failing_pubkeys: FailingPubkeys,
 }
 
@@ -153,6 +159,11 @@ impl SignatureCollecting for MockSignatureCollector {
         {
             return Box::pin(async { Err(CollectionError::CollectionTimeout) });
         }
+        // Stands in for a root whose quorum never arrives: the future stays pending, so the
+        // caller's deadline is what ends the wait.
+        if self.hangs.load(Ordering::Relaxed) {
+            return Box::pin(std::future::pending());
+        }
         let sig = Signature::infinity().expect("infinity signature");
         Box::pin(async move { Ok(Arc::new(sig)) })
     }
@@ -164,17 +175,20 @@ fn create_mock_collector() -> (
     Box<dyn SignatureCollecting>,
     CapturedCalls,
     Arc<AtomicBool>,
+    Arc<AtomicBool>,
     FailingPubkeys,
 ) {
     let captured: CapturedCalls = Arc::new(Mutex::new(Vec::new()));
     let fails = Arc::new(AtomicBool::new(false));
+    let hangs = Arc::new(AtomicBool::new(false));
     let failing_pubkeys: FailingPubkeys = Arc::new(Mutex::new(HashSet::new()));
     let mock = MockSignatureCollector {
         captured: Arc::clone(&captured),
         fails: Arc::clone(&fails),
+        hangs: Arc::clone(&hangs),
         failing_pubkeys: Arc::clone(&failing_pubkeys),
     };
-    (Box::new(mock), captured, fails, failing_pubkeys)
+    (Box::new(mock), captured, fails, hangs, failing_pubkeys)
 }
 
 // ==================== Committee setup ====================
@@ -301,6 +315,8 @@ pub(super) struct ValidatorStoreTestHarness {
     pub(super) captured_calls: CapturedCalls,
     /// Set by [`Self::fail_signature_collection`]; read by the mock collector on every call.
     signature_collection_fails: Arc<AtomicBool>,
+    /// Filled by [`Self::hang_signature_collection`]; read by the mock collector on every call.
+    signature_collection_hangs: Arc<AtomicBool>,
     /// Filled by [`Self::fail_signature_collection_for`]; read by the mock collector on every
     /// call.
     failing_pubkeys: FailingPubkeys,
@@ -388,8 +404,13 @@ impl ValidatorStoreTestHarness {
             "test",
         ));
 
-        let (mock_collector, captured_calls, signature_collection_fails, failing_pubkeys) =
-            create_mock_collector();
+        let (
+            mock_collector,
+            captured_calls,
+            signature_collection_fails,
+            signature_collection_hangs,
+            failing_pubkeys,
+        ) = create_mock_collector();
 
         // Database
         let database = Arc::new(
@@ -479,6 +500,7 @@ impl ValidatorStoreTestHarness {
             committee_setups,
             captured_calls,
             signature_collection_fails,
+            signature_collection_hangs,
             failing_pubkeys,
             slot_clock,
             is_synced_tx,
@@ -635,6 +657,14 @@ impl ValidatorStoreTestHarness {
     /// never reaches quorum takes. Calls are still captured.
     pub(super) fn fail_signature_collection(&self) {
         self.signature_collection_fails
+            .store(true, Ordering::Relaxed);
+    }
+
+    /// Makes every subsequent `sign_and_collect` call hang forever, so the caller's own deadline
+    /// decides each root's fate. This is the only way to reach a per-root deadline-expiry path;
+    /// [`Self::fail_signature_collection`] resolves to an error instead. Calls are still captured.
+    pub(super) fn hang_signature_collection(&self) {
+        self.signature_collection_hangs
             .store(true, Ordering::Relaxed);
     }
 

--- a/anchor/validator_store/src/testing/common.rs
+++ b/anchor/validator_store/src/testing/common.rs
@@ -41,9 +41,10 @@ use tokio::{
 };
 use types::{
     Attestation, AttestationBase, AttestationData, ChainSpec, Checkpoint, Epoch, EthSpec, Graffiti,
-    Hash256, MainnetEthSpec, SelectionProof, SignedAggregateAndProof, Slot, SyncSubnetId,
+    Hash256, MainnetEthSpec, SelectionProof, SignedAggregateAndProof, SignedContributionAndProof,
+    Slot, SyncCommitteeContribution, SyncSelectionProof, SyncSubnetId,
 };
-use validator_store::{AggregateToSign, AttestationToSign, ValidatorStore};
+use validator_store::{AggregateToSign, AttestationToSign, ContributionToSign, ValidatorStore};
 
 use crate::{
     AggregationAssignments, AnchorValidatorStore, Error, VotingAssignments, VotingContext,
@@ -59,6 +60,10 @@ pub(super) const STREAM_TIMEOUT: Duration = Duration::from_secs(5);
 /// What the Lighthouse aggregate callback yields: one result per stream item.
 pub(super) type SignAggregatesResult =
     Vec<Result<Vec<SignedAggregateAndProof<MainnetEthSpec>>, Error>>;
+
+/// What the Lighthouse contribution callback yields: one result per stream item.
+pub(super) type SignContributionsResult =
+    Vec<Result<Vec<SignedContributionAndProof<MainnetEthSpec>>, Error>>;
 
 // ==================== Mock consensus decider ====================
 
@@ -178,6 +183,54 @@ pub(super) struct CommitteeSetup {
     pub(super) cluster: Cluster,
     pub(super) validators: Vec<ValidatorMetadata>,
     shares: Vec<Share>,
+}
+
+/// Standard two-committee topology shared by the Boole+ callback-gate tests
+/// (`committee_aggregate.rs` and `committee_contribution.rs`): a primary and a secondary
+/// committee with distinct operator sets and disjoint validator index spaces, both containing
+/// this operator.
+pub(super) const PRIMARY_COMMITTEE_OPERATOR_IDS: [OperatorId; 4] =
+    [OperatorId(1), OperatorId(2), OperatorId(3), OperatorId(4)];
+pub(super) const SECONDARY_COMMITTEE_OPERATOR_IDS: [OperatorId; 4] =
+    [OperatorId(1), OperatorId(5), OperatorId(6), OperatorId(7)];
+pub(super) const PRIMARY_COMMITTEE_STARTING_VALIDATOR_INDEX: usize = 0;
+pub(super) const SECONDARY_COMMITTEE_STARTING_VALIDATOR_INDEX: usize = 100;
+
+/// [`create_committee_setup`] for the standard primary committee.
+pub(super) fn create_primary_committee_setup(num_validators: usize) -> CommitteeSetup {
+    create_committee_setup(
+        &PRIMARY_COMMITTEE_OPERATOR_IDS,
+        num_validators,
+        PRIMARY_COMMITTEE_STARTING_VALIDATOR_INDEX,
+    )
+}
+
+/// [`create_committee_setup`] for the standard secondary committee.
+pub(super) fn create_secondary_committee_setup(num_validators: usize) -> CommitteeSetup {
+    create_committee_setup(
+        &SECONDARY_COMMITTEE_OPERATOR_IDS,
+        num_validators,
+        SECONDARY_COMMITTEE_STARTING_VALIDATOR_INDEX,
+    )
+}
+
+/// Asserts a callback stream yielded exactly one item and that item is an empty batch.
+///
+/// The empty batch is the Boole+ contract for both callback classes: Lighthouse's publish loops
+/// drop an empty result silently, which is what keeps Anchor the single publisher of committee
+/// duties. `what` names the class in failure messages ("aggregates", "sync contributions").
+pub(super) fn assert_single_empty_batch<T>(results: Vec<Result<Vec<T>, Error>>, what: &str) {
+    assert_eq!(results.len(), 1, "expected exactly one stream item");
+    let batch = results
+        .into_iter()
+        .next()
+        .expect("stream item should exist")
+        .unwrap_or_else(|e| panic!("the callback for {what} should not fail: {e:?}"));
+    assert!(
+        batch.is_empty(),
+        "Lighthouse must receive nothing to publish at Boole+; the metadata service publishes \
+         committee {what} from the decided value"
+    );
 }
 
 /// Builds a synthetic committee with deterministic validator and share data.
@@ -537,6 +590,45 @@ impl ValidatorStoreTestHarness {
         tokio::time::timeout(STREAM_TIMEOUT, stream.collect())
             .await
             .expect("the aggregate callback should complete within the stream timeout")
+    }
+
+    /// Runs the Lighthouse contribution callback to completion.
+    pub(super) async fn collect_contributions(
+        &self,
+        contributions: Vec<ContributionToSign<MainnetEthSpec>>,
+    ) -> SignContributionsResult {
+        let stream = self
+            .validator_store
+            .sign_sync_committee_contributions(contributions);
+        tokio::time::timeout(STREAM_TIMEOUT, stream.collect())
+            .await
+            .expect("the contribution callback should complete within the stream timeout")
+    }
+
+    /// A contribution request at `TEST_SLOT`, as Lighthouse's sync committee service would send.
+    pub(super) fn create_contribution(
+        &self,
+        committee_idx: usize,
+        validator_idx: usize,
+        subcommittee_index: u64,
+    ) -> ContributionToSign<MainnetEthSpec> {
+        let validator = &self.committee_setups[committee_idx].validators[validator_idx];
+        let validator_index = validator
+            .index
+            .expect("test validator should have an index");
+
+        ContributionToSign {
+            aggregator_index: *validator_index as u64,
+            aggregator_pubkey: validator.public_key,
+            contribution: SyncCommitteeContribution {
+                slot: Slot::new(TEST_SLOT),
+                beacon_block_root: Hash256::zero(),
+                subcommittee_index,
+                aggregation_bits: Default::default(),
+                signature: AggregateSignature::infinity(),
+            },
+            selection_proof: SyncSelectionProof::from(Signature::empty()),
+        }
     }
 
     /// Makes every subsequent `sign_and_collect` call fail, for tests of the paths a root that

--- a/anchor/validator_store/src/testing/mod.rs
+++ b/anchor/validator_store/src/testing/mod.rs
@@ -3,6 +3,7 @@ mod common;
 mod aggregator_post_consensus;
 mod committee_aggregate;
 mod committee_attestation;
+mod committee_contribution;
 mod proposer_delay;
 mod sync_contribution;
 mod sync_selection_proof;


### PR DESCRIPTION
## Problem, Evidence, and Context (Required)

At Boole+, one QBFT decision per SSV committee carries both attestation aggregates and sync contributions. #1245 made Anchor the authoritative publisher for aggregates but left contributions on the Lighthouse callback, on the premise that "sync selection proofs are precomputed a slot ahead".

That premise is wrong for Anchor's configuration. `lookahead_slot: 1` is effective *zero* lookahead: `fill_in_aggregation_proofs` uses `start_slot = current_slot + 1` and `proof_slot = slot - 1`, so slot N's proof signing begins at slot N's boundary, in the same slot-start partial-signature batch as the attestation proofs. Lighthouse's duty snapshot can therefore be cloned before the proofs exist, and `get_duties_for_slot` silently omits any aggregator whose proof is not installed. An empty aggregators map spawns zero tasks and logs nothing.

Measured on a scale-100 ssv-mini devnet (4 Anchor operators, 100 managed validators, head-event-triggered sync duties via an unmerged Lighthouse PR backported onto the current pin), 238 post-Boole slots, this branch against an identical build without it:

| | with this PR | without |
|---|---|---|
| subnet-slots published | 952/952 (100%) | 367/952 (38.6%) |
| slots publishing nothing | 0 | 144 (60.5%) |
| contribution identities published | 9260 | 0 |
| publish failures / quorum skips | 0 / 0 | 0 / 0 |

The pre-fix build lost 60% of slots silently: no error, no warning, no metric movement. The cause is confirmed from Anchor's own metrics rather than inferred: `voting_context_triggers_total{trigger="head_event"} = 143` versus `{trigger="timer"} = 10`, with head events arriving inside 250ms at the median.

The same race is reachable on the current pin without any Lighthouse change, because the timer arm snapshots at 4s while Anchor's proof deadline is 2/3 slot.

Closes #1260. Follows #1245.

## Change Overview (Required)

The metadata service's publisher now drains both classes of a decided outcome. Aggregates keep their existing path; contributions are assembled from the decided message plus the reconstructed threshold signature and POSTed one call per `(validator, subcommittee)` identity. The Lighthouse contribution callback becomes inert at Boole+, exactly like the aggregate gate in #1245.

Reading order: `lib.rs` first (the outer gate and the deleted per-committee helper), then `aggregator_post_consensus.rs` (`publish_one_contribution` and the both-class drain), then `metadata_service.rs` (the POST helper).

Contributions bound their signature wait at slot end rather than sharing the aggregate two-slot deadline. Beacon nodes accept a contribution only during its own slot (`sync_committee_verification.rs` floors at the current slot, unlike aggregates' one-epoch tolerance), so a later quorum could only produce a rejected POST. The campaign observed exactly that on Lighthouse's pre-Boole path: `PastSlot { message_slot: Slot(141), earliest_permissible_slot: Slot(142) }`.

Unchanged: pre-Boole behavior, `AGGREGATOR_COMMITTEE_PUBLISH_TOTAL` stays aggregate-only, no new metrics, no Lighthouse-side changes, no eligibility validation.

Removing the callback also removed the last readers of several structures, which this PR deletes rather than leaves dangling: the post-consensus retention map's values (now a key set, so a finished outcome is freed when its publisher completes instead of being pinned for two epochs), the `ConsensusDataNotFound` variant, `drain_signatures`' deadline parameter, and the metadata service's own fork-schedule handle. Both callback gates and the publisher's registration gate now call one predicate, so "exactly one path publishes per duty" is structural rather than argued in three doc comments.

## Risks, Trade-offs, and Mitigations (Required)

- The gate and the publisher must land together. Separating them leaves a state that either double-publishes or publishes nothing.
- Publication stays process-scoped in-memory exactly-once with no durable record: a restart can lose an in-flight slot, the same trade already accepted for aggregates.
- Committee-level join failures count once per committee on both class counters: an undercount against multiple lost roots, an overcount for a class the committee had no duties in. Documented in code and pinned by a test. Making it exact means threading per-class counts through the publisher for a signal that only moves during already-alarming QBFT failures.
- A contribution missing from consensus data (first-node `Ok(None)` fetch, #1236) still cannot be published by any downstream mechanism. Out of scope here.
- Known growth point: the publisher carries four generic parameters for its two publish operations. A third duty class would double that again; a small trait is the natural fix, deliberately kept out of a behavior-change PR.
- Peak request count rises: one POST per contribution identity rather than one batch per subnet. This matches go-ssv, and it isolates failures (a bad identity no longer fails its siblings' POST).

## Validation (Required)

- `cargo nextest run -p anchor_validator_store`: 79 passed, 0 failed.
- `cargo clippy -p anchor_validator_store -p client --all-targets -- -D warnings`: clean.
- New `testing/committee_contribution.rs` pins the inert-callback contract. The previous "contributions-only committee never publishes" assertion is inverted. Added coverage for mixed outcomes, contribution-only committees, a late publisher reading the cached execution, cross-class quorum-miss independence, dedup, and multi-subcommittee assembly.
- Devnet A/B above, 238 post-Boole slots each, identical topology and Lighthouse pin, image as the only variable.
- go-ssv parity checked field by field against the Boole runner (`protocol/v2/ssv/runner/aggregator_committee.go` at `48d4f3ac5`): same message contents, same `ContributionAndProof` domain at the duty slot's epoch, one contribution per POST, continue-past-failure on submit errors.

## Rollback (Required for behavior or runtime changes; optional otherwise)

Revert the commit. No config, data, or operational impact. Reverting restores the silent loss under head-triggered sync duties.

## Blockers / Dependencies (Optional)

None for merge. The acute form of the bug activates when Anchor's Lighthouse pin gains head-event-triggered sync committee duties; the milder form is reachable on the current pin.

## Additional Info / Next Steps (Optional)

- The measurement has one trap worth knowing for future campaigns: the `Signed ContributionAndProof` debug line sits inside the old callback pre-fix and inside the publisher post-fix, so it counts different things in each build. The A/B above uses `(slot, subnet)` pairs, a denominator neither build can bias.
- `run_committee_signing` drops to a single caller with this change.
