### PR TITLE
chore(deps): bump h2 to 0.4.16 for RUSTSEC-2026-0258

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3601,9 +3601,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",


### PR DESCRIPTION
## Problem, Evidence, and Context

`cargo audit` fails on every open PR against `unstable`, blocking the `check-code` job:

```
error: 1 vulnerability found!
Crate:    h2
Version:  0.4.13
Title:    h2 unbounded empty DATA frames
Date:     2026-08-17
ID:       RUSTSEC-2026-0258
Solution: Upgrade to >=0.4.16
```

The advisory landed on 2026-08-17, after the last lockfile-touching merge. `test-suite.yml` only runs on pull requests, so `unstable` itself shows no failure, but every PR opened since inherits it. Observed on #1264, whose diff touches no dependency files.

`h2` is transitive via `hyper` (used by `client`, the HTTP API, and metrics) and `reqwest`.

- Advisory: https://rustsec.org/advisories/RUSTSEC-2026-0258

## Change Overview

Lockfile-only bump of `h2` from 0.4.13 to 0.4.16. Two lines: version and checksum. No manifest change, since every consumer already requires `h2 = "0.4"`.

The entry is edited directly rather than via `cargo update -p h2`. That command reports one package changed but rewrites 28 lines, re-pointing `windows-sys` and `socket2` dependency edges *backwards* (`windows-sys` 0.61.2 -> 0.60.2, `socket2` 0.6.4 -> 0.5.10) for `hyper-util`, `quinn-udp`, `rustix`, `tempfile`, and others. Those downgrades are unrelated resolver churn and do not belong in a security bump. `cargo metadata --locked` succeeding on the hand-edited lock proves 0.4.16's dependency list matches what the lock records, and that no other package needs to move.

Nothing else in the dependency graph changes.

## Risks, Trade-offs, and Mitigations

Blast radius is the HTTP/2 stack behind `hyper` and `reqwest`: beacon node API calls, the HTTP API, and the metrics endpoint. This is a patch-level upgrade inside one semver-compatible range, so the risk is low.

The trade-off is the hand-edited lock entry: it deliberately declines the resolver churn a full `cargo update` would introduce, which means the lockfile stays at whatever the resolver last chose for the unrelated packages. That is the intended outcome.

## Validation

- `cargo audit --ignore RUSTSEC-2026-0118 --ignore RUSTSEC-2026-0119` (the `audit-CI` target) exits 0, with the same 10 allowed warnings CI reports and zero vulnerabilities.
- `cargo metadata --locked` succeeds, confirming the lock is complete and self-consistent.
- `cargo check --locked --workspace --all-targets` exits 0.

## Rollback

Straight revert of the single commit. No config, data, or operational impact.
