### PR TITLE
chore: merge unstable into epbs (CI check only, do not squash)

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -107,17 +107,11 @@ queue_rules:
     batch_max_wait_time: 60 s
     checks_timeout: 10800 s
     merge_method: squash
-    commit_message_template: |
-      {{ title }} (#{{ number }})
-
-        {{ body | get_section("## Issue Addressed", "") }}
-
-
-        {{ body | get_section("## Proposed Changes", "") }}
-      
-      {% for commit in commits | unique(attribute='email_author') %}
-      Co-Authored-By: {{ commit.author }} <{{ commit.email_author }}>
-      {% endfor %}
+    commit_message_format:
+      title: pr-title
+      body: empty
+      trailers:
+        - co-authored-by
     queue_conditions:
       - "#approved-reviews-by >= 1"
       - "check-success=license/cla"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3601,9 +3601,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3305,6 +3305,7 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 name = "fork"
 version = "0.1.0"
 dependencies = [
+ "futures",
  "serde",
  "slot_clock",
  "ssv_types",
@@ -3619,9 +3620,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -5436,6 +5437,7 @@ dependencies = [
  "ssz_types",
  "subnet_service",
  "task_executor",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3303,6 +3303,7 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 name = "fork"
 version = "0.1.0"
 dependencies = [
+ "futures",
  "serde",
  "slot_clock",
  "ssv_types",
@@ -5403,6 +5404,7 @@ dependencies = [
  "ssz_types",
  "subnet_service",
  "task_executor",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "tracing",

--- a/anchor/client/src/lib.rs
+++ b/anchor/client/src/lib.rs
@@ -450,7 +450,6 @@ impl Client {
             fork_schedule.clone(),
             slot_clock.clone(),
             E::slots_per_epoch(),
-            spec.get_slot_duration().as_secs(),
             executor.clone(),
         )?;
 
@@ -784,7 +783,6 @@ impl Client {
             beacon_nodes.clone(),
             executor.clone(),
             spec.clone(),
-            fork_schedule.clone(),
             config.with_weighted_attestation_data,
         );
 

--- a/anchor/client/src/lib.rs
+++ b/anchor/client/src/lib.rs
@@ -448,7 +448,6 @@ impl Client {
             fork_schedule.clone(),
             slot_clock.clone(),
             E::slots_per_epoch(),
-            spec.get_slot_duration().as_secs(),
             executor.clone(),
         )?;
 

--- a/anchor/client/src/lib.rs
+++ b/anchor/client/src/lib.rs
@@ -780,7 +780,6 @@ impl Client {
             beacon_nodes.clone(),
             executor.clone(),
             spec.clone(),
-            fork_schedule.clone(),
             config.with_weighted_attestation_data,
         );
 

--- a/anchor/common/fork/Cargo.toml
+++ b/anchor/common/fork/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Sigma Prime <contact@sigmaprime.io>"]
 edition = { workspace = true }
 
 [dependencies]
+futures = { workspace = true }
 serde = { workspace = true }
 slot_clock = { workspace = true }
 ssv_types = { workspace = true }

--- a/anchor/common/fork/src/lifecycle.rs
+++ b/anchor/common/fork/src/lifecycle.rs
@@ -1,13 +1,13 @@
 //! Fork lifecycle state management.
 //!
 //! Provides [`ForkLifecycle`] for tracking the current fork transition state
-//! across all components via a `tokio::sync::watch` channel. The
-//! [`ForkMonitor`](crate::monitor) is the sole writer (sender); all other
-//! components hold receivers.
+//! across all components via a `tokio::sync::watch` channel. The fork monitor
+//! task ([`monitor::spawn`](crate::monitor::spawn)) is the sole writer
+//! (sender); all other components hold receivers.
 
 use crate::ForkConfig;
 
-/// Fork lifecycle state. Updated only by ForkMonitor.
+/// Fork lifecycle state. Updated only by the fork monitor task.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum ForkLifecycle {
     /// Operating on a single fork. No transition in progress.

--- a/anchor/common/fork/src/monitor.rs
+++ b/anchor/common/fork/src/monitor.rs
@@ -1,292 +1,315 @@
 //! Fork transition monitoring.
 //!
-//! This module provides a standalone task that monitors and logs fork transitions,
-//! giving operators visibility into:
-//! - Current active fork at startup
-//! - Entering the preparation window before a fork
-//! - Fork activation when it occurs
+//! A standalone task derives the fork lifecycle from every fresh slot-clock
+//! observation via [`ForkSchedule::lifecycle_at`] and publishes changes on a
+//! watch channel. Because published state is always a pure function of the
+//! observed slot, transitions land at exact slot boundaries, a jump across
+//! several boundaries publishes only the state for the current slot, and a
+//! restart in any window re-derives the same state.
 //!
-//! The monitor pre-computes all fork transition points at creation time from the
-//! deterministic fork schedule. The `run()` method simply sleeps until each
-//! transition slot and sends the corresponding lifecycle update.
-//!
-//! The monitor exits automatically when all scheduled forks have activated.
+//! Sleeps are bounded to one slot so wall-clock corrections are noticed
+//! promptly. Clock failures fail closed by requesting a client-wide shutdown,
+//! as does a backwards clock that crosses a lifecycle boundary: published
+//! state (ENR, handshake, scoring) cannot be rolled back. Both guards live as
+//! long as the process but no longer: the highest observed slot is not
+//! persisted, so a restart with a still-rolled-back clock re-derives and
+//! re-advertises the earlier lifecycle without error.
 
 use std::{sync::Arc, time::Duration};
 
+use futures::channel::mpsc::Sender;
 use slot_clock::SlotClock;
-use task_executor::TaskExecutor;
+use task_executor::{ShutdownReason, TaskExecutor};
 use tokio::sync::watch;
-use tracing::{debug, error, info};
+use tracing::{error, info, warn};
 use types::{Epoch, Slot};
 
 use crate::{FORK_PREPARATION_EPOCHS, Fork, ForkLifecycle, ForkSchedule, SUBSEQUENT_WINDOW_SLOTS};
 
-/// A pre-computed fork transition at a specific slot.
-#[derive(Debug, Clone, PartialEq, Eq)]
-struct ScheduledTransition {
-    slot: Slot,
-    lifecycle: ForkLifecycle,
-}
-
-/// Pre-computed fork monitor with all transition points determined at creation.
+/// Classification of a fresh slot observation against the highest slot seen.
 ///
-/// The full transition timeline is deterministic from the fork schedule, so all
-/// `(slot, ForkLifecycle)` pairs are computed up front. The `run()` method becomes
-/// a simple sleep-and-send loop.
-pub(crate) struct ForkMonitor {
-    /// Lifecycle to send immediately
-    initial: ForkLifecycle,
-    /// Future transitions sorted by slot.
-    transitions: Vec<ScheduledTransition>,
+/// Pure decision logic for the monitor's backwards-clock policy: all effects
+/// (publishing, warning, shutdown) live in [`run`].
+#[derive(Debug, PartialEq, Eq)]
+enum ClockObservation {
+    /// The clock moved forward or held steady.
+    Advanced,
+    /// The clock moved backwards, but the lifecycle derived for the observed
+    /// slot matches the published one; tolerated with a warning.
+    BackwardsWithinWindow,
+    /// The clock moved backwards across a lifecycle boundary. Published state
+    /// cannot be rolled back, so the node must fail closed.
+    BackwardsAcrossBoundary,
 }
 
-impl ForkMonitor {
-    /// Create a new fork monitor by pre-computing all transition points.
-    ///
-    /// For each non-genesis fork (epoch > 0), three transitions are generated:
-    /// - `WarmUp` at the preparation window start (`fork_epoch - 1` epochs)
-    /// - `GracePeriod` at fork activation (`fork_epoch`)
-    /// - `Normal` after the grace period (`fork_epoch + SUBSEQUENT_WINDOW_SLOTS` slots)
-    ///
-    /// All transitions are sorted by slot, then split at `current_slot`:
-    /// - The last transition at or before `current_slot` becomes the initial state.
-    /// - Remaining future transitions are stored for the run loop.
-    ///
-    /// This handles all restart scenarios uniformly — whether the node starts
-    /// before any fork, during a warm-up window, during a grace period, or
-    /// after all forks have activated.
-    fn new(schedule: &ForkSchedule, current_slot: Slot, slots_per_epoch: u64) -> Self {
-        let current_epoch = current_slot.epoch(slots_per_epoch);
-        let current_fork_config = schedule.active_fork_config(current_epoch);
-        info!(fork = %current_fork_config.fork, epoch = %current_epoch, "Fork monitor started");
+/// Classify `now` against the highest slot observed so far.
+fn classify_observation(
+    schedule: &ForkSchedule,
+    slots_per_epoch: u64,
+    highest_observed_slot: Slot,
+    now: Slot,
+) -> ClockObservation {
+    if now >= highest_observed_slot {
+        ClockObservation::Advanced
+    } else if schedule.lifecycle_at(now, slots_per_epoch)
+        == schedule.lifecycle_at(highest_observed_slot, slots_per_epoch)
+    {
+        ClockObservation::BackwardsWithinWindow
+    } else {
+        ClockObservation::BackwardsAcrossBoundary
+    }
+}
 
-        // Step 1: Generate all transitions for every non-genesis fork.
-        //
-        // Each fork produces three transitions at deterministic slots:
-        //   prep_slot ──────> activation ──────> grace_end
-        //   [WarmUp]          [GracePeriod]      [Normal]
-        let mut all_transitions: Vec<ScheduledTransition> = Vec::new();
-
-        for &fork in Fork::all() {
-            let Some(fork_config) = schedule.config(fork) else {
-                continue;
-            };
-            let fork_epoch = fork_config.epoch.as_u64();
-            // Genesis forks (epoch 0) are active from the start — no transitions needed.
-            if fork_epoch == 0 {
-                continue;
-            }
-
-            // The fork active just before this one (safe: fork_epoch > 0).
-            let prev_fork = schedule.active_fork_config(Epoch::new(fork_epoch - 1));
-
-            // Compute the three transition slots for this fork.
-            let prep_slot = fork_epoch.saturating_sub(FORK_PREPARATION_EPOCHS) * slots_per_epoch;
-            let activation = fork_epoch * slots_per_epoch;
-            let grace_end = activation + SUBSEQUENT_WINDOW_SLOTS;
-
-            // Guard: the previous fork's grace period must not overlap this fork's warmup.
-            let prev_activation = prev_fork.epoch.as_u64() * slots_per_epoch;
-            let prev_grace_end = prev_activation + SUBSEQUENT_WINDOW_SLOTS;
-            if prev_activation != 0 && prev_grace_end > prep_slot {
-                error!("Fork preparation overlaps with previous's grace period");
-            }
-
-            // WarmUp: dual-subscribe to current + upcoming fork topics.
-            all_transitions.push(ScheduledTransition {
-                slot: Slot::new(prep_slot),
-                lifecycle: ForkLifecycle::WarmUp {
-                    current: prev_fork.clone(),
-                    upcoming: fork_config.clone(),
-                },
-            });
-            // GracePeriod: fork activates, keep old subscriptions for late messages.
-            all_transitions.push(ScheduledTransition {
-                slot: Slot::new(activation),
-                lifecycle: ForkLifecycle::GracePeriod {
-                    current: fork_config.clone(),
-                    previous: prev_fork.clone(),
-                },
-            });
-            // Normal: grace period ends, drop old fork subscriptions.
-            all_transitions.push(ScheduledTransition {
-                slot: Slot::new(grace_end),
-                lifecycle: ForkLifecycle::Normal {
-                    current: fork_config.clone(),
-                },
-            });
-        }
-
-        // Step 2: Sort by slot, then partition into past and future at current_slot.
-        //
-        // The half-open split [past: slot <= current] [future: slot > current] means:
-        // - A transition exactly at current_slot is considered "already happened".
-        // - The last past transition determines what state we should be in right now.
-        // - If no transitions are past, we're in Normal (pre-fork or genesis-only).
-        //
-        // Example: Boole at epoch 100, restart at activation + 5:
-        //   past:   [WarmUp@ep99, GracePeriod@ep100]  → initial = GracePeriod
-        //   future: [Normal@ep100+32slots]             → run loop sends this later
-        all_transitions.sort_by_key(|t| t.slot);
-        let split = all_transitions.partition_point(|t| t.slot <= current_slot);
-
-        let initial = if split > 0 {
-            all_transitions[split - 1].lifecycle.clone()
-        } else {
-            ForkLifecycle::Normal {
-                current: current_fork_config.clone(),
-            }
+/// Log an error when any fork's preparation window overlaps the previous fork's grace
+/// period. `ForkSchedule::lifecycle_at` resolves such an overlap in favor of
+/// `WarmUp`, which drops the previous fork's topics early; schedules should
+/// keep forks at least `FORK_PREPARATION_EPOCHS` plus the subsequent window
+/// apart.
+fn error_on_overlapping_windows(schedule: &ForkSchedule, slots_per_epoch: u64) {
+    for &fork in Fork::all() {
+        let Some(config) = schedule.config(fork) else {
+            continue;
         };
-
-        let transitions = all_transitions.split_off(split);
-
-        // Log upcoming fork.
-        if let Some((fork, fork_epoch)) = schedule.next_fork_after(current_epoch) {
-            info!(
+        let fork_epoch = config.epoch.as_u64();
+        if fork_epoch == 0 {
+            continue;
+        }
+        let previous = schedule.active_fork_config(Epoch::new(fork_epoch - 1));
+        let previous_activation_slot = previous.epoch.as_u64() * slots_per_epoch;
+        if previous_activation_slot == 0 {
+            continue;
+        }
+        let previous_grace_end = previous_activation_slot + SUBSEQUENT_WINDOW_SLOTS;
+        let preparation_start =
+            fork_epoch.saturating_sub(FORK_PREPARATION_EPOCHS) * slots_per_epoch;
+        if previous_grace_end > preparation_start {
+            error!(
                 fork = %fork,
-                fork_epoch = %fork_epoch,
-                epochs_until = fork_epoch.as_u64().saturating_sub(current_epoch.as_u64()),
-                "Fork scheduled"
+                previous_fork = %previous.fork,
+                "Fork preparation window overlaps the previous fork's grace period"
             );
         }
+    }
+}
 
-        Self {
-            initial,
-            transitions,
+/// Log the operator-facing message for a published lifecycle.
+fn log_transition(lifecycle: &ForkLifecycle) {
+    match lifecycle {
+        ForkLifecycle::WarmUp {
+            current, upcoming, ..
+        } => {
+            info!(
+                current_fork = %current.fork,
+                upcoming_fork = %upcoming.fork,
+                "Entering fork preparation window"
+            );
+        }
+        ForkLifecycle::GracePeriod {
+            current, previous, ..
+        } => {
+            info!(
+                previous_fork = %previous.fork,
+                new_fork = %current.fork,
+                "Fork activated"
+            );
+        }
+        ForkLifecycle::Normal { current, .. } => {
+            info!(
+                current_fork = %current.fork,
+                grace_window_slots = SUBSEQUENT_WINDOW_SLOTS,
+                "Fork transition grace period ended"
+            );
         }
     }
 }
 
-/// Sleep until just before the target slot.
-///
-/// Wakes up 1 slot before the target to ensure we're ready.
-/// This accounts for potential timing variations.
-async fn sleep_until_slot<S: SlotClock>(slot_clock: &S, target_slot: u64, seconds_per_slot: u64) {
-    let Some(current_slot) = slot_clock.now() else {
-        return;
-    };
-
-    // Wake up 1 slot before the target
-    let buffer_slots = 1;
-    let wake_slot = target_slot.saturating_sub(buffer_slots);
-
-    if current_slot.as_u64() >= wake_slot {
-        return; // Already at or past the target
+/// Request a client-wide shutdown. A stale fork lifecycle silently corrupts
+/// networking, scoring, and ENR state, so clock failures must stop the node
+/// rather than leave only the monitor task dead.
+fn request_shutdown(shutdown_tx: &mut Sender<ShutdownReason>, reason: &'static str) {
+    error!(reason, "Fork monitor failed; requesting client shutdown");
+    if let Err(e) = shutdown_tx.try_send(ShutdownReason::Failure(reason))
+        && !e.is_full()
+    {
+        // A full channel means a shutdown is already pending; a closed one means
+        // there is no receiver left to act, which we can only surface in logs.
+        error!("Failed to deliver shutdown request: channel closed");
     }
-
-    let slots_to_wait = wake_slot - current_slot.as_u64();
-    let sleep_duration = Duration::from_secs(slots_to_wait * seconds_per_slot);
-
-    tokio::time::sleep(sleep_duration).await;
 }
 
 /// Run the fork monitor.
 ///
 /// This is the core async logic, separated from `spawn` for testability.
 ///
-/// Pre-computes all transition points from the fork schedule, then sleeps
-/// until each transition slot and sends the corresponding lifecycle update.
-///
-/// When fork transitions occur, [`ForkLifecycle`] updates are sent through the channel:
-/// - `WarmUp`: When entering the preparation window (time to dual-subscribe)
-/// - `GracePeriod`: When the fork activates (update ENR, but keep old subscriptions)
-/// - `Normal`: When the grace period ends (time to unsubscribe old topics)
+/// Each iteration takes a fresh slot-clock observation, derives the lifecycle
+/// for it, and publishes it if it changed, so a transition is never published
+/// before its slot and a jump across several boundaries publishes only the
+/// final state. An unreadable clock, or one that rolls back across a
+/// lifecycle boundary, requests a client-wide shutdown (fail closed). The
+/// loop never exits on its own; it is cancelled with the client.
 async fn run<S: SlotClock>(
-    monitor: ForkMonitor,
+    schedule: Arc<ForkSchedule>,
+    slots_per_epoch: u64,
     slot_clock: S,
-    seconds_per_slot: u64,
+    initial_slot: Slot,
     lifecycle_tx: watch::Sender<ForkLifecycle>,
+    mut shutdown_tx: Sender<ShutdownReason>,
 ) {
-    for transition in monitor.transitions {
-        sleep_until_slot(&slot_clock, transition.slot.as_u64(), seconds_per_slot).await;
+    let mut highest_observed_slot = initial_slot;
+    let mut boundary_unavailable_streak = 0u32;
 
-        match &transition.lifecycle {
-            ForkLifecycle::WarmUp {
-                current, upcoming, ..
-            } => {
-                info!(
-                    current_fork = %current.fork,
-                    upcoming_fork = %upcoming.fork,
-                    "Entering fork preparation window"
+    loop {
+        let Some(now) = slot_clock.now() else {
+            request_shutdown(&mut shutdown_tx, "Fork monitor: slot clock unreadable");
+            return;
+        };
+
+        match classify_observation(&schedule, slots_per_epoch, highest_observed_slot, now) {
+            ClockObservation::Advanced => highest_observed_slot = now,
+            ClockObservation::BackwardsWithinWindow => {
+                warn!(
+                    observed_slot = %now,
+                    highest_observed_slot = %highest_observed_slot,
+                    "Slot clock moved backwards within the current fork lifecycle window"
                 );
             }
-            ForkLifecycle::GracePeriod {
-                current, previous, ..
-            } => {
-                info!(
-                    previous_fork = %previous.fork,
-                    new_fork = %current.fork,
-                    "Fork activated"
+            ClockObservation::BackwardsAcrossBoundary => {
+                error!(
+                    observed_slot = %now,
+                    highest_observed_slot = %highest_observed_slot,
+                    "Slot clock rolled back across a published fork transition"
                 );
-            }
-            ForkLifecycle::Normal { current, .. } => {
-                info!(
-                    current_fork = %current.fork,
-                    grace_window_slots = SUBSEQUENT_WINDOW_SLOTS,
-                    "Fork transition grace period ended"
+                request_shutdown(
+                    &mut shutdown_tx,
+                    "Fork monitor: clock rolled back across a published fork transition",
                 );
+                return;
             }
         }
 
-        let _ = lifecycle_tx.send(transition.lifecycle);
+        // Publish from the highest observed slot so published state never
+        // regresses, even while a within-window backwards clock is tolerated.
+        let lifecycle = schedule.lifecycle_at(highest_observed_slot, slots_per_epoch);
+        let changed = lifecycle_tx.send_if_modified(|current| {
+            if *current == lifecycle {
+                false
+            } else {
+                *current = lifecycle.clone();
+                true
+            }
+        });
+        if changed {
+            log_transition(&lifecycle);
+        }
+
+        // Target the boundary after `now` rather than a second clock reading.
+        // `duration_to_slot` re-reads the clock, so `None` means the boundary
+        // already passed: re-observe at once. Consecutive `None`s instead pace
+        // at one slot, so a clock that never yields a boundary cannot spin.
+        // The cap bounds a sleep computed against a wall clock stepped far back.
+        let one_slot = slot_clock.slot_duration();
+        let sleep_duration = match slot_clock.duration_to_slot(now + 1) {
+            Some(until_boundary) => {
+                boundary_unavailable_streak = 0;
+                until_boundary.min(one_slot)
+            }
+            None => {
+                boundary_unavailable_streak += 1;
+                if boundary_unavailable_streak > 1 {
+                    one_slot
+                } else {
+                    Duration::ZERO
+                }
+            }
+        };
+        tokio::time::sleep(sleep_duration).await;
     }
 }
 
 /// Spawns a standalone task that monitors and logs fork transitions.
 ///
-/// The monitor will exit automatically when all scheduled forks have activated,
-/// or immediately if no forks are scheduled.
-///
-/// When fork transitions occur, the new [`ForkLifecycle`] state is sent through
-/// the watch channel so all receivers see the update immediately.
+/// The task derives the lifecycle from the slot clock once per slot for the
+/// node's lifetime and publishes changes through the returned watch channel,
+/// so all receivers see updates immediately.
 pub fn spawn<S: SlotClock + 'static>(
     fork_schedule: Arc<ForkSchedule>,
     slot_clock: S,
     slots_per_epoch: u64,
-    seconds_per_slot: u64,
     executor: TaskExecutor,
 ) -> Result<watch::Receiver<ForkLifecycle>, String> {
     let Some(current_slot) = slot_clock.now() else {
         return Err("Fork monitor: unable to determine current slot".to_string());
     };
+    let current_epoch = current_slot.epoch(slots_per_epoch);
+    let initial = fork_schedule.lifecycle_at(current_slot, slots_per_epoch);
+    info!(
+        fork = %initial.current_fork_config().fork,
+        epoch = %current_epoch,
+        "Fork monitor started"
+    );
+    if let Some((fork, fork_epoch)) = fork_schedule.next_fork_after(current_epoch) {
+        info!(
+            fork = %fork,
+            fork_epoch = %fork_epoch,
+            epochs_until = fork_epoch.as_u64().saturating_sub(current_epoch.as_u64()),
+            "Fork scheduled"
+        );
+    }
+    error_on_overlapping_windows(&fork_schedule, slots_per_epoch);
 
-    let monitor = ForkMonitor::new(&fork_schedule, current_slot, slots_per_epoch);
-
-    let (lifecycle_tx, lifecycle_rx) = watch::channel(monitor.initial.clone());
-
+    let (lifecycle_tx, lifecycle_rx) = watch::channel(initial);
+    let shutdown_tx = executor.shutdown_sender();
     executor.spawn(
-        async move {
-            run(monitor, slot_clock, seconds_per_slot, lifecycle_tx).await;
-
-            debug!("No more forks scheduled, fork monitor exiting")
-        },
+        run(
+            fork_schedule,
+            slots_per_epoch,
+            slot_clock,
+            current_slot,
+            lifecycle_tx,
+            shutdown_tx,
+        ),
         "fork_monitor",
     );
 
     Ok(lifecycle_rx)
 }
-
 #[cfg(test)]
 mod tests {
-    use std::collections::BTreeMap;
+    use std::{
+        collections::BTreeMap,
+        sync::atomic::{AtomicU64, Ordering},
+        time::Duration,
+    };
 
+    use futures::channel::mpsc::{Receiver, channel};
     use slot_clock::ManualSlotClock;
     use ssv_types::domain_type::DomainType;
-    use types::{ChainSpec, EthSpec, MinimalEthSpec, Slot};
+    use task_executor::test_utils::TestRuntime;
 
     use super::*;
-    use crate::{FORK_PREPARATION_EPOCHS, ForkConfig};
+    use crate::ForkConfig;
 
-    // Epoch constants for ForkMonitor tests
-    const BOOLE_FORK_EPOCH: u64 = 100;
-    const CURRENT_EPOCH: u64 = 50;
-    const PREPARATION_EPOCH: u64 = BOOLE_FORK_EPOCH - FORK_PREPARATION_EPOCHS;
-    const AFTER_FORK_EPOCH: u64 = 150;
+    /// Slots per epoch for these tests. `run` and `lifecycle_at` take this as a plain
+    /// parameter, so a small value keeps the transition slots close together.
+    const TEST_SLOTS_PER_EPOCH: u64 = 8;
+    /// The Boole activation epoch used by most tests.
+    const BOOLE_FORK_EPOCH: u64 = 2;
+    /// First slot of the warm-up window: `FORK_PREPARATION_EPOCHS` before activation.
+    const PREPARATION_START_SLOT: u64 =
+        (BOOLE_FORK_EPOCH - FORK_PREPARATION_EPOCHS) * TEST_SLOTS_PER_EPOCH;
+    /// First slot of the grace period: the Boole activation slot.
+    const ACTIVATION_SLOT: u64 = BOOLE_FORK_EPOCH * TEST_SLOTS_PER_EPOCH;
+    /// First slot after the grace period: back to `Normal`, now on Boole.
+    const GRACE_END_SLOT: u64 = ACTIVATION_SLOT + SUBSEQUENT_WINDOW_SLOTS;
 
-    // Epoch constants for async activation sequence test
-    const ASYNC_BOOLE_FORK_EPOCH: u64 = 10;
-    const ASYNC_START_EPOCH: u64 = 8;
+    /// Slot duration for the async loop tests, small enough to keep virtual time short.
+    const TEST_SLOT_DURATION: Duration = Duration::from_secs(1);
+    /// A slot duration that is not a whole number of seconds, used to catch truncation to
+    /// second precision anywhere in the sleep calculation.
+    const FRACTIONAL_SLOT_DURATION: Duration = Duration::from_millis(1_500);
+    /// The time to a slot boundary as reported by a clock that stepped behind genesis: far
+    /// longer than a slot, and far longer than the monitor may sleep for.
+    const UNUSABLE_SLEEP: Duration = Duration::from_secs(3_600);
 
     // Test network name
     const TEST_NETWORK: &str = "test";
@@ -294,16 +317,6 @@ mod tests {
     // Test domain types
     const TEST_BASELINE_DOMAIN: DomainType = DomainType([0, 0, 0, 1]);
     const TEST_BOOLE_DOMAIN: DomainType = DomainType([0, 0, 0, 2]);
-
-    /// Get slots per epoch from minimal spec (faster tests).
-    fn slots_per_epoch() -> u64 {
-        MinimalEthSpec::slots_per_epoch()
-    }
-
-    /// Get seconds per slot from minimal spec.
-    fn seconds_per_slot() -> u64 {
-        ChainSpec::minimal().get_slot_duration().as_secs()
-    }
 
     fn make_schedule_with_boole(boole_epoch: u64) -> Arc<ForkSchedule> {
         let mut configs = BTreeMap::new();
@@ -323,515 +336,880 @@ mod tests {
         ))
     }
 
-    /// Create a ManualSlotClock at the given epoch.
-    fn clock_at_epoch(epoch: u64) -> ManualSlotClock {
-        let clock = ManualSlotClock::new(
-            Slot::new(0),
-            Duration::from_secs(0),
-            Duration::from_secs(seconds_per_slot()),
-        );
-        clock.set_slot(epoch * slots_per_epoch());
+    /// Create a ManualSlotClock at the given slot, with genesis at the UNIX epoch so slot
+    /// starts and virtual Tokio time share an origin.
+    fn clock_at_slot(slot: u64) -> ManualSlotClock {
+        let clock = ManualSlotClock::new(Slot::new(0), Duration::ZERO, TEST_SLOT_DURATION);
+        clock.set_slot(slot);
         clock
     }
 
-    /// Duration of one epoch.
-    fn epoch_duration() -> Duration {
-        Duration::from_secs(slots_per_epoch() * seconds_per_slot())
+    /// A clock whose current slot is readable but whose reported time to any slot boundary is
+    /// unusable.
+    ///
+    /// This is the shape `SystemTimeSlotClock` takes when it steps behind genesis between two
+    /// reads: `now()` still answers from the first reading, while `duration_to_slot` takes its
+    /// own wall-clock reading and reports the whole remaining time until genesis instead of
+    /// the time to the requested boundary. The over-long report proves the `min(one_slot)` cap
+    /// engages.
+    #[derive(Clone)]
+    struct UnusableNextSlotClock {
+        inner: ManualSlotClock,
     }
 
-    /// Create a test watch channel for lifecycle, returning the sender.
-    /// The receiver is dropped since ForkMonitor tests verify fields directly.
-    fn test_lifecycle_tx() -> watch::Sender<ForkLifecycle> {
-        let (tx, _rx) = watch::channel(ForkLifecycle::Normal {
-            current: ForkConfig::new(Fork::Alan, Epoch::new(0), TEST_BASELINE_DOMAIN),
-        });
-        tx
-    }
-
-    /// Convert epoch to slot for testing.
-    fn epoch_to_slot(epoch: u64) -> Slot {
-        Slot::new(epoch * slots_per_epoch())
-    }
-
-    // ==================== ForkMonitor initialization tests ====================
-
-    #[test]
-    fn test_new_with_scheduled_fork_has_transitions() {
-        // Arrange
-        let schedule = make_schedule_with_boole(BOOLE_FORK_EPOCH);
-
-        // Act
-        let monitor = ForkMonitor::new(&schedule, epoch_to_slot(CURRENT_EPOCH), slots_per_epoch());
-
-        // Assert: initial is Normal{Alan}, with 3 future transitions
-        assert!(
-            matches!(&monitor.initial, ForkLifecycle::Normal { current } if current.fork == Fork::Alan)
-        );
-        assert_eq!(
-            monitor.transitions.len(),
-            3,
-            "Expected WarmUp, GracePeriod, Normal"
-        );
-        assert!(matches!(
-            &monitor.transitions[0].lifecycle,
-            ForkLifecycle::WarmUp { .. }
-        ));
-        assert!(matches!(
-            &monitor.transitions[1].lifecycle,
-            ForkLifecycle::GracePeriod { .. }
-        ));
-        assert!(matches!(
-            &monitor.transitions[2].lifecycle,
-            ForkLifecycle::Normal { .. }
-        ));
-    }
-
-    #[test]
-    fn test_new_without_future_forks_has_no_transitions() {
-        // Arrange
-        let schedule = make_schedule_no_future_forks();
-
-        // Act
-        let monitor = ForkMonitor::new(&schedule, epoch_to_slot(CURRENT_EPOCH), slots_per_epoch());
-
-        // Assert
-        assert!(monitor.transitions.is_empty());
-        assert!(
-            matches!(&monitor.initial, ForkLifecycle::Normal { current } if current.fork == Fork::Alan)
-        );
-    }
-
-    #[test]
-    fn test_new_in_preparation_window_emits_initial_warmup() {
-        // Arrange
-        let schedule = make_schedule_with_boole(BOOLE_FORK_EPOCH);
-
-        // Act
-        let monitor = ForkMonitor::new(
-            &schedule,
-            epoch_to_slot(PREPARATION_EPOCH),
-            slots_per_epoch(),
-        );
-
-        // Assert: initial is WarmUp (past prep slot), 2 future transitions
-        assert!(
-            matches!(
-                &monitor.initial,
-                ForkLifecycle::WarmUp { upcoming, .. } if upcoming.fork == Fork::Boole
-            ),
-            "Should emit WarmUp when starting in preparation window"
-        );
-        assert_eq!(
-            monitor.transitions.len(),
-            2,
-            "Expected GracePeriod + Normal"
-        );
-        assert!(matches!(
-            &monitor.transitions[0].lifecycle,
-            ForkLifecycle::GracePeriod { .. }
-        ));
-        assert!(matches!(
-            &monitor.transitions[1].lifecycle,
-            ForkLifecycle::Normal { .. }
-        ));
-    }
-
-    #[test]
-    fn test_new_restart_at_exact_prep_slot_emits_warmup() {
-        // Arrange: Start exactly at the preparation slot (lower boundary of warm-up window)
-        let schedule = make_schedule_with_boole(BOOLE_FORK_EPOCH);
-        let spe = slots_per_epoch();
-        let prep_slot = Slot::new(PREPARATION_EPOCH * spe);
-
-        // Act
-        let monitor = ForkMonitor::new(&schedule, prep_slot, spe);
-
-        // Assert: initial is WarmUp{Alan, Boole} (exact prep slot is "already happened")
-        assert!(
-            matches!(
-                &monitor.initial,
-                ForkLifecycle::WarmUp { current, upcoming }
-                    if current.fork == Fork::Alan && upcoming.fork == Fork::Boole
-            ),
-            "Should emit WarmUp when restarting at exact preparation slot"
-        );
-
-        // Assert: 2 future transitions remain (GracePeriod + Normal)
-        assert_eq!(
-            monitor.transitions.len(),
-            2,
-            "Expected GracePeriod + Normal"
-        );
-    }
-
-    #[test]
-    fn test_new_after_all_forks_activated_no_transitions() {
-        // Arrange
-        let schedule = make_schedule_with_boole(BOOLE_FORK_EPOCH);
-
-        // Act
-        let monitor = ForkMonitor::new(
-            &schedule,
-            epoch_to_slot(AFTER_FORK_EPOCH),
-            slots_per_epoch(),
-        );
-
-        // Assert: Boole already active, no transitions to process
-        assert!(monitor.transitions.is_empty());
-        assert!(
-            matches!(&monitor.initial, ForkLifecycle::Normal { current, .. } if current.fork == Fork::Boole)
-        );
-    }
-
-    #[test]
-    fn test_new_restart_during_grace_period_emits_grace_period() {
-        // Arrange: Start 1 slot after fork activation — inside the grace period window.
-        let schedule = make_schedule_with_boole(BOOLE_FORK_EPOCH);
-        let grace_slot = Slot::new(BOOLE_FORK_EPOCH * slots_per_epoch() + 1);
-
-        // Act
-        let monitor = ForkMonitor::new(&schedule, grace_slot, slots_per_epoch());
-
-        // Assert: Restart during grace period emits GracePeriod{Boole, Alan}
-        assert!(
-            matches!(
-                &monitor.initial,
-                ForkLifecycle::GracePeriod { current, previous }
-                    if current.fork == Fork::Boole && previous.fork == Fork::Alan
-            ),
-            "Should emit GracePeriod when restarting inside the grace window"
-        );
-
-        // Assert: Exactly 1 scheduled transition — Normal at grace end
-        assert_eq!(
-            monitor.transitions.len(),
-            1,
-            "Expected exactly 1 transition (Normal at grace end)"
-        );
-        assert!(
-            matches!(
-                &monitor.transitions[0].lifecycle,
-                ForkLifecycle::Normal { current } if current.fork == Fork::Boole
-            ),
-            "Scheduled transition should be Normal{{Boole}}"
-        );
-        assert_eq!(
-            monitor.transitions[0].slot,
-            Slot::new(BOOLE_FORK_EPOCH * slots_per_epoch() + SUBSEQUENT_WINDOW_SLOTS),
-            "Normal transition should be scheduled at grace end slot"
-        );
-    }
-
-    #[test]
-    fn test_new_restart_at_exact_activation_emits_grace_period() {
-        // Arrange: Start exactly at the fork activation slot (lower boundary of grace window).
-        let schedule = make_schedule_with_boole(BOOLE_FORK_EPOCH);
-        let activation_slot = Slot::new(BOOLE_FORK_EPOCH * slots_per_epoch());
-
-        // Act
-        let monitor = ForkMonitor::new(&schedule, activation_slot, slots_per_epoch());
-
-        // Assert: Restart at exact activation emits GracePeriod{Boole, Alan}
-        assert!(
-            matches!(
-                &monitor.initial,
-                ForkLifecycle::GracePeriod { current, previous }
-                    if current.fork == Fork::Boole && previous.fork == Fork::Alan
-            ),
-            "Should emit GracePeriod when restarting at exact activation slot"
-        );
-        assert_eq!(
-            monitor.transitions.len(),
-            1,
-            "Expected exactly 1 transition (Normal at grace end)"
-        );
-    }
-
-    #[test]
-    fn test_new_restart_at_grace_end_emits_normal() {
-        // Arrange: Start exactly at grace end slot — grace period has expired.
-        let schedule = make_schedule_with_boole(BOOLE_FORK_EPOCH);
-        let grace_end_slot =
-            Slot::new(BOOLE_FORK_EPOCH * slots_per_epoch() + SUBSEQUENT_WINDOW_SLOTS);
-
-        // Act
-        let monitor = ForkMonitor::new(&schedule, grace_end_slot, slots_per_epoch());
-
-        // Assert: Grace period expired, initial is Normal{Boole}
-        assert!(
-            matches!(
-                &monitor.initial,
-                ForkLifecycle::Normal { current } if current.fork == Fork::Boole
-            ),
-            "Should emit Normal when starting at or after grace end slot"
-        );
-
-        // Assert: No transitions remaining
-        assert!(
-            monitor.transitions.is_empty(),
-            "No transitions should be scheduled after grace period ends"
-        );
-    }
-
-    // ==================== Transition slot verification tests ====================
-
-    #[test]
-    fn test_transitions_warmup_at_correct_slot() {
-        // Arrange
-        let schedule = make_schedule_with_boole(BOOLE_FORK_EPOCH);
-        let expected_slot = (BOOLE_FORK_EPOCH - FORK_PREPARATION_EPOCHS) * slots_per_epoch();
-
-        // Act
-        let monitor = ForkMonitor::new(&schedule, epoch_to_slot(CURRENT_EPOCH), slots_per_epoch());
-
-        // Assert
-        assert_eq!(monitor.transitions[0].slot, Slot::new(expected_slot));
-        assert!(matches!(
-            &monitor.transitions[0].lifecycle,
-            ForkLifecycle::WarmUp { current, upcoming }
-                if current.fork == Fork::Alan
-                    && upcoming.fork == Fork::Boole
-                    && current.domain_type == TEST_BASELINE_DOMAIN
-        ));
-    }
-
-    #[test]
-    fn test_transitions_grace_period_at_correct_slot() {
-        // Arrange
-        let schedule = make_schedule_with_boole(BOOLE_FORK_EPOCH);
-        let expected_slot = BOOLE_FORK_EPOCH * slots_per_epoch();
-
-        // Act
-        let monitor = ForkMonitor::new(&schedule, epoch_to_slot(CURRENT_EPOCH), slots_per_epoch());
-
-        // Assert
-        assert_eq!(monitor.transitions[1].slot, Slot::new(expected_slot));
-        assert!(matches!(
-            &monitor.transitions[1].lifecycle,
-            ForkLifecycle::GracePeriod { current, previous }
-                if current.fork == Fork::Boole
-                    && previous.fork == Fork::Alan
-                    && current.domain_type == TEST_BOOLE_DOMAIN
-        ));
-    }
-
-    #[test]
-    fn test_transitions_normal_at_correct_slot() {
-        // Arrange
-        let schedule = make_schedule_with_boole(BOOLE_FORK_EPOCH);
-        let expected_slot = BOOLE_FORK_EPOCH * slots_per_epoch() + SUBSEQUENT_WINDOW_SLOTS;
-
-        // Act
-        let monitor = ForkMonitor::new(&schedule, epoch_to_slot(CURRENT_EPOCH), slots_per_epoch());
-
-        // Assert
-        assert_eq!(monitor.transitions[2].slot, Slot::new(expected_slot));
-        assert!(matches!(
-            &monitor.transitions[2].lifecycle,
-            ForkLifecycle::Normal { current }
-                if current.fork == Fork::Boole
-                    && current.domain_type == TEST_BOOLE_DOMAIN
-        ));
-    }
-
-    #[test]
-    fn test_full_transition_sequence() {
-        // Arrange
-        let schedule = make_schedule_with_boole(BOOLE_FORK_EPOCH);
-        let spe = slots_per_epoch();
-        let prep_slot = (BOOLE_FORK_EPOCH - FORK_PREPARATION_EPOCHS) * spe;
-        let activation_slot = BOOLE_FORK_EPOCH * spe;
-        let grace_end_slot = activation_slot + SUBSEQUENT_WINDOW_SLOTS;
-
-        // Act
-        let monitor = ForkMonitor::new(&schedule, epoch_to_slot(CURRENT_EPOCH), spe);
-
-        // Assert: All 3 transitions in correct order with correct slots
-        assert_eq!(monitor.transitions.len(), 3);
-
-        assert_eq!(monitor.transitions[0].slot, Slot::new(prep_slot));
-        assert!(matches!(
-            &monitor.transitions[0].lifecycle,
-            ForkLifecycle::WarmUp { .. }
-        ));
-
-        assert_eq!(monitor.transitions[1].slot, Slot::new(activation_slot));
-        assert!(matches!(
-            &monitor.transitions[1].lifecycle,
-            ForkLifecycle::GracePeriod { .. }
-        ));
-
-        assert_eq!(monitor.transitions[2].slot, Slot::new(grace_end_slot));
-        assert!(matches!(
-            &monitor.transitions[2].lifecycle,
-            ForkLifecycle::Normal { .. }
-        ));
-    }
-
-    // ==================== Edge case tests ====================
-
-    #[test]
-    fn test_epoch_zero_forks_produce_no_transitions() {
-        // Arrange: Both Alan and Boole at epoch 0 (all forks active from genesis).
-        let mut configs = BTreeMap::new();
-        configs.insert(Fork::Alan, (Epoch::new(0), TEST_BASELINE_DOMAIN));
-        configs.insert(Fork::Boole, (Epoch::new(0), TEST_BOOLE_DOMAIN));
-        let schedule = Arc::new(
-            ForkSchedule::from_fork_configs(configs, TEST_NETWORK).expect("valid schedule"),
-        );
-
-        // Act
-        let monitor = ForkMonitor::new(&schedule, Slot::new(0), slots_per_epoch());
-
-        // Assert: No transitions — both forks at epoch 0, Boole is the active fork.
-        assert!(monitor.transitions.is_empty());
-        assert!(
-            matches!(&monitor.initial, ForkLifecycle::Normal { current, .. } if current.fork == Fork::Boole)
-        );
-    }
-
-    #[test]
-    fn test_early_fork_produces_all_transitions() {
-        // Arrange: Boole at epoch 2 (very early fork).
-        let schedule = make_schedule_with_boole(2);
-
-        // Act
-        let monitor = ForkMonitor::new(&schedule, Slot::new(0), slots_per_epoch());
-
-        // Assert: All 3 transitions emitted.
-        assert_eq!(monitor.transitions.len(), 3);
-        assert!(matches!(
-            &monitor.transitions[0].lifecycle,
-            ForkLifecycle::WarmUp { .. }
-        ));
-        assert!(matches!(
-            &monitor.transitions[1].lifecycle,
-            ForkLifecycle::GracePeriod { .. }
-        ));
-        assert!(matches!(
-            &monitor.transitions[2].lifecycle,
-            ForkLifecycle::Normal { current, .. } if current.fork == Fork::Boole
-        ));
-    }
-
-    // ==================== Async run() tests ====================
-
-    #[tokio::test]
-    async fn test_run_exits_immediately_when_no_forks_scheduled() {
-        // Arrange
-        let schedule = make_schedule_no_future_forks();
-        let clock = clock_at_epoch(CURRENT_EPOCH);
-        let monitor = ForkMonitor::new(&schedule, epoch_to_slot(CURRENT_EPOCH), slots_per_epoch());
-        let lifecycle_tx = test_lifecycle_tx();
-
-        // Act — completes immediately since there are no transitions
-        run(monitor, clock, seconds_per_slot(), lifecycle_tx).await;
-    }
-
-    #[tokio::test]
-    async fn test_run_exits_immediately_when_fork_already_active() {
-        // Arrange
-        let schedule = make_schedule_with_boole(BOOLE_FORK_EPOCH);
-        let clock = clock_at_epoch(AFTER_FORK_EPOCH);
-        let monitor = ForkMonitor::new(
-            &schedule,
-            epoch_to_slot(AFTER_FORK_EPOCH),
-            slots_per_epoch(),
-        );
-        let lifecycle_tx = test_lifecycle_tx();
-
-        // Act — completes immediately since all forks already activated
-        run(monitor, clock, seconds_per_slot(), lifecycle_tx).await;
-    }
-
-    /// Tests that the monitor correctly processes fork activation and grace period over time.
-    /// Uses tokio's time control to simulate slot progression.
-    #[tokio::test(start_paused = true)]
-    async fn test_run_completes_full_fork_activation_sequence() {
-        // Arrange
-        let schedule = make_schedule_with_boole(ASYNC_BOOLE_FORK_EPOCH);
-        let clock = clock_at_epoch(ASYNC_START_EPOCH);
-        let monitor = ForkMonitor::new(
-            &schedule,
-            epoch_to_slot(ASYNC_START_EPOCH),
-            slots_per_epoch(),
-        );
-        let (lifecycle_tx, mut lifecycle_rx) = watch::channel(monitor.initial.clone());
-
-        // Act: Spawn monitor and advance time through fork activation and grace period
-        let handle = tokio::spawn({
-            let clock = clock.clone();
-            async move {
-                run(monitor, clock, seconds_per_slot(), lifecycle_tx).await;
+    impl SlotClock for UnusableNextSlotClock {
+        fn new(genesis_slot: Slot, genesis_duration: Duration, slot_duration: Duration) -> Self {
+            Self {
+                inner: ManualSlotClock::new(genesis_slot, genesis_duration, slot_duration),
             }
-        });
+        }
 
-        // Let the spawned task start and hit the first sleep
+        fn duration_to_next_slot(&self) -> Option<Duration> {
+            Some(UNUSABLE_SLEEP)
+        }
+
+        fn now(&self) -> Option<Slot> {
+            self.inner.now()
+        }
+
+        fn is_prior_to_genesis(&self) -> Option<bool> {
+            self.inner.is_prior_to_genesis()
+        }
+
+        fn now_duration(&self) -> Option<Duration> {
+            self.inner.now_duration()
+        }
+
+        fn slot_of(&self, now: Duration) -> Option<Slot> {
+            self.inner.slot_of(now)
+        }
+
+        fn slot_duration(&self) -> Duration {
+            self.inner.slot_duration()
+        }
+
+        fn duration_to_slot(&self, _slot: Slot) -> Option<Duration> {
+            Some(UNUSABLE_SLEEP)
+        }
+
+        fn duration_to_next_epoch(&self, slots_per_epoch: u64) -> Option<Duration> {
+            self.inner.duration_to_next_epoch(slots_per_epoch)
+        }
+
+        fn start_of(&self, slot: Slot) -> Option<Duration> {
+            self.inner.start_of(slot)
+        }
+
+        fn genesis_slot(&self) -> Slot {
+            self.inner.genesis_slot()
+        }
+
+        fn genesis_duration(&self) -> Duration {
+            SlotClock::genesis_duration(&self.inner)
+        }
+    }
+
+    /// A clock that advances one slot per `now()` read, whose first `duration_to_slot`
+    /// query fails (the boundary-slipped race) and whose later queries resolve normally.
+    ///
+    /// This isolates the first step of the fallback ladder: a single `None` must re-observe
+    /// immediately, which is provable because the next slot's transition publishes without
+    /// any virtual time passing.
+    #[derive(Clone)]
+    struct BoundaryOnceUnavailableClock {
+        start_slot: u64,
+        now_reads: Arc<AtomicU64>,
+        boundary_reads: Arc<AtomicU64>,
+    }
+
+    impl BoundaryOnceUnavailableClock {
+        fn starting_at(start_slot: u64) -> Self {
+            Self {
+                start_slot,
+                now_reads: Arc::new(AtomicU64::new(0)),
+                boundary_reads: Arc::new(AtomicU64::new(0)),
+            }
+        }
+    }
+
+    impl SlotClock for BoundaryOnceUnavailableClock {
+        fn new(_genesis_slot: Slot, _genesis_duration: Duration, _slot_duration: Duration) -> Self {
+            unimplemented!("constructed via BoundaryOnceUnavailableClock::starting_at")
+        }
+
+        fn now(&self) -> Option<Slot> {
+            let reads = self.now_reads.fetch_add(1, Ordering::SeqCst);
+            Some(Slot::new(self.start_slot + reads))
+        }
+
+        fn is_prior_to_genesis(&self) -> Option<bool> {
+            Some(false)
+        }
+
+        fn now_duration(&self) -> Option<Duration> {
+            None
+        }
+
+        fn slot_of(&self, _now: Duration) -> Option<Slot> {
+            None
+        }
+
+        fn slot_duration(&self) -> Duration {
+            TEST_SLOT_DURATION
+        }
+
+        fn duration_to_slot(&self, _slot: Slot) -> Option<Duration> {
+            (self.boundary_reads.fetch_add(1, Ordering::SeqCst) > 0).then_some(TEST_SLOT_DURATION)
+        }
+
+        fn duration_to_next_slot(&self) -> Option<Duration> {
+            None
+        }
+
+        fn duration_to_next_epoch(&self, _slots_per_epoch: u64) -> Option<Duration> {
+            None
+        }
+
+        fn start_of(&self, _slot: Slot) -> Option<Duration> {
+            None
+        }
+
+        fn genesis_slot(&self) -> Slot {
+            Slot::new(0)
+        }
+
+        fn genesis_duration(&self) -> Duration {
+            Duration::ZERO
+        }
+    }
+
+    /// A clock frozen at one readable slot whose `duration_to_slot` never resolves: `now()`
+    /// keeps succeeding while every boundary query fails.
+    ///
+    /// This is the pathological shape the streak-based fallback exists for: only the first
+    /// consecutive failure may re-observe immediately, every following one must pace at a
+    /// full slot.
+    #[derive(Clone)]
+    struct FrozenNoBoundaryClock {
+        slot: Slot,
+    }
+
+    impl SlotClock for FrozenNoBoundaryClock {
+        fn new(_genesis_slot: Slot, _genesis_duration: Duration, _slot_duration: Duration) -> Self {
+            unimplemented!("constructed directly from a slot")
+        }
+
+        fn now(&self) -> Option<Slot> {
+            Some(self.slot)
+        }
+
+        fn is_prior_to_genesis(&self) -> Option<bool> {
+            Some(false)
+        }
+
+        fn now_duration(&self) -> Option<Duration> {
+            None
+        }
+
+        fn slot_of(&self, _now: Duration) -> Option<Slot> {
+            None
+        }
+
+        fn slot_duration(&self) -> Duration {
+            TEST_SLOT_DURATION
+        }
+
+        fn duration_to_slot(&self, _slot: Slot) -> Option<Duration> {
+            None
+        }
+
+        fn duration_to_next_slot(&self) -> Option<Duration> {
+            None
+        }
+
+        fn duration_to_next_epoch(&self, _slots_per_epoch: u64) -> Option<Duration> {
+            None
+        }
+
+        fn start_of(&self, _slot: Slot) -> Option<Duration> {
+            None
+        }
+
+        fn genesis_slot(&self) -> Slot {
+            Slot::new(0)
+        }
+
+        fn genesis_duration(&self) -> Duration {
+            Duration::ZERO
+        }
+    }
+
+    /// A shutdown channel with the same capacity as the one `TaskExecutor` hands out.
+    fn test_shutdown_channel() -> (Sender<ShutdownReason>, Receiver<ShutdownReason>) {
+        channel(1)
+    }
+
+    /// Assert the monitor failed closed by requesting a client-wide shutdown.
+    fn assert_shutdown_requested(shutdown_rx: &mut Receiver<ShutdownReason>) {
+        match shutdown_rx.try_recv() {
+            Ok(reason) => assert!(
+                matches!(reason, ShutdownReason::Failure(_)),
+                "expected a failure shutdown reason, got {reason:?}"
+            ),
+            Err(e) => panic!("expected a shutdown request, got {e:?}"),
+        }
+    }
+
+    fn assert_no_shutdown_requested(shutdown_rx: &mut Receiver<ShutdownReason>) {
+        if let Ok(reason) = shutdown_rx.try_recv() {
+            panic!("unexpected shutdown request: {reason:?}");
+        }
+    }
+
+    fn alan_config() -> ForkConfig {
+        ForkConfig::new(Fork::Alan, Epoch::new(0), TEST_BASELINE_DOMAIN)
+    }
+
+    fn boole_config() -> ForkConfig {
+        ForkConfig::new(Fork::Boole, Epoch::new(BOOLE_FORK_EPOCH), TEST_BOOLE_DOMAIN)
+    }
+
+    fn normal_alan_lifecycle() -> ForkLifecycle {
+        ForkLifecycle::Normal {
+            current: alan_config(),
+        }
+    }
+
+    fn warmup_lifecycle() -> ForkLifecycle {
+        ForkLifecycle::WarmUp {
+            current: alan_config(),
+            upcoming: boole_config(),
+        }
+    }
+
+    fn grace_period_lifecycle() -> ForkLifecycle {
+        ForkLifecycle::GracePeriod {
+            current: boole_config(),
+            previous: alan_config(),
+        }
+    }
+
+    fn normal_boole_lifecycle() -> ForkLifecycle {
+        ForkLifecycle::Normal {
+            current: boole_config(),
+        }
+    }
+
+    /// A monitor `run` task driven by a test clock, plus the handles a test needs to observe
+    /// it.
+    struct RunningMonitor {
+        handle: tokio::task::JoinHandle<()>,
+        lifecycle_rx: watch::Receiver<ForkLifecycle>,
+        shutdown_rx: Receiver<ShutdownReason>,
+    }
+
+    /// Spawn `run` against the given clock, mirroring `spawn`'s initialization: the watch
+    /// channel starts at the lifecycle derived for the clock's current slot. Yields once so
+    /// the first iteration has run and the task is parked on its slot-boundary sleep.
+    async fn start_run<S: SlotClock + 'static>(
+        schedule: Arc<ForkSchedule>,
+        clock: S,
+    ) -> RunningMonitor {
+        let initial_slot = clock.now().expect("test clock should be readable at start");
+        let (lifecycle_tx, lifecycle_rx) =
+            watch::channel(schedule.lifecycle_at(initial_slot, TEST_SLOTS_PER_EPOCH));
+        let (shutdown_tx, shutdown_rx) = test_shutdown_channel();
+        let handle = tokio::spawn(run(
+            schedule,
+            TEST_SLOTS_PER_EPOCH,
+            clock,
+            initial_slot,
+            lifecycle_tx,
+            shutdown_tx,
+        ));
         tokio::task::yield_now().await;
-
-        // Track observed lifecycle states
-        let mut saw_warmup = false;
-        let mut saw_grace_period = false;
-        let mut saw_normal_boole = false;
-
-        // Advance through epochs until fork activation
-        for epoch in (ASYNC_START_EPOCH + 1)..=ASYNC_BOOLE_FORK_EPOCH {
-            clock.set_slot(epoch * slots_per_epoch());
-            tokio::time::advance(epoch_duration()).await;
-            tokio::task::yield_now().await;
-            check_lifecycle(
-                &mut lifecycle_rx,
-                &mut saw_warmup,
-                &mut saw_grace_period,
-                &mut saw_normal_boole,
-            );
+        RunningMonitor {
+            handle,
+            lifecycle_rx,
+            shutdown_rx,
         }
-
-        // Advance through the grace period (32 slots = 4 epochs on minimal spec)
-        let grace_period_epochs = SUBSEQUENT_WINDOW_SLOTS / slots_per_epoch();
-        for i in 1..=grace_period_epochs {
-            let epoch = ASYNC_BOOLE_FORK_EPOCH + i;
-            clock.set_slot(epoch * slots_per_epoch());
-            tokio::time::advance(epoch_duration()).await;
-            tokio::task::yield_now().await;
-            check_lifecycle(
-                &mut lifecycle_rx,
-                &mut saw_warmup,
-                &mut saw_grace_period,
-                &mut saw_normal_boole,
-            );
-        }
-
-        handle.await.unwrap();
-
-        // Check final state
-        check_lifecycle(
-            &mut lifecycle_rx,
-            &mut saw_warmup,
-            &mut saw_grace_period,
-            &mut saw_normal_boole,
-        );
-
-        assert!(saw_warmup, "Expected WarmUp lifecycle state");
-        assert!(saw_grace_period, "Expected GracePeriod lifecycle state");
-        assert!(saw_normal_boole, "Expected Normal(Boole) lifecycle state");
     }
 
-    /// Helper to check the current lifecycle state against the expected progression.
-    fn check_lifecycle(
-        rx: &mut watch::Receiver<ForkLifecycle>,
-        saw_warmup: &mut bool,
-        saw_grace_period: &mut bool,
-        saw_normal_boole: &mut bool,
-    ) {
-        let state = rx.borrow_and_update().clone();
-        match &state {
-            ForkLifecycle::WarmUp { .. } => *saw_warmup = true,
-            ForkLifecycle::GracePeriod { .. } => *saw_grace_period = true,
-            ForkLifecycle::Normal { current, .. } if current.fork == Fork::Boole => {
-                *saw_normal_boole = true;
-            }
-            _ => {}
+    /// Fire the monitor's pending one-slot sleep and let the woken iteration run.
+    async fn wake_after_one_slot() {
+        tokio::time::advance(TEST_SLOT_DURATION).await;
+        tokio::task::yield_now().await;
+    }
+
+    // ==================== `classify_observation` tests ====================
+
+    #[test]
+    fn test_classify_forward_observation_is_advanced() {
+        // Arrange
+        let schedule = make_schedule_with_boole(BOOLE_FORK_EPOCH);
+
+        // Act
+        let observation =
+            classify_observation(&schedule, TEST_SLOTS_PER_EPOCH, Slot::new(5), Slot::new(6));
+
+        // Assert
+        assert_eq!(observation, ClockObservation::Advanced);
+    }
+
+    #[test]
+    fn test_classify_equal_observation_is_advanced() {
+        // Arrange
+        let schedule = make_schedule_with_boole(BOOLE_FORK_EPOCH);
+
+        // Act
+        let observation =
+            classify_observation(&schedule, TEST_SLOTS_PER_EPOCH, Slot::new(5), Slot::new(5));
+
+        // Assert
+        assert_eq!(observation, ClockObservation::Advanced);
+    }
+
+    #[test]
+    fn test_classify_backwards_within_the_grace_window_is_tolerated() {
+        // Arrange: both slots sit inside the grace period, so the derived lifecycle matches.
+        let schedule = make_schedule_with_boole(BOOLE_FORK_EPOCH);
+
+        // Act
+        let observation = classify_observation(
+            &schedule,
+            TEST_SLOTS_PER_EPOCH,
+            Slot::new(ACTIVATION_SLOT + 5),
+            Slot::new(ACTIVATION_SLOT + 1),
+        );
+
+        // Assert
+        assert_eq!(observation, ClockObservation::BackwardsWithinWindow);
+    }
+
+    #[test]
+    fn test_classify_backwards_onto_the_grace_window_start_is_tolerated() {
+        // Arrange: the observation lands exactly on the activation slot, the half-open
+        // start of the grace window the highest slot is still inside.
+        let schedule = make_schedule_with_boole(BOOLE_FORK_EPOCH);
+
+        // Act
+        let observation = classify_observation(
+            &schedule,
+            TEST_SLOTS_PER_EPOCH,
+            Slot::new(ACTIVATION_SLOT + 5),
+            Slot::new(ACTIVATION_SLOT),
+        );
+
+        // Assert
+        assert_eq!(observation, ClockObservation::BackwardsWithinWindow);
+    }
+
+    #[test]
+    fn test_classify_backwards_across_the_activation_boundary_is_fatal() {
+        // Arrange: the highest slot is in the grace period, the observation in the warm-up
+        // window just before activation.
+        let schedule = make_schedule_with_boole(BOOLE_FORK_EPOCH);
+
+        // Act
+        let observation = classify_observation(
+            &schedule,
+            TEST_SLOTS_PER_EPOCH,
+            Slot::new(ACTIVATION_SLOT),
+            Slot::new(ACTIVATION_SLOT - 1),
+        );
+
+        // Assert
+        assert_eq!(observation, ClockObservation::BackwardsAcrossBoundary);
+    }
+
+    #[test]
+    fn test_classify_backwards_across_the_grace_end_boundary_is_fatal() {
+        // Arrange: the highest slot has left the grace period, the observation is still in it.
+        let schedule = make_schedule_with_boole(BOOLE_FORK_EPOCH);
+
+        // Act
+        let observation = classify_observation(
+            &schedule,
+            TEST_SLOTS_PER_EPOCH,
+            Slot::new(GRACE_END_SLOT),
+            Slot::new(GRACE_END_SLOT - 1),
+        );
+
+        // Assert
+        assert_eq!(observation, ClockObservation::BackwardsAcrossBoundary);
+    }
+
+    #[test]
+    fn test_classify_backwards_from_warmup_into_pre_warmup_normal_is_fatal() {
+        // Arrange: the highest slot is at the exact start of the warm-up window, the
+        // observation just before it, where the lifecycle is still the pre-fork Normal.
+        let schedule = make_schedule_with_boole(BOOLE_FORK_EPOCH);
+
+        // Act
+        let observation = classify_observation(
+            &schedule,
+            TEST_SLOTS_PER_EPOCH,
+            Slot::new(PREPARATION_START_SLOT),
+            Slot::new(PREPARATION_START_SLOT - 1),
+        );
+
+        // Assert
+        assert_eq!(observation, ClockObservation::BackwardsAcrossBoundary);
+    }
+
+    // ==================== `spawn` initial state tests ====================
+
+    /// Spawn the monitor with the clock at the given slot and return the lifecycle receiver.
+    fn spawn_monitor_at_slot(slot: u64) -> Result<watch::Receiver<ForkLifecycle>, String> {
+        let schedule = make_schedule_with_boole(BOOLE_FORK_EPOCH);
+        let runtime = TestRuntime::default();
+        spawn(
+            schedule,
+            clock_at_slot(slot),
+            TEST_SLOTS_PER_EPOCH,
+            runtime.task_executor.clone(),
+        )
+    }
+
+    #[tokio::test]
+    async fn test_spawn_initial_state_is_normal_before_the_preparation_window() {
+        // Arrange and act: the last slot before the warm-up window starts.
+        let lifecycle_rx =
+            spawn_monitor_at_slot(PREPARATION_START_SLOT - 1).expect("spawn should succeed");
+
+        // Assert
+        assert_eq!(*lifecycle_rx.borrow(), normal_alan_lifecycle());
+    }
+
+    #[tokio::test]
+    async fn test_spawn_initial_state_is_warmup_inside_the_preparation_window() {
+        // Arrange and act: the exact first slot of the warm-up window.
+        let lifecycle_rx =
+            spawn_monitor_at_slot(PREPARATION_START_SLOT).expect("spawn should succeed");
+
+        // Assert
+        assert_eq!(*lifecycle_rx.borrow(), warmup_lifecycle());
+    }
+
+    #[tokio::test]
+    async fn test_spawn_initial_state_is_grace_period_inside_the_grace_window() {
+        // Arrange and act: the exact activation slot, the first slot of the grace period.
+        let lifecycle_rx = spawn_monitor_at_slot(ACTIVATION_SLOT).expect("spawn should succeed");
+
+        // Assert
+        assert_eq!(*lifecycle_rx.borrow(), grace_period_lifecycle());
+    }
+
+    #[tokio::test]
+    async fn test_spawn_initial_state_is_normal_after_the_grace_window() {
+        // Arrange and act: the exact first slot after the grace period.
+        let lifecycle_rx = spawn_monitor_at_slot(GRACE_END_SLOT).expect("spawn should succeed");
+
+        // Assert
+        assert_eq!(*lifecycle_rx.borrow(), normal_boole_lifecycle());
+    }
+
+    #[tokio::test]
+    async fn test_spawn_fails_when_the_clock_is_unreadable() {
+        // Arrange: the clock sits before genesis, so `now()` returns `None`.
+        let schedule = make_schedule_with_boole(BOOLE_FORK_EPOCH);
+        let genesis_time = Duration::from_secs(10);
+        let clock = ManualSlotClock::new(Slot::new(0), genesis_time, TEST_SLOT_DURATION);
+        clock.set_current_time(genesis_time - Duration::from_secs(1));
+        let runtime = TestRuntime::default();
+
+        // Act
+        let result = spawn(
+            schedule,
+            clock,
+            TEST_SLOTS_PER_EPOCH,
+            runtime.task_executor.clone(),
+        );
+
+        // Assert
+        assert!(
+            result.is_err(),
+            "spawn must refuse to start without a readable clock"
+        );
+    }
+
+    // ==================== Async `run` tests ====================
+
+    /// The loop sleeps only to the next slot boundary, so it wakes many times before a distant
+    /// transition. Each wake must decide from a fresh observation rather than assume it is
+    /// due, and the transition must land exactly when the clock reaches its slot.
+    #[tokio::test(start_paused = true)]
+    async fn test_run_publishes_the_warmup_transition_at_its_exact_slot() {
+        // Arrange: start well before the warm-up window.
+        let schedule = make_schedule_with_boole(BOOLE_FORK_EPOCH);
+        let clock = clock_at_slot(0);
+        let mut monitor = start_run(schedule, clock.clone()).await;
+
+        // Act: wake the Tokio timer repeatedly while the slot clock stays at slot 0.
+        for _ in 0..3 {
+            wake_after_one_slot().await;
         }
+
+        // Assert: early wakes publish nothing.
+        assert_eq!(
+            *monitor.lifecycle_rx.borrow(),
+            normal_alan_lifecycle(),
+            "Nothing may be published while the slot clock is before the transition"
+        );
+
+        // Act and assert at the slot before the transition
+        clock.set_slot(PREPARATION_START_SLOT - 1);
+        wake_after_one_slot().await;
+        assert_eq!(
+            *monitor.lifecycle_rx.borrow(),
+            normal_alan_lifecycle(),
+            "The transition must not be published one slot early"
+        );
+
+        // Act and assert at the exact transition slot
+        clock.set_slot(PREPARATION_START_SLOT);
+        wake_after_one_slot().await;
+        assert_eq!(*monitor.lifecycle_rx.borrow(), warmup_lifecycle());
+        assert!(!monitor.handle.is_finished(), "Monitor must keep running");
+        assert_no_shutdown_requested(&mut monitor.shutdown_rx);
+    }
+
+    /// Walk the clock across every boundary in order and observe each phase land at its exact
+    /// slot: WarmUp at the preparation slot, GracePeriod at activation, Normal at grace end.
+    #[tokio::test(start_paused = true)]
+    async fn test_run_publishes_each_phase_at_its_boundary_as_the_clock_advances() {
+        // Arrange
+        let schedule = make_schedule_with_boole(BOOLE_FORK_EPOCH);
+        let clock = clock_at_slot(0);
+        let mut monitor = start_run(schedule, clock.clone()).await;
+        assert_eq!(*monitor.lifecycle_rx.borrow(), normal_alan_lifecycle());
+
+        // Act and assert: preparation window opens.
+        clock.set_slot(PREPARATION_START_SLOT);
+        wake_after_one_slot().await;
+        assert_eq!(*monitor.lifecycle_rx.borrow(), warmup_lifecycle());
+
+        // Act and assert: fork activates.
+        clock.set_slot(ACTIVATION_SLOT);
+        wake_after_one_slot().await;
+        assert_eq!(*monitor.lifecycle_rx.borrow(), grace_period_lifecycle());
+
+        // Act and assert: grace period ends.
+        clock.set_slot(GRACE_END_SLOT);
+        wake_after_one_slot().await;
+        assert_eq!(*monitor.lifecycle_rx.borrow(), normal_boole_lifecycle());
+
+        assert!(!monitor.handle.is_finished(), "Monitor must keep running");
+        assert_no_shutdown_requested(&mut monitor.shutdown_rx);
+    }
+
+    /// A clock jump across several boundaries must publish only the lifecycle derived from the
+    /// current slot: the lifecycle is state, not an event stream, so replaying the
+    /// intermediate states would hand receivers fork configurations that are already stale.
+    #[tokio::test(start_paused = true)]
+    async fn test_run_publishes_only_the_final_state_after_a_jump_across_all_boundaries() {
+        // Arrange: start before the warm-up window.
+        let schedule = make_schedule_with_boole(BOOLE_FORK_EPOCH);
+        let clock = clock_at_slot(0);
+        let mut monitor = start_run(schedule, clock.clone()).await;
+
+        // Act: jump the clock past every boundary, giving the loop a single wake to notice.
+        clock.set_slot(GRACE_END_SLOT + 5);
+        wake_after_one_slot().await;
+
+        // Assert: exactly one change is pending and it is the final state. The jump was
+        // observed in a single iteration, so at most one value was ever sent.
+        assert!(
+            monitor.lifecycle_rx.has_changed().expect("sender is alive"),
+            "The jump must publish a change"
+        );
+        assert_eq!(
+            *monitor.lifecycle_rx.borrow_and_update(),
+            normal_boole_lifecycle(),
+            "Only the state for the current slot may be published, not the skipped phases"
+        );
+
+        // Assert: nothing further is published afterwards.
+        wake_after_one_slot().await;
+        assert!(
+            !monitor.lifecycle_rx.has_changed().expect("sender is alive"),
+            "No further publishes may follow the jump"
+        );
+        assert_no_shutdown_requested(&mut monitor.shutdown_rx);
+    }
+
+    /// An unreadable clock freezes the lifecycle wherever it happened to be, which silently
+    /// corrupts networking, scoring and ENR state, so the node must fail closed.
+    #[tokio::test(start_paused = true)]
+    async fn test_run_requests_shutdown_when_clock_becomes_unavailable() {
+        // Arrange: a clock with genesis later than the time we set below.
+        let schedule = make_schedule_with_boole(BOOLE_FORK_EPOCH);
+        let genesis_time = Duration::from_secs(10);
+        let clock = ManualSlotClock::new(Slot::new(0), genesis_time, TEST_SLOT_DURATION);
+        let mut monitor = start_run(schedule, clock.clone()).await;
+
+        // Act: step the clock behind genesis, so `now()` returns `None` on the next wake.
+        clock.set_current_time(genesis_time - Duration::from_secs(1));
+        tokio::time::advance(TEST_SLOT_DURATION).await;
+        monitor
+            .handle
+            .await
+            .expect("fork monitor task should complete");
+
+        // Assert
+        assert_shutdown_requested(&mut monitor.shutdown_rx);
+        assert_eq!(
+            *monitor.lifecycle_rx.borrow(),
+            normal_alan_lifecycle(),
+            "The lifecycle must stay frozen at its last published state"
+        );
+    }
+
+    /// A published lifecycle cannot be taken back, so a clock that rolls back across one
+    /// leaves the node advertising a fork state its own clock says has not happened yet.
+    #[tokio::test(start_paused = true)]
+    async fn test_run_requests_shutdown_when_clock_rolls_back_across_published_transition() {
+        // Arrange: start in the warm-up window, then publish the activation.
+        let schedule = make_schedule_with_boole(BOOLE_FORK_EPOCH);
+        let clock = clock_at_slot(ACTIVATION_SLOT - 2);
+        let mut monitor = start_run(schedule, clock.clone()).await;
+
+        clock.set_slot(ACTIVATION_SLOT);
+        wake_after_one_slot().await;
+        assert_eq!(
+            *monitor.lifecycle_rx.borrow(),
+            grace_period_lifecycle(),
+            "The transition should have been published before the rollback"
+        );
+
+        // Act: roll the clock back across the activation boundary.
+        clock.set_slot(ACTIVATION_SLOT - 1);
+        tokio::time::advance(TEST_SLOT_DURATION).await;
+        monitor
+            .handle
+            .await
+            .expect("fork monitor task should complete");
+
+        // Assert
+        assert_shutdown_requested(&mut monitor.shutdown_rx);
+        assert_eq!(
+            *monitor.lifecycle_rx.borrow(),
+            grace_period_lifecycle(),
+            "The published lifecycle must stay as it was; it cannot be rolled back"
+        );
+    }
+
+    /// A clock correction that stays inside the current lifecycle window changes nothing a
+    /// receiver can observe, so it is tolerated with a warning rather than being fatal, and
+    /// the monitor keeps working afterwards.
+    #[tokio::test(start_paused = true)]
+    async fn test_run_tolerates_a_clock_rollback_within_the_current_window() {
+        // Arrange: start inside the grace period.
+        let schedule = make_schedule_with_boole(BOOLE_FORK_EPOCH);
+        let clock = clock_at_slot(ACTIVATION_SLOT + 5);
+        let mut monitor = start_run(schedule, clock.clone()).await;
+
+        // Act: fall back to an earlier slot that is still inside the grace period.
+        clock.set_slot(ACTIVATION_SLOT + 1);
+        wake_after_one_slot().await;
+
+        // Assert: no publish, no shutdown, and the task keeps running.
+        assert!(
+            !monitor.lifecycle_rx.has_changed().expect("sender is alive"),
+            "A within-window rollback must not publish anything"
+        );
+        assert_eq!(*monitor.lifecycle_rx.borrow(), grace_period_lifecycle());
+        assert!(!monitor.handle.is_finished(), "Monitor must keep running");
+        assert_no_shutdown_requested(&mut monitor.shutdown_rx);
+
+        // Act and assert: the monitor still publishes the next transition once the clock
+        // moves forward again.
+        clock.set_slot(GRACE_END_SLOT);
+        wake_after_one_slot().await;
+        assert_eq!(*monitor.lifecycle_rx.borrow(), normal_boole_lifecycle());
+        assert_no_shutdown_requested(&mut monitor.shutdown_rx);
+    }
+
+    /// The sleep is capped at one slot regardless of what the clock reports, because a clock
+    /// that stepped behind genesis reports the whole time until genesis as the time to the
+    /// requested boundary. Without the cap the monitor would park for that whole span and
+    /// miss every transition due in it.
+    #[tokio::test(start_paused = true)]
+    async fn test_run_caps_the_sleep_at_one_slot_when_the_clock_reports_a_longer_wait() {
+        // Arrange
+        let schedule = make_schedule_with_boole(BOOLE_FORK_EPOCH);
+        let started_at = tokio::time::Instant::now();
+        let clock = UnusableNextSlotClock::new(Slot::new(0), Duration::ZERO, TEST_SLOT_DURATION);
+        let mut monitor = start_run(schedule, clock.clone()).await;
+
+        // Act: one slot of Tokio time, against a clock asking for an hour.
+        clock.inner.set_slot(PREPARATION_START_SLOT);
+        wake_after_one_slot().await;
+
+        // Assert
+        assert_eq!(*monitor.lifecycle_rx.borrow(), warmup_lifecycle());
+        assert!(
+            started_at.elapsed() < UNUSABLE_SLEEP,
+            "The monitor must re-observe within one slot, not after the reported wait"
+        );
+        assert!(!monitor.handle.is_finished(), "Monitor must keep running");
+        assert_no_shutdown_requested(&mut monitor.shutdown_rx);
+    }
+
+    /// When a single `duration_to_slot` returns `None` (the boundary slipped past between
+    /// the two clock reads), the loop falls back to `Duration::ZERO` and re-observes
+    /// immediately instead of oversleeping. The proof: the clock advances one slot per read
+    /// and reaches the preparation slot on the re-observation, so the WarmUp transition
+    /// publishes without any virtual time passing at all.
+    #[tokio::test(start_paused = true)]
+    async fn test_run_rechecks_immediately_after_a_single_unavailable_boundary() {
+        // Arrange: the first run-loop read lands one slot before the transition and its
+        // boundary query fails; the immediate re-observation lands on the transition slot.
+        let schedule = make_schedule_with_boole(BOOLE_FORK_EPOCH);
+        let clock = BoundaryOnceUnavailableClock::starting_at(PREPARATION_START_SLOT - 2);
+        let mut monitor = start_run(schedule, clock).await;
+
+        // Act: yield without advancing time; only a zero-duration sleep lets the loop
+        // re-observe here.
+        for _ in 0..3 {
+            tokio::task::yield_now().await;
+        }
+
+        // Assert
+        assert_eq!(
+            *monitor.lifecycle_rx.borrow(),
+            warmup_lifecycle(),
+            "The re-observation after a single unavailable boundary must happen immediately"
+        );
+        assert!(!monitor.handle.is_finished(), "Monitor must keep running");
+        assert_no_shutdown_requested(&mut monitor.shutdown_rx);
+    }
+
+    /// A pathological clock whose `now()` keeps answering while `duration_to_slot` never
+    /// resolves must not hot-spin on the zero-sleep fallback: only the first consecutive
+    /// failure re-observes immediately, every following one paces at one full slot. Under
+    /// paused time a hot spin would never yield back to this test, so completing the bounded
+    /// advances below is itself the proof of pacing.
+    #[tokio::test(start_paused = true)]
+    async fn test_run_paces_at_one_slot_when_the_boundary_stays_unavailable() {
+        // Arrange: a readable slot before any transition, with no resolvable boundary.
+        let schedule = make_schedule_with_boole(BOOLE_FORK_EPOCH);
+        let clock = FrozenNoBoundaryClock { slot: Slot::new(5) };
+        let mut monitor = start_run(schedule, clock).await;
+
+        // Act: several slots of virtual time; every wake finds the boundary still
+        // unavailable and must park for another full slot.
+        for _ in 0..3 {
+            wake_after_one_slot().await;
+        }
+
+        // Assert: the monitor is still pacing, published nothing new, and did not fail.
+        assert!(!monitor.handle.is_finished(), "Monitor must keep running");
+        assert_eq!(*monitor.lifecycle_rx.borrow(), normal_alan_lifecycle());
+        assert!(
+            !monitor.lifecycle_rx.has_changed().expect("sender is alive"),
+            "A frozen clock must not produce lifecycle changes"
+        );
+        assert_no_shutdown_requested(&mut monitor.shutdown_rx);
+    }
+
+    /// Slot durations are not required to be whole seconds, so nothing in the sleep
+    /// calculation may truncate to second precision and wake the monitor into an early
+    /// publish.
+    #[tokio::test(start_paused = true)]
+    async fn test_run_publishes_at_exact_target_with_fractional_slot_duration() {
+        // Arrange
+        let one_millisecond = Duration::from_millis(1);
+        let schedule = make_schedule_with_boole(BOOLE_FORK_EPOCH);
+        let clock = ManualSlotClock::new(Slot::new(0), Duration::ZERO, FRACTIONAL_SLOT_DURATION);
+        let mut monitor = start_run(schedule, clock.clone()).await;
+
+        // Act and assert at the slot before the transition
+        clock.set_slot(PREPARATION_START_SLOT - 1);
+        tokio::time::advance(FRACTIONAL_SLOT_DURATION).await;
+        tokio::task::yield_now().await;
+        assert_eq!(
+            *monitor.lifecycle_rx.borrow(),
+            normal_alan_lifecycle(),
+            "Lifecycle must not publish one slot before the transition"
+        );
+
+        // Act and assert with the clock one millisecond before the transition slot starts
+        let just_before_target = FRACTIONAL_SLOT_DURATION
+            * u32::try_from(PREPARATION_START_SLOT).expect("small slot")
+            - one_millisecond;
+        clock.set_current_time(just_before_target);
+        tokio::time::advance(FRACTIONAL_SLOT_DURATION).await;
+        tokio::task::yield_now().await;
+        assert_eq!(
+            *monitor.lifecycle_rx.borrow(),
+            normal_alan_lifecycle(),
+            "A fractional slot duration must not be rounded down into an early publish"
+        );
+        assert!(!monitor.handle.is_finished(), "Monitor must keep running");
+
+        // Act and assert at the exact transition slot
+        clock.set_slot(PREPARATION_START_SLOT);
+        tokio::time::advance(one_millisecond).await;
+        tokio::task::yield_now().await;
+        assert_eq!(*monitor.lifecycle_rx.borrow(), warmup_lifecycle());
+        assert_no_shutdown_requested(&mut monitor.shutdown_rx);
+    }
+
+    /// The monitor guards against clock rollbacks for the node's lifetime, so it must keep
+    /// running (and keep the watch sender alive) after the last scheduled fork's grace period
+    /// has ended.
+    #[tokio::test(start_paused = true)]
+    async fn test_run_stays_alive_after_the_final_grace_period_ends() {
+        // Arrange: start well past the grace end of the last scheduled fork.
+        let schedule = make_schedule_with_boole(BOOLE_FORK_EPOCH);
+        let clock = clock_at_slot(GRACE_END_SLOT + 10);
+        let mut monitor = start_run(schedule, clock.clone()).await;
+        assert_eq!(*monitor.lifecycle_rx.borrow(), normal_boole_lifecycle());
+
+        // Act: keep the clock moving for several slots.
+        for slot in (GRACE_END_SLOT + 11)..(GRACE_END_SLOT + 14) {
+            clock.set_slot(slot);
+            wake_after_one_slot().await;
+        }
+
+        // Assert: the task is still running and the sender is still alive (`has_changed`
+        // returns `Ok`, not the closed-channel `Err`).
+        assert!(
+            !monitor.handle.is_finished(),
+            "The monitor must not exit after the final grace period"
+        );
+        assert!(
+            !monitor
+                .lifecycle_rx
+                .has_changed()
+                .expect("the lifecycle sender must stay alive after the final grace period"),
+            "No lifecycle change is expected after the final grace period"
+        );
+        assert_no_shutdown_requested(&mut monitor.shutdown_rx);
+    }
+
+    /// With no future forks scheduled there is nothing to publish, but the monitor still owns
+    /// the rollback and clock-failure guards, so it keeps running.
+    #[tokio::test(start_paused = true)]
+    async fn test_run_keeps_running_when_no_forks_are_scheduled() {
+        // Arrange
+        let schedule = make_schedule_no_future_forks();
+        let clock = clock_at_slot(0);
+        let mut monitor = start_run(schedule, clock.clone()).await;
+
+        // Act
+        for slot in 1..4 {
+            clock.set_slot(slot);
+            wake_after_one_slot().await;
+        }
+
+        // Assert
+        assert_eq!(*monitor.lifecycle_rx.borrow(), normal_alan_lifecycle());
+        assert!(
+            !monitor.handle.is_finished(),
+            "The monitor must keep running with nothing scheduled"
+        );
+        assert_no_shutdown_requested(&mut monitor.shutdown_rx);
     }
 }

--- a/anchor/common/fork/src/schedule.rs
+++ b/anchor/common/fork/src/schedule.rs
@@ -6,9 +6,9 @@
 use std::collections::BTreeMap;
 
 use ssv_types::domain_type::DomainType;
-use types::Epoch;
+use types::{Epoch, Slot};
 
-use crate::Fork;
+use crate::{Fork, ForkLifecycle};
 
 /// Number of epochs before a fork to start preparing (dual-subscribing, etc.).
 ///
@@ -209,6 +209,55 @@ impl ForkSchedule {
             .expect("constructors ensure there is at least one fork at epoch 0")
     }
 
+    /// Derive the fork lifecycle state for a slot directly from the schedule.
+    ///
+    /// This is the single source of truth for lifecycle state: the same slot
+    /// always maps to the same state, so restarts, clock jumps, and steady
+    /// operation all go through one code path.
+    ///
+    /// Windows, using the fork's activation slot `A` (all half-open):
+    /// - `WarmUp` in `[A - FORK_PREPARATION_EPOCHS in slots, A)`
+    /// - `GracePeriod` in `[A, A + SUBSEQUENT_WINDOW_SLOTS)`
+    /// - `Normal` everywhere else
+    ///
+    /// `WarmUp` takes precedence when an upcoming fork's preparation window
+    /// overlaps the current fork's grace period: preparing for the imminent
+    /// fork matters more than retaining the previous fork's topics. Schedules
+    /// that trigger this overlap (forks less than
+    /// `FORK_PREPARATION_EPOCHS + SUBSEQUENT_WINDOW_SLOTS` apart) are
+    /// logged as errors at monitor spawn.
+    pub fn lifecycle_at(&self, slot: Slot, slots_per_epoch: u64) -> ForkLifecycle {
+        let epoch = slot.epoch(slots_per_epoch);
+        let current = self.active_fork_config(epoch).clone();
+
+        // WarmUp: an upcoming fork's preparation window has started.
+        if let Some((upcoming_fork, upcoming_epoch)) = self.next_fork_after(epoch) {
+            let preparation_start_slot = upcoming_epoch
+                .as_u64()
+                .saturating_sub(FORK_PREPARATION_EPOCHS)
+                * slots_per_epoch;
+            if slot.as_u64() >= preparation_start_slot {
+                let upcoming = self
+                    .config(upcoming_fork)
+                    .expect("next_fork_after only returns scheduled forks")
+                    .clone();
+                return ForkLifecycle::WarmUp { current, upcoming };
+            }
+        }
+
+        // GracePeriod: within the subsequent window of a non-genesis activation.
+        // Genesis forks (epoch 0) have no previous fork to grace out of.
+        let activation_slot = current.epoch.as_u64() * slots_per_epoch;
+        if current.epoch.as_u64() > 0 && slot.as_u64() < activation_slot + SUBSEQUENT_WINDOW_SLOTS {
+            let previous = self
+                .active_fork_config(Epoch::new(current.epoch.as_u64() - 1))
+                .clone();
+            return ForkLifecycle::GracePeriod { current, previous };
+        }
+
+        ForkLifecycle::Normal { current }
+    }
+
     /// Get the next scheduled fork after the given epoch.
     pub fn next_fork_after(&self, epoch: Epoch) -> Option<(Fork, Epoch)> {
         self.configs
@@ -229,11 +278,31 @@ mod tests {
     const BASELINE_DOMAIN: DomainType = DomainType([0, 0, 0, 1]);
     const BOOLE_DOMAIN: DomainType = DomainType([0, 0, 0, 2]);
 
+    // Mainnet slots per epoch, used by the `lifecycle_at` boundary tests.
+    const SLOTS_PER_EPOCH: u64 = 32;
+    // The Boole activation epoch used by the `lifecycle_at` boundary tests.
+    const BOOLE_FORK_EPOCH: u64 = 100;
+    // First slot of the warm-up window: `FORK_PREPARATION_EPOCHS` before activation.
+    const PREPARATION_START_SLOT: u64 =
+        (BOOLE_FORK_EPOCH - FORK_PREPARATION_EPOCHS) * SLOTS_PER_EPOCH;
+    // First slot of the grace period: the Boole activation slot.
+    const ACTIVATION_SLOT: u64 = BOOLE_FORK_EPOCH * SLOTS_PER_EPOCH;
+    // First slot after the grace period: back to `Normal`, now on Boole.
+    const GRACE_END_SLOT: u64 = ACTIVATION_SLOT + SUBSEQUENT_WINDOW_SLOTS;
+
     fn schedule_with_boole(epoch: u64) -> ForkSchedule {
         let mut configs = BTreeMap::new();
         configs.insert(Fork::Alan, (Epoch::new(0), BASELINE_DOMAIN));
         configs.insert(Fork::Boole, (Epoch::new(epoch), BOOLE_DOMAIN));
         ForkSchedule::from_fork_configs(configs, TEST_NETWORK).expect("valid test schedule")
+    }
+
+    fn alan_config() -> ForkConfig {
+        ForkConfig::new(Fork::Alan, Epoch::new(0), BASELINE_DOMAIN)
+    }
+
+    fn boole_config_at(epoch: u64) -> ForkConfig {
+        ForkConfig::new(Fork::Boole, Epoch::new(epoch), BOOLE_DOMAIN)
     }
 
     #[test]
@@ -365,5 +434,131 @@ mod tests {
 
         let prefix_holesky = Fork::Boole.topic_prefix("holesky");
         assert_eq!(prefix_holesky, "/ssv/holesky/boole/");
+    }
+
+    // ==================== `lifecycle_at` boundary tests ====================
+    //
+    // Note: the documented WarmUp-over-GracePeriod precedence on overlapping windows cannot
+    // be exercised with the current two-fork enum. An overlap needs a third fork whose
+    // preparation window starts inside Boole's grace period; Alan is the genesis fork (no
+    // grace period of its own) and no fork follows Boole, so no two-fork schedule can
+    // construct the overlap.
+
+    /// Every window boundary is half-open, so each phase must start at its exact slot and end
+    /// one slot before the next phase's start.
+    #[test]
+    fn test_lifecycle_at_boundary_table() {
+        // Arrange
+        let schedule = schedule_with_boole(BOOLE_FORK_EPOCH);
+        let boole = boole_config_at(BOOLE_FORK_EPOCH);
+        let normal_alan = ForkLifecycle::Normal {
+            current: alan_config(),
+        };
+        let warmup = ForkLifecycle::WarmUp {
+            current: alan_config(),
+            upcoming: boole.clone(),
+        };
+        let grace_period = ForkLifecycle::GracePeriod {
+            current: boole.clone(),
+            previous: alan_config(),
+        };
+        let normal_boole = ForkLifecycle::Normal { current: boole };
+        let cases = [
+            // Last slot before the preparation window opens.
+            (PREPARATION_START_SLOT - 1, &normal_alan),
+            // Exact preparation start: 99 * 32 = 3168.
+            (PREPARATION_START_SLOT, &warmup),
+            // Last slot of the warm-up window: 3199.
+            (ACTIVATION_SLOT - 1, &warmup),
+            // Exact activation slot: 3200.
+            (ACTIVATION_SLOT, &grace_period),
+            // Last slot of the grace period: 3200 + 31.
+            (GRACE_END_SLOT - 1, &grace_period),
+            // First slot after the grace period: 3200 + 32.
+            (GRACE_END_SLOT, &normal_boole),
+            // Far after the transition.
+            (GRACE_END_SLOT + 100_000, &normal_boole),
+        ];
+
+        for (slot, expected) in cases {
+            // Act
+            let lifecycle = schedule.lifecycle_at(Slot::new(slot), SLOTS_PER_EPOCH);
+
+            // Assert
+            assert_eq!(&lifecycle, expected, "unexpected lifecycle at slot {slot}");
+        }
+    }
+
+    /// With no future fork scheduled there is no warm-up window, and a genesis fork has no
+    /// previous fork to grace out of, so every slot is `Normal`.
+    #[test]
+    fn test_lifecycle_at_alan_only_schedule_is_always_normal() {
+        // Arrange
+        let schedule = ForkSchedule::new(Fork::Alan, BASELINE_DOMAIN, TEST_NETWORK);
+        let normal_alan = ForkLifecycle::Normal {
+            current: alan_config(),
+        };
+
+        for slot in [0, 1, SLOTS_PER_EPOCH, ACTIVATION_SLOT, u64::MAX / 2] {
+            // Act
+            let lifecycle = schedule.lifecycle_at(Slot::new(slot), SLOTS_PER_EPOCH);
+
+            // Assert
+            assert_eq!(
+                lifecycle, normal_alan,
+                "an Alan-only schedule must be Normal at slot {slot}"
+            );
+        }
+    }
+
+    /// A fork scheduled at epoch 0 activates at genesis: there is no previous fork to grace
+    /// out of, so the grace period must not apply.
+    #[test]
+    fn test_lifecycle_at_genesis_fork_has_no_grace_period() {
+        // Arrange: both forks at epoch 0.
+        let mut configs = BTreeMap::new();
+        configs.insert(Fork::Alan, (Epoch::new(0), BASELINE_DOMAIN));
+        configs.insert(Fork::Boole, (Epoch::new(0), BOOLE_DOMAIN));
+        let schedule =
+            ForkSchedule::from_fork_configs(configs, TEST_NETWORK).expect("valid test schedule");
+
+        // Act
+        let lifecycle = schedule.lifecycle_at(Slot::new(0), SLOTS_PER_EPOCH);
+
+        // Assert
+        assert_eq!(
+            lifecycle,
+            ForkLifecycle::Normal {
+                current: boole_config_at(0),
+            }
+        );
+    }
+
+    /// A fork at epoch 1 has its whole preparation window inside epoch 0, so the warm-up
+    /// starts at genesis itself.
+    #[test]
+    fn test_lifecycle_at_early_fork_preparation_window_starts_at_genesis() {
+        // Arrange
+        let schedule = schedule_with_boole(1);
+        let warmup = ForkLifecycle::WarmUp {
+            current: alan_config(),
+            upcoming: boole_config_at(1),
+        };
+
+        // Act and assert: the warm-up window covers genesis through the last epoch-0 slot.
+        assert_eq!(schedule.lifecycle_at(Slot::new(0), SLOTS_PER_EPOCH), warmup);
+        assert_eq!(
+            schedule.lifecycle_at(Slot::new(SLOTS_PER_EPOCH - 1), SLOTS_PER_EPOCH),
+            warmup
+        );
+
+        // Act and assert: activation at the first epoch-1 slot enters the grace period.
+        assert_eq!(
+            schedule.lifecycle_at(Slot::new(SLOTS_PER_EPOCH), SLOTS_PER_EPOCH),
+            ForkLifecycle::GracePeriod {
+                current: boole_config_at(1),
+                previous: alan_config(),
+            }
+        );
     }
 }

--- a/anchor/common/fork/src/schedule.rs
+++ b/anchor/common/fork/src/schedule.rs
@@ -3,7 +3,7 @@
 //! This module provides the `ForkSchedule` type for managing fork activations
 //! and determining which fork is active at a given epoch.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 
 use ssv_types::domain_type::DomainType;
 use types::{Epoch, Slot};
@@ -96,7 +96,11 @@ pub struct ForkSchedule {
 }
 
 impl ForkSchedule {
-    /// Create a new fork schedule with the given fork active from epoch 0.
+    /// Create a fork schedule with every fork up to `fork` active from epoch 0.
+    ///
+    /// Every included fork uses `baseline_domain_type`. This constructor is intended for
+    /// Alan-only network defaults and test schedules. Explicit production fork schedules should
+    /// use [`Self::from_fork_configs`] so ordering and domain uniqueness are validated.
     pub fn new(fork: Fork, baseline_domain_type: DomainType, network_name: &str) -> Self {
         let mut configs = BTreeMap::new();
         for fork in Fork::all().iter().take_while(|&f| f <= &fork) {
@@ -133,6 +137,7 @@ impl ForkSchedule {
     /// - Alan fork is missing from configs
     /// - Alan fork is not at epoch 0
     /// - Fork epochs are not in chronological order
+    /// - Fork domain types are not unique
     pub fn from_fork_configs(
         raw_configs: BTreeMap<Fork, (Epoch, DomainType)>,
         network_name: &str,
@@ -151,7 +156,8 @@ impl ForkSchedule {
         // Validate chronological ordering - earlier forks must have < epochs
         // The exception is epoch 0, which may schedule multiple forks (to enable them at genesis)
         let mut prev_epoch: Option<u64> = None;
-        for (fork, (epoch, _)) in &raw_configs {
+        let mut domains = HashMap::new();
+        for (fork, (epoch, domain_type)) in &raw_configs {
             if let Some(prev) = prev_epoch
                 && epoch.as_u64() <= prev
                 && epoch.as_u64() != 0
@@ -161,6 +167,15 @@ impl ForkSchedule {
                     epoch.as_u64()
                 ));
             }
+
+            if let Some(previous_fork) = domains.get(domain_type) {
+                return Err(format!(
+                    "Fork {fork} reuses domain {} already assigned to fork {previous_fork}",
+                    String::from(*domain_type)
+                ));
+            }
+            domains.insert(*domain_type, *fork);
+
             prev_epoch = Some(epoch.as_u64());
         }
 
@@ -415,6 +430,34 @@ mod tests {
         let result = ForkSchedule::from_fork_configs(configs, TEST_NETWORK);
         assert!(result.is_err());
         assert!(result.unwrap_err().contains("must be at epoch 0"));
+    }
+
+    #[test]
+    fn test_from_fork_configs_rejects_duplicate_domains() {
+        let mut configs = BTreeMap::new();
+        configs.insert(Fork::Alan, (Epoch::new(0), BASELINE_DOMAIN));
+        configs.insert(Fork::Boole, (Epoch::new(100), BASELINE_DOMAIN));
+
+        let error = ForkSchedule::from_fork_configs(configs, TEST_NETWORK)
+            .expect_err("fork domains must be unique");
+        assert_eq!(
+            error,
+            "Fork boole reuses domain 00000001 already assigned to fork alan"
+        );
+    }
+
+    #[test]
+    fn test_from_fork_configs_rejects_duplicate_domains_at_epoch_zero() {
+        let mut configs = BTreeMap::new();
+        configs.insert(Fork::Alan, (Epoch::new(0), BASELINE_DOMAIN));
+        configs.insert(Fork::Boole, (Epoch::new(0), BASELINE_DOMAIN));
+
+        let error = ForkSchedule::from_fork_configs(configs, TEST_NETWORK)
+            .expect_err("fork domains must be unique");
+        assert_eq!(
+            error,
+            "Fork boole reuses domain 00000001 already assigned to fork alan"
+        );
     }
 
     #[test]

--- a/anchor/common/fork/src/schedule.rs
+++ b/anchor/common/fork/src/schedule.rs
@@ -3,12 +3,12 @@
 //! This module provides the `ForkSchedule` type for managing fork activations
 //! and determining which fork is active at a given epoch.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 
 use ssv_types::domain_type::DomainType;
-use types::Epoch;
+use types::{Epoch, Slot};
 
-use crate::Fork;
+use crate::{Fork, ForkLifecycle};
 
 /// Number of epochs before a fork to start preparing (dual-subscribing, etc.).
 ///
@@ -96,7 +96,11 @@ pub struct ForkSchedule {
 }
 
 impl ForkSchedule {
-    /// Create a new fork schedule with the given fork active from epoch 0.
+    /// Create a fork schedule with every fork up to `fork` active from epoch 0.
+    ///
+    /// Every included fork uses `baseline_domain_type`. This constructor is intended for
+    /// Alan-only network defaults and test schedules. Explicit production fork schedules should
+    /// use [`Self::from_fork_configs`] so ordering and domain uniqueness are validated.
     pub fn new(fork: Fork, baseline_domain_type: DomainType, network_name: &str) -> Self {
         let mut configs = BTreeMap::new();
         for fork in Fork::all().iter().take_while(|&f| f <= &fork) {
@@ -133,6 +137,7 @@ impl ForkSchedule {
     /// - Alan fork is missing from configs
     /// - Alan fork is not at epoch 0
     /// - Fork epochs are not in chronological order
+    /// - Fork domain types are not unique
     pub fn from_fork_configs(
         raw_configs: BTreeMap<Fork, (Epoch, DomainType)>,
         network_name: &str,
@@ -151,7 +156,8 @@ impl ForkSchedule {
         // Validate chronological ordering - earlier forks must have < epochs
         // The exception is epoch 0, which may schedule multiple forks (to enable them at genesis)
         let mut prev_epoch: Option<u64> = None;
-        for (fork, (epoch, _)) in &raw_configs {
+        let mut domains = HashMap::new();
+        for (fork, (epoch, domain_type)) in &raw_configs {
             if let Some(prev) = prev_epoch
                 && epoch.as_u64() <= prev
                 && epoch.as_u64() != 0
@@ -161,6 +167,15 @@ impl ForkSchedule {
                     epoch.as_u64()
                 ));
             }
+
+            if let Some(previous_fork) = domains.get(domain_type) {
+                return Err(format!(
+                    "Fork {fork} reuses domain {} already assigned to fork {previous_fork}",
+                    String::from(*domain_type)
+                ));
+            }
+            domains.insert(*domain_type, *fork);
+
             prev_epoch = Some(epoch.as_u64());
         }
 
@@ -209,6 +224,55 @@ impl ForkSchedule {
             .expect("constructors ensure there is at least one fork at epoch 0")
     }
 
+    /// Derive the fork lifecycle state for a slot directly from the schedule.
+    ///
+    /// This is the single source of truth for lifecycle state: the same slot
+    /// always maps to the same state, so restarts, clock jumps, and steady
+    /// operation all go through one code path.
+    ///
+    /// Windows, using the fork's activation slot `A` (all half-open):
+    /// - `WarmUp` in `[A - FORK_PREPARATION_EPOCHS in slots, A)`
+    /// - `GracePeriod` in `[A, A + SUBSEQUENT_WINDOW_SLOTS)`
+    /// - `Normal` everywhere else
+    ///
+    /// `WarmUp` takes precedence when an upcoming fork's preparation window
+    /// overlaps the current fork's grace period: preparing for the imminent
+    /// fork matters more than retaining the previous fork's topics. Schedules
+    /// that trigger this overlap (forks less than
+    /// `FORK_PREPARATION_EPOCHS + SUBSEQUENT_WINDOW_SLOTS` apart) are
+    /// logged as errors at monitor spawn.
+    pub fn lifecycle_at(&self, slot: Slot, slots_per_epoch: u64) -> ForkLifecycle {
+        let epoch = slot.epoch(slots_per_epoch);
+        let current = self.active_fork_config(epoch).clone();
+
+        // WarmUp: an upcoming fork's preparation window has started.
+        if let Some((upcoming_fork, upcoming_epoch)) = self.next_fork_after(epoch) {
+            let preparation_start_slot = upcoming_epoch
+                .as_u64()
+                .saturating_sub(FORK_PREPARATION_EPOCHS)
+                * slots_per_epoch;
+            if slot.as_u64() >= preparation_start_slot {
+                let upcoming = self
+                    .config(upcoming_fork)
+                    .expect("next_fork_after only returns scheduled forks")
+                    .clone();
+                return ForkLifecycle::WarmUp { current, upcoming };
+            }
+        }
+
+        // GracePeriod: within the subsequent window of a non-genesis activation.
+        // Genesis forks (epoch 0) have no previous fork to grace out of.
+        let activation_slot = current.epoch.as_u64() * slots_per_epoch;
+        if current.epoch.as_u64() > 0 && slot.as_u64() < activation_slot + SUBSEQUENT_WINDOW_SLOTS {
+            let previous = self
+                .active_fork_config(Epoch::new(current.epoch.as_u64() - 1))
+                .clone();
+            return ForkLifecycle::GracePeriod { current, previous };
+        }
+
+        ForkLifecycle::Normal { current }
+    }
+
     /// Get the next scheduled fork after the given epoch.
     pub fn next_fork_after(&self, epoch: Epoch) -> Option<(Fork, Epoch)> {
         self.configs
@@ -229,11 +293,31 @@ mod tests {
     const BASELINE_DOMAIN: DomainType = DomainType([0, 0, 0, 1]);
     const BOOLE_DOMAIN: DomainType = DomainType([0, 0, 0, 2]);
 
+    // Mainnet slots per epoch, used by the `lifecycle_at` boundary tests.
+    const SLOTS_PER_EPOCH: u64 = 32;
+    // The Boole activation epoch used by the `lifecycle_at` boundary tests.
+    const BOOLE_FORK_EPOCH: u64 = 100;
+    // First slot of the warm-up window: `FORK_PREPARATION_EPOCHS` before activation.
+    const PREPARATION_START_SLOT: u64 =
+        (BOOLE_FORK_EPOCH - FORK_PREPARATION_EPOCHS) * SLOTS_PER_EPOCH;
+    // First slot of the grace period: the Boole activation slot.
+    const ACTIVATION_SLOT: u64 = BOOLE_FORK_EPOCH * SLOTS_PER_EPOCH;
+    // First slot after the grace period: back to `Normal`, now on Boole.
+    const GRACE_END_SLOT: u64 = ACTIVATION_SLOT + SUBSEQUENT_WINDOW_SLOTS;
+
     fn schedule_with_boole(epoch: u64) -> ForkSchedule {
         let mut configs = BTreeMap::new();
         configs.insert(Fork::Alan, (Epoch::new(0), BASELINE_DOMAIN));
         configs.insert(Fork::Boole, (Epoch::new(epoch), BOOLE_DOMAIN));
         ForkSchedule::from_fork_configs(configs, TEST_NETWORK).expect("valid test schedule")
+    }
+
+    fn alan_config() -> ForkConfig {
+        ForkConfig::new(Fork::Alan, Epoch::new(0), BASELINE_DOMAIN)
+    }
+
+    fn boole_config_at(epoch: u64) -> ForkConfig {
+        ForkConfig::new(Fork::Boole, Epoch::new(epoch), BOOLE_DOMAIN)
     }
 
     #[test]
@@ -349,6 +433,34 @@ mod tests {
     }
 
     #[test]
+    fn test_from_fork_configs_rejects_duplicate_domains() {
+        let mut configs = BTreeMap::new();
+        configs.insert(Fork::Alan, (Epoch::new(0), BASELINE_DOMAIN));
+        configs.insert(Fork::Boole, (Epoch::new(100), BASELINE_DOMAIN));
+
+        let error = ForkSchedule::from_fork_configs(configs, TEST_NETWORK)
+            .expect_err("fork domains must be unique");
+        assert_eq!(
+            error,
+            "Fork boole reuses domain 00000001 already assigned to fork alan"
+        );
+    }
+
+    #[test]
+    fn test_from_fork_configs_rejects_duplicate_domains_at_epoch_zero() {
+        let mut configs = BTreeMap::new();
+        configs.insert(Fork::Alan, (Epoch::new(0), BASELINE_DOMAIN));
+        configs.insert(Fork::Boole, (Epoch::new(0), BASELINE_DOMAIN));
+
+        let error = ForkSchedule::from_fork_configs(configs, TEST_NETWORK)
+            .expect_err("fork domains must be unique");
+        assert_eq!(
+            error,
+            "Fork boole reuses domain 00000001 already assigned to fork alan"
+        );
+    }
+
+    #[test]
     fn test_topic_prefix_for_fork_alan() {
         let prefix = Fork::Alan.topic_prefix("mainnet");
         assert_eq!(prefix, ALAN_TOPIC_PREFIX);
@@ -365,5 +477,131 @@ mod tests {
 
         let prefix_holesky = Fork::Boole.topic_prefix("holesky");
         assert_eq!(prefix_holesky, "/ssv/holesky/boole/");
+    }
+
+    // ==================== `lifecycle_at` boundary tests ====================
+    //
+    // Note: the documented WarmUp-over-GracePeriod precedence on overlapping windows cannot
+    // be exercised with the current two-fork enum. An overlap needs a third fork whose
+    // preparation window starts inside Boole's grace period; Alan is the genesis fork (no
+    // grace period of its own) and no fork follows Boole, so no two-fork schedule can
+    // construct the overlap.
+
+    /// Every window boundary is half-open, so each phase must start at its exact slot and end
+    /// one slot before the next phase's start.
+    #[test]
+    fn test_lifecycle_at_boundary_table() {
+        // Arrange
+        let schedule = schedule_with_boole(BOOLE_FORK_EPOCH);
+        let boole = boole_config_at(BOOLE_FORK_EPOCH);
+        let normal_alan = ForkLifecycle::Normal {
+            current: alan_config(),
+        };
+        let warmup = ForkLifecycle::WarmUp {
+            current: alan_config(),
+            upcoming: boole.clone(),
+        };
+        let grace_period = ForkLifecycle::GracePeriod {
+            current: boole.clone(),
+            previous: alan_config(),
+        };
+        let normal_boole = ForkLifecycle::Normal { current: boole };
+        let cases = [
+            // Last slot before the preparation window opens.
+            (PREPARATION_START_SLOT - 1, &normal_alan),
+            // Exact preparation start: 99 * 32 = 3168.
+            (PREPARATION_START_SLOT, &warmup),
+            // Last slot of the warm-up window: 3199.
+            (ACTIVATION_SLOT - 1, &warmup),
+            // Exact activation slot: 3200.
+            (ACTIVATION_SLOT, &grace_period),
+            // Last slot of the grace period: 3200 + 31.
+            (GRACE_END_SLOT - 1, &grace_period),
+            // First slot after the grace period: 3200 + 32.
+            (GRACE_END_SLOT, &normal_boole),
+            // Far after the transition.
+            (GRACE_END_SLOT + 100_000, &normal_boole),
+        ];
+
+        for (slot, expected) in cases {
+            // Act
+            let lifecycle = schedule.lifecycle_at(Slot::new(slot), SLOTS_PER_EPOCH);
+
+            // Assert
+            assert_eq!(&lifecycle, expected, "unexpected lifecycle at slot {slot}");
+        }
+    }
+
+    /// With no future fork scheduled there is no warm-up window, and a genesis fork has no
+    /// previous fork to grace out of, so every slot is `Normal`.
+    #[test]
+    fn test_lifecycle_at_alan_only_schedule_is_always_normal() {
+        // Arrange
+        let schedule = ForkSchedule::new(Fork::Alan, BASELINE_DOMAIN, TEST_NETWORK);
+        let normal_alan = ForkLifecycle::Normal {
+            current: alan_config(),
+        };
+
+        for slot in [0, 1, SLOTS_PER_EPOCH, ACTIVATION_SLOT, u64::MAX / 2] {
+            // Act
+            let lifecycle = schedule.lifecycle_at(Slot::new(slot), SLOTS_PER_EPOCH);
+
+            // Assert
+            assert_eq!(
+                lifecycle, normal_alan,
+                "an Alan-only schedule must be Normal at slot {slot}"
+            );
+        }
+    }
+
+    /// A fork scheduled at epoch 0 activates at genesis: there is no previous fork to grace
+    /// out of, so the grace period must not apply.
+    #[test]
+    fn test_lifecycle_at_genesis_fork_has_no_grace_period() {
+        // Arrange: both forks at epoch 0.
+        let mut configs = BTreeMap::new();
+        configs.insert(Fork::Alan, (Epoch::new(0), BASELINE_DOMAIN));
+        configs.insert(Fork::Boole, (Epoch::new(0), BOOLE_DOMAIN));
+        let schedule =
+            ForkSchedule::from_fork_configs(configs, TEST_NETWORK).expect("valid test schedule");
+
+        // Act
+        let lifecycle = schedule.lifecycle_at(Slot::new(0), SLOTS_PER_EPOCH);
+
+        // Assert
+        assert_eq!(
+            lifecycle,
+            ForkLifecycle::Normal {
+                current: boole_config_at(0),
+            }
+        );
+    }
+
+    /// A fork at epoch 1 has its whole preparation window inside epoch 0, so the warm-up
+    /// starts at genesis itself.
+    #[test]
+    fn test_lifecycle_at_early_fork_preparation_window_starts_at_genesis() {
+        // Arrange
+        let schedule = schedule_with_boole(1);
+        let warmup = ForkLifecycle::WarmUp {
+            current: alan_config(),
+            upcoming: boole_config_at(1),
+        };
+
+        // Act and assert: the warm-up window covers genesis through the last epoch-0 slot.
+        assert_eq!(schedule.lifecycle_at(Slot::new(0), SLOTS_PER_EPOCH), warmup);
+        assert_eq!(
+            schedule.lifecycle_at(Slot::new(SLOTS_PER_EPOCH - 1), SLOTS_PER_EPOCH),
+            warmup
+        );
+
+        // Act and assert: activation at the first epoch-1 slot enters the grace period.
+        assert_eq!(
+            schedule.lifecycle_at(Slot::new(SLOTS_PER_EPOCH), SLOTS_PER_EPOCH),
+            ForkLifecycle::GracePeriod {
+                current: boole_config_at(1),
+                previous: alan_config(),
+            }
+        );
     }
 }

--- a/anchor/common/ssv_network_config/src/lib.rs
+++ b/anchor/common/ssv_network_config/src/lib.rs
@@ -202,7 +202,7 @@ fn read<T: FromStr>(file: &Path) -> Result<T, String> {
 
 #[cfg(test)]
 mod tests {
-    use std::io::Write;
+    use std::{collections::HashMap, io::Write};
 
     use fork::ALAN_TOPIC_PREFIX;
     use tempfile::TempDir;
@@ -316,6 +316,30 @@ mod tests {
         }
     }
 
+    #[test]
+    fn test_builtin_network_fork_domains_are_globally_unique() {
+        let mut domains = HashMap::new();
+
+        for network in [MAINNET, HOLESKY, HOODI] {
+            let config = SsvNetworkConfig::constant(network).unwrap().unwrap();
+
+            for &fork in Fork::all() {
+                let Some(domain_type) = config.fork_schedule.domain_type(fork) else {
+                    continue;
+                };
+
+                if let Some((previous_network, previous_fork)) = domains.get(&domain_type) {
+                    panic!(
+                        "Domain {} is shared by {previous_network}/{previous_fork} and \
+                         {network}/{fork}; built-in network fork domains must be globally unique",
+                        String::from(domain_type)
+                    );
+                }
+                domains.insert(domain_type, (network, fork));
+            }
+        }
+    }
+
     // ==================== Config loading tests ====================
 
     #[test]
@@ -350,6 +374,30 @@ boole:
         assert_eq!(
             config.fork_schedule.domain_type(Fork::Boole),
             Some(BOOLE_DOMAIN_TYPE)
+        );
+    }
+
+    #[test]
+    fn test_load_rejects_duplicate_fork_domains() {
+        // Arrange
+        let yaml = format!(
+            r#"
+boole:
+  epoch: {}
+  domain_type: "00000001"
+"#,
+            LARGE_BOOLE_EPOCH
+        );
+        let dir = create_test_config_dir(Some(&yaml));
+
+        // Act
+        let error = SsvNetworkConfig::load(dir.path().to_path_buf())
+            .expect_err("fork domains must be unique");
+
+        // Assert
+        assert_eq!(
+            error,
+            "Fork boole reuses domain 00000001 already assigned to fork alan"
         );
     }
 

--- a/anchor/common/ssv_network_config/src/lib.rs
+++ b/anchor/common/ssv_network_config/src/lib.rs
@@ -202,7 +202,7 @@ fn read<T: FromStr>(file: &Path) -> Result<T, String> {
 
 #[cfg(test)]
 mod tests {
-    use std::io::Write;
+    use std::{collections::HashMap, io::Write};
 
     use fork::ALAN_TOPIC_PREFIX;
     use tempfile::TempDir;
@@ -226,6 +226,7 @@ mod tests {
     // activation) are derived inline at the use site.
     const ALAN_FORK_EPOCH: u64 = 0;
     const BOOLE_FORK_EPOCH: u64 = 100;
+    const LARGE_BOOLE_EPOCH: u64 = 12500;
 
     /// Construct expected Boole topic prefix for a network.
     fn expected_boole_prefix(network: &str) -> String {
@@ -314,6 +315,30 @@ mod tests {
         }
     }
 
+    #[test]
+    fn test_builtin_network_fork_domains_are_globally_unique() {
+        let mut domains = HashMap::new();
+
+        for network in [MAINNET, HOLESKY, HOODI] {
+            let config = SsvNetworkConfig::constant(network).unwrap().unwrap();
+
+            for &fork in Fork::all() {
+                let Some(domain_type) = config.fork_schedule.domain_type(fork) else {
+                    continue;
+                };
+
+                if let Some((previous_network, previous_fork)) = domains.get(&domain_type) {
+                    panic!(
+                        "Domain {} is shared by {previous_network}/{previous_fork} and \
+                         {network}/{fork}; built-in network fork domains must be globally unique",
+                        String::from(domain_type)
+                    );
+                }
+                domains.insert(domain_type, (network, fork));
+            }
+        }
+    }
+
     // ==================== Config loading tests ====================
 
     #[test]
@@ -348,6 +373,30 @@ boole:
         assert_eq!(
             config.fork_schedule.domain_type(Fork::Boole),
             Some(BOOLE_DOMAIN_TYPE)
+        );
+    }
+
+    #[test]
+    fn test_load_rejects_duplicate_fork_domains() {
+        // Arrange
+        let yaml = format!(
+            r#"
+boole:
+  epoch: {}
+  domain_type: "00000001"
+"#,
+            LARGE_BOOLE_EPOCH
+        );
+        let dir = create_test_config_dir(Some(&yaml));
+
+        // Act
+        let error = SsvNetworkConfig::load(dir.path().to_path_buf())
+            .expect_err("fork domains must be unique");
+
+        // Assert
+        assert_eq!(
+            error,
+            "Fork boole reuses domain 00000001 already assigned to fork alan"
         );
     }
 

--- a/anchor/common/ssv_types/src/consensus.rs
+++ b/anchor/common/ssv_types/src/consensus.rs
@@ -695,34 +695,6 @@ pub struct AggregatorCommitteeConsensusData<E: EthSpec> {
         VariableList<SyncCommitteeContribution<E>, MaxSyncContributions>,
 }
 
-impl<E: EthSpec> AggregatorCommitteeConsensusData<E> {
-    /// Counts the total number of expected post-consensus signatures for this committee.
-    ///
-    /// This includes both aggregators and contributors that match the given filter.
-    /// Used to ensure all signatures are batched into a single message rather than
-    /// being split across multiple messages.
-    ///
-    /// Returns: count(aggregators) + count(contributors) filtered by committee membership
-    pub fn post_consensus_signature_count<F>(&self, is_in_committee: F) -> usize
-    where
-        F: Fn(&ValidatorIndex) -> bool,
-    {
-        let aggregator_count = self
-            .aggregators
-            .iter()
-            .filter(|agg| is_in_committee(&agg.validator_index))
-            .count();
-
-        let contributor_count = self
-            .contributors
-            .iter()
-            .filter(|contrib| is_in_committee(&contrib.validator_index))
-            .count();
-
-        aggregator_count + contributor_count
-    }
-}
-
 impl<E: EthSpec> QbftData for AggregatorCommitteeConsensusData<E> {
     type Hash = Hash256;
 

--- a/anchor/common/ssv_types/src/consensus.rs
+++ b/anchor/common/ssv_types/src/consensus.rs
@@ -526,34 +526,6 @@ pub struct AggregatorCommitteeConsensusData<E: EthSpec> {
         VariableList<SyncCommitteeContribution<E>, MaxSyncContributions>,
 }
 
-impl<E: EthSpec> AggregatorCommitteeConsensusData<E> {
-    /// Counts the total number of expected post-consensus signatures for this committee.
-    ///
-    /// This includes both aggregators and contributors that match the given filter.
-    /// Used to ensure all signatures are batched into a single message rather than
-    /// being split across multiple messages.
-    ///
-    /// Returns: count(aggregators) + count(contributors) filtered by committee membership
-    pub fn post_consensus_signature_count<F>(&self, is_in_committee: F) -> usize
-    where
-        F: Fn(&ValidatorIndex) -> bool,
-    {
-        let aggregator_count = self
-            .aggregators
-            .iter()
-            .filter(|agg| is_in_committee(&agg.validator_index))
-            .count();
-
-        let contributor_count = self
-            .contributors
-            .iter()
-            .filter(|contrib| is_in_committee(&contrib.validator_index))
-            .count();
-
-        aggregator_count + contributor_count
-    }
-}
-
 impl<E: EthSpec> QbftData for AggregatorCommitteeConsensusData<E> {
     type Hash = Hash256;
 

--- a/anchor/message_validator/src/lib.rs
+++ b/anchor/message_validator/src/lib.rs
@@ -118,7 +118,6 @@ pub enum ValidationFailure {
     NonExistentCommitteeID,
     RoundTooHigh,
     ValidatorIndexMismatch,
-    TooManyDutiesPerEpoch,
     NoDuty,
     EstimatedRoundNotInAllowedSpread {
         got: String,
@@ -243,7 +242,7 @@ impl From<&ValidationFailure> for MessageAcceptance {
             | ValidationFailure::RoundTooHigh
             | ValidationFailure::RoundOverflow
             | ValidationFailure::ValidatorIndexMismatch
-            | ValidationFailure::TooManyDutiesPerEpoch
+            | ValidationFailure::ExcessiveDutyCount { .. }
             | ValidationFailure::NoDuty
             | ValidationFailure::EstimatedRoundNotInAllowedSpread { .. } => {
                 MessageAcceptance::Ignore
@@ -762,6 +761,22 @@ fn verify_message_signatures(
     Ok(())
 }
 
+/// Returns the single validator index of a non-committee duty message.
+///
+/// The index is absent when the validator is known locally but its beacon metadata has not been
+/// synced yet. That is a gap in the local view, not a fault of the sending peer, so it maps to
+/// [`ValidationFailure::NoShareMetadata`] (Ignore) rather than a Reject.
+fn single_validator_index(
+    validation_context: &ValidationContext<impl SlotClock>,
+) -> Result<ValidatorIndex, ValidationFailure> {
+    validation_context
+        .committee_info
+        .validator_indices
+        .first()
+        .copied()
+        .ok_or(ValidationFailure::NoShareMetadata)
+}
+
 /// Validates if a validator is assigned to a specific duty
 pub(crate) fn validate_beacon_duty(
     validation_context: &ValidationContext<impl SlotClock>,
@@ -792,15 +807,7 @@ pub(crate) fn validate_beacon_duty(
             return Ok(());
         }
 
-        // Non-committee roles always have one validator index
-        let validator_index = validation_context
-            .committee_info
-            .validator_indices
-            .first()
-            .copied()
-            .ok_or(ValidationFailure::UnexpectedFailure {
-                msg: "Unexpected error when getting first validator index".to_string(),
-            })?;
+        let validator_index = single_validator_index(validation_context)?;
 
         if !duty_provider.is_validator_proposer_at_slot(slot, validator_index) {
             return Err(ValidationFailure::NoDuty);
@@ -811,14 +818,7 @@ pub(crate) fn validate_beacon_duty(
     if role == Role::SyncCommittee {
         let period =
             sync_committee_period(epoch, validation_context.epochs_per_sync_committee_period)?;
-        let validator_index = validation_context
-            .committee_info
-            .validator_indices
-            .first()
-            .copied()
-            .ok_or(ValidationFailure::UnexpectedFailure {
-                msg: "Unexpected error when getting first validator index".to_string(),
-            })?;
+        let validator_index = single_validator_index(validation_context)?;
 
         if !duty_provider.is_validator_in_sync_committee(period, validator_index) {
             return Err(ValidationFailure::NoDuty);

--- a/anchor/message_validator/src/lib.rs
+++ b/anchor/message_validator/src/lib.rs
@@ -846,6 +846,22 @@ fn verify_message_signatures(
     Ok(())
 }
 
+/// Returns the single validator index of a non-committee duty message.
+///
+/// The index is absent when the validator is known locally but its beacon metadata has not been
+/// synced yet. That is a gap in the local view, not a fault of the sending peer, so it maps to
+/// [`ValidationFailure::NoShareMetadata`] (Ignore) rather than a Reject.
+fn single_validator_index(
+    validation_context: &ValidationContext<impl SlotClock>,
+) -> Result<ValidatorIndex, ValidationFailure> {
+    validation_context
+        .committee_info
+        .validator_indices
+        .first()
+        .copied()
+        .ok_or(ValidationFailure::NoShareMetadata)
+}
+
 /// Validates if a validator is assigned to a specific duty
 pub(crate) fn validate_beacon_duty(
     validation_context: &ValidationContext<impl SlotClock>,
@@ -876,15 +892,7 @@ pub(crate) fn validate_beacon_duty(
             return Ok(());
         }
 
-        // Non-committee roles always have one validator index
-        let validator_index = validation_context
-            .committee_info
-            .validator_indices
-            .first()
-            .copied()
-            .ok_or(ValidationFailure::UnexpectedFailure {
-                msg: "Unexpected error when getting first validator index".to_string(),
-            })?;
+        let validator_index = single_validator_index(validation_context)?;
 
         if !duty_provider.is_validator_proposer_at_slot(slot, validator_index) {
             return Err(ValidationFailure::NoDuty);
@@ -917,14 +925,7 @@ pub(crate) fn validate_beacon_duty(
     if role == Role::SyncCommittee {
         let period =
             sync_committee_period(epoch, validation_context.epochs_per_sync_committee_period)?;
-        let validator_index = validation_context
-            .committee_info
-            .validator_indices
-            .first()
-            .copied()
-            .ok_or(ValidationFailure::UnexpectedFailure {
-                msg: "Unexpected error when getting first validator index".to_string(),
-            })?;
+        let validator_index = single_validator_index(validation_context)?;
 
         if !duty_provider.is_validator_in_sync_committee(period, validator_index) {
             return Err(ValidationFailure::NoDuty);

--- a/anchor/message_validator/src/partial_signature.rs
+++ b/anchor/message_validator/src/partial_signature.rs
@@ -351,9 +351,13 @@ mod tests {
     use types::{EthSpec, MainnetEthSpec, Slot};
 
     use super::*;
-    use crate::tests::{
-        FOUR_NODE_COMMITTEE, MockDutiesProvider, assert_validation_error, create_committee_info,
-        create_message_id_for_test, create_operator_pub_keys, generate_random_rsa_public_keys,
+    use crate::{
+        MessageAcceptance,
+        tests::{
+            FOUR_NODE_COMMITTEE, MockDutiesProvider, assert_validation_error,
+            create_committee_info, create_message_id_for_test, create_operator_pub_keys,
+            generate_random_rsa_public_keys,
+        },
     };
 
     // Options for creating test partial signature messages
@@ -856,6 +860,101 @@ mod tests {
             result,
             |failure| matches!(failure, ValidationFailure::ValidatorIndexMismatch),
             "ValidatorIndexMismatch",
+        );
+    }
+
+    /// Runs a single-validator partial signature message through validation with an empty
+    /// `validator_indices` (validator known locally, beacon index not synced yet).
+    fn validate_with_empty_validator_indices(
+        role: Role,
+        kind: PartialSignatureKind,
+    ) -> Result<ValidatedSSVMessage, ValidationFailure> {
+        let mut committee_info = create_committee_info(FOUR_NODE_COMMITTEE);
+        committee_info.validator_indices = vec![];
+
+        let (_, signed_msg) = create_test_partial_signature(
+            role,
+            kind,
+            OperatorId(1),
+            PartialSigTestOptions::default(),
+            None,
+        );
+
+        let binding = generate_random_rsa_public_keys(signed_msg.operator_ids().len());
+        let map = create_operator_pub_keys(committee_info.committee_members.clone(), binding);
+
+        let validation_context = create_test_validation_context(
+            &signed_msg,
+            &committee_info,
+            role,
+            &map,
+            generate_fork_schedule(Fork::Alan),
+        );
+
+        validate_partial_signature_message(
+            validation_context,
+            &mut DutyState::new(2),
+            Arc::new(MockDutiesProvider {
+                voluntary_exit_duty_count: 0,
+            }),
+        )
+    }
+
+    fn assert_no_share_metadata_ignored(result: Result<ValidatedSSVMessage, ValidationFailure>) {
+        assert_validation_error(
+            result,
+            |failure| {
+                matches!(failure, ValidationFailure::NoShareMetadata)
+                    && MessageAcceptance::from(failure) == MessageAcceptance::Ignore
+            },
+            "NoShareMetadata (Ignore)",
+        );
+    }
+
+    #[test]
+    fn test_proposer_missing_validator_index_returns_no_share_metadata() {
+        // PostConsensus, not RANDAO, so the first-slot RANDAO carve-out does not apply
+        let result = validate_with_empty_validator_indices(
+            Role::Proposer,
+            PartialSignatureKind::PostConsensus,
+        );
+
+        assert_no_share_metadata_ignored(result);
+    }
+
+    #[test]
+    fn test_sync_committee_missing_validator_index_returns_no_share_metadata() {
+        let result = validate_with_empty_validator_indices(
+            Role::SyncCommittee,
+            PartialSignatureKind::PostConsensus,
+        );
+
+        assert_no_share_metadata_ignored(result);
+    }
+
+    #[test]
+    fn test_committee_role_missing_validator_index_skips_single_index_lookup() {
+        // Committee roles never look up a single validator index, so validation proceeds past
+        // validate_beacon_duty. With zero known validators the per-slot duty limit is 0, which
+        // is the downstream failure we expect to reach instead of NoShareMetadata.
+        let result = validate_with_empty_validator_indices(
+            Role::Committee,
+            PartialSignatureKind::PostConsensus,
+        );
+
+        assert_validation_error(
+            result,
+            |failure| {
+                matches!(
+                    failure,
+                    ValidationFailure::ExcessiveDutyCount {
+                        limit: 0,
+                        role: Role::Committee,
+                        ..
+                    }
+                ) && MessageAcceptance::from(failure) == MessageAcceptance::Ignore
+            },
+            "ExcessiveDutyCount (Ignore)",
         );
     }
 

--- a/anchor/message_validator/src/partial_signature.rs
+++ b/anchor/message_validator/src/partial_signature.rs
@@ -893,6 +893,103 @@ mod tests {
         );
     }
 
+    /// Runs a single-validator partial signature message through validation with an empty
+    /// `validator_indices` (validator known locally, beacon index not synced yet).
+    fn validate_with_empty_validator_indices(
+        role: Role,
+        kind: PartialSignatureKind,
+    ) -> Result<ValidatedSSVMessage, ValidationFailure> {
+        let mut committee_info = create_committee_info(FOUR_NODE_COMMITTEE);
+        committee_info.validator_indices = vec![];
+
+        let (_, signed_msg) = create_test_partial_signature(
+            role,
+            kind,
+            OperatorId(1),
+            PartialSigTestOptions::default(),
+            None,
+        );
+
+        let binding = generate_random_rsa_public_keys(signed_msg.operator_ids().len());
+        let map = create_operator_pub_keys(committee_info.committee_members.clone(), binding);
+
+        let validation_context = create_test_validation_context(
+            &signed_msg,
+            &committee_info,
+            role,
+            &map,
+            generate_fork_schedule(Fork::Alan),
+        );
+
+        validate_partial_signature_message(
+            validation_context,
+            &mut DutyState::new(2),
+            Arc::new(MockDutiesProvider {
+                voluntary_exit_duty_count: 0,
+                ..Default::default()
+            }),
+            None,
+        )
+    }
+
+    fn assert_no_share_metadata_ignored(result: Result<ValidatedSSVMessage, ValidationFailure>) {
+        assert_validation_error(
+            result,
+            |failure| {
+                matches!(failure, ValidationFailure::NoShareMetadata)
+                    && MessageAcceptance::from(failure) == MessageAcceptance::Ignore
+            },
+            "NoShareMetadata (Ignore)",
+        );
+    }
+
+    #[test]
+    fn test_proposer_missing_validator_index_returns_no_share_metadata() {
+        // PostConsensus, not RANDAO, so the first-slot RANDAO carve-out does not apply
+        let result = validate_with_empty_validator_indices(
+            Role::Proposer,
+            PartialSignatureKind::PostConsensus,
+        );
+
+        assert_no_share_metadata_ignored(result);
+    }
+
+    #[test]
+    fn test_sync_committee_missing_validator_index_returns_no_share_metadata() {
+        let result = validate_with_empty_validator_indices(
+            Role::SyncCommittee,
+            PartialSignatureKind::PostConsensus,
+        );
+
+        assert_no_share_metadata_ignored(result);
+    }
+
+    #[test]
+    fn test_committee_role_missing_validator_index_skips_single_index_lookup() {
+        // Committee roles never look up a single validator index, so validation proceeds past
+        // validate_beacon_duty. With zero known validators the per-slot duty limit is 0, which
+        // is the downstream failure we expect to reach instead of NoShareMetadata.
+        let result = validate_with_empty_validator_indices(
+            Role::Committee,
+            PartialSignatureKind::PostConsensus,
+        );
+
+        assert_validation_error(
+            result,
+            |failure| {
+                matches!(
+                    failure,
+                    ValidationFailure::ExcessiveDutyCount {
+                        limit: 0,
+                        role: Role::Committee,
+                        ..
+                    }
+                ) && MessageAcceptance::from(failure) == MessageAcceptance::Ignore
+            },
+            "ExcessiveDutyCount (Ignore)",
+        );
+    }
+
     #[test]
     fn test_committee_role_skips_validator_index_check() {
         // Create committee info with specific validator indices

--- a/anchor/network/Cargo.toml
+++ b/anchor/network/Cargo.toml
@@ -37,5 +37,6 @@ version = { workspace = true }
 [dev-dependencies]
 libp2p-swarm-test = { git = "https://github.com/sigp/rust-libp2p.git", rev = "c774d4e71357d7cd2f792c4767d616d2dd369ee3" }
 message_receiver = { workspace = true }
+tempfile = { workspace = true }
 tokio = { workspace = true, features = ["rt", "macros", "time", "test-util"] }
 tracing-subscriber = { workspace = true }

--- a/anchor/network/src/network.rs
+++ b/anchor/network/src/network.rs
@@ -8,7 +8,7 @@ use std::{
 };
 
 use fork::{ForkLifecycle, ForkSchedule};
-use futures::StreamExt;
+use futures::{StreamExt, channel::mpsc::Sender as ShutdownSender};
 use libp2p::{
     Multiaddr, PeerId, Swarm, SwarmBuilder, TransportError,
     core::{
@@ -25,7 +25,7 @@ use libp2p::{
 use message_receiver::{MessageReceiver, Outcome, TopicContext};
 use prometheus_client::registry::Registry;
 use subnet_service::{SUBNET_COUNT, SubnetId, TopicEvent, topic};
-use task_executor::TaskExecutor;
+use task_executor::{ShutdownReason, TaskExecutor};
 use thiserror::Error;
 use tokio::sync::{mpsc, watch};
 use tracing::{debug, error, info, trace, warn};
@@ -65,6 +65,24 @@ pub enum NetworkError {
 
     #[error("DNS transport config error: {0}")]
     DnsTransport(std::io::Error),
+
+    #[error("ENR reconciliation error: {0}")]
+    EnrReconcile(String),
+}
+
+/// Bring the local ENR's `domaintype` in line with the current lifecycle.
+///
+/// A fork may have activated while `Discovery::new` awaited discv5 startup and bootnode
+/// requests, after it had already built the ENR from the older lifecycle. This reads the
+/// lifecycle without marking it seen: if a change is pending, the run loop's `changed()`
+/// arm re-applies it, which `update_enr_domain_type` turns into a no-op when the ENR
+/// already matches.
+fn reconcile_enr_domain(
+    behaviour: &mut AnchorBehaviour,
+    lifecycle_rx: &watch::Receiver<ForkLifecycle>,
+) -> Result<(), String> {
+    let domain = lifecycle_rx.borrow().current_fork_config().domain_type;
+    behaviour.discovery.update_enr_domain_type(domain)
 }
 
 pub struct Network<R: MessageReceiver> {
@@ -83,9 +101,9 @@ pub struct Network<R: MessageReceiver> {
     /// Receiver for fork lifecycle state changes.
     /// Used to update ENR domain type on fork activation.
     lifecycle_rx: watch::Receiver<ForkLifecycle>,
-    /// Previous lifecycle state, used to detect actual domain type changes
-    /// and avoid redundant ENR updates.
-    prev_lifecycle: ForkLifecycle,
+    /// Requests a client-wide shutdown when the network cannot keep its
+    /// advertised state consistent with the fork lifecycle (fail closed).
+    shutdown_tx: ShutdownSender<ShutdownReason>,
 }
 
 impl<R: MessageReceiver> Network<R> {
@@ -101,7 +119,7 @@ impl<R: MessageReceiver> Network<R> {
         executor: TaskExecutor,
         spec: Arc<ChainSpec>,
         fork_schedule: Arc<ForkSchedule>,
-        mut lifecycle_rx: watch::Receiver<ForkLifecycle>,
+        lifecycle_rx: watch::Receiver<ForkLifecycle>,
     ) -> Result<Network<R>, Box<NetworkError>> {
         let local_keypair: Keypair = load_private_key(&config.network_dir.key_file());
 
@@ -113,7 +131,7 @@ impl<R: MessageReceiver> Network<R> {
 
         let mut metrics_registry = Registry::default();
 
-        let behaviour = AnchorBehaviour::new::<E>(
+        let mut behaviour = AnchorBehaviour::new::<E>(
             local_keypair.clone(),
             config,
             &mut metrics_registry,
@@ -126,7 +144,12 @@ impl<R: MessageReceiver> Network<R> {
 
         let peer_id = local_keypair.public().to_peer_id();
 
-        let prev_lifecycle = lifecycle_rx.borrow_and_update().clone();
+        // Failing to reconcile would return a network that advertises a domain
+        // known to disagree with its lifecycle, so it fails construction instead.
+        reconcile_enr_domain(&mut behaviour, &lifecycle_rx)
+            .map_err(|e| Box::new(NetworkError::EnrReconcile(e)))?;
+
+        let shutdown_tx = executor.shutdown_sender();
         let mut network = Network {
             swarm: build_swarm(
                 executor.clone(),
@@ -145,7 +168,7 @@ impl<R: MessageReceiver> Network<R> {
             is_dynamic_target_peers,
             subnet_subscription_counts: HashMap::new(),
             lifecycle_rx,
-            prev_lifecycle,
+            shutdown_tx,
         };
 
         info!(%peer_id, "Network starting");
@@ -201,9 +224,9 @@ impl<R: MessageReceiver> Network<R> {
                 }
 
                 Ok(()) = self.lifecycle_rx.changed() => {
-                    let new = self.lifecycle_rx.borrow_and_update().clone();
-                    self.apply_fork_transition(&new);
-                    self.prev_lifecycle = new;
+                    if let ControlFlow::Break(()) = self.on_lifecycle_changed() {
+                        return;
+                    }
                 }
             }
         }
@@ -430,25 +453,36 @@ impl<R: MessageReceiver> Network<R> {
         }
     }
 
-    /// Handle fork lifecycle state changes.
+    /// Handle a fork lifecycle state change.
     ///
-    /// Only updates the ENR when the domain type actually changes between
-    /// lifecycle states. Transition logging is owned by the fork monitor.
-    fn apply_fork_transition(&mut self, new: &ForkLifecycle) {
-        let prev_domain = self.prev_lifecycle.current_fork_config().domain_type;
-        let new_domain = new.current_fork_config().domain_type;
+    /// Brings the ENR domain in line with the new lifecycle;
+    /// `update_enr_domain_type` no-ops when the ENR already matches, and logs
+    /// when it actually changes. Transition logging is owned by the fork
+    /// monitor. On failure the ENR disagrees with the lifecycle and never
+    /// recovers on its own (the next lifecycle change keeps the same domain),
+    /// so fail closed: request a client-wide shutdown and stop the network
+    /// loop instead of continuing with a stale ENR.
+    fn on_lifecycle_changed(&mut self) -> ControlFlow<()> {
+        let domain = self
+            .lifecycle_rx
+            .borrow_and_update()
+            .current_fork_config()
+            .domain_type;
 
-        // Only update ENR when the domain type actually changed.
-        if new_domain != prev_domain {
-            info!(
-                ?prev_domain,
-                ?new_domain,
-                "Updating ENR domain type after fork transition"
-            );
-            if let Err(e) = self.discovery().update_enr_domain_type(new_domain) {
-                error!(?e, "Failed to update ENR domain type after fork transition");
+        if let Err(e) = self.discovery().update_enr_domain_type(domain) {
+            error!(error = %e, "Failed to update ENR for fork transition; requesting client shutdown");
+            if let Err(e) = self.shutdown_tx.try_send(ShutdownReason::Failure(
+                "Network: failed to update ENR for fork transition",
+            )) && !e.is_full()
+            {
+                // A full channel means a shutdown is already pending; a closed
+                // one means there is no receiver left to act, which we can only
+                // surface in logs.
+                error!("Failed to deliver shutdown request: channel closed");
             }
+            return ControlFlow::Break(());
         }
+        ControlFlow::Continue(())
     }
 
     fn on_new_listen_addr(&mut self, listener_id: ListenerId, address: Multiaddr) {
@@ -922,4 +956,415 @@ fn build_swarm(
         .build();
 
     Ok(swarm)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use fork::{Fork, ForkConfig, ForkLifecycle};
+    use global_config::data_dir::DataDir;
+    use network_utils::listen_addr::{ListenAddr, ListenAddress};
+    use ssv_types::domain_type::DomainType;
+    use subnet_service::topic::create_topic;
+    use task_executor::test_utils::TestRuntime;
+    use tempfile::TempDir;
+    use types::{ChainSpec, Epoch, MinimalEthSpec};
+
+    use super::*;
+
+    const TEST_NETWORK: &str = "test";
+    const ALAN_DOMAIN: DomainType = DomainType([0, 0, 0, 1]);
+    const BOOLE_DOMAIN: DomainType = DomainType([0, 0, 0, 2]);
+    const BOOLE_FORK_EPOCH: u64 = 100;
+    /// Arbitrary subnet used by the topic scoring test.
+    const TEST_SUBNET: u64 = 7;
+    /// Any finite, non-negative rate; the scoring parameters derived from it are what matters.
+    const TEST_MESSAGE_RATE: f64 = 1.5;
+    /// Channel capacities: the tests drive the handlers directly, so nothing is queued.
+    const TEST_CHANNEL_CAPACITY: usize = 1;
+
+    /// A `MessageReceiver` that never sees a message, because these tests drive the network's
+    /// handlers directly instead of gossiping.
+    struct UnusedMessageReceiver;
+
+    impl MessageReceiver for UnusedMessageReceiver {
+        fn receive(
+            &self,
+            _propagation_source: PeerId,
+            _message_id: gossipsub::MessageId,
+            _message: gossipsub::Message,
+            _topic_context: TopicContext,
+        ) -> Result<(), message_receiver::Error> {
+            unreachable!("these tests do not deliver gossip messages")
+        }
+    }
+
+    fn test_fork_schedule() -> (Arc<ForkSchedule>, ForkConfig, ForkConfig) {
+        let mut configs = BTreeMap::new();
+        configs.insert(Fork::Alan, (Epoch::new(0), ALAN_DOMAIN));
+        configs.insert(Fork::Boole, (Epoch::new(BOOLE_FORK_EPOCH), BOOLE_DOMAIN));
+        let schedule = Arc::new(
+            ForkSchedule::from_fork_configs(configs, TEST_NETWORK)
+                .expect("test fork schedule should be valid"),
+        );
+        let alan_config = schedule
+            .config(Fork::Alan)
+            .cloned()
+            .expect("Alan config should exist");
+        let boole_config = schedule
+            .config(Fork::Boole)
+            .cloned()
+            .expect("Boole config should exist");
+        (schedule, alan_config, boole_config)
+    }
+
+    /// A config that binds ephemeral ports and starts neither discv5 nor UPnP, so the network
+    /// can be constructed in a unit test without touching the outside world.
+    fn test_config(network_dir: global_config::data_dir::NetworkDir) -> Config {
+        let mut config = Config::new(network_dir);
+        config.listen_addresses = ListenAddress::V4(ListenAddr {
+            addr: std::net::Ipv4Addr::LOCALHOST,
+            disc_port: 0,
+            quic_port: 0,
+            tcp_port: 0,
+        });
+        config.disable_discovery = true;
+        config.disable_quic_support = true;
+        config.upnp_enabled = false;
+        config
+    }
+
+    /// A bare `AnchorBehaviour` plus its lifecycle channel, standing in for the interval
+    /// inside `try_new` between building the behaviour and reconciling the ENR.
+    struct TestBehaviour {
+        behaviour: AnchorBehaviour,
+        lifecycle_tx: watch::Sender<ForkLifecycle>,
+        lifecycle_rx: watch::Receiver<ForkLifecycle>,
+        alan_config: ForkConfig,
+        boole_config: ForkConfig,
+        // Keep this last so it drops after the behaviour and its ENR file.
+        _temp_dir: TempDir,
+    }
+
+    impl TestBehaviour {
+        async fn new(
+            initial_lifecycle: impl FnOnce(&ForkConfig, &ForkConfig) -> ForkLifecycle,
+        ) -> Self {
+            let temp_dir = TempDir::new().expect("should create temp directory for network dir");
+            let data_dir =
+                DataDir::new(temp_dir.path().to_path_buf()).expect("should create data dir");
+            let config = test_config(data_dir.network_dir());
+
+            let (fork_schedule, alan_config, boole_config) = test_fork_schedule();
+            let (lifecycle_tx, lifecycle_rx) =
+                watch::channel(initial_lifecycle(&alan_config, &boole_config));
+
+            let behaviour = AnchorBehaviour::new::<MinimalEthSpec>(
+                Keypair::generate_secp256k1(),
+                &config,
+                &mut Registry::default(),
+                &ChainSpec::minimal(),
+                &fork_schedule,
+                lifecycle_rx.clone(),
+            )
+            .await
+            .expect("test behaviour should build");
+
+            Self {
+                behaviour,
+                lifecycle_tx,
+                lifecycle_rx,
+                alan_config,
+                boole_config,
+                _temp_dir: temp_dir,
+            }
+        }
+
+        fn send_lifecycle(
+            &self,
+            lifecycle: impl FnOnce(&ForkConfig, &ForkConfig) -> ForkLifecycle,
+        ) {
+            self.lifecycle_tx
+                .send(lifecycle(&self.alan_config, &self.boole_config))
+                .expect("the behaviour should still hold a lifecycle receiver");
+        }
+
+        fn enr_domain_type(&self) -> [u8; 4] {
+            self.behaviour
+                .discovery
+                .local_enr()
+                .get_decodable::<[u8; 4]>("domaintype")
+                .expect("local ENR should carry a domaintype")
+                .expect("domaintype should decode as four bytes")
+        }
+
+        /// The local ENR's sequence number, which only advances when the record is rewritten.
+        fn enr_seq(&self) -> u64 {
+            self.behaviour.discovery.local_enr().seq()
+        }
+    }
+
+    /// A live `Network` plus the handles a test needs to drive it.
+    struct TestNetwork {
+        network: Network<UnusedMessageReceiver>,
+        lifecycle_tx: watch::Sender<ForkLifecycle>,
+        alan_config: ForkConfig,
+        boole_config: ForkConfig,
+        _runtime: TestRuntime,
+        // Keep this last so it drops after the network and its ENR file.
+        _temp_dir: TempDir,
+    }
+
+    impl TestNetwork {
+        async fn new(
+            initial_lifecycle: impl FnOnce(&ForkConfig, &ForkConfig) -> ForkLifecycle,
+        ) -> Self {
+            let temp_dir = TempDir::new().expect("should create temp directory for network dir");
+            let data_dir =
+                DataDir::new(temp_dir.path().to_path_buf()).expect("should create data dir");
+            let config = test_config(data_dir.network_dir());
+
+            let (fork_schedule, alan_config, boole_config) = test_fork_schedule();
+            let (lifecycle_tx, lifecycle_rx) =
+                watch::channel(initial_lifecycle(&alan_config, &boole_config));
+
+            let (_topic_event_tx, topic_event_rx) = mpsc::channel(TEST_CHANNEL_CAPACITY);
+            let (_message_tx, message_rx) = mpsc::channel(TEST_CHANNEL_CAPACITY);
+            let (_outcome_tx, outcome_rx) = mpsc::channel(TEST_CHANNEL_CAPACITY);
+
+            let runtime = TestRuntime::default();
+            let network = Network::try_new::<MinimalEthSpec>(
+                &config,
+                topic_event_rx,
+                message_rx,
+                Arc::new(UnusedMessageReceiver),
+                outcome_rx,
+                runtime.task_executor.clone(),
+                Arc::new(ChainSpec::minimal()),
+                fork_schedule,
+                lifecycle_rx,
+            )
+            .await
+            .expect("test network should build");
+
+            Self {
+                network,
+                lifecycle_tx,
+                alan_config,
+                boole_config,
+                _runtime: runtime,
+                _temp_dir: temp_dir,
+            }
+        }
+
+        fn send_lifecycle(
+            &self,
+            lifecycle: impl FnOnce(&ForkConfig, &ForkConfig) -> ForkLifecycle,
+        ) {
+            self.lifecycle_tx
+                .send(lifecycle(&self.alan_config, &self.boole_config))
+                .expect("network should still hold the lifecycle receiver");
+        }
+
+        /// The `domaintype` currently advertised in the local ENR.
+        fn enr_domain_type(&mut self) -> [u8; 4] {
+            self.network
+                .discovery()
+                .local_enr()
+                .get_decodable::<[u8; 4]>("domaintype")
+                .expect("local ENR should carry a domaintype")
+                .expect("domaintype should decode as four bytes")
+        }
+
+        /// The local ENR's sequence number, which only advances when the record is rewritten.
+        fn enr_seq(&mut self) -> u64 {
+            self.network.discovery().local_enr().seq()
+        }
+    }
+
+    fn normal_on_alan(alan_config: &ForkConfig, _boole_config: &ForkConfig) -> ForkLifecycle {
+        ForkLifecycle::Normal {
+            current: alan_config.clone(),
+        }
+    }
+
+    fn grace_period_current_boole_previous_alan(
+        alan_config: &ForkConfig,
+        boole_config: &ForkConfig,
+    ) -> ForkLifecycle {
+        ForkLifecycle::GracePeriod {
+            current: boole_config.clone(),
+            previous: alan_config.clone(),
+        }
+    }
+
+    fn normal_on_boole(_alan_config: &ForkConfig, boole_config: &ForkConfig) -> ForkLifecycle {
+        ForkLifecycle::Normal {
+            current: boole_config.clone(),
+        }
+    }
+
+    // ==================== ENR domain reconciliation tests ====================
+
+    #[tokio::test]
+    async fn test_try_new_advertises_the_current_lifecycle_domain() {
+        // Arrange and act
+        let mut network = TestNetwork::new(normal_on_alan).await;
+
+        // Assert
+        assert_eq!(network.enr_domain_type(), ALAN_DOMAIN.0);
+    }
+
+    #[tokio::test]
+    async fn test_try_new_advertises_the_domain_of_a_fork_already_active_at_startup() {
+        // Arrange and act
+        let mut network = TestNetwork::new(grace_period_current_boole_previous_alan).await;
+
+        // Assert
+        assert_eq!(network.enr_domain_type(), BOOLE_DOMAIN.0);
+    }
+
+    /// The race the reconcile exists for: `Discovery::new` snapshots the lifecycle and builds
+    /// the ENR from it, then awaits discv5 startup and bootnode requests. A fork activating
+    /// during those awaits reaches the watch channel but not the ENR, so without the
+    /// reconcile the node would advertise the old domain until the run loop first polls the
+    /// channel.
+    #[tokio::test]
+    async fn test_reconcile_picks_up_a_fork_that_activated_during_behaviour_construction() {
+        // Arrange: the ENR Discovery built has only ever seen Alan.
+        let mut fixture = TestBehaviour::new(normal_on_alan).await;
+        assert_eq!(fixture.enr_domain_type(), ALAN_DOMAIN.0);
+
+        // Act: the fork activates in the window `try_new` owns, after the behaviour exists.
+        fixture.send_lifecycle(grace_period_current_boole_previous_alan);
+        reconcile_enr_domain(&mut fixture.behaviour, &fixture.lifecycle_rx)
+            .expect("reconcile should update the ENR");
+
+        // Assert
+        assert_eq!(fixture.enr_domain_type(), BOOLE_DOMAIN.0);
+        assert!(
+            fixture.lifecycle_rx.has_changed().expect("sender is alive"),
+            "the reconcile must not mark the change seen; it stays pending for the run loop"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_lifecycle_change_updates_the_advertised_enr_domain() {
+        // Arrange
+        let mut network = TestNetwork::new(normal_on_alan).await;
+        assert_eq!(network.enr_domain_type(), ALAN_DOMAIN.0);
+
+        // Act
+        network.send_lifecycle(grace_period_current_boole_previous_alan);
+        let control_flow = network.network.on_lifecycle_changed();
+
+        // Assert
+        assert_eq!(control_flow, ControlFlow::Continue(()));
+        assert_eq!(network.enr_domain_type(), BOOLE_DOMAIN.0);
+    }
+
+    /// Most lifecycle transitions keep the current fork, and rewriting the ENR for them would
+    /// burn sequence numbers and re-broadcast an unchanged record for nothing.
+    #[tokio::test]
+    async fn test_lifecycle_change_within_a_fork_leaves_the_enr_untouched() {
+        // Arrange: reach Boole, so the following transition keeps the same domain.
+        let mut network = TestNetwork::new(normal_on_alan).await;
+        network.send_lifecycle(grace_period_current_boole_previous_alan);
+        assert_eq!(
+            network.network.on_lifecycle_changed(),
+            ControlFlow::Continue(())
+        );
+        let seq_after_activation = network.enr_seq();
+
+        // Act: GracePeriod(Boole) -> Normal(Boole) ends the grace window, same domain.
+        network.send_lifecycle(normal_on_boole);
+        let control_flow = network.network.on_lifecycle_changed();
+
+        // Assert
+        assert_eq!(control_flow, ControlFlow::Continue(()));
+        assert_eq!(network.enr_domain_type(), BOOLE_DOMAIN.0);
+        assert_eq!(
+            network.enr_seq(),
+            seq_after_activation,
+            "an unchanged domain must not rewrite the ENR"
+        );
+    }
+
+    /// `reconcile_enr_domain` reads the lifecycle without marking it seen, so a change that
+    /// landed before the reconcile stays pending and the run loop re-applies it later. That
+    /// re-application must be harmless: the ENR already matches, so applying the same
+    /// lifecycle again must not rewrite the record.
+    #[tokio::test]
+    async fn test_reconcile_leaves_a_pending_change_pending_and_reapplication_is_a_no_op() {
+        // Arrange: a fork activates before the reconcile runs.
+        let mut fixture = TestBehaviour::new(normal_on_alan).await;
+        fixture.send_lifecycle(grace_period_current_boole_previous_alan);
+
+        // Act
+        reconcile_enr_domain(&mut fixture.behaviour, &fixture.lifecycle_rx)
+            .expect("reconcile should update the ENR");
+
+        // Assert: the ENR is already correct and the change is still pending for the run loop.
+        assert_eq!(fixture.enr_domain_type(), BOOLE_DOMAIN.0);
+        assert!(
+            fixture.lifecycle_rx.has_changed().expect("sender is alive"),
+            "a change published before the reconcile must stay pending for the run loop"
+        );
+
+        // Act and assert: re-applying the already-matching lifecycle leaves the ENR untouched.
+        let seq_after_reconcile = fixture.enr_seq();
+        reconcile_enr_domain(&mut fixture.behaviour, &fixture.lifecycle_rx)
+            .expect("re-applying an already-matching lifecycle should succeed");
+        assert_eq!(
+            fixture.enr_seq(),
+            seq_after_reconcile,
+            "re-applying an unchanged domain must not rewrite the ENR"
+        );
+    }
+
+    // ==================== Topic scoring tests ====================
+
+    /// Topics subscribed rate-less during WarmUp are scored by a later `RateUpdate`, so that
+    /// event has to install their gossipsub scoring parameters.
+    #[tokio::test]
+    async fn test_rate_update_installs_topic_score_params() {
+        // Arrange
+        let mut network = TestNetwork::new(normal_on_alan).await;
+        let topic = create_topic(
+            &Fork::Boole.topic_prefix(TEST_NETWORK),
+            SubnetId::new(TEST_SUBNET),
+        );
+        let ident_topic = IdentTopic::new(&topic);
+        assert!(
+            network
+                .network
+                .swarm
+                .behaviour()
+                .gossipsub
+                .get_topic_params(&ident_topic)
+                .is_none(),
+            "the topic should be unscored before the rate update"
+        );
+
+        // Act
+        network
+            .network
+            .on_topic_event::<MinimalEthSpec>(TopicEvent::RateUpdate {
+                topic,
+                message_rate: TEST_MESSAGE_RATE,
+            });
+
+        // Assert
+        assert!(
+            network
+                .network
+                .swarm
+                .behaviour()
+                .gossipsub
+                .get_topic_params(&ident_topic)
+                .is_some(),
+            "the rate update should have installed topic score parameters"
+        );
+    }
 }

--- a/anchor/signature_collector/src/lib.rs
+++ b/anchor/signature_collector/src/lib.rs
@@ -80,15 +80,32 @@ struct CommitteePartialSignatureBatch {
     for_slot: Slot,
 }
 
-/// One unique pre-Boole sync selection proof root and its original position multiplicity.
+/// One unique pre-Boole sync committee subnet and signing root pair.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct SyncSelectionProofDescriptor {
-    /// Unique sync committee subnet represented by this entry.
+pub struct SyncCommitteeBatchEntry {
+    /// Sync committee subnet represented by this entry.
     pub subnet_id: SyncSubnetId,
-    /// Ethereum signing root for the subnet's selection proof.
+    /// Ethereum signing root for this partial signature.
     pub signing_root: Hash256,
-    /// Number of original sync committee positions that map to this subnet and root.
-    pub position_count: usize,
+    /// Raw committee-position count for type 3, or repeated identical decided-entry count for
+    /// type 0.
+    pub multiplicity: usize,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+enum SingleValidatorBatchPhase {
+    ContributionProofs,
+    PostConsensus,
+}
+
+impl SingleValidatorBatchPhase {
+    fn from_kind(kind: PartialSignatureKind) -> Option<Self> {
+        match kind {
+            PartialSignatureKind::ContributionProofs => Some(Self::ContributionProofs),
+            PartialSignatureKind::PostConsensus => Some(Self::PostConsensus),
+            _ => None,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -97,11 +114,12 @@ enum SingleValidatorBatchState {
     Admitted,
 }
 
-/// Canonical outgoing pre-Boole sync selection proof batch for one validator and slot.
+/// Canonical outgoing pre-Boole sync committee partial signature batch for one validator, phase,
+/// and slot.
 struct SingleValidatorBatchRecord {
     validator_index: ValidatorIndex,
     committee_id: CommitteeId,
-    descriptor: Vec<SyncSelectionProofDescriptor>,
+    descriptor: Vec<SyncCommitteeBatchEntry>,
     /// The guard may cover only bounded synchronous signing, SSZ construction, and admission-only
     /// `sign_and_send`. Never await or perform a blocking channel send while holding it.
     state: Mutex<SingleValidatorBatchState>,
@@ -129,9 +147,13 @@ pub struct SignatureCollectorManager<S: SlotClock> {
     /// Note that this hash may differ from the actual signing root.
     committee_partial_signature_batches:
         DashMap<(Hash256, CommitteeId), CommitteePartialSignatureBatch>,
-    /// Pre-Boole batches keyed independently from root-specific collectors. Pending and admitted
-    /// records, including records created by detached callback work, are removed by slot cleanup.
-    single_validator_batches: DashMap<(Slot, PublicKeyBytes), Arc<SingleValidatorBatchRecord>>,
+    /// Pre-Boole batches keyed independently by phase and from root-specific collectors. Pending
+    /// and admitted records, including records created by detached callback work, are removed by
+    /// slot cleanup.
+    single_validator_batches:
+        DashMap<(SingleValidatorBatchPhase, Slot, PublicKeyBytes), Arc<SingleValidatorBatchRecord>>,
+    #[cfg(test)]
+    single_validator_batch_before_state_lock: Mutex<Option<Box<dyn FnOnce() + Send>>>,
 }
 
 impl<S: SlotClock + Clone + 'static> SignatureCollectorManager<S> {
@@ -155,6 +177,8 @@ impl<S: SlotClock + Clone + 'static> SignatureCollectorManager<S> {
             signature_collectors: DashMap::new(),
             committee_partial_signature_batches: DashMap::new(),
             single_validator_batches: DashMap::new(),
+            #[cfg(test)]
+            single_validator_batch_before_state_lock: Mutex::new(None),
         });
 
         manager
@@ -239,21 +263,10 @@ impl<S: SlotClock + Clone + 'static> SignatureCollectorManager<S> {
         self.processor.urgent_consensus.send_blocking(
             move || {
                 trace!(root = ?validator_signing_data.root, "Signing...");
-                // If we have no share, we can not actually sign the message, because we are running
-                // in impostor mode.
-                let partial_signature = if let Some(share) = &validator_signing_data.share {
-                    share.sign(validator_signing_data.root)
-                } else {
-                    Signature::empty()
-                };
+                let message = validator_signing_data
+                    .partial_signature_message(validator_signing_data.root, signer);
                 trace!(root = ?validator_signing_data.root, "Signed");
 
-                let message = PartialSignatureMessage {
-                    partial_signature,
-                    signing_root: validator_signing_data.root,
-                    signer,
-                    validator_index: validator_signing_data.index,
-                };
                 let messages_to_inject = match requester {
                     SignatureRequester::SingleValidator { pubkey } => {
                         // we do not have to wait for other partial signatures - send the message
@@ -377,7 +390,7 @@ impl<S: SlotClock + Clone + 'static> SignatureCollectorManager<S> {
         Ok(result_rx.await?)
     }
 
-    /// Builds and attempts the canonical pre-Boole selection-proof batch for one callback.
+    /// Builds and attempts the canonical pre-Boole sync committee batch for one callback.
     ///
     /// Returns the unique real messages this callback should inject after the record lock is
     /// released. An attempted send returns all descriptor roots, an admitted sibling or an
@@ -387,7 +400,7 @@ impl<S: SlotClock + Clone + 'static> SignatureCollectorManager<S> {
         metadata: &SignatureMetadata,
         pubkey: PublicKeyBytes,
         subnet_id: SyncSubnetId,
-        descriptor: Vec<SyncSelectionProofDescriptor>,
+        descriptor: Vec<SyncCommitteeBatchEntry>,
         validator_signing_data: &ValidatorSigningData,
         current_message: PartialSignatureMessage,
     ) -> Vec<PartialSignatureMessage> {
@@ -397,9 +410,32 @@ impl<S: SlotClock + Clone + 'static> SignatureCollectorManager<S> {
             return Vec::new();
         }
 
+        let Some(phase) = SingleValidatorBatchPhase::from_kind(metadata.kind) else {
+            error!(
+                reason = "unsupported_kind",
+                kind = ?metadata.kind,
+                slot = %metadata.slot,
+                callback_subnet = ?subnet_id,
+                "Suppressing single-validator batch publication for unsupported metadata"
+            );
+            return vec![current_message];
+        };
+        if metadata.role != Role::SyncCommittee {
+            error!(
+                reason = "role_mismatch",
+                kind = ?metadata.kind,
+                role = ?metadata.role,
+                slot = %metadata.slot,
+                callback_subnet = ?subnet_id,
+                "Suppressing single-validator batch publication for unsupported metadata"
+            );
+            return vec![current_message];
+        }
+
         if pubkey != validator_signing_data.validator_pubkey {
             error!(
                 reason = "validator_pubkey_mismatch",
+                kind = ?metadata.kind,
                 slot = %metadata.slot,
                 requester_pubkey = ?pubkey,
                 signing_data_pubkey = ?validator_signing_data.validator_pubkey,
@@ -409,12 +445,12 @@ impl<S: SlotClock + Clone + 'static> SignatureCollectorManager<S> {
             return vec![current_message];
         }
         if !descriptor.iter().any(|entry| {
-            entry.subnet_id == subnet_id
-                && entry.signing_root == validator_signing_data.root
+            entry.signing_root == validator_signing_data.root
                 && entry.signing_root == current_message.signing_root
         }) {
             error!(
                 reason = "descriptor_mismatch",
+                kind = ?metadata.kind,
                 slot = %metadata.slot,
                 ?pubkey,
                 callback_subnet = ?subnet_id,
@@ -425,7 +461,10 @@ impl<S: SlotClock + Clone + 'static> SignatureCollectorManager<S> {
             return vec![current_message];
         }
 
-        let record = match self.single_validator_batches.entry((metadata.slot, pubkey)) {
+        let record = match self
+            .single_validator_batches
+            .entry((phase, metadata.slot, pubkey))
+        {
             Entry::Occupied(entry) => Arc::clone(entry.get()),
             Entry::Vacant(entry) => {
                 let record = Arc::new(SingleValidatorBatchRecord {
@@ -442,6 +481,7 @@ impl<S: SlotClock + Clone + 'static> SignatureCollectorManager<S> {
         if record.committee_id != metadata.committee_id {
             error!(
                 reason = "committee_id_mismatch",
+                kind = ?metadata.kind,
                 slot = %metadata.slot,
                 ?pubkey,
                 callback_subnet = ?subnet_id,
@@ -454,6 +494,7 @@ impl<S: SlotClock + Clone + 'static> SignatureCollectorManager<S> {
         if record.validator_index != current_message.validator_index {
             error!(
                 reason = "validator_index_mismatch",
+                kind = ?metadata.kind,
                 slot = %metadata.slot,
                 ?pubkey,
                 callback_subnet = ?subnet_id,
@@ -466,6 +507,7 @@ impl<S: SlotClock + Clone + 'static> SignatureCollectorManager<S> {
         if record.descriptor != descriptor {
             error!(
                 reason = "descriptor_mismatch",
+                kind = ?metadata.kind,
                 slot = %metadata.slot,
                 ?pubkey,
                 callback_subnet = ?subnet_id,
@@ -476,9 +518,14 @@ impl<S: SlotClock + Clone + 'static> SignatureCollectorManager<S> {
             return vec![current_message];
         }
 
+        #[cfg(test)]
+        if let Some(hook) = self.single_validator_batch_before_state_lock.lock().take() {
+            hook();
+        }
         let mut state = record.state.lock();
         if *state == SingleValidatorBatchState::Admitted {
             trace!(
+                kind = ?metadata.kind,
                 slot = %metadata.slot,
                 validator_index = ?record.validator_index,
                 callback_subnet = ?subnet_id,
@@ -488,46 +535,29 @@ impl<S: SlotClock + Clone + 'static> SignatureCollectorManager<S> {
             return vec![current_message];
         }
 
-        let unique_messages = record
+        let signer = current_message.signer;
+        let mut injection_messages = vec![current_message];
+        let expanded_entries = record
             .descriptor
             .iter()
-            .map(|entry| {
-                let partial_signature = if entry.subnet_id == subnet_id {
-                    current_message.partial_signature.clone()
-                } else if let Some(share) = &validator_signing_data.share {
-                    share.sign(entry.signing_root)
-                } else {
-                    Signature::empty()
-                };
-                PartialSignatureMessage {
-                    partial_signature,
-                    signing_root: entry.signing_root,
-                    signer: current_message.signer,
-                    validator_index: current_message.validator_index,
-                }
-            })
-            .collect::<Vec<_>>();
-
-        let mut injection_messages = Vec::with_capacity(unique_messages.len());
-        injection_messages.push(current_message);
-        injection_messages.extend(
-            record
-                .descriptor
-                .iter()
-                .zip(&unique_messages)
-                .filter(|(entry, _)| entry.subnet_id != subnet_id)
-                .map(|(_, message)| message.clone()),
-        );
-
-        let expanded_positions = record
-            .descriptor
-            .iter()
-            .map(|entry| entry.position_count)
+            .map(|entry| entry.multiplicity)
             .sum();
-        let mut expanded_messages = Vec::with_capacity(expanded_positions);
-        for (entry, message) in record.descriptor.iter().zip(&unique_messages) {
-            expanded_messages.extend(std::iter::repeat_n(message.clone(), entry.position_count));
+        let mut expanded_messages = Vec::with_capacity(expanded_entries);
+        for entry in &record.descriptor {
+            let message = if let Some(index) = injection_messages
+                .iter()
+                .position(|message| message.signing_root == entry.signing_root)
+            {
+                injection_messages[index].clone()
+            } else {
+                let message =
+                    validator_signing_data.partial_signature_message(entry.signing_root, signer);
+                injection_messages.push(message.clone());
+                message
+            };
+            expanded_messages.extend(std::iter::repeat_n(message, entry.multiplicity));
         }
+        let unique_root_count = injection_messages.len();
 
         let outgoing = match self.create_message(
             metadata,
@@ -538,12 +568,13 @@ impl<S: SlotClock + Clone + 'static> SignatureCollectorManager<S> {
             Err(err) => {
                 error!(
                     %err,
+                    kind = ?metadata.kind,
                     slot = %metadata.slot,
                     committee_id = ?metadata.committee_id,
                     validator_index = ?record.validator_index,
                     callback_subnet = ?subnet_id,
-                    unique_roots = record.descriptor.len(),
-                    expanded_positions,
+                    unique_roots = unique_root_count,
+                    expanded_entries,
                     "Failed to construct single-validator partial signature batch"
                 );
                 drop(state);
@@ -558,23 +589,25 @@ impl<S: SlotClock + Clone + 'static> SignatureCollectorManager<S> {
             Ok(()) => {
                 *state = SingleValidatorBatchState::Admitted;
                 trace!(
+                    kind = ?metadata.kind,
                     slot = %metadata.slot,
                     validator_index = ?record.validator_index,
                     callback_subnet = ?subnet_id,
-                    unique_roots = record.descriptor.len(),
-                    expanded_positions,
+                    unique_roots = unique_root_count,
+                    expanded_entries,
                     "Admitted single-validator partial signature batch"
                 );
             }
             Err(err) => {
                 error!(
                     ?err,
+                    kind = ?metadata.kind,
                     slot = %metadata.slot,
                     committee_id = ?metadata.committee_id,
                     validator_index = ?record.validator_index,
                     callback_subnet = ?subnet_id,
-                    unique_roots = record.descriptor.len(),
-                    expanded_positions,
+                    unique_roots = unique_root_count,
+                    expanded_entries,
                     batch_state = "pending",
                     "Failed to admit single-validator partial signature batch for sending"
                 );
@@ -714,7 +747,7 @@ impl<S: SlotClock + Clone + 'static> SignatureCollectorManager<S> {
         self.committee_partial_signature_batches
             .retain(|_, batch| batch.for_slot >= cutoff);
         self.single_validator_batches
-            .retain(|(slot, _), _| *slot >= cutoff);
+            .retain(|(_, slot, _), _| *slot >= cutoff);
     }
 
     async fn cleaner(self: Arc<Self>) {
@@ -767,14 +800,15 @@ pub enum SignatureRequester {
         /// The public key of the validator. Used in the created network message.
         pubkey: PublicKeyBytes,
     },
-    /// Pre-Boole sync selection proofs for one validator are sent in one expanded envelope.
+    /// Pre-Boole sync committee partial signatures for one validator are sent in one expanded
+    /// envelope.
     SingleValidatorBatch {
         /// Public key used by the validator-scoped message ID and batch identity.
         pubkey: PublicKeyBytes,
         /// Subnet requested by this callback.
         subnet_id: SyncSubnetId,
-        /// Canonical descriptor for every unique subnet assigned to this validator and slot.
-        descriptor: Vec<SyncSelectionProofDescriptor>,
+        /// Canonical descriptor for every unique subnet and signing root pair in this batch.
+        descriptor: Vec<SyncCommitteeBatchEntry>,
     },
     /// The local operator is signing for multiple validators in one committee round.
     /// We batch those validator partial signatures into a single outgoing committee message instead
@@ -799,6 +833,26 @@ pub struct ValidatorSigningData {
     pub index: ValidatorIndex,
     pub validator_pubkey: PublicKeyBytes,
     pub share: Option<SecretKey>,
+}
+
+impl ValidatorSigningData {
+    fn partial_signature_message(
+        &self,
+        signing_root: Hash256,
+        signer: OperatorId,
+    ) -> PartialSignatureMessage {
+        // Without a share, impostor mode publishes the expected shape with empty signatures.
+        let partial_signature = self
+            .share
+            .as_ref()
+            .map_or_else(Signature::empty, |share| share.sign(signing_root));
+        PartialSignatureMessage {
+            partial_signature,
+            signing_root,
+            signer,
+            validator_index: self.index,
+        }
+    }
 }
 
 struct CollectorMessage<G = DropOnFinish> {

--- a/anchor/signature_collector/src/tests.rs
+++ b/anchor/signature_collector/src/tests.rs
@@ -404,17 +404,29 @@ impl BatchScenario {
     }
 }
 
-fn descriptor(entries: &[(u64, Hash256, usize)]) -> Vec<SyncSelectionProofDescriptor> {
+fn descriptor(entries: &[(u64, Hash256, usize)]) -> Vec<SyncCommitteeBatchEntry> {
     entries
         .iter()
         .map(
-            |(subnet_id, signing_root, position_count)| SyncSelectionProofDescriptor {
+            |(subnet_id, signing_root, multiplicity)| SyncCommitteeBatchEntry {
                 subnet_id: SyncSubnetId::new(*subnet_id),
                 signing_root: *signing_root,
-                position_count: *position_count,
+                multiplicity: *multiplicity,
             },
         )
         .collect()
+}
+
+fn batch_key(
+    metadata: &SignatureMetadata,
+    pubkey: PublicKeyBytes,
+) -> (SingleValidatorBatchPhase, Slot, PublicKeyBytes) {
+    (
+        SingleValidatorBatchPhase::from_kind(metadata.kind)
+            .expect("batch test metadata should use a supported phase"),
+        metadata.slot,
+        pubkey,
+    )
 }
 
 fn process_batch(
@@ -424,13 +436,36 @@ fn process_batch(
     validator_key: &SecretKey,
     validator_index: ValidatorIndex,
     subnet_id: SyncSubnetId,
-    descriptor: Vec<SyncSelectionProofDescriptor>,
+    descriptor: Vec<SyncCommitteeBatchEntry>,
 ) -> Vec<PartialSignatureMessage> {
     let signing_root = descriptor
         .iter()
         .find(|entry| entry.subnet_id == subnet_id)
         .expect("callback subnet should be in its descriptor")
         .signing_root;
+    process_batch_for_root(
+        manager,
+        metadata,
+        pubkey,
+        validator_key,
+        validator_index,
+        subnet_id,
+        signing_root,
+        descriptor,
+    )
+}
+
+#[expect(clippy::too_many_arguments)]
+fn process_batch_for_root(
+    manager: &SignatureCollectorManager<ManualSlotClock>,
+    metadata: &SignatureMetadata,
+    pubkey: PublicKeyBytes,
+    validator_key: &SecretKey,
+    validator_index: ValidatorIndex,
+    subnet_id: SyncSubnetId,
+    signing_root: Hash256,
+    descriptor: Vec<SyncCommitteeBatchEntry>,
+) -> Vec<PartialSignatureMessage> {
     let signing_data = ValidatorSigningData {
         root: signing_root,
         index: validator_index,
@@ -458,7 +493,7 @@ async fn sign_and_collect_batch(
     metadata: SignatureMetadata,
     validator_index: ValidatorIndex,
     subnet_id: SyncSubnetId,
-    descriptor: Vec<SyncSelectionProofDescriptor>,
+    descriptor: Vec<SyncCommitteeBatchEntry>,
 ) -> Arc<Signature> {
     let signing_root = descriptor
         .iter()
@@ -493,6 +528,40 @@ async fn wait_until(mut predicate: impl FnMut() -> bool) {
     })
     .await
     .expect("condition should become true promptly");
+}
+
+async fn drain_batch_processor_work(manager: &SignatureCollectorManager<ManualSlotClock>) {
+    let (urgent_done_tx, urgent_done_rx) = oneshot::channel();
+    manager
+        .processor
+        .urgent_consensus
+        .send_blocking(
+            move || {
+                let _ = urgent_done_tx.send(());
+            },
+            "batch_test_urgent_barrier",
+        )
+        .expect("urgent barrier should enter the processor");
+    tokio::time::timeout(Duration::from_secs(5), urgent_done_rx)
+        .await
+        .expect("urgent barrier should run promptly")
+        .expect("urgent barrier should signal completion");
+
+    let (permitless_done_tx, permitless_done_rx) = oneshot::channel();
+    manager
+        .processor
+        .permitless
+        .send_immediate(
+            move |_drop_on_finish| {
+                let _ = permitless_done_tx.send(());
+            },
+            "batch_test_permitless_barrier",
+        )
+        .expect("permitless barrier should enter the processor");
+    tokio::time::timeout(Duration::from_secs(5), permitless_done_rx)
+        .await
+        .expect("permitless barrier should run promptly")
+        .expect("permitless barrier should signal completion");
 }
 
 async fn register_manager_notifier(
@@ -543,6 +612,7 @@ fn single_validator_batch_envelope_cases() {
             0,
             vec![root_0],
             vec![root_0],
+            PartialSignatureKind::ContributionProofs,
             "one position",
         ),
         (
@@ -550,6 +620,7 @@ fn single_validator_batch_envelope_cases() {
             0,
             vec![root_0, root_0],
             vec![root_0],
+            PartialSignatureKind::ContributionProofs,
             "same-subnet multiplicity",
         ),
         (
@@ -557,17 +628,27 @@ fn single_validator_batch_envelope_cases() {
             1,
             vec![root_0, root_0, root_1],
             vec![root_1, root_0],
+            PartialSignatureKind::ContributionProofs,
             "multiple subnets",
+        ),
+        (
+            descriptor(&[(0, root_0, 2), (1, root_1, 1)]),
+            0,
+            vec![root_0, root_0, root_1],
+            vec![root_0, root_1],
+            PartialSignatureKind::PostConsensus,
+            "post-consensus decided root multiset",
         ),
     ];
 
     for (
         case_index,
-        (descriptor, callback_subnet, expected_wire_roots, expected_injection_roots, label),
+        (descriptor, callback_subnet, expected_wire_roots, expected_injection_roots, kind, label),
     ) in cases.into_iter().enumerate()
     {
         let mut metadata = scenario.metadata.clone();
         metadata.slot += case_index as u64;
+        metadata.kind = kind;
         let unique_messages = process_batch(
             &scenario.manager,
             &metadata,
@@ -601,7 +682,7 @@ fn single_validator_batch_envelope_cases() {
         );
         let messages = PartialSignatureMessages::from_ssz_bytes(unsigned.ssv_message.data())
             .expect("captured batch should decode");
-        assert_eq!(messages.kind, PartialSignatureKind::ContributionProofs);
+        assert_eq!(messages.kind, kind, "{label}");
         assert_eq!(messages.slot, metadata.slot);
         assert_eq!(
             messages
@@ -615,14 +696,175 @@ fn single_validator_batch_envelope_cases() {
         assert!(messages.messages.iter().all(|message| {
             message.signer == TEST_OPERATOR_ID && message.validator_index == ValidatorIndex(42)
         }));
+        for (message, signing_root) in messages.messages.iter().zip(&expected_wire_roots) {
+            assert_eq!(
+                message.partial_signature,
+                scenario.validator_key.sign(*signing_root),
+                "{label}"
+            );
+        }
     }
-    assert_eq!(sender.attempts(), 3);
+    assert_eq!(sender.attempts(), 4);
+}
+
+#[test]
+fn post_consensus_uses_exact_roots_for_same_subnet_callbacks() {
+    let sender = Arc::new(RecordingMessageSender::new(0));
+    let mut scenario = BatchScenario::new(Arc::clone(&sender) as Arc<dyn MessageSender>);
+    scenario.metadata.kind = PartialSignatureKind::PostConsensus;
+    let first_root = Hash256::repeat_byte(0x18);
+    let callback_root = Hash256::repeat_byte(0x19);
+    let descriptor = descriptor(&[(1, first_root, 1), (1, callback_root, 1)]);
+
+    let injections = process_batch_for_root(
+        &scenario.manager,
+        &scenario.metadata,
+        scenario.validator_pubkey,
+        &scenario.validator_key,
+        ValidatorIndex(42),
+        SyncSubnetId::new(1),
+        callback_root,
+        descriptor,
+    );
+
+    assert_eq!(
+        injections
+            .iter()
+            .map(|message| message.signing_root)
+            .collect::<Vec<_>>(),
+        vec![callback_root, first_root]
+    );
+    let sent = sender.messages();
+    assert_eq!(sent.len(), 1);
+    let messages = PartialSignatureMessages::from_ssz_bytes(sent[0].ssv_message.data())
+        .expect("post-consensus batch should decode");
+    assert_eq!(messages.kind, PartialSignatureKind::PostConsensus);
+    assert_eq!(messages.messages.len(), 2);
+    assert_eq!(messages.messages[0].signing_root, first_root);
+    assert_eq!(messages.messages[1].signing_root, callback_root);
+    assert_eq!(
+        messages.messages[0].partial_signature,
+        scenario.validator_key.sign(first_root)
+    );
+    assert_eq!(
+        messages.messages[1].partial_signature,
+        scenario.validator_key.sign(callback_root)
+    );
+}
+
+#[test]
+fn post_consensus_injects_one_message_for_one_root_on_multiple_subnets() {
+    let sender = Arc::new(RecordingMessageSender::new(0));
+    let mut scenario = BatchScenario::new(Arc::clone(&sender) as Arc<dyn MessageSender>);
+    scenario.metadata.kind = PartialSignatureKind::PostConsensus;
+    let signing_root = Hash256::repeat_byte(0x1A);
+
+    let injections = process_batch(
+        &scenario.manager,
+        &scenario.metadata,
+        scenario.validator_pubkey,
+        &scenario.validator_key,
+        ValidatorIndex(42),
+        SyncSubnetId::new(0),
+        descriptor(&[(0, signing_root, 1), (1, signing_root, 1)]),
+    );
+
+    assert_eq!(injections.len(), 1);
+    assert_eq!(injections[0].signing_root, signing_root);
+    let sent = sender.messages();
+    let messages = PartialSignatureMessages::from_ssz_bytes(sent[0].ssv_message.data())
+        .expect("post-consensus batch should decode");
+    assert_eq!(messages.kind, PartialSignatureKind::PostConsensus);
+    assert_eq!(messages.messages.len(), 2);
+    assert!(
+        messages
+            .messages
+            .iter()
+            .all(|message| message.signing_root == signing_root)
+    );
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn first_callback_injects_all_roots_and_admitted_sibling_reinjects() {
+async fn post_consensus_impostor_sends_empty_batch_without_sibling_injection() {
     let sender = Arc::new(RecordingMessageSender::new(0));
-    let scenario = BatchScenario::new(Arc::clone(&sender) as Arc<dyn MessageSender>);
+    let mut scenario =
+        BatchScenario::new_with_max_workers(Arc::clone(&sender) as Arc<dyn MessageSender>, 1);
+    scenario.metadata.kind = PartialSignatureKind::PostConsensus;
+    let validator_index = ValidatorIndex(42);
+    let current_root = Hash256::repeat_byte(0x1B);
+    let sibling_root = Hash256::repeat_byte(0x1C);
+    let collector_key = (current_root, validator_index);
+    let sibling_collector_key = (sibling_root, validator_index);
+    let manager = Arc::clone(&scenario.manager);
+    let metadata = scenario.metadata.clone();
+    let validator_pubkey = scenario.validator_pubkey;
+
+    let task = tokio::spawn(async move {
+        manager
+            .sign_and_collect(
+                metadata,
+                SignatureRequester::SingleValidatorBatch {
+                    pubkey: validator_pubkey,
+                    subnet_id: SyncSubnetId::new(0),
+                    descriptor: descriptor(&[(0, current_root, 1), (1, sibling_root, 1)]),
+                },
+                ValidatorSigningData {
+                    root: current_root,
+                    index: validator_index,
+                    validator_pubkey,
+                    share: None,
+                },
+            )
+            .await
+    });
+
+    wait_until(|| sender.attempts() == 1).await;
+    drain_batch_processor_work(&scenario.manager).await;
+
+    let sent = sender.messages();
+    let messages = PartialSignatureMessages::from_ssz_bytes(sent[0].ssv_message.data())
+        .expect("impostor post-consensus batch should decode");
+    assert_eq!(messages.kind, PartialSignatureKind::PostConsensus);
+    assert_eq!(messages.slot, scenario.metadata.slot);
+    assert_eq!(messages.messages.len(), 2);
+    assert_eq!(
+        messages
+            .messages
+            .iter()
+            .map(|message| message.signing_root)
+            .collect::<Vec<_>>(),
+        vec![current_root, sibling_root]
+    );
+    assert!(
+        messages
+            .messages
+            .iter()
+            .all(|message| message.partial_signature == Signature::empty()
+                && message.signer == TEST_OPERATOR_ID
+                && message.validator_index == validator_index)
+    );
+    assert!(
+        scenario
+            .manager
+            .signature_collectors
+            .contains_key(&collector_key)
+    );
+    assert!(
+        !scenario
+            .manager
+            .signature_collectors
+            .contains_key(&sibling_collector_key),
+        "impostor mode must not inject an empty sibling share"
+    );
+
+    task.abort();
+    let _ = task.await;
+}
+
+async fn run_first_callback_injection_and_reinjection(kind: PartialSignatureKind) {
+    let sender = Arc::new(RecordingMessageSender::new(0));
+    let mut scenario = BatchScenario::new(Arc::clone(&sender) as Arc<dyn MessageSender>);
+    scenario.metadata.kind = kind;
     let validator_index = ValidatorIndex(42);
     let root_0 = Hash256::repeat_byte(0x20);
     let root_1 = Hash256::repeat_byte(0x21);
@@ -686,10 +928,20 @@ async fn first_callback_injects_all_roots_and_admitted_sibling_reinjects() {
     );
 }
 
-#[test]
-fn failed_admission_stays_pending_and_sibling_retries() {
+#[tokio::test(flavor = "multi_thread")]
+async fn first_callback_injects_all_roots_and_admitted_sibling_reinjects() {
+    run_first_callback_injection_and_reinjection(PartialSignatureKind::ContributionProofs).await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn post_consensus_first_callback_injects_all_roots_and_admitted_sibling_reinjects() {
+    run_first_callback_injection_and_reinjection(PartialSignatureKind::PostConsensus).await;
+}
+
+fn run_failed_admission_and_sibling_retry(kind: PartialSignatureKind) {
     let sender = Arc::new(RecordingMessageSender::new(1));
-    let scenario = BatchScenario::new(Arc::clone(&sender) as Arc<dyn MessageSender>);
+    let mut scenario = BatchScenario::new(Arc::clone(&sender) as Arc<dyn MessageSender>);
+    scenario.metadata.kind = kind;
     let root_0 = Hash256::repeat_byte(0x30);
     let root_1 = Hash256::repeat_byte(0x31);
     let descriptor = descriptor(&[(0, root_0, 1), (1, root_1, 1)]);
@@ -709,7 +961,7 @@ fn failed_admission_stays_pending_and_sibling_retries() {
     let record = scenario
         .manager
         .single_validator_batches
-        .get(&(scenario.metadata.slot, scenario.validator_pubkey))
+        .get(&batch_key(&scenario.metadata, scenario.validator_pubkey))
         .expect("pending record should be retained");
     assert_eq!(*record.state.lock(), SingleValidatorBatchState::Pending);
     drop(record);
@@ -724,11 +976,30 @@ fn failed_admission_stays_pending_and_sibling_retries() {
         descriptor.clone(),
     );
     assert_eq!(sender.attempts(), 2);
-    assert_eq!(sender.messages().len(), 1);
+    let sent = sender.messages();
+    assert_eq!(sent.len(), 1);
+    let messages = PartialSignatureMessages::from_ssz_bytes(sent[0].ssv_message.data())
+        .expect("retried single-validator batch should decode");
+    assert_eq!(messages.kind, kind);
+    assert_eq!(messages.slot, scenario.metadata.slot);
+    assert_eq!(messages.messages.len(), 2);
+    assert_eq!(
+        messages
+            .messages
+            .iter()
+            .map(|message| message.signing_root)
+            .collect::<Vec<_>>(),
+        vec![root_0, root_1]
+    );
+    assert!(messages.messages.iter().all(|message| {
+        message.signer == TEST_OPERATOR_ID
+            && message.validator_index == ValidatorIndex(42)
+            && message.partial_signature == scenario.validator_key.sign(message.signing_root)
+    }));
     let record = scenario
         .manager
         .single_validator_batches
-        .get(&(scenario.metadata.slot, scenario.validator_pubkey))
+        .get(&batch_key(&scenario.metadata, scenario.validator_pubkey))
         .expect("admitted record should be retained");
     assert_eq!(*record.state.lock(), SingleValidatorBatchState::Admitted);
     drop(record);
@@ -743,13 +1014,53 @@ fn failed_admission_stays_pending_and_sibling_retries() {
         descriptor,
     );
     assert_eq!(admitted_injections.len(), 1);
+    assert_eq!(admitted_injections[0].signing_root, root_0);
     assert_eq!(sender.attempts(), 2);
 }
 
 #[test]
-fn concurrent_callbacks_produce_one_admitted_send() {
+fn failed_admission_stays_pending_and_sibling_retries() {
+    run_failed_admission_and_sibling_retry(PartialSignatureKind::ContributionProofs);
+}
+
+#[test]
+fn post_consensus_failed_admission_stays_pending_and_sibling_retries() {
+    run_failed_admission_and_sibling_retry(PartialSignatureKind::PostConsensus);
+}
+
+#[test]
+fn post_consensus_construction_failure_retains_pending_for_retry() {
+    let sender = Arc::new(RecordingMessageSender::new(0));
+    let mut scenario = BatchScenario::new(Arc::clone(&sender) as Arc<dyn MessageSender>);
+    scenario.metadata.kind = PartialSignatureKind::PostConsensus;
+    let signing_root = Hash256::repeat_byte(0x38);
+    let oversized_multiplicity = PartialSignatureMessagesLen::USIZE + 1;
+
+    let injections = process_batch(
+        &scenario.manager,
+        &scenario.metadata,
+        scenario.validator_pubkey,
+        &scenario.validator_key,
+        ValidatorIndex(42),
+        SyncSubnetId::new(0),
+        descriptor(&[(0, signing_root, oversized_multiplicity)]),
+    );
+
+    assert_eq!(injections.len(), 1);
+    assert_eq!(injections[0].signing_root, signing_root);
+    assert_eq!(sender.attempts(), 0);
+    let record = scenario
+        .manager
+        .single_validator_batches
+        .get(&batch_key(&scenario.metadata, scenario.validator_pubkey))
+        .expect("construction failure should retain the batch record");
+    assert_eq!(*record.state.lock(), SingleValidatorBatchState::Pending);
+}
+
+fn run_concurrent_callbacks(kind: PartialSignatureKind) {
     let (sender, first_attempt_entered) = BlockingMessageSender::new();
-    let scenario = BatchScenario::new(Arc::clone(&sender) as Arc<dyn MessageSender>);
+    let mut scenario = BatchScenario::new(Arc::clone(&sender) as Arc<dyn MessageSender>);
+    scenario.metadata.kind = kind;
     let descriptor = descriptor(&[
         (0, Hash256::repeat_byte(0x40), 1),
         (1, Hash256::repeat_byte(0x41), 1),
@@ -778,6 +1089,25 @@ fn concurrent_callbacks_produce_one_admitted_send() {
     first_attempt_entered
         .recv_timeout(Duration::from_secs(5))
         .expect("first callback should enter sign_and_send");
+    let record = scenario
+        .manager
+        .single_validator_batches
+        .get(&batch_key(&scenario.metadata, scenario.validator_pubkey))
+        .expect("concurrent batch record should exist");
+    assert!(
+        record.state.try_lock().is_none(),
+        "the first callback should hold admission state while sending"
+    );
+    drop(record);
+    let (second_at_lock_tx, second_at_lock_rx) = std_mpsc::sync_channel(1);
+    *scenario
+        .manager
+        .single_validator_batch_before_state_lock
+        .lock() = Some(Box::new(move || {
+        second_at_lock_tx
+            .send(())
+            .expect("test should observe the sibling at the state lock");
+    }));
 
     let second = std::thread::spawn(move || {
         process_batch(
@@ -790,7 +1120,9 @@ fn concurrent_callbacks_produce_one_admitted_send() {
             descriptor_b,
         )
     });
-    std::thread::sleep(Duration::from_millis(50));
+    second_at_lock_rx
+        .recv_timeout(Duration::from_secs(5))
+        .expect("sibling callback should reach the state lock during admission");
     assert_eq!(sender.attempts(), 1);
     sender.release();
 
@@ -816,10 +1148,20 @@ fn concurrent_callbacks_produce_one_admitted_send() {
     );
 }
 
-#[tokio::test(flavor = "multi_thread")]
-async fn mismatched_callbacks_suppress_publication_but_inject_current_share() {
-    let sender = Arc::new(RecordingMessageSender::new(0));
-    let scenario = BatchScenario::new(Arc::clone(&sender) as Arc<dyn MessageSender>);
+#[test]
+fn concurrent_callbacks_produce_one_admitted_send() {
+    run_concurrent_callbacks(PartialSignatureKind::ContributionProofs);
+}
+
+#[test]
+fn concurrent_post_consensus_callbacks_produce_one_admitted_send() {
+    run_concurrent_callbacks(PartialSignatureKind::PostConsensus);
+}
+
+async fn run_mismatched_callbacks(kind: PartialSignatureKind) {
+    let sender = Arc::new(RecordingMessageSender::new(usize::MAX));
+    let mut scenario = BatchScenario::new(Arc::clone(&sender) as Arc<dyn MessageSender>);
+    scenario.metadata.kind = kind;
     let validator_index = ValidatorIndex(42);
     let root_0 = Hash256::repeat_byte(0x50);
     let root_1 = Hash256::repeat_byte(0x51);
@@ -835,6 +1177,15 @@ async fn mismatched_callbacks_suppress_publication_but_inject_current_share() {
     )
     .await;
     assert_eq!(sender.attempts(), 1);
+    let record_key = batch_key(&scenario.metadata, scenario.validator_pubkey);
+    let record = scenario
+        .manager
+        .single_validator_batches
+        .get(&record_key)
+        .expect("canonical pending record should be retained");
+    assert_eq!(*record.state.lock(), SingleValidatorBatchState::Pending);
+    assert_eq!(record.descriptor, canonical);
+    drop(record);
 
     let mismatched = descriptor(&[(1, root_1, 1)]);
     scenario.seed_remote_shares(root_1, validator_index);
@@ -867,7 +1218,7 @@ async fn mismatched_callbacks_suppress_publication_but_inject_current_share() {
         &scenario.validator_key,
         ValidatorIndex(43),
         SyncSubnetId::new(0),
-        canonical,
+        canonical.clone(),
     );
     let other_pubkey = SecretKey::random().public_key().compress();
     let pubkey_mismatch_injections = scenario.manager.process_single_validator_batch(
@@ -888,10 +1239,81 @@ async fn mismatched_callbacks_suppress_publication_but_inject_current_share() {
             validator_index,
         },
     );
+    let mut unsupported_kind = scenario.metadata.clone();
+    unsupported_kind.kind = PartialSignatureKind::RandaoPartialSig;
+    let unsupported_kind_injections = process_batch(
+        &scenario.manager,
+        &unsupported_kind,
+        scenario.validator_pubkey,
+        &scenario.validator_key,
+        validator_index,
+        SyncSubnetId::new(0),
+        descriptor(&[(0, root_0, 1)]),
+    );
+    let mut wrong_role = scenario.metadata.clone();
+    wrong_role.role = Role::Aggregator;
+    let wrong_role_injections = process_batch(
+        &scenario.manager,
+        &wrong_role,
+        scenario.validator_pubkey,
+        &scenario.validator_key,
+        validator_index,
+        SyncSubnetId::new(0),
+        descriptor(&[(0, root_0, 1)]),
+    );
     assert_eq!(committee_injections.len(), 1);
     assert_eq!(index_injections.len(), 1);
     assert_eq!(pubkey_mismatch_injections.len(), 1);
+    assert_eq!(unsupported_kind_injections.len(), 1);
+    assert_eq!(wrong_role_injections.len(), 1);
     assert_eq!(sender.attempts(), 1);
+    assert_eq!(scenario.manager.single_validator_batches.len(), 1);
+    let record = scenario
+        .manager
+        .single_validator_batches
+        .get(&record_key)
+        .expect("mismatches should preserve the canonical pending record");
+    assert_eq!(*record.state.lock(), SingleValidatorBatchState::Pending);
+    assert_eq!(record.descriptor, canonical);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn mismatched_callbacks_suppress_publication_but_inject_current_share() {
+    run_mismatched_callbacks(PartialSignatureKind::ContributionProofs).await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn mismatched_post_consensus_callbacks_suppress_publication_but_inject_current_share() {
+    run_mismatched_callbacks(PartialSignatureKind::PostConsensus).await;
+}
+
+#[test]
+fn post_consensus_callback_root_must_be_in_the_descriptor() {
+    let sender = Arc::new(RecordingMessageSender::new(0));
+    let mut scenario = BatchScenario::new(Arc::clone(&sender) as Arc<dyn MessageSender>);
+    scenario.metadata.kind = PartialSignatureKind::PostConsensus;
+    let descriptor_root = Hash256::repeat_byte(0x58);
+    let callback_root = Hash256::repeat_byte(0x59);
+
+    let injections = process_batch_for_root(
+        &scenario.manager,
+        &scenario.metadata,
+        scenario.validator_pubkey,
+        &scenario.validator_key,
+        ValidatorIndex(42),
+        SyncSubnetId::new(0),
+        callback_root,
+        descriptor(&[(0, descriptor_root, 1)]),
+    );
+
+    assert_eq!(injections.len(), 1);
+    assert_eq!(injections[0].signing_root, callback_root);
+    assert_eq!(
+        injections[0].partial_signature,
+        scenario.validator_key.sign(callback_root)
+    );
+    assert_eq!(sender.attempts(), 0);
+    assert!(scenario.manager.single_validator_batches.is_empty());
 }
 
 #[test]
@@ -935,6 +1357,122 @@ fn validator_and_slot_batch_records_are_isolated() {
     assert_eq!(sender.attempts(), 3);
     assert_eq!(sender.messages().len(), 3);
     assert_eq!(scenario.manager.single_validator_batches.len(), 3);
+}
+
+#[test]
+fn contribution_proof_and_post_consensus_records_are_isolated() {
+    let sender = Arc::new(RecordingMessageSender::new(0));
+    let scenario = BatchScenario::new(Arc::clone(&sender) as Arc<dyn MessageSender>);
+    let type_three_root = Hash256::repeat_byte(0x68);
+    let type_zero_root = Hash256::repeat_byte(0x69);
+    let mut post_consensus = scenario.metadata.clone();
+    post_consensus.kind = PartialSignatureKind::PostConsensus;
+
+    process_batch(
+        &scenario.manager,
+        &scenario.metadata,
+        scenario.validator_pubkey,
+        &scenario.validator_key,
+        ValidatorIndex(42),
+        SyncSubnetId::new(0),
+        descriptor(&[(0, type_three_root, 1)]),
+    );
+    process_batch(
+        &scenario.manager,
+        &post_consensus,
+        scenario.validator_pubkey,
+        &scenario.validator_key,
+        ValidatorIndex(42),
+        SyncSubnetId::new(0),
+        descriptor(&[(0, type_zero_root, 1)]),
+    );
+
+    assert_eq!(scenario.manager.single_validator_batches.len(), 2);
+    assert!(
+        scenario
+            .manager
+            .single_validator_batches
+            .contains_key(&batch_key(&scenario.metadata, scenario.validator_pubkey))
+    );
+    assert!(
+        scenario
+            .manager
+            .single_validator_batches
+            .contains_key(&batch_key(&post_consensus, scenario.validator_pubkey))
+    );
+    let kinds = sender
+        .messages()
+        .iter()
+        .map(|unsigned| {
+            PartialSignatureMessages::from_ssz_bytes(unsigned.ssv_message.data())
+                .expect("phase-isolated batch should decode")
+                .kind
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(
+        kinds,
+        vec![
+            PartialSignatureKind::ContributionProofs,
+            PartialSignatureKind::PostConsensus
+        ]
+    );
+}
+
+#[test]
+fn cleanup_removes_pending_and_admitted_records_from_both_phases() {
+    let sender = Arc::new(RecordingMessageSender::new(1));
+    let scenario = BatchScenario::new(Arc::clone(&sender) as Arc<dyn MessageSender>);
+    let descriptor = descriptor(&[(0, Hash256::repeat_byte(0x70), 1)]);
+    let mut stale = scenario.metadata.clone();
+    stale.slot = BATCH_TEST_SLOT - 2;
+    let mut stale_post_consensus = stale.clone();
+    stale_post_consensus.kind = PartialSignatureKind::PostConsensus;
+    scenario.manager.slot_clock.set_slot(stale.slot.as_u64());
+
+    process_batch(
+        &scenario.manager,
+        &stale,
+        scenario.validator_pubkey,
+        &scenario.validator_key,
+        ValidatorIndex(42),
+        SyncSubnetId::new(0),
+        descriptor.clone(),
+    );
+    process_batch(
+        &scenario.manager,
+        &stale_post_consensus,
+        scenario.validator_pubkey,
+        &scenario.validator_key,
+        ValidatorIndex(42),
+        SyncSubnetId::new(0),
+        descriptor.clone(),
+    );
+    scenario
+        .manager
+        .slot_clock
+        .set_slot(BATCH_TEST_SLOT.as_u64());
+    process_batch(
+        &scenario.manager,
+        &scenario.metadata,
+        scenario.validator_pubkey,
+        &scenario.validator_key,
+        ValidatorIndex(42),
+        SyncSubnetId::new(0),
+        descriptor,
+    );
+    assert_eq!(scenario.manager.single_validator_batches.len(), 3);
+
+    scenario
+        .manager
+        .remove_stale_entries(BATCH_TEST_SLOT.saturating_sub(SIGNATURE_COLLECTOR_RETAIN_SLOTS));
+
+    assert_eq!(scenario.manager.single_validator_batches.len(), 1);
+    assert!(
+        scenario
+            .manager
+            .single_validator_batches
+            .contains_key(&batch_key(&scenario.metadata, scenario.validator_pubkey))
+    );
 }
 
 #[test]
@@ -990,17 +1528,17 @@ fn cleanup_removes_pending_and_admitted_batch_records() {
         scenario
             .manager
             .single_validator_batches
-            .contains_key(&(BATCH_TEST_SLOT, scenario.validator_pubkey))
+            .contains_key(&batch_key(&scenario.metadata, scenario.validator_pubkey))
     );
 }
 
-#[test]
-fn stale_callback_after_cleanup_does_not_recreate_or_publish_batch() {
+fn run_stale_callback_after_cleanup(kind: PartialSignatureKind) {
     let sender = Arc::new(RecordingMessageSender::new(0));
-    let scenario = BatchScenario::new(Arc::clone(&sender) as Arc<dyn MessageSender>);
+    let mut scenario = BatchScenario::new(Arc::clone(&sender) as Arc<dyn MessageSender>);
+    scenario.metadata.kind = kind;
     let signing_root = Hash256::repeat_byte(0x71);
     let descriptor = descriptor(&[(0, signing_root, 1)]);
-    let batch_key = (scenario.metadata.slot, scenario.validator_pubkey);
+    let batch_key = batch_key(&scenario.metadata, scenario.validator_pubkey);
 
     let initial_injections = process_batch(
         &scenario.manager,
@@ -1082,16 +1620,26 @@ fn stale_callback_after_cleanup_does_not_recreate_or_publish_batch() {
     );
 }
 
-#[tokio::test(flavor = "multi_thread")]
-async fn stale_sign_and_collect_does_not_recreate_cleaned_collectors() {
+#[test]
+fn stale_callback_after_cleanup_does_not_recreate_or_publish_batch() {
+    run_stale_callback_after_cleanup(PartialSignatureKind::ContributionProofs);
+}
+
+#[test]
+fn stale_post_consensus_callback_after_cleanup_does_not_recreate_or_publish_batch() {
+    run_stale_callback_after_cleanup(PartialSignatureKind::PostConsensus);
+}
+
+async fn run_stale_sign_and_collect(kind: PartialSignatureKind) {
     let sender = Arc::new(RecordingMessageSender::new(0));
-    let scenario =
+    let mut scenario =
         BatchScenario::new_with_max_workers(Arc::clone(&sender) as Arc<dyn MessageSender>, 1);
+    scenario.metadata.kind = kind;
     let validator_index = ValidatorIndex(42);
     let signing_root = Hash256::repeat_byte(0x72);
     let descriptor = descriptor(&[(0, signing_root, 1)]);
     let collector_key = (signing_root, validator_index);
-    let batch_key = (scenario.metadata.slot, scenario.validator_pubkey);
+    let batch_key = batch_key(&scenario.metadata, scenario.validator_pubkey);
 
     drop(
         scenario
@@ -1138,39 +1686,7 @@ async fn stale_sign_and_collect_does_not_recreate_cleaned_collectors() {
     .expect("stale notifier should be dropped promptly");
     assert!(matches!(result, Err(CollectionError::QueueClosedError)));
 
-    let (urgent_done_tx, urgent_done_rx) = oneshot::channel();
-    scenario
-        .manager
-        .processor
-        .urgent_consensus
-        .send_blocking(
-            move || {
-                let _ = urgent_done_tx.send(());
-            },
-            "stale_batch_urgent_barrier",
-        )
-        .expect("urgent barrier should enter the processor");
-    tokio::time::timeout(Duration::from_secs(5), urgent_done_rx)
-        .await
-        .expect("urgent barrier should run promptly")
-        .expect("urgent barrier should signal completion");
-
-    let (permitless_done_tx, permitless_done_rx) = oneshot::channel();
-    scenario
-        .manager
-        .processor
-        .permitless
-        .send_immediate(
-            move |_drop_on_finish| {
-                let _ = permitless_done_tx.send(());
-            },
-            "stale_batch_permitless_barrier",
-        )
-        .expect("permitless barrier should enter the processor");
-    tokio::time::timeout(Duration::from_secs(5), permitless_done_rx)
-        .await
-        .expect("permitless barrier should run promptly")
-        .expect("permitless barrier should signal completion");
+    drain_batch_processor_work(&scenario.manager).await;
 
     assert_eq!(sender.attempts(), 0);
     assert!(
@@ -1185,6 +1701,16 @@ async fn stale_sign_and_collect_does_not_recreate_cleaned_collectors() {
             .single_validator_batches
             .contains_key(&batch_key)
     );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn stale_sign_and_collect_does_not_recreate_cleaned_collectors() {
+    run_stale_sign_and_collect(PartialSignatureKind::ContributionProofs).await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn stale_post_consensus_sign_and_collect_does_not_recreate_cleaned_collectors() {
+    run_stale_sign_and_collect(PartialSignatureKind::PostConsensus).await;
 }
 
 #[tokio::test]

--- a/anchor/subnet_service/src/subscriptions.rs
+++ b/anchor/subnet_service/src/subscriptions.rs
@@ -99,15 +99,30 @@ impl<S: SlotClock> SubnetService<S> {
         loop {
             let delay = calculate_duration_to_next_epoch::<E>(&*self.slot_clock);
             tokio::select! {
-                _ = db.changed(), if !self.subscribe_all_subnets => {
+                result = db.changed(), if !self.subscribe_all_subnets => {
+                    // A dropped database sender makes `changed()` return
+                    // immediately and forever, so binding it with `_` would
+                    // spin this arm rather than disable it.
+                    if result.is_err() {
+                        warn!("Database channel closed; stopping subnet service");
+                        return;
+                    }
                     self.handle_subnet_changes::<E>(&mut service_state).await;
                 }
                 _ = sleep(delay), if !self.disable_gossipsub_topic_scoring => {
                     self.send_scoring_rate_updates::<E>(&service_state).await;
                 }
-                Ok(()) = lifecycle_rx.changed() => {
+                result = lifecycle_rx.changed() => {
+                    // The fork monitor only drops the sender after requesting a
+                    // client shutdown (or during teardown). Stop the service
+                    // instead of pattern-disabling the arm, which could leave
+                    // the select with no enabled branches and panic.
+                    if result.is_err() {
+                        warn!("Fork lifecycle channel closed; stopping subnet service");
+                        return;
+                    }
                     let new_lifecycle = lifecycle_rx.borrow_and_update().clone();
-                    self.on_lifecycle_transition(new_lifecycle, &mut service_state).await;
+                    self.on_lifecycle_transition::<E>(new_lifecycle, &mut service_state).await;
                     self.handle_subnet_changes::<E>(&mut service_state).await;
                 }
             }
@@ -122,7 +137,18 @@ impl<S: SlotClock> SubnetService<S> {
     /// - WarmUp/Normal → GracePeriod: update fork_to_score, insert current fork
     /// - GracePeriod → Normal: remove & unsubscribe previous fork
     /// - GracePeriod → WarmUp: remove previous + insert upcoming (overlapping transition)
-    async fn on_lifecycle_transition(&self, new: ForkLifecycle, service_state: &mut ServiceState) {
+    ///
+    /// A fork activation (a `fork_to_score` change) also installs scoring
+    /// parameters for the new current fork's already-subscribed topics
+    /// immediately: they were subscribed rate-less during WarmUp, and the
+    /// epoch timer would leave them unscored (no P4 penalty) until the next
+    /// epoch boundary.
+    async fn on_lifecycle_transition<E: EthSpec>(
+        &self,
+        new: ForkLifecycle,
+        service_state: &mut ServiceState,
+    ) {
+        let fork_to_score_changed = service_state.fork_to_score != new.current_fork_config().fork;
         service_state.fork_to_score = new.current_fork_config().fork;
         let removed = match new {
             ForkLifecycle::Normal { current } => service_state.set_subscribed_forks([current]),
@@ -144,6 +170,9 @@ impl<S: SlotClock> SubnetService<S> {
                 error!("Failed to unsubscribe from fork: {:?}", err);
             }
         }
+        if fork_to_score_changed && !self.disable_gossipsub_topic_scoring {
+            self.send_scoring_rate_updates::<E>(service_state).await;
+        }
     }
 
     async fn initial_service_state<E: EthSpec>(
@@ -157,7 +186,7 @@ impl<S: SlotClock> SubnetService<S> {
         };
 
         let initial_lifecycle = lifecycle_rx.borrow_and_update().clone();
-        self.on_lifecycle_transition(initial_lifecycle, &mut service_state)
+        self.on_lifecycle_transition::<E>(initial_lifecycle, &mut service_state)
             .await;
 
         self.handle_subnet_changes::<E>(&mut service_state).await;
@@ -319,10 +348,10 @@ mod tests {
         time::timeout,
     };
     use types::{
-        ChainSpec, Epoch, MinimalEthSpec, Slot, test_utils::generate_deterministic_keypair,
+        ChainSpec, Epoch, EthSpec, MinimalEthSpec, Slot, test_utils::generate_deterministic_keypair,
     };
 
-    use crate::{SUBNET_COUNT, SubnetId, TopicEvent, start_subnet_service};
+    use crate::{SUBNET_COUNT, SubnetId, TopicEvent, TopicRouter, start_subnet_service};
 
     const TEST_NETWORK: &str = "test";
     const ALAN_DOMAIN: DomainType = DomainType([0, 0, 0, 1]);
@@ -373,6 +402,14 @@ mod tests {
         /// `subnet_message_rate` returns `None` when scoring is disabled.
         fn new_normal_on_alan_with_scoring() -> Self {
             Self::new_with_flags(normal_on_alan, false, false)
+        }
+
+        /// All-subnet subscriptions with gossipsub topic scoring enabled, so lifecycle
+        /// transitions also exercise the scoring rate updates a fork activation triggers.
+        fn new_with_scoring(
+            initial_lifecycle: impl FnOnce(&ForkConfig, &ForkConfig) -> ForkLifecycle,
+        ) -> Self {
+            Self::new_with_flags(initial_lifecycle, true, false)
         }
 
         /// Build a service with an initial lifecycle and ready-to-assert event receiver.
@@ -597,7 +634,131 @@ mod tests {
         // Assert
         // WarmUp(Alan->Boole) and GracePeriod(current=Boole, previous=Alan) track the same fork
         // set, so no subscribe/unsubscribe topic events should be emitted for this
-        // transition.
+        // transition. This harness also disables topic scoring, so the fork activation emits
+        // no rate updates either.
+        harness.assert_no_additional_events().await;
+    }
+
+    /// A fork activation must not leave the new current fork's topics unscored until the next
+    /// epoch boundary: they were subscribed rate-less during WarmUp, so the transition itself
+    /// has to install their scoring parameters.
+    #[tokio::test]
+    async fn warmup_to_grace_period_with_scoring_rescores_current_fork_topics() {
+        // Arrange
+        let mut harness = TestHarness::new_with_scoring(warmup_from_alan_to_boole);
+        harness.consume_startup_events(SUBNET_COUNT * 2).await;
+
+        // Act: no epoch boundary is crossed, only the lifecycle transition.
+        harness.transition_to_grace_period_current_boole_previous_alan();
+        let events = harness.recv_transition_events(SUBNET_COUNT).await;
+
+        // Assert: every Boole topic is rescored, and the fork set is unchanged so nothing is
+        // subscribed or unsubscribed.
+        assert_all_events_match(&events, "Boole rate update event", is_boole_rate_update);
+        harness.assert_no_additional_events().await;
+    }
+
+    /// Restarting into `Normal` and then receiving `GracePeriod` skips the WarmUp step, so
+    /// this transition subscribes the Boole topics for the first time. The activation rescore
+    /// runs before those subscriptions exist and therefore emits nothing; the subscribes
+    /// themselves carry the rates, so every topic is scored without duplicate rate updates.
+    #[tokio::test]
+    async fn normal_to_grace_period_with_scoring_subscribes_current_fork_topics_with_rates() {
+        // Arrange
+        let mut harness = TestHarness::new_with_scoring(normal_on_alan);
+        harness.consume_startup_events(SUBNET_COUNT).await;
+
+        // Act
+        harness.transition_to_grace_period_current_boole_previous_alan();
+        let events = harness.recv_transition_events(SUBNET_COUNT).await;
+
+        // Assert: every event is a Boole subscribe that already carries a rate, and no
+        // separate rate updates follow.
+        assert_all_events_match(&events, "Boole subscribe event", is_boole_subscribe);
+        for (index, event) in events.iter().enumerate() {
+            let TopicEvent::Subscribe { message_rate, .. } = event else {
+                unreachable!("asserted above that every event is a subscribe");
+            };
+            assert!(
+                message_rate.is_some(),
+                "Boole subscribe at index {index} should carry a message rate when scoring is enabled"
+            );
+        }
+        harness.assert_no_additional_events().await;
+    }
+
+    /// A restart can miss the grace period entirely: WarmUp is followed directly by
+    /// `Normal{current: Boole}`. The removal of the previous fork emits its unsubscribes
+    /// first (`on_lifecycle_transition` handles removals before the rescore), and because
+    /// `fork_to_score` flips to Boole, the Boole topics subscribed rate-less during WarmUp
+    /// are rescored in the same transition. The subnet diff afterwards adds nothing because
+    /// the Boole set is already complete.
+    #[tokio::test]
+    async fn warmup_to_normal_with_scoring_unsubscribes_previous_and_rescores_current_fork() {
+        // Arrange
+        let mut harness = TestHarness::new_with_scoring(warmup_from_alan_to_boole);
+        harness.consume_startup_events(SUBNET_COUNT * 2).await;
+
+        // Act: skip the grace period, jumping straight to Normal on Boole.
+        harness.transition_to_normal_on_boole();
+        let events = harness.recv_transition_events(SUBNET_COUNT * 2).await;
+
+        // Assert: all Alan unsubscribes first, then a rate update for every Boole topic.
+        let (unsubscribes, rate_updates) = events.split_at(SUBNET_COUNT);
+        assert_all_events_match(unsubscribes, "Alan unsubscribe event", is_alan_unsubscribe);
+        assert_all_events_match(
+            rate_updates,
+            "Boole rate update event",
+            is_boole_rate_update,
+        );
+        harness.assert_no_additional_events().await;
+    }
+
+    /// A service that starts directly in `GracePeriod{current: Boole}` (a restart after the
+    /// fork activated) runs the activation rescore path during startup, but at that point no
+    /// topics are subscribed yet, so the rescore emits nothing. Startup therefore emits only
+    /// the initial subscribes for both tracked forks, and the subscribes for the fork being
+    /// scored already carry message rates, so no topic is left unscored.
+    #[tokio::test]
+    async fn initial_grace_period_with_scoring_emits_rated_subscribes_and_no_rate_updates() {
+        // Arrange
+        let mut harness = TestHarness::new_with_scoring(grace_period_current_boole_previous_alan);
+
+        // Act: capture everything startup emits.
+        let events = harness.recv_transition_events(SUBNET_COUNT * 2).await;
+
+        // Assert: every startup event is a subscribe; the startup rescore ran against an
+        // empty subscription set, so no separate rate updates appear.
+        assert_all_events_match(&events, "subscribe event", is_subscribe_event);
+        let alan_subscribes = events
+            .iter()
+            .filter(|event| is_alan_subscribe(event))
+            .count();
+        let boole_subscribes = events
+            .iter()
+            .filter(|event| is_boole_subscribe(event))
+            .count();
+        assert_eq!(alan_subscribes, SUBNET_COUNT);
+        assert_eq!(boole_subscribes, SUBNET_COUNT);
+
+        // Assert: Boole is the fork being scored, so its subscribes carry rates; Alan is the
+        // graced-out previous fork, so its subscribes are rate-less.
+        for (index, event) in events.iter().enumerate() {
+            let TopicEvent::Subscribe { message_rate, .. } = event else {
+                unreachable!("asserted above that every event is a subscribe");
+            };
+            if is_boole_subscribe(event) {
+                assert!(
+                    message_rate.is_some(),
+                    "Boole subscribe at index {index} should carry a message rate"
+                );
+            } else {
+                assert!(
+                    message_rate.is_none(),
+                    "Alan subscribe at index {index} should not carry a message rate"
+                );
+            }
+        }
         harness.assert_no_additional_events().await;
     }
 
@@ -623,6 +784,99 @@ mod tests {
         assert_eq!(alan_subscribes, SUBNET_COUNT);
         assert_eq!(boole_subscribes, SUBNET_COUNT);
         harness.assert_no_additional_events().await;
+    }
+
+    /// Dropping the lifecycle sender must stop the run loop cleanly. With
+    /// `subscribe_all_subnets` disabling the db arm and `disable_gossipsub_topic_scoring`
+    /// disabling the epoch timer, the lifecycle arm is the only live select branch, so its
+    /// `Err` result is the loop's only exit; without that handling the select would have no
+    /// enabled branches left and panic.
+    #[tokio::test]
+    async fn run_stops_cleanly_when_lifecycle_sender_is_dropped() {
+        // Arrange: build the service directly so the test owns the run task's join handle.
+        let temp_dir = TempDir::new().expect("should create temp directory for test database");
+        let db_path = temp_dir.path().join("subnet_service_sender_drop.db");
+        let db = NetworkDatabase::new_as_impostor(&db_path, &OWN_OPERATOR_ID, TEST_NETWORK)
+            .expect("should build test database");
+        let (fork_schedule, alan_config, _boole_config) = test_fork_schedule();
+        let (lifecycle_tx, lifecycle_rx) = watch::channel(ForkLifecycle::Normal {
+            current: alan_config,
+        });
+        let (tx, mut topic_event_rx) = mpsc::channel(SUBNET_COUNT);
+        let service = Arc::new(crate::SubnetService {
+            tx,
+            db: db.watch(),
+            subscribe_all_subnets: true,
+            disable_gossipsub_topic_scoring: true,
+            slot_clock: Arc::new(ManualSlotClock::new(
+                Slot::new(0),
+                Duration::from_secs(0),
+                Duration::from_secs(12),
+            )),
+            chain_spec: Arc::new(ChainSpec::minimal()),
+            router: TopicRouter::new(fork_schedule, MinimalEthSpec::slots_per_epoch()),
+        });
+        let handle = tokio::spawn(service.clone().run::<MinimalEthSpec>(lifecycle_rx));
+
+        // Drain the startup subscribes so the loop is parked in the select.
+        for _ in 0..SUBNET_COUNT {
+            timeout(EVENT_TIMEOUT, topic_event_rx.recv())
+                .await
+                .expect("timed out waiting for startup subscribe")
+                .expect("topic event channel closed unexpectedly");
+        }
+
+        // Act
+        drop(lifecycle_tx);
+
+        // Assert: the task returns, and returns cleanly (a panic would surface as a
+        // JoinError).
+        timeout(EVENT_TIMEOUT, handle)
+            .await
+            .expect("run should return after the lifecycle sender is dropped")
+            .expect("run must not panic when the lifecycle sender is dropped");
+    }
+
+    /// The database arm binds `changed()` with a name rather than `_`, so a dropped
+    /// database sender stops the service instead of leaving the arm permanently ready
+    /// and spinning the loop.
+    #[tokio::test]
+    async fn run_stops_cleanly_when_database_sender_is_dropped() {
+        // Arrange: keep the database arm enabled (subscribe_all_subnets = false) so the
+        // dropped sender reaches it, and own the run task's join handle.
+        let temp_dir = TempDir::new().expect("should create temp directory for test database");
+        let db_path = temp_dir.path().join("subnet_service_db_drop.db");
+        let db = NetworkDatabase::new_as_impostor(&db_path, &OWN_OPERATOR_ID, TEST_NETWORK)
+            .expect("should build test database");
+        let (fork_schedule, alan_config, _boole_config) = test_fork_schedule();
+        let (_lifecycle_tx, lifecycle_rx) = watch::channel(ForkLifecycle::Normal {
+            current: alan_config,
+        });
+        let (tx, _topic_event_rx) = mpsc::channel(SUBNET_COUNT);
+        let service = Arc::new(crate::SubnetService {
+            tx,
+            db: db.watch(),
+            subscribe_all_subnets: false,
+            disable_gossipsub_topic_scoring: true,
+            slot_clock: Arc::new(ManualSlotClock::new(
+                Slot::new(0),
+                Duration::from_secs(0),
+                Duration::from_secs(12),
+            )),
+            chain_spec: Arc::new(ChainSpec::minimal()),
+            router: TopicRouter::new(fork_schedule, MinimalEthSpec::slots_per_epoch()),
+        });
+        let handle = tokio::spawn(service.clone().run::<MinimalEthSpec>(lifecycle_rx));
+
+        // Act: an empty database emits no startup subscriptions, so the loop is already
+        // parked in the select when the sender drops.
+        drop(db);
+
+        // Assert: the task returns rather than spinning, and does not panic.
+        timeout(EVENT_TIMEOUT, handle)
+            .await
+            .expect("run should return after the database sender is dropped")
+            .expect("run must not panic when the database sender is dropped");
     }
 
     #[tokio::test]
@@ -854,6 +1108,13 @@ mod tests {
         matches!(
             event,
             TopicEvent::Subscribe { topic, .. } if topic.starts_with(boole_topic_prefix())
+        )
+    }
+
+    fn is_boole_rate_update(event: &TopicEvent) -> bool {
+        matches!(
+            event,
+            TopicEvent::RateUpdate { topic, .. } if topic.starts_with(boole_topic_prefix())
         )
     }
 

--- a/anchor/validator_store/src/aggregator_post_consensus.rs
+++ b/anchor/validator_store/src/aggregator_post_consensus.rs
@@ -1,0 +1,905 @@
+//! Post-consensus signing for Boole+ `AggregatorCommittee` duties.
+//!
+//! One QBFT decision carries both attestation aggregates and sync contributions for an SSV
+//! committee, and the operator must emit exactly one committee partial-signature message per
+//! `(committee, slot)` covering everything it can sign. The decided value drives both what gets
+//! signed and what gets published: Anchor owns Boole+ publication of both classes outright,
+//! through the metadata service's publisher, because the protocol's unit of agreement is the
+//! decided value and no local Lighthouse view is part of it. Lighthouse's duty snapshots are
+//! cloned before slot-start selection proofs finish (both classes share one slot-start
+//! partial-signature batch), so routing publication through either callback would silently skip
+//! late-installed proofs, and a callback may not fire at all (issue #1227).
+//!
+//! The signing set is therefore a property of the duty, not of any consumer. The slot pipeline
+//! starts one execution per committee when it publishes the decided value at 2/3 slot, and the
+//! publisher drains that execution's roots of both classes itself; the Lighthouse callbacks
+//! return empty batches. This is the ssv-spec-normative shape, where the decided value drives
+//! what gets signed and published, matching go-ssv's runner-owned post-consensus submission.
+
+use std::{
+    collections::{HashMap, HashSet, hash_map::Entry},
+    future::Future,
+    sync::{Arc, LazyLock},
+};
+
+use bls::Signature;
+use database::{NonUniqueIndex, UniqueIndex};
+use futures::{
+    FutureExt, StreamExt,
+    future::{BoxFuture, Either, Shared},
+    stream::FuturesUnordered,
+};
+use qbft_manager::ConsensusDecider;
+use slot_clock::SlotClock;
+use ssv_types::{
+    Cluster, CommitteeId, ValidatorIndex, ValidatorMetadata,
+    consensus::{AggregatorCommitteeConsensusData, AssignedAggregator, QbftData},
+    msgid::Role,
+    partial_sig::PartialSignatureKind,
+};
+use tokio::time::Instant;
+use tracing::{Instrument, debug, error, info, info_span, warn};
+use types::{
+    AggregateAndProof, Attestation, ContributionAndProof, Domain, EthSpec, ForkName, Hash256,
+    SelectionProof, SignedAggregateAndProof, SignedContributionAndProof, SignedRoot, Slot,
+};
+use validator_metrics::IntCounterVec;
+
+use crate::{
+    AggregationAssignments, AnchorValidatorStore, CollectionMode, Error, SigningRequest,
+    SpecificError, metrics,
+};
+
+/// Epochs to retain started `AggregatorCommittee` post-consensus keys.
+///
+/// Matches the message validator's per-signer duplicate-detection window, so a repeated
+/// `(committee, slot)` inside the window finds its registered key rather than starting a second
+/// execution. Each entry is one key, not a handle; the executions live in their detached tasks.
+const AGGREGATOR_POST_CONSENSUS_RETAIN_EPOCHS: u64 = 2;
+
+/// A result shared between the detached task producing it and any number of joiners.
+type SharedResult<T> = Shared<BoxFuture<'static, Result<T, Arc<Error>>>>;
+
+pub(crate) type AggregatorPostConsensusShared<E> =
+    SharedResult<Arc<AggregatorPostConsensusOutcome<E>>>;
+
+/// One decided root this operator signs, with the handle to its signature.
+///
+/// The underlying `collect_signature` call runs in its own task, so the local partial reaches the
+/// committee batch even when no callback ever awaits the signature.
+pub(crate) struct PreparedRoot<M> {
+    pub(crate) request: SigningRequest<M>,
+    pub(crate) signature: SharedResult<Signature>,
+}
+
+/// Everything this operator signs for one decided `AggregatorCommittee` round, keyed by signing
+/// identity: validator index for aggregates, `(validator index, subcommittee index)` for
+/// contributions. Both classes are read by the metadata service's publisher.
+pub(crate) struct AggregatorPostConsensusOutcome<E: EthSpec> {
+    /// Fork the decided value's SSZ payloads were decoded under (its `DataVersion`). The
+    /// publisher derives its HTTP endpoint choice and fork header from this, so they cannot
+    /// diverge from the payload variant of the decided aggregates.
+    pub(crate) fork_name: ForkName,
+    pub(crate) aggregates: HashMap<ValidatorIndex, PreparedRoot<AggregateAndProof<E>>>,
+    pub(crate) contributions: HashMap<(ValidatorIndex, u64), PreparedRoot<ContributionAndProof<E>>>,
+}
+
+/// The signing worklist derived from one decided `AggregatorCommitteeConsensusData`.
+struct DecidedWorklist<E: EthSpec> {
+    aggregates: HashMap<ValidatorIndex, SigningRequest<AggregateAndProof<E>>>,
+    contributions: HashMap<(ValidatorIndex, u64), SigningRequest<ContributionAndProof<E>>>,
+}
+
+fn post_consensus_aborted() -> Arc<Error> {
+    Arc::new(Error::SpecificError(SpecificError::PostConsensusAborted))
+}
+
+/// Await a detached task spawned with `TaskExecutor::spawn_handle`, mapping every way it can die
+/// without a result (spawn refused, executor exit, panic) onto `PostConsensusAborted`.
+async fn join_detached_task<R>(
+    handle: Option<tokio::task::JoinHandle<Option<R>>>,
+) -> Result<R, Arc<Error>> {
+    match handle {
+        Some(handle) => handle.await.ok().flatten(),
+        None => None,
+    }
+    .ok_or_else(post_consensus_aborted)
+}
+
+/// Await one decided root's threshold signature under the deadline, of either class.
+///
+/// Returns `None` after logging the skip and counting the failure on `signed_total` (the
+/// class's Lighthouse-era signing counter): `other_error` when collection failed, `timeout` when
+/// the deadline expired before quorum (matching the committee-level join arm, now that expiry is
+/// distinguishable from a collection failure). `collect_signature` failures are also logged by
+/// the detached signing task, but a task that died without a result (spawn refused, executor
+/// exit, panic) is only visible here, so the collection-failure arm carries the error into its
+/// warn.
+async fn await_root_signature<M>(
+    slot: Slot,
+    deadline: Instant,
+    root: &PreparedRoot<M>,
+    signed_total: &LazyLock<validator_metrics::Result<IntCounterVec>>,
+    skip_message: &'static str,
+) -> Option<Signature> {
+    let label = match tokio::time::timeout_at(deadline, root.signature.clone()).await {
+        Ok(Ok(signature)) => return Some(signature),
+        Ok(Err(e)) => {
+            warn!(
+                pubkey = ?root.request.validator.public_key,
+                %slot,
+                error = ?e,
+                "{skip_message}"
+            );
+            metrics::OTHER_ERROR
+        }
+        // Deadline expired before this root's quorum; only this root is withheld.
+        Err(_) => {
+            warn!(
+                pubkey = ?root.request.validator.public_key,
+                %slot,
+                "{skip_message}"
+            );
+            metrics::TIMEOUT
+        }
+    };
+    validator_metrics::inc_counter_vec(signed_total, &[label]);
+    None
+}
+
+/// Await one decided root's threshold signature under the deadline and publish it on quorum,
+/// one publish call per aggregate.
+///
+/// Both publish arms reproduce the per-aggregate log Lighthouse emits on its pre-Boole path;
+/// operator pipelines key on `type="aggregated"`.
+async fn publish_one_root<E: EthSpec, F, Fut>(
+    slot: Slot,
+    fork_name: ForkName,
+    deadline: Instant,
+    root: &PreparedRoot<AggregateAndProof<E>>,
+    publish: &F,
+) where
+    F: Fn(ForkName, SignedAggregateAndProof<E>) -> Fut,
+    Fut: Future<Output = Result<(), String>>,
+{
+    let Some(signature) = await_root_signature(
+        slot,
+        deadline,
+        root,
+        &validator_metrics::SIGNED_AGGREGATES_TOTAL,
+        "Missing signature, skipping aggregate",
+    )
+    .await
+    else {
+        // The publish-outcome counter is aggregate-only; contributions are tracked by their
+        // signing counter and publish logs alone.
+        metrics::inc_publish_result(metrics::NO_SIGNATURES);
+        return;
+    };
+
+    let message = root.request.duty_data.clone();
+    debug!(
+        aggregator_index = message.aggregator_index(),
+        data = ?message.aggregate().data(),
+        num_set_aggregation_bits = message.aggregate().num_set_aggregation_bits(),
+        "Signed AggregateAndProof (Boole+ committee consensus)"
+    );
+    validator_metrics::inc_counter_vec(
+        &validator_metrics::SIGNED_AGGREGATES_TOTAL,
+        &[validator_metrics::SUCCESS],
+    );
+    let signed = SignedAggregateAndProof::from_aggregate_and_proof(message, signature);
+
+    let aggregator = signed.message().aggregator_index();
+    let attestation = signed.message().aggregate();
+    let signatures = attestation.num_set_aggregation_bits();
+    let head_block = format!("{:?}", attestation.data().beacon_block_root);
+    let committee_index = attestation.committee_index();
+
+    let result = publish(fork_name, signed)
+        .instrument(info_span!("publish_aggregate", aggregator))
+        .await;
+    match result {
+        Ok(()) => {
+            info!(
+                aggregator,
+                signatures,
+                head_block,
+                committee_index,
+                slot = slot.as_u64(),
+                "type" = "aggregated",
+                "Successfully published attestation"
+            );
+            metrics::inc_publish_result(validator_metrics::SUCCESS);
+        }
+        Err(e) => {
+            error!(
+                error = %e,
+                aggregator,
+                committee_index,
+                slot = slot.as_u64(),
+                "type" = "aggregated",
+                "Failed to publish attestation"
+            );
+            metrics::inc_publish_result(metrics::HTTP_ERROR);
+        }
+    }
+}
+
+/// Await one decided contribution's threshold signature under the deadline and publish it on
+/// quorum, one publish call per contribution.
+///
+/// Signing outcomes keep the Lighthouse-era `SIGNED_SYNC_COMMITTEE_CONTRIBUTIONS_TOTAL`
+/// accounting that used to live in the contribution callback, and the publish arms reproduce the
+/// per-publish logs Lighthouse emits on its pre-Boole path, so operator pipelines keyed on
+/// either keep working. `AGGREGATOR_COMMITTEE_PUBLISH_TOTAL` stays aggregate-only.
+async fn publish_one_contribution<E: EthSpec, F, Fut>(
+    slot: Slot,
+    deadline: Instant,
+    root: &PreparedRoot<ContributionAndProof<E>>,
+    publish: &F,
+) where
+    F: Fn(SignedContributionAndProof<E>) -> Fut,
+    Fut: Future<Output = Result<(), String>>,
+{
+    let Some(signature) = await_root_signature(
+        slot,
+        deadline,
+        root,
+        &validator_metrics::SIGNED_SYNC_COMMITTEE_CONTRIBUTIONS_TOTAL,
+        "Missing signature, skipping sync committee contribution",
+    )
+    .await
+    else {
+        return;
+    };
+
+    let message = root.request.duty_data.clone();
+    debug!(
+        aggregator_index = message.aggregator_index,
+        slot = %message.contribution.slot,
+        block_root = ?message.contribution.beacon_block_root,
+        subcommittee_index = message.contribution.subcommittee_index,
+        num_set_aggregation_bits = message.contribution.aggregation_bits.num_set_bits(),
+        "Signed ContributionAndProof (Boole+ committee consensus)"
+    );
+    validator_metrics::inc_counter_vec(
+        &validator_metrics::SIGNED_SYNC_COMMITTEE_CONTRIBUTIONS_TOTAL,
+        &[validator_metrics::SUCCESS],
+    );
+
+    let aggregator_index = message.aggregator_index;
+    let subnet = message.contribution.subcommittee_index;
+    let beacon_block_root = message.contribution.beacon_block_root;
+    let num_signers = message.contribution.aggregation_bits.num_set_bits();
+    let signed = SignedContributionAndProof { message, signature };
+
+    let result = publish(signed)
+        .instrument(info_span!("publish_contribution", aggregator_index))
+        .await;
+    match result {
+        Ok(()) => {
+            info!(
+                aggregator_index,
+                subnet,
+                beacon_block_root = ?beacon_block_root,
+                num_signers,
+                slot = slot.as_u64(),
+                "Successfully published sync contributions"
+            );
+        }
+        Err(e) => {
+            error!(
+                error = %e,
+                aggregator_index,
+                subnet,
+                slot = slot.as_u64(),
+                "Unable to publish signed contributions and proofs"
+            );
+        }
+    }
+}
+
+impl<T: SlotClock + 'static, E: EthSpec, C: ConsensusDecider<E> + 'static>
+    AnchorValidatorStore<T, E, C>
+{
+    /// Start one post-consensus execution per committee in freshly built assignments, returning
+    /// the executions newly registered by this call.
+    ///
+    /// This is the only place executions are created, so exactly one committee message per
+    /// `(committee, slot)` holds by construction rather than by locking. Called from
+    /// `update_aggregation_assignments` before the watch channel is published.
+    ///
+    /// The returned handles feed the metadata service's publisher, which is their sole consumer.
+    /// Returning only first-insertions gives the publisher the same exactly-once property as the
+    /// executions themselves: a repeated call for one `(committee, slot)` registers nothing and
+    /// therefore publishes nothing twice. Both properties are scoped to the process lifetime and
+    /// to the retention window below: after a key is pruned, only a slot clock stepping backwards
+    /// past the window could present its `(committee, slot)` again, and that would re-register.
+    ///
+    /// Pre-Boole there is no consensus data and this is a no-op returning no executions.
+    #[must_use = "dropping the returned executions disables Boole+ aggregate and contribution \
+                  publication"]
+    pub(crate) fn start_aggregator_post_consensus(
+        self: &Arc<Self>,
+        assignments: &AggregationAssignments<E>,
+    ) -> Vec<(CommitteeId, AggregatorPostConsensusShared<E>)> {
+        let slot = assignments.slot;
+        let mut executions = self.aggregator_post_consensus.lock();
+
+        let cutoff =
+            slot.saturating_sub(AGGREGATOR_POST_CONSENSUS_RETAIN_EPOCHS * E::slots_per_epoch());
+        executions.retain(|&(_, execution_slot)| execution_slot >= cutoff);
+
+        let mut new_executions = Vec::new();
+        for (&committee_id, decided_data) in &assignments.consensus_data_by_ssv_committee {
+            // First-insert-only, so registration is idempotent. A second execution for one key
+            // would spawn a second QBFT round and a second set of detached signing tasks while
+            // the first set kept running, putting two committee messages on the wire for one
+            // slot, which peers reject with a gossip penalty. The slot pipeline publishes once
+            // per slot today, but that is a property of another module's timing loop; keeping
+            // this first-insert-only makes exactly-once hold here regardless of how often it is
+            // called.
+            if executions.insert((committee_id, slot)) {
+                let store = Arc::clone(self);
+                let decided_data = Arc::clone(decided_data);
+                let execution = self.spawn_shared("aggregator_post_consensus", async move {
+                    store
+                        .run_aggregator_post_consensus(committee_id, slot, decided_data)
+                        .await
+                });
+                new_executions.push((committee_id, execution));
+            }
+        }
+        new_executions
+    }
+
+    /// Join one committee's execution under the shared deadline, returning the outcome and the
+    /// deadline for the caller to reuse when draining its own roots.
+    ///
+    /// The single deadline (one slot past the duty slot's end) is an anti-hang backstop, not a
+    /// duty-freshness bound: QBFT `SlotTime` rounds legitimately decide after the slot ends and
+    /// reconstruction needs a network round trip after that, so bounding at slot end would discard
+    /// results decided in contended rounds.
+    async fn join_execution(
+        &self,
+        slot: Slot,
+        execution: AggregatorPostConsensusShared<E>,
+    ) -> Result<(Instant, Arc<AggregatorPostConsensusOutcome<E>>), Error> {
+        let deadline = self.get_instant_in_slot(slot, self.spec.get_slot_duration() * 2)?;
+        let outcome = tokio::time::timeout_at(deadline, execution)
+            .await
+            .map_err(|_| Error::SpecificError(SpecificError::Timeout))?
+            .map_err(|e| (*e).clone())?;
+
+        Ok((deadline, outcome))
+    }
+
+    /// Join one committee's post-consensus execution and publish each decided root this operator
+    /// signed, of both classes, as soon as its threshold signature reconstructs.
+    ///
+    /// This backs [`Self::publish_decided_aggregates`], which owns Boole+ publication of
+    /// aggregates and sync contributions: Lighthouse's callbacks return empty batches at Boole+,
+    /// because their duty snapshots are cloned before slot-start selection proofs finish,
+    /// silently skipping any proof installed after the clone. The publisher works from the
+    /// decided value instead, so publication does not depend on Lighthouse's snapshot timing.
+    ///
+    /// Takes the execution handle directly rather than re-entering the assignments watch channel,
+    /// so a late-polled publisher cannot observe `AggregatorInfoSlotPassed` for an execution that
+    /// still exists in the retention map.
+    async fn publish_committee_aggregates<FA, FutA, FC, FutC>(
+        &self,
+        committee_id: CommitteeId,
+        slot: Slot,
+        execution: AggregatorPostConsensusShared<E>,
+        publish_aggregate: &FA,
+        publish_contribution: &FC,
+    ) where
+        FA: Fn(ForkName, SignedAggregateAndProof<E>) -> FutA,
+        FutA: Future<Output = Result<(), String>>,
+        FC: Fn(SignedContributionAndProof<E>) -> FutC,
+        FutC: Future<Output = Result<(), String>>,
+    {
+        let (deadline, outcome) = match self.join_execution(slot, execution).await {
+            Ok(joined) => joined,
+            Err(e) => {
+                warn!(
+                    ?committee_id,
+                    %slot,
+                    error = ?e,
+                    "Aggregator post-consensus failed, nothing to publish"
+                );
+                // Keeps the Lighthouse-era signing counters alive for dashboards keyed on them.
+                // The per-root counts and class composition are unknowable before the outcome
+                // resolves, so failures count once per committee on both class counters: an
+                // undercount against multiple lost roots, an overcount for a class the committee
+                // had no duties in, but never silence.
+                let label = match e {
+                    Error::SpecificError(SpecificError::Timeout) => metrics::TIMEOUT,
+                    _ => metrics::OTHER_ERROR,
+                };
+                validator_metrics::inc_counter_vec(
+                    &validator_metrics::SIGNED_AGGREGATES_TOTAL,
+                    &[label],
+                );
+                validator_metrics::inc_counter_vec(
+                    &validator_metrics::SIGNED_SYNC_COMMITTEE_CONTRIBUTIONS_TOTAL,
+                    &[label],
+                );
+                metrics::inc_publish_result(metrics::CONSENSUS_ERROR);
+                return;
+            }
+        };
+
+        // A decided value can legitimately hold either class alone; each root publishes
+        // independently, and an empty drain below is a no-op. The aggregate-only publish counter
+        // keeps its committee-level `no_aggregates` outcome.
+        if outcome.aggregates.is_empty() {
+            debug!(?committee_id, %slot, "Decided worklist holds no aggregates");
+            metrics::inc_publish_result(metrics::NO_AGGREGATES);
+        }
+
+        // Beacon nodes accept a contribution only for its own slot (no lookback window, unlike
+        // aggregates' one-epoch tolerance), so a contribution quorum arriving after the slot ends
+        // is unpublishable. Bound that wait at slot end instead of POSTing a guaranteed
+        // rejection; aggregates keep the full deadline.
+        let contribution_deadline = self
+            .get_instant_in_slot(slot, self.spec.get_slot_duration())
+            .unwrap_or(deadline);
+
+        // Each root of either class publishes independently under its class's deadline, so a
+        // root that never reaches quorum withholds only itself and never delays a sibling's
+        // POST, in its own class or the other.
+        let mut roots: FuturesUnordered<_> = outcome
+            .aggregates
+            .values()
+            .map(|root| {
+                Either::Left(publish_one_root(
+                    slot,
+                    outcome.fork_name,
+                    deadline,
+                    root,
+                    publish_aggregate,
+                ))
+            })
+            .chain(outcome.contributions.values().map(|root| {
+                Either::Right(publish_one_contribution(
+                    slot,
+                    contribution_deadline,
+                    root,
+                    publish_contribution,
+                ))
+            }))
+            .collect();
+        while roots.next().await.is_some() {}
+    }
+
+    /// Resolve each committee's decided roots and hand each signed aggregate or contribution to
+    /// its publish operation the moment its threshold signature reconstructs, one publish call
+    /// per root. This is go-ssv's publication shape at the reference pin: a bad root cannot fail
+    /// a sibling's POST, and a no-quorum root cannot delay its committee's other roots.
+    ///
+    /// This is the authoritative Boole+ publication driver for both classes, spawned per slot by
+    /// the metadata service with the executions its assignment update newly registered. Generic
+    /// over the publish operations so tests (in `testing/aggregator_post_consensus.rs`) can
+    /// inject recorders instead of an HTTP client. Each committee runs as one `FuturesUnordered`
+    /// entry and each of its roots as another inside it, so committees and roots are all mutually
+    /// independent.
+    ///
+    /// Owns every `AGGREGATOR_COMMITTEE_PUBLISH_TOTAL` increment, together with
+    /// [`publish_one_root`]: `consensus_error` and `no_aggregates` count committees (those
+    /// failures occur before per-root work exists), while `success`, `http_error`, and
+    /// `no_signatures` count individual aggregates. Contribution outcomes are tracked by
+    /// `SIGNED_SYNC_COMMITTEE_CONTRIBUTIONS_TOTAL` and per-publish logs instead (see
+    /// [`publish_one_contribution`]).
+    ///
+    /// The fork handed to `publish_aggregate` is the one the decided value's payloads were
+    /// decoded under, so the closure's endpoint choice always matches the payload variant. The
+    /// contribution endpoint is fork-independent at the pin, so `publish_contribution` takes
+    /// none.
+    pub(crate) async fn publish_decided_aggregates<FA, FutA, FC, FutC>(
+        &self,
+        slot: Slot,
+        executions: Vec<(CommitteeId, AggregatorPostConsensusShared<E>)>,
+        publish_aggregate: FA,
+        publish_contribution: FC,
+    ) where
+        FA: Fn(ForkName, SignedAggregateAndProof<E>) -> FutA,
+        FutA: Future<Output = Result<(), String>>,
+        FC: Fn(SignedContributionAndProof<E>) -> FutC,
+        FutC: Future<Output = Result<(), String>>,
+    {
+        let publish_aggregate = &publish_aggregate;
+        let publish_contribution = &publish_contribution;
+        let mut pending: FuturesUnordered<_> = executions
+            .into_iter()
+            .map(|(committee_id, execution)| {
+                self.publish_committee_aggregates(
+                    committee_id,
+                    slot,
+                    execution,
+                    publish_aggregate,
+                    publish_contribution,
+                )
+            })
+            .collect();
+
+        while pending.next().await.is_some() {}
+    }
+
+    /// Spawn `fut` detached and hand out a `Shared` view of its result.
+    fn spawn_shared<R: Clone + Send + Sync + 'static>(
+        &self,
+        task_name: &'static str,
+        fut: impl Future<Output = Result<R, Arc<Error>>> + Send + 'static,
+    ) -> SharedResult<R> {
+        let handle = self.task_executor.spawn_handle(fut, task_name);
+        async move { join_detached_task(handle).await.and_then(|result| result) }
+            .boxed()
+            .shared()
+    }
+
+    /// Decide the committee's value, then submit every root this operator can sign from it.
+    ///
+    /// Which Lighthouse callbacks happen to fire has no influence on what is signed, only on what
+    /// is returned to Lighthouse.
+    async fn run_aggregator_post_consensus(
+        self: Arc<Self>,
+        committee_id: CommitteeId,
+        slot: Slot,
+        our_consensus_data: Arc<AggregatorCommitteeConsensusData<E>>,
+    ) -> Result<Arc<AggregatorPostConsensusOutcome<E>>, Arc<Error>> {
+        let Some(cluster) = self.committee_cluster(&committee_id) else {
+            warn!(
+                ?committee_id,
+                %slot,
+                "No active cluster for committee, skipping aggregator post-consensus"
+            );
+            return Ok(Arc::new(AggregatorPostConsensusOutcome {
+                fork_name: ForkName::from(our_consensus_data.version),
+                aggregates: HashMap::new(),
+                contributions: HashMap::new(),
+            }));
+        };
+        let cluster = Arc::new(cluster);
+
+        let decided_data = self
+            .run_aggregator_committee_consensus(committee_id, slot, &cluster, &our_consensus_data)
+            .await
+            .map_err(Arc::new)?;
+
+        let worklist = self.build_decided_worklist(&decided_data, &committee_id, slot);
+
+        // The batch size is the number of partials this operator actually submits. Peers do not
+        // validate completeness for `AggregatorCommittee` (committee views may differ), and a count
+        // local filtering cannot reach stalls the batch forever.
+        let batch_size = worklist.aggregates.len() + worklist.contributions.len();
+        if batch_size == 0 {
+            debug!(
+                ?committee_id,
+                %slot,
+                "No locally signable entries in decided aggregator committee data"
+            );
+        }
+        let collection_mode = CollectionMode::Committee {
+            validator_partial_signature_batch_size: batch_size,
+            base_hash: decided_data.hash(),
+        };
+
+        Ok(Arc::new(AggregatorPostConsensusOutcome {
+            fork_name: ForkName::from(decided_data.version),
+            aggregates: self.prepare_roots(worklist.aggregates, &collection_mode, &cluster, slot),
+            contributions: self.prepare_roots(
+                worklist.contributions,
+                &collection_mode,
+                &cluster,
+                slot,
+            ),
+        }))
+    }
+
+    /// Any active cluster in the committee.
+    ///
+    /// `Cluster::committee_id` is derived from `cluster_members`, so every cluster sharing a
+    /// committee has the same operator set and the same `f`, which is all consensus and the
+    /// signature threshold need. Per-validator liquidation is still filtered in the worklist.
+    fn committee_cluster(&self, committee_id: &CommitteeId) -> Option<Cluster> {
+        let state = self.database.state();
+        state
+            .metadata()
+            .get_all_by(committee_id)
+            .find_map(|validator| {
+                let cluster = state.clusters().get_by(&validator.cluster_id)?;
+                (!cluster.liquidated).then(|| cluster.clone())
+            })
+    }
+
+    /// Spawn one detached signing task per worklist entry.
+    fn prepare_roots<K: std::hash::Hash + Eq, M>(
+        self: &Arc<Self>,
+        requests: HashMap<K, SigningRequest<M>>,
+        collection_mode: &CollectionMode,
+        cluster: &Arc<Cluster>,
+        slot: Slot,
+    ) -> HashMap<K, PreparedRoot<M>> {
+        requests
+            .into_iter()
+            .map(|(key, request)| {
+                let signature = self.spawn_root_collection(
+                    collection_mode.clone(),
+                    request.validator.clone(),
+                    Arc::clone(cluster),
+                    request.signing_root,
+                    slot,
+                );
+                (key, PreparedRoot { request, signature })
+            })
+            .collect()
+    }
+
+    /// Spawn one root's signature collection as its own detached task.
+    ///
+    /// The task hands the partial to the committee batch even if no callback ever awaits the
+    /// returned handle, so an absent or dropped Lighthouse callback cannot strand the batch below
+    /// its expected size.
+    fn spawn_root_collection(
+        self: &Arc<Self>,
+        collection_mode: CollectionMode,
+        validator: ValidatorMetadata,
+        cluster: Arc<Cluster>,
+        signing_root: Hash256,
+        slot: Slot,
+    ) -> SharedResult<Signature> {
+        let store = Arc::clone(self);
+        self.spawn_shared("aggregator_post_consensus_root", async move {
+            let result = store
+                .collect_signature(
+                    PartialSignatureKind::PostConsensus,
+                    Role::AggregatorCommittee,
+                    collection_mode,
+                    &validator,
+                    &cluster,
+                    signing_root,
+                    slot,
+                )
+                .await;
+            if let Err(e) = &result {
+                // Callbacks only see failures for roots they requested; log here so a failed
+                // unrequested root (which leaves the committee batch under-filled and unsent) is
+                // still visible to operators.
+                error!(
+                    ?signing_root,
+                    pubkey = ?validator.public_key,
+                    error = ?e,
+                    "Post-consensus root signing failed; the committee batch for this duty \
+                     may not be sent"
+                );
+            }
+            result.map_err(Arc::new)
+        })
+    }
+
+    /// Build the signing worklist from a decided value.
+    ///
+    /// Resolves metadata, cluster status and share availability for every decided entry under one
+    /// database snapshot, then keys the result by signing identity: validator index for aggregates,
+    /// `(validator, subcommittee)` for contributions. Keying by identity collapses repeated decided
+    /// entries (a root submitted twice would double-count the batch) and holds every validator
+    /// inside the receivers' five-roots-per-validator cap; a decided value carrying conflicting
+    /// roots for one identity signs the first and logs the rest.
+    fn build_decided_worklist(
+        &self,
+        decided_data: &AggregatorCommitteeConsensusData<E>,
+        committee_id: &CommitteeId,
+        slot: Slot,
+    ) -> DecidedWorklist<E> {
+        let decided_indices: HashSet<ValidatorIndex> = decided_data
+            .aggregators
+            .iter()
+            .chain(decided_data.contributors.iter())
+            .map(|entry| entry.validator_index)
+            .collect();
+
+        // One snapshot for metadata, liquidation and share rows, so entries cannot mix database
+        // states. Released before any signing.
+        let locals: HashMap<ValidatorIndex, ValidatorMetadata> = {
+            let state = self.database.state();
+            state
+                .metadata()
+                .get_all_by(committee_id)
+                .filter_map(|validator| {
+                    let index = validator.index.filter(|i| decided_indices.contains(i))?;
+                    let cluster = state.clusters().get_by(&validator.cluster_id)?;
+                    if cluster.liquidated {
+                        return None;
+                    }
+                    // Without a share row this operator cannot sign for the validator, and counting
+                    // it would leave the committee batch permanently short.
+                    state.shares().get_by(&validator.public_key)?;
+                    Some((index, validator.clone()))
+                })
+                .collect()
+        };
+
+        let epoch = slot.epoch(E::slots_per_epoch());
+        let aggregate_domain = self.get_domain(epoch, Domain::AggregateAndProof);
+        let contribution_domain = self.get_domain(epoch, Domain::ContributionAndProof);
+
+        let mut aggregates = HashMap::new();
+        for decided_aggregator in decided_data.aggregators.iter() {
+            let Some(validator) = locals.get(&decided_aggregator.validator_index) else {
+                continue;
+            };
+            let request = match Self::resolve_decided_aggregate(
+                decided_data,
+                decided_aggregator,
+                validator,
+                slot,
+                aggregate_domain,
+            ) {
+                Ok(request) => request,
+                Err(e) => {
+                    debug!(
+                        validator_index = ?decided_aggregator.validator_index,
+                        error = e,
+                        "Skipping decided aggregate"
+                    );
+                    continue;
+                }
+            };
+            match aggregates.entry(decided_aggregator.validator_index) {
+                Entry::Vacant(vacant) => {
+                    vacant.insert(request);
+                }
+                Entry::Occupied(kept) if kept.get().signing_root != request.signing_root => warn!(
+                    validator_index = ?decided_aggregator.validator_index,
+                    "Decided value contains conflicting aggregate roots for one validator, \
+                     signing the first"
+                ),
+                Entry::Occupied(_) => {}
+            }
+        }
+
+        let mut contributions = HashMap::new();
+        for decided_contributor in decided_data.contributors.iter() {
+            let Some(validator) = locals.get(&decided_contributor.validator_index) else {
+                continue;
+            };
+            let request = match Self::resolve_decided_contribution(
+                decided_data,
+                decided_contributor,
+                validator,
+                slot,
+                contribution_domain,
+            ) {
+                Ok(request) => request,
+                Err(e) => {
+                    debug!(
+                        validator_index = ?decided_contributor.validator_index,
+                        subcommittee_index = decided_contributor.committee_index,
+                        error = e,
+                        "Skipping decided contribution"
+                    );
+                    continue;
+                }
+            };
+            match contributions.entry((
+                decided_contributor.validator_index,
+                decided_contributor.committee_index,
+            )) {
+                Entry::Vacant(vacant) => {
+                    vacant.insert(request);
+                }
+                Entry::Occupied(kept) if kept.get().signing_root != request.signing_root => warn!(
+                    validator_index = ?decided_contributor.validator_index,
+                    subcommittee_index = decided_contributor.committee_index,
+                    "Decided value contains conflicting contribution roots for one identity, \
+                     signing the first"
+                ),
+                Entry::Occupied(_) => {}
+            }
+        }
+
+        DecidedWorklist {
+            aggregates,
+            contributions,
+        }
+    }
+
+    /// Resolve one decided aggregator entry into a signable `AggregateAndProof`.
+    ///
+    /// Finds the matching committee index, decodes the aggregate attestation from SSZ, and binds
+    /// the decoded slot to the duty slot. The signing domain comes from the duty slot's epoch,
+    /// matching the beacon spec (domain at the epoch of `aggregate.data.slot`) and go-ssv's
+    /// expected roots.
+    fn resolve_decided_aggregate(
+        decided_data: &AggregatorCommitteeConsensusData<E>,
+        decided_aggregator: &AssignedAggregator,
+        validator: &ValidatorMetadata,
+        slot: Slot,
+        domain_hash: Hash256,
+    ) -> Result<SigningRequest<AggregateAndProof<E>>, String> {
+        let aggregator_index = decided_aggregator.validator_index.0 as u64;
+
+        let committee_index = decided_aggregator.committee_index;
+
+        // Find the position of this committee index in decided data
+        let decided_aggregate_idx = decided_data
+            .aggregator_committee_indexes
+            .iter()
+            .position(|&idx| idx == committee_index)
+            .ok_or("Committee index not found in decided data")?;
+
+        let decided_aggregate_bytes = decided_data
+            .aggregated_attestations
+            .get(decided_aggregate_idx)
+            .ok_or("Aggregate attestation bytes not found in decided data")?;
+
+        // Decode with the shape the decided version selects (Gloas merkleizes progressively,
+        // so the shape drives the signing root computed below).
+        let decided_aggregate: Attestation<E> = decided_data
+            .version
+            .decode_attestation(decided_aggregate_bytes)
+            .map_err(|e| format!("Failed to decode decided aggregate: {e}"))?;
+
+        let aggregate_slot = decided_aggregate.data().slot;
+        if aggregate_slot != slot {
+            return Err(format!(
+                "Decided aggregate slot {aggregate_slot} does not match duty slot {slot}"
+            ));
+        }
+
+        let decided_selection_proof =
+            SelectionProof::from(decided_aggregator.selection_proof.clone());
+
+        let message = AggregateAndProof::from_attestation(
+            aggregator_index,
+            decided_aggregate,
+            decided_selection_proof,
+        );
+
+        Ok(SigningRequest {
+            validator: validator.clone(),
+            signing_root: message.signing_root(domain_hash),
+            duty_data: message,
+        })
+    }
+
+    /// Resolve one decided contributor entry into a signable `ContributionAndProof`.
+    fn resolve_decided_contribution(
+        decided_data: &AggregatorCommitteeConsensusData<E>,
+        decided_contributor: &AssignedAggregator,
+        validator: &ValidatorMetadata,
+        slot: Slot,
+        domain_hash: Hash256,
+    ) -> Result<SigningRequest<ContributionAndProof<E>>, String> {
+        let subcommittee_index = decided_contributor.committee_index;
+
+        // Find the contribution for this subcommittee
+        let decided_contribution = decided_data
+            .sync_committee_contributions
+            .iter()
+            .find(|c| c.subcommittee_index == subcommittee_index)
+            .ok_or(
+                "Contribution not in consensus data - likely filtered due to beacon API failure",
+            )?;
+        if decided_contribution.slot != slot {
+            return Err(format!(
+                "Decided contribution slot {} does not match duty slot {slot}",
+                decided_contribution.slot
+            ));
+        }
+
+        let message = ContributionAndProof {
+            aggregator_index: decided_contributor.validator_index.0 as u64,
+            contribution: decided_contribution.clone(),
+            selection_proof: decided_contributor.selection_proof.clone(),
+        };
+
+        Ok(SigningRequest {
+            validator: validator.clone(),
+            signing_root: message.signing_root(domain_hash),
+            duty_data: message,
+        })
+    }
+}

--- a/anchor/validator_store/src/aggregator_post_consensus.rs
+++ b/anchor/validator_store/src/aggregator_post_consensus.rs
@@ -3,31 +3,30 @@
 //! One QBFT decision carries both attestation aggregates and sync contributions for an SSV
 //! committee, and the operator must emit exactly one committee partial-signature message per
 //! `(committee, slot)` covering everything it can sign. The decided value drives both what gets
-//! signed and what gets published: Anchor owns Boole+ aggregate publication outright, through
-//! the metadata service's publisher, because the protocol's unit of agreement is the decided
-//! value and no local Lighthouse view is part of it. (Lighthouse's duty snapshot in particular
-//! is cloned before slot-start selection proofs finish, so routing publication through it would
-//! silently skip late-installed proofs.) Contributions are returned through a Lighthouse
-//! callback that may or may not fire (issue #1227), so no callback can own the committee
-//! message either.
+//! signed and what gets published: Anchor owns Boole+ publication of both classes outright,
+//! through the metadata service's publisher, because the protocol's unit of agreement is the
+//! decided value and no local Lighthouse view is part of it. Lighthouse's duty snapshots are
+//! cloned before slot-start selection proofs finish (both classes share one slot-start
+//! partial-signature batch), so routing publication through either callback would silently skip
+//! late-installed proofs, and a callback may not fire at all (issue #1227).
 //!
 //! The signing set is therefore a property of the duty, not of any consumer. The slot pipeline
-//! starts one execution per committee when it publishes the decided value at 2/3 slot; the
-//! contributions callback and the aggregate publisher only look up their own results. This is
-//! the ssv-spec-normative shape, where the decided value drives what gets signed and local state
-//! only filters.
+//! starts one execution per committee when it publishes the decided value at 2/3 slot, and the
+//! publisher drains that execution's roots of both classes itself; the Lighthouse callbacks
+//! return empty batches. This is the ssv-spec-normative shape, where the decided value drives
+//! what gets signed and published, matching go-ssv's runner-owned post-consensus submission.
 
 use std::{
     collections::{HashMap, HashSet, hash_map::Entry},
     future::Future,
-    sync::Arc,
+    sync::{Arc, LazyLock},
 };
 
 use bls::Signature;
 use database::{NonUniqueIndex, UniqueIndex};
 use futures::{
     FutureExt, StreamExt,
-    future::{BoxFuture, Shared},
+    future::{BoxFuture, Either, Shared},
     stream::FuturesUnordered,
 };
 use qbft_manager::ConsensusDecider;
@@ -43,19 +42,21 @@ use tokio::time::Instant;
 use tracing::{Instrument, debug, error, info, info_span, warn};
 use types::{
     AggregateAndProof, Attestation, AttestationBase, AttestationElectra, ContributionAndProof,
-    Domain, EthSpec, ForkName, Hash256, SelectionProof, SignedAggregateAndProof, SignedRoot, Slot,
+    Domain, EthSpec, ForkName, Hash256, SelectionProof, SignedAggregateAndProof,
+    SignedContributionAndProof, SignedRoot, Slot,
 };
+use validator_metrics::IntCounterVec;
 
 use crate::{
     AggregationAssignments, AnchorValidatorStore, CollectionMode, Error, SigningRequest,
     SpecificError, metrics,
 };
 
-/// Epochs to retain finished `AggregatorCommittee` post-consensus executions.
+/// Epochs to retain started `AggregatorCommittee` post-consensus keys.
 ///
-/// Matches the message validator's per-signer duplicate-detection window, so a very late Lighthouse
-/// callback finds the execution it belongs to rather than nothing. Each entry is one small future
-/// per committee-slot.
+/// Matches the message validator's per-signer duplicate-detection window, so a repeated
+/// `(committee, slot)` inside the window finds its registered key rather than starting a second
+/// execution. Each entry is one key, not a handle; the executions live in their detached tasks.
 const AGGREGATOR_POST_CONSENSUS_RETAIN_EPOCHS: u64 = 2;
 
 /// A result shared between the detached task producing it and any number of joiners.
@@ -74,8 +75,8 @@ pub(crate) struct PreparedRoot<M> {
 }
 
 /// Everything this operator signs for one decided `AggregatorCommittee` round, keyed by signing
-/// identity: validator index for aggregates (read by the aggregate publisher),
-/// `(validator index, subcommittee index)` for contributions (read by the Lighthouse callback).
+/// identity: validator index for aggregates, `(validator index, subcommittee index)` for
+/// contributions. Both classes are read by the metadata service's publisher.
 pub(crate) struct AggregatorPostConsensusOutcome<E: EthSpec> {
     /// Fork the decided value's SSZ payloads were decoded under (its `DataVersion`). The
     /// publisher derives its HTTP endpoint choice and fork header from this, so they cannot
@@ -107,6 +108,47 @@ async fn join_detached_task<R>(
     .ok_or_else(post_consensus_aborted)
 }
 
+/// Await one decided root's threshold signature under the deadline, of either class.
+///
+/// Returns `None` after logging the skip and counting the failure on `signed_total` (the
+/// class's Lighthouse-era signing counter): `other_error` when collection failed, `timeout` when
+/// the deadline expired before quorum (matching the committee-level join arm, now that expiry is
+/// distinguishable from a collection failure). `collect_signature` failures are also logged by
+/// the detached signing task, but a task that died without a result (spawn refused, executor
+/// exit, panic) is only visible here, so the collection-failure arm carries the error into its
+/// warn.
+async fn await_root_signature<M>(
+    slot: Slot,
+    deadline: Instant,
+    root: &PreparedRoot<M>,
+    signed_total: &LazyLock<validator_metrics::Result<IntCounterVec>>,
+    skip_message: &'static str,
+) -> Option<Signature> {
+    let label = match tokio::time::timeout_at(deadline, root.signature.clone()).await {
+        Ok(Ok(signature)) => return Some(signature),
+        Ok(Err(e)) => {
+            warn!(
+                pubkey = ?root.request.validator.public_key,
+                %slot,
+                error = ?e,
+                "{skip_message}"
+            );
+            metrics::OTHER_ERROR
+        }
+        // Deadline expired before this root's quorum; only this root is withheld.
+        Err(_) => {
+            warn!(
+                pubkey = ?root.request.validator.public_key,
+                %slot,
+                "{skip_message}"
+            );
+            metrics::TIMEOUT
+        }
+    };
+    validator_metrics::inc_counter_vec(signed_total, &[label]);
+    None
+}
+
 /// Await one decided root's threshold signature under the deadline and publish it on quorum,
 /// one publish call per aggregate.
 ///
@@ -122,41 +164,19 @@ async fn publish_one_root<E: EthSpec, F, Fut>(
     F: Fn(ForkName, SignedAggregateAndProof<E>) -> Fut,
     Fut: Future<Output = Result<(), String>>,
 {
-    let signature = match tokio::time::timeout_at(deadline, root.signature.clone()).await {
-        Ok(Ok(signature)) => signature,
-        // `collect_signature` failures are also logged by the detached signing task, but a task
-        // that died without a result (spawn refused, executor exit, panic) is only visible here,
-        // so carry the error into the warn.
-        Ok(Err(e)) => {
-            warn!(
-                pubkey = ?root.request.validator.public_key,
-                %slot,
-                error = ?e,
-                "Missing signature, skipping aggregate"
-            );
-            validator_metrics::inc_counter_vec(
-                &validator_metrics::SIGNED_AGGREGATES_TOTAL,
-                &[metrics::OTHER_ERROR],
-            );
-            metrics::inc_publish_result(metrics::NO_SIGNATURES);
-            return;
-        }
-        // Deadline expired before this root's quorum; only this root is withheld. Labelled
-        // `timeout` to match the committee-level join arm, now that expiry is distinguishable
-        // from a collection failure.
-        Err(_) => {
-            warn!(
-                pubkey = ?root.request.validator.public_key,
-                %slot,
-                "Missing signature, skipping aggregate"
-            );
-            validator_metrics::inc_counter_vec(
-                &validator_metrics::SIGNED_AGGREGATES_TOTAL,
-                &[metrics::TIMEOUT],
-            );
-            metrics::inc_publish_result(metrics::NO_SIGNATURES);
-            return;
-        }
+    let Some(signature) = await_root_signature(
+        slot,
+        deadline,
+        root,
+        &validator_metrics::SIGNED_AGGREGATES_TOTAL,
+        "Missing signature, skipping aggregate",
+    )
+    .await
+    else {
+        // The publish-outcome counter is aggregate-only; contributions are tracked by their
+        // signing counter and publish logs alone.
+        metrics::inc_publish_result(metrics::NO_SIGNATURES);
+        return;
     };
 
     let message = root.request.duty_data.clone();
@@ -208,26 +228,100 @@ async fn publish_one_root<E: EthSpec, F, Fut>(
     }
 }
 
+/// Await one decided contribution's threshold signature under the deadline and publish it on
+/// quorum, one publish call per contribution.
+///
+/// Signing outcomes keep the Lighthouse-era `SIGNED_SYNC_COMMITTEE_CONTRIBUTIONS_TOTAL`
+/// accounting that used to live in the contribution callback, and the publish arms reproduce the
+/// per-publish logs Lighthouse emits on its pre-Boole path, so operator pipelines keyed on
+/// either keep working. `AGGREGATOR_COMMITTEE_PUBLISH_TOTAL` stays aggregate-only.
+async fn publish_one_contribution<E: EthSpec, F, Fut>(
+    slot: Slot,
+    deadline: Instant,
+    root: &PreparedRoot<ContributionAndProof<E>>,
+    publish: &F,
+) where
+    F: Fn(SignedContributionAndProof<E>) -> Fut,
+    Fut: Future<Output = Result<(), String>>,
+{
+    let Some(signature) = await_root_signature(
+        slot,
+        deadline,
+        root,
+        &validator_metrics::SIGNED_SYNC_COMMITTEE_CONTRIBUTIONS_TOTAL,
+        "Missing signature, skipping sync committee contribution",
+    )
+    .await
+    else {
+        return;
+    };
+
+    let message = root.request.duty_data.clone();
+    debug!(
+        aggregator_index = message.aggregator_index,
+        slot = %message.contribution.slot,
+        block_root = ?message.contribution.beacon_block_root,
+        subcommittee_index = message.contribution.subcommittee_index,
+        num_set_aggregation_bits = message.contribution.aggregation_bits.num_set_bits(),
+        "Signed ContributionAndProof (Boole+ committee consensus)"
+    );
+    validator_metrics::inc_counter_vec(
+        &validator_metrics::SIGNED_SYNC_COMMITTEE_CONTRIBUTIONS_TOTAL,
+        &[validator_metrics::SUCCESS],
+    );
+
+    let aggregator_index = message.aggregator_index;
+    let subnet = message.contribution.subcommittee_index;
+    let beacon_block_root = message.contribution.beacon_block_root;
+    let num_signers = message.contribution.aggregation_bits.num_set_bits();
+    let signed = SignedContributionAndProof { message, signature };
+
+    let result = publish(signed)
+        .instrument(info_span!("publish_contribution", aggregator_index))
+        .await;
+    match result {
+        Ok(()) => {
+            info!(
+                aggregator_index,
+                subnet,
+                beacon_block_root = ?beacon_block_root,
+                num_signers,
+                slot = slot.as_u64(),
+                "Successfully published sync contributions"
+            );
+        }
+        Err(e) => {
+            error!(
+                error = %e,
+                aggregator_index,
+                subnet,
+                slot = slot.as_u64(),
+                "Unable to publish signed contributions and proofs"
+            );
+        }
+    }
+}
+
 impl<T: SlotClock + 'static, E: EthSpec, C: ConsensusDecider<E> + 'static>
     AnchorValidatorStore<T, E, C>
 {
     /// Start one post-consensus execution per committee in freshly built assignments, returning
     /// the executions newly registered by this call.
     ///
-    /// This is the only place executions are created. Callbacks look results up and never start
-    /// work, so exactly one committee message per `(committee, slot)` holds by construction rather
-    /// than by locking. Called from `update_aggregation_assignments` before the watch channel is
-    /// published, so any consumer that can observe the assignments can also observe the execution.
+    /// This is the only place executions are created, so exactly one committee message per
+    /// `(committee, slot)` holds by construction rather than by locking. Called from
+    /// `update_aggregation_assignments` before the watch channel is published.
     ///
-    /// The returned handles feed the metadata service's aggregate publisher. Returning only the
-    /// vacant insertions gives the publisher the same exactly-once property as the executions
-    /// themselves: a repeated call for one `(committee, slot)` registers nothing and therefore
-    /// publishes nothing twice. Both properties are scoped to the process lifetime and to the
-    /// retention window below: after an entry is pruned, only a slot clock stepping backwards
+    /// The returned handles feed the metadata service's publisher, which is their sole consumer.
+    /// Returning only first-insertions gives the publisher the same exactly-once property as the
+    /// executions themselves: a repeated call for one `(committee, slot)` registers nothing and
+    /// therefore publishes nothing twice. Both properties are scoped to the process lifetime and
+    /// to the retention window below: after a key is pruned, only a slot clock stepping backwards
     /// past the window could present its `(committee, slot)` again, and that would re-register.
     ///
     /// Pre-Boole there is no consensus data and this is a no-op returning no executions.
-    #[must_use = "dropping the returned executions disables Boole+ aggregate publication"]
+    #[must_use = "dropping the returned executions disables Boole+ aggregate and contribution \
+                  publication"]
     pub(crate) fn start_aggregator_post_consensus(
         self: &Arc<Self>,
         assignments: &AggregationAssignments<E>,
@@ -237,17 +331,18 @@ impl<T: SlotClock + 'static, E: EthSpec, C: ConsensusDecider<E> + 'static>
 
         let cutoff =
             slot.saturating_sub(AGGREGATOR_POST_CONSENSUS_RETAIN_EPOCHS * E::slots_per_epoch());
-        executions.retain(|(_, execution_slot), _| *execution_slot >= cutoff);
+        executions.retain(|&(_, execution_slot)| execution_slot >= cutoff);
 
         let mut new_executions = Vec::new();
         for (&committee_id, decided_data) in &assignments.consensus_data_by_ssv_committee {
-            // Vacant-only, so registration is idempotent. Overwriting would spawn a second QBFT
-            // round and a second set of detached signing tasks while the first set kept running,
-            // putting two committee messages on the wire for one slot, which peers reject with a
-            // gossip penalty. The slot pipeline publishes once per slot today, but that is a
-            // property of another module's timing loop; keeping this vacant-only makes
-            // exactly-once hold here regardless of how often it is called.
-            if let Entry::Vacant(vacant) = executions.entry((committee_id, slot)) {
+            // First-insert-only, so registration is idempotent. A second execution for one key
+            // would spawn a second QBFT round and a second set of detached signing tasks while
+            // the first set kept running, putting two committee messages on the wire for one
+            // slot, which peers reject with a gossip penalty. The slot pipeline publishes once
+            // per slot today, but that is a property of another module's timing loop; keeping
+            // this first-insert-only makes exactly-once hold here regardless of how often it is
+            // called.
+            if executions.insert((committee_id, slot)) {
                 let store = Arc::clone(self);
                 let decided_data = Arc::clone(decided_data);
                 let execution = self.spawn_shared("aggregator_post_consensus", async move {
@@ -255,7 +350,6 @@ impl<T: SlotClock + 'static, E: EthSpec, C: ConsensusDecider<E> + 'static>
                         .run_aggregator_post_consensus(committee_id, slot, decided_data)
                         .await
                 });
-                vacant.insert(execution.clone());
                 new_executions.push((committee_id, execution));
             }
         }
@@ -283,27 +377,30 @@ impl<T: SlotClock + 'static, E: EthSpec, C: ConsensusDecider<E> + 'static>
         Ok((deadline, outcome))
     }
 
-    /// Join one committee's post-consensus execution and publish each decided aggregate this
-    /// operator signed as soon as its threshold signature reconstructs.
+    /// Join one committee's post-consensus execution and publish each decided root this operator
+    /// signed, of both classes, as soon as its threshold signature reconstructs.
     ///
-    /// This backs [`Self::publish_decided_aggregates`], which owns Boole+ aggregate publication:
-    /// Lighthouse's aggregate callback returns an empty batch at Boole+, because its duty
-    /// snapshot is cloned before slot-start selection proofs finish, silently skipping any proof
-    /// installed after the clone. The publisher works from the decided value instead, so
-    /// publication does not depend on Lighthouse's snapshot timing.
+    /// This backs [`Self::publish_decided_aggregates`], which owns Boole+ publication of
+    /// aggregates and sync contributions: Lighthouse's callbacks return empty batches at Boole+,
+    /// because their duty snapshots are cloned before slot-start selection proofs finish,
+    /// silently skipping any proof installed after the clone. The publisher works from the
+    /// decided value instead, so publication does not depend on Lighthouse's snapshot timing.
     ///
     /// Takes the execution handle directly rather than re-entering the assignments watch channel,
     /// so a late-polled publisher cannot observe `AggregatorInfoSlotPassed` for an execution that
     /// still exists in the retention map.
-    async fn publish_committee_aggregates<F, Fut>(
+    async fn publish_committee_aggregates<FA, FutA, FC, FutC>(
         &self,
         committee_id: CommitteeId,
         slot: Slot,
         execution: AggregatorPostConsensusShared<E>,
-        publish: &F,
+        publish_aggregate: &FA,
+        publish_contribution: &FC,
     ) where
-        F: Fn(ForkName, SignedAggregateAndProof<E>) -> Fut,
-        Fut: Future<Output = Result<(), String>>,
+        FA: Fn(ForkName, SignedAggregateAndProof<E>) -> FutA,
+        FutA: Future<Output = Result<(), String>>,
+        FC: Fn(SignedContributionAndProof<E>) -> FutC,
+        FutC: Future<Output = Result<(), String>>,
     {
         let (deadline, outcome) = match self.join_execution(slot, execution).await {
             Ok(joined) => joined,
@@ -312,11 +409,13 @@ impl<T: SlotClock + 'static, E: EthSpec, C: ConsensusDecider<E> + 'static>
                     ?committee_id,
                     %slot,
                     error = ?e,
-                    "Aggregator post-consensus failed, no aggregates to publish"
+                    "Aggregator post-consensus failed, nothing to publish"
                 );
-                // Keeps the Lighthouse-era signing counter alive for dashboards keyed on it. The
-                // per-aggregate count is unknowable before the outcome resolves, so failures
-                // count once per committee, an undercount but not silence.
+                // Keeps the Lighthouse-era signing counters alive for dashboards keyed on them.
+                // The per-root counts and class composition are unknowable before the outcome
+                // resolves, so failures count once per committee on both class counters: an
+                // undercount against multiple lost roots, an overcount for a class the committee
+                // had no duties in, but never silence.
                 let label = match e {
                     Error::SpecificError(SpecificError::Timeout) => metrics::TIMEOUT,
                     _ => metrics::OTHER_ERROR,
@@ -325,86 +424,109 @@ impl<T: SlotClock + 'static, E: EthSpec, C: ConsensusDecider<E> + 'static>
                     &validator_metrics::SIGNED_AGGREGATES_TOTAL,
                     &[label],
                 );
+                validator_metrics::inc_counter_vec(
+                    &validator_metrics::SIGNED_SYNC_COMMITTEE_CONTRIBUTIONS_TOTAL,
+                    &[label],
+                );
                 metrics::inc_publish_result(metrics::CONSENSUS_ERROR);
                 return;
             }
         };
 
-        // A decided value can legitimately hold contributions only; nothing to publish then.
+        // A decided value can legitimately hold either class alone; each root publishes
+        // independently, and an empty drain below is a no-op. The aggregate-only publish counter
+        // keeps its committee-level `no_aggregates` outcome.
         if outcome.aggregates.is_empty() {
             debug!(?committee_id, %slot, "Decided worklist holds no aggregates");
             metrics::inc_publish_result(metrics::NO_AGGREGATES);
-            return;
         }
 
-        // Each root publishes independently under the shared deadline, so a root that never
-        // reaches quorum withholds only itself and never delays a sibling's POST.
+        // Beacon nodes accept a contribution only for its own slot (no lookback window, unlike
+        // aggregates' one-epoch tolerance), so a contribution quorum arriving after the slot ends
+        // is unpublishable. Bound that wait at slot end instead of POSTing a guaranteed
+        // rejection; aggregates keep the full deadline.
+        let contribution_deadline = self
+            .get_instant_in_slot(slot, self.spec.get_slot_duration())
+            .unwrap_or(deadline);
+
+        // Each root of either class publishes independently under its class's deadline, so a
+        // root that never reaches quorum withholds only itself and never delays a sibling's
+        // POST, in its own class or the other.
         let mut roots: FuturesUnordered<_> = outcome
             .aggregates
             .values()
-            .map(|root| publish_one_root(slot, outcome.fork_name, deadline, root, publish))
+            .map(|root| {
+                Either::Left(publish_one_root(
+                    slot,
+                    outcome.fork_name,
+                    deadline,
+                    root,
+                    publish_aggregate,
+                ))
+            })
+            .chain(outcome.contributions.values().map(|root| {
+                Either::Right(publish_one_contribution(
+                    slot,
+                    contribution_deadline,
+                    root,
+                    publish_contribution,
+                ))
+            }))
             .collect();
         while roots.next().await.is_some() {}
     }
 
-    /// Resolve each committee's decided aggregates and hand each signed aggregate to `publish`
-    /// the moment its threshold signature reconstructs, one publish call per aggregate. This is
-    /// go-ssv's publication shape at the reference pin: a bad aggregate cannot fail a sibling's
-    /// POST, and a no-quorum root cannot delay its committee's other aggregates.
+    /// Resolve each committee's decided roots and hand each signed aggregate or contribution to
+    /// its publish operation the moment its threshold signature reconstructs, one publish call
+    /// per root. This is go-ssv's publication shape at the reference pin: a bad root cannot fail
+    /// a sibling's POST, and a no-quorum root cannot delay its committee's other roots.
     ///
-    /// This is the authoritative Boole+ aggregate publication driver, spawned per slot by the
-    /// metadata service with the executions its assignment update newly registered. Generic over
-    /// the publish operation so tests (in `testing/aggregator_post_consensus.rs`) can inject a
-    /// recorder instead of an HTTP client. Each committee runs as one `FuturesUnordered` entry
-    /// and each of its roots as another inside it, so committees and roots are all mutually
+    /// This is the authoritative Boole+ publication driver for both classes, spawned per slot by
+    /// the metadata service with the executions its assignment update newly registered. Generic
+    /// over the publish operations so tests (in `testing/aggregator_post_consensus.rs`) can
+    /// inject recorders instead of an HTTP client. Each committee runs as one `FuturesUnordered`
+    /// entry and each of its roots as another inside it, so committees and roots are all mutually
     /// independent.
     ///
     /// Owns every `AGGREGATOR_COMMITTEE_PUBLISH_TOTAL` increment, together with
     /// [`publish_one_root`]: `consensus_error` and `no_aggregates` count committees (those
     /// failures occur before per-root work exists), while `success`, `http_error`, and
-    /// `no_signatures` count individual aggregates.
+    /// `no_signatures` count individual aggregates. Contribution outcomes are tracked by
+    /// `SIGNED_SYNC_COMMITTEE_CONTRIBUTIONS_TOTAL` and per-publish logs instead (see
+    /// [`publish_one_contribution`]).
     ///
-    /// The fork handed to `publish` is the one the decided value's payloads were decoded under,
-    /// so the closure's endpoint choice always matches the payload variant.
-    pub(crate) async fn publish_decided_aggregates<F, Fut>(
+    /// The fork handed to `publish_aggregate` is the one the decided value's payloads were
+    /// decoded under, so the closure's endpoint choice always matches the payload variant. The
+    /// contribution endpoint is fork-independent at the pin, so `publish_contribution` takes
+    /// none.
+    pub(crate) async fn publish_decided_aggregates<FA, FutA, FC, FutC>(
         &self,
         slot: Slot,
         executions: Vec<(CommitteeId, AggregatorPostConsensusShared<E>)>,
-        publish: F,
+        publish_aggregate: FA,
+        publish_contribution: FC,
     ) where
-        F: Fn(ForkName, SignedAggregateAndProof<E>) -> Fut,
-        Fut: Future<Output = Result<(), String>>,
+        FA: Fn(ForkName, SignedAggregateAndProof<E>) -> FutA,
+        FutA: Future<Output = Result<(), String>>,
+        FC: Fn(SignedContributionAndProof<E>) -> FutC,
+        FutC: Future<Output = Result<(), String>>,
     {
-        let publish = &publish;
+        let publish_aggregate = &publish_aggregate;
+        let publish_contribution = &publish_contribution;
         let mut pending: FuturesUnordered<_> = executions
             .into_iter()
             .map(|(committee_id, execution)| {
-                self.publish_committee_aggregates(committee_id, slot, execution, publish)
+                self.publish_committee_aggregates(
+                    committee_id,
+                    slot,
+                    execution,
+                    publish_aggregate,
+                    publish_contribution,
+                )
             })
             .collect();
 
         while pending.next().await.is_some() {}
-    }
-
-    /// Join the post-consensus execution for `(committee, slot)`, returning the outcome and the
-    /// deadline that bounded the join, for the caller to reuse when draining its own roots.
-    pub(crate) async fn post_consensus_outcome(
-        &self,
-        committee_id: CommitteeId,
-        slot: Slot,
-    ) -> Result<(Instant, Arc<AggregatorPostConsensusOutcome<E>>), Error> {
-        // Waiting on the assignments is what makes the lookup below race-free: the execution was
-        // registered before this slot's assignments were published.
-        self.get_aggregation_assignments(slot).await?;
-
-        let execution = self
-            .aggregator_post_consensus
-            .lock()
-            .get(&(committee_id, slot))
-            .cloned()
-            .ok_or(Error::SpecificError(SpecificError::ConsensusDataNotFound))?;
-
-        self.join_execution(slot, execution).await
     }
 
     /// Spawn `fut` detached and hand out a `Shared` view of its result.

--- a/anchor/validator_store/src/aggregator_post_consensus.rs
+++ b/anchor/validator_store/src/aggregator_post_consensus.rs
@@ -1,0 +1,549 @@
+//! Post-consensus signing for Boole+ `AggregatorCommittee` duties.
+//!
+//! One QBFT decision carries both attestation aggregates and sync contributions for an SSV
+//! committee, and the operator must emit exactly one committee partial-signature message per
+//! `(committee, slot)` covering everything it can sign. Lighthouse asks for signatures through two
+//! independent callbacks, one per object class, so neither callback can own that message: whichever
+//! one fires, the other class still has to be signed (issue #1227).
+//!
+//! The signing set is therefore a property of the duty, not of any callback. The slot pipeline
+//! starts one execution per committee when it publishes the decided value at 2/3 slot, and the
+//! callbacks only look up their own results. This is the ssv-spec-normative shape, where the
+//! decided value drives what gets signed and local state only filters.
+
+use std::{
+    collections::{HashMap, HashSet, hash_map::Entry},
+    future::Future,
+    sync::Arc,
+};
+
+use bls::Signature;
+use database::{NonUniqueIndex, UniqueIndex};
+use futures::{
+    FutureExt,
+    future::{BoxFuture, Shared},
+};
+use qbft_manager::ConsensusDecider;
+use slot_clock::SlotClock;
+use ssv_types::{
+    Cluster, CommitteeId, ValidatorIndex, ValidatorMetadata,
+    consensus::{AggregatorCommitteeConsensusData, AssignedAggregator, DataVersion, QbftData},
+    msgid::Role,
+    partial_sig::PartialSignatureKind,
+};
+use ssz::Decode;
+use tokio::time::Instant;
+use tracing::{debug, error, warn};
+use types::{
+    AggregateAndProof, Attestation, AttestationBase, AttestationElectra, ContributionAndProof,
+    Domain, EthSpec, ForkName, Hash256, SelectionProof, SignedRoot, Slot,
+};
+
+use crate::{
+    AggregationAssignments, AnchorValidatorStore, CollectionMode, Error, SigningRequest,
+    SpecificError,
+};
+
+/// Epochs to retain finished `AggregatorCommittee` post-consensus executions.
+///
+/// Matches the message validator's per-signer duplicate-detection window, so a very late Lighthouse
+/// callback finds the execution it belongs to rather than nothing. Each entry is one small future
+/// per committee-slot.
+const AGGREGATOR_POST_CONSENSUS_RETAIN_EPOCHS: u64 = 2;
+
+/// A result shared between the detached task producing it and any number of joiners.
+type SharedResult<T> = Shared<BoxFuture<'static, Result<T, Arc<Error>>>>;
+
+pub(crate) type AggregatorPostConsensusShared<E> =
+    SharedResult<Arc<AggregatorPostConsensusOutcome<E>>>;
+
+/// One decided root this operator signs, with the handle to its signature.
+///
+/// The underlying `collect_signature` call runs in its own task, so the local partial reaches the
+/// committee batch even when no callback ever awaits the signature.
+pub(crate) struct PreparedRoot<M> {
+    pub(crate) request: SigningRequest<M>,
+    pub(crate) signature: SharedResult<Signature>,
+}
+
+/// Everything this operator signs for one decided `AggregatorCommittee` round, keyed by the
+/// identities the Lighthouse callbacks look up: validator index for aggregates,
+/// `(validator index, subcommittee index)` for contributions.
+pub(crate) struct AggregatorPostConsensusOutcome<E: EthSpec> {
+    pub(crate) aggregates: HashMap<ValidatorIndex, PreparedRoot<AggregateAndProof<E>>>,
+    pub(crate) contributions: HashMap<(ValidatorIndex, u64), PreparedRoot<ContributionAndProof<E>>>,
+}
+
+/// The signing worklist derived from one decided `AggregatorCommitteeConsensusData`.
+struct DecidedWorklist<E: EthSpec> {
+    aggregates: HashMap<ValidatorIndex, SigningRequest<AggregateAndProof<E>>>,
+    contributions: HashMap<(ValidatorIndex, u64), SigningRequest<ContributionAndProof<E>>>,
+}
+
+fn post_consensus_aborted() -> Arc<Error> {
+    Arc::new(Error::SpecificError(SpecificError::PostConsensusAborted))
+}
+
+/// Await a detached task spawned with `TaskExecutor::spawn_handle`, mapping every way it can die
+/// without a result (spawn refused, executor exit, panic) onto `PostConsensusAborted`.
+async fn join_detached_task<R>(
+    handle: Option<tokio::task::JoinHandle<Option<R>>>,
+) -> Result<R, Arc<Error>> {
+    match handle {
+        Some(handle) => handle.await.ok().flatten(),
+        None => None,
+    }
+    .ok_or_else(post_consensus_aborted)
+}
+
+impl<T: SlotClock + 'static, E: EthSpec, C: ConsensusDecider<E> + 'static>
+    AnchorValidatorStore<T, E, C>
+{
+    /// Start one post-consensus execution per committee in freshly built assignments.
+    ///
+    /// This is the only place executions are created. Callbacks look results up and never start
+    /// work, so exactly one committee message per `(committee, slot)` holds by construction rather
+    /// than by locking. Called from `update_aggregation_assignments` before the watch channel is
+    /// published, so any consumer that can observe the assignments can also observe the execution.
+    ///
+    /// Pre-Boole there is no consensus data and this is a no-op.
+    pub(crate) fn start_aggregator_post_consensus(
+        self: &Arc<Self>,
+        assignments: &AggregationAssignments<E>,
+    ) {
+        let slot = assignments.slot;
+        let mut executions = self.aggregator_post_consensus.lock();
+
+        let cutoff =
+            slot.saturating_sub(AGGREGATOR_POST_CONSENSUS_RETAIN_EPOCHS * E::slots_per_epoch());
+        executions.retain(|(_, execution_slot), _| *execution_slot >= cutoff);
+
+        for (&committee_id, decided_data) in &assignments.consensus_data_by_ssv_committee {
+            // Vacant-only, so registration is idempotent. Overwriting would spawn a second QBFT
+            // round and a second set of detached signing tasks while the first set kept running,
+            // putting two committee messages on the wire for one slot, which peers reject with a
+            // gossip penalty. The slot pipeline publishes once per slot today, but that is a
+            // property of another module's timing loop; keeping this vacant-only makes
+            // exactly-once hold here regardless of how often it is called.
+            if let Entry::Vacant(vacant) = executions.entry((committee_id, slot)) {
+                let store = Arc::clone(self);
+                let decided_data = Arc::clone(decided_data);
+                vacant.insert(self.spawn_shared("aggregator_post_consensus", async move {
+                    store
+                        .run_aggregator_post_consensus(committee_id, slot, decided_data)
+                        .await
+                }));
+            }
+        }
+    }
+
+    /// Join the post-consensus execution for `(committee, slot)`, returning the outcome and the
+    /// deadline that bounded the join, for the caller to reuse when draining its own roots.
+    ///
+    /// The single deadline (one slot past the duty slot's end) is an anti-hang backstop, not a
+    /// duty-freshness bound: QBFT `SlotTime` rounds legitimately decide after the slot ends and
+    /// reconstruction needs a network round trip after that, so bounding at slot end would discard
+    /// results decided in contended rounds.
+    pub(crate) async fn post_consensus_outcome(
+        &self,
+        committee_id: CommitteeId,
+        slot: Slot,
+    ) -> Result<(Instant, Arc<AggregatorPostConsensusOutcome<E>>), Error> {
+        // Waiting on the assignments is what makes the lookup below race-free: the execution was
+        // registered before this slot's assignments were published.
+        self.get_aggregation_assignments(slot).await?;
+
+        let execution = self
+            .aggregator_post_consensus
+            .lock()
+            .get(&(committee_id, slot))
+            .cloned()
+            .ok_or(Error::SpecificError(SpecificError::ConsensusDataNotFound))?;
+
+        let deadline = self.get_instant_in_slot(slot, self.spec.get_slot_duration() * 2)?;
+        let outcome = tokio::time::timeout_at(deadline, execution)
+            .await
+            .map_err(|_| Error::SpecificError(SpecificError::Timeout))?
+            .map_err(|e| (*e).clone())?;
+
+        Ok((deadline, outcome))
+    }
+
+    /// Spawn `fut` detached and hand out a `Shared` view of its result.
+    fn spawn_shared<R: Clone + Send + Sync + 'static>(
+        &self,
+        task_name: &'static str,
+        fut: impl Future<Output = Result<R, Arc<Error>>> + Send + 'static,
+    ) -> SharedResult<R> {
+        let handle = self.task_executor.spawn_handle(fut, task_name);
+        async move { join_detached_task(handle).await.and_then(|result| result) }
+            .boxed()
+            .shared()
+    }
+
+    /// Decide the committee's value, then submit every root this operator can sign from it.
+    ///
+    /// Which Lighthouse callbacks happen to fire has no influence on what is signed, only on what
+    /// is returned to Lighthouse.
+    async fn run_aggregator_post_consensus(
+        self: Arc<Self>,
+        committee_id: CommitteeId,
+        slot: Slot,
+        our_consensus_data: Arc<AggregatorCommitteeConsensusData<E>>,
+    ) -> Result<Arc<AggregatorPostConsensusOutcome<E>>, Arc<Error>> {
+        let Some(cluster) = self.committee_cluster(&committee_id) else {
+            warn!(
+                ?committee_id,
+                %slot,
+                "No active cluster for committee, skipping aggregator post-consensus"
+            );
+            return Ok(Arc::new(AggregatorPostConsensusOutcome {
+                aggregates: HashMap::new(),
+                contributions: HashMap::new(),
+            }));
+        };
+        let cluster = Arc::new(cluster);
+
+        let decided_data = self
+            .run_aggregator_committee_consensus(committee_id, slot, &cluster, &our_consensus_data)
+            .await
+            .map_err(Arc::new)?;
+
+        let worklist = self.build_decided_worklist(&decided_data, &committee_id, slot);
+
+        // The batch size is the number of partials this operator actually submits. Peers do not
+        // validate completeness for `AggregatorCommittee` (committee views may differ), and a count
+        // local filtering cannot reach stalls the batch forever.
+        let batch_size = worklist.aggregates.len() + worklist.contributions.len();
+        if batch_size == 0 {
+            debug!(
+                ?committee_id,
+                %slot,
+                "No locally signable entries in decided aggregator committee data"
+            );
+        }
+        let collection_mode = CollectionMode::Committee {
+            validator_partial_signature_batch_size: batch_size,
+            base_hash: decided_data.hash(),
+        };
+
+        Ok(Arc::new(AggregatorPostConsensusOutcome {
+            aggregates: self.prepare_roots(worklist.aggregates, &collection_mode, &cluster, slot),
+            contributions: self.prepare_roots(
+                worklist.contributions,
+                &collection_mode,
+                &cluster,
+                slot,
+            ),
+        }))
+    }
+
+    /// Any active cluster in the committee.
+    ///
+    /// `Cluster::committee_id` is derived from `cluster_members`, so every cluster sharing a
+    /// committee has the same operator set and the same `f`, which is all consensus and the
+    /// signature threshold need. Per-validator liquidation is still filtered in the worklist.
+    fn committee_cluster(&self, committee_id: &CommitteeId) -> Option<Cluster> {
+        let state = self.database.state();
+        state
+            .metadata()
+            .get_all_by(committee_id)
+            .find_map(|validator| {
+                let cluster = state.clusters().get_by(&validator.cluster_id)?;
+                (!cluster.liquidated).then(|| cluster.clone())
+            })
+    }
+
+    /// Spawn one detached signing task per worklist entry.
+    fn prepare_roots<K: std::hash::Hash + Eq, M>(
+        self: &Arc<Self>,
+        requests: HashMap<K, SigningRequest<M>>,
+        collection_mode: &CollectionMode,
+        cluster: &Arc<Cluster>,
+        slot: Slot,
+    ) -> HashMap<K, PreparedRoot<M>> {
+        requests
+            .into_iter()
+            .map(|(key, request)| {
+                let signature = self.spawn_root_collection(
+                    collection_mode.clone(),
+                    request.validator.clone(),
+                    Arc::clone(cluster),
+                    request.signing_root,
+                    slot,
+                );
+                (key, PreparedRoot { request, signature })
+            })
+            .collect()
+    }
+
+    /// Spawn one root's signature collection as its own detached task.
+    ///
+    /// The task hands the partial to the committee batch even if no callback ever awaits the
+    /// returned handle, so an absent or dropped Lighthouse callback cannot strand the batch below
+    /// its expected size.
+    fn spawn_root_collection(
+        self: &Arc<Self>,
+        collection_mode: CollectionMode,
+        validator: ValidatorMetadata,
+        cluster: Arc<Cluster>,
+        signing_root: Hash256,
+        slot: Slot,
+    ) -> SharedResult<Signature> {
+        let store = Arc::clone(self);
+        self.spawn_shared("aggregator_post_consensus_root", async move {
+            let result = store
+                .collect_signature(
+                    PartialSignatureKind::PostConsensus,
+                    Role::AggregatorCommittee,
+                    collection_mode,
+                    &validator,
+                    &cluster,
+                    signing_root,
+                    slot,
+                )
+                .await;
+            if let Err(e) = &result {
+                // Callbacks only see failures for roots they requested; log here so a failed
+                // unrequested root (which leaves the committee batch under-filled and unsent) is
+                // still visible to operators.
+                error!(
+                    ?signing_root,
+                    pubkey = ?validator.public_key,
+                    error = ?e,
+                    "Post-consensus root signing failed; the committee batch for this duty \
+                     may not be sent"
+                );
+            }
+            result.map_err(Arc::new)
+        })
+    }
+
+    /// Build the signing worklist from a decided value.
+    ///
+    /// Resolves metadata, cluster status and share availability for every decided entry under one
+    /// database snapshot, then keys the result by signing identity: validator index for aggregates,
+    /// `(validator, subcommittee)` for contributions. Keying by identity collapses repeated decided
+    /// entries (a root submitted twice would double-count the batch) and holds every validator
+    /// inside the receivers' five-roots-per-validator cap; a decided value carrying conflicting
+    /// roots for one identity signs the first and logs the rest.
+    fn build_decided_worklist(
+        &self,
+        decided_data: &AggregatorCommitteeConsensusData<E>,
+        committee_id: &CommitteeId,
+        slot: Slot,
+    ) -> DecidedWorklist<E> {
+        let decided_indices: HashSet<ValidatorIndex> = decided_data
+            .aggregators
+            .iter()
+            .chain(decided_data.contributors.iter())
+            .map(|entry| entry.validator_index)
+            .collect();
+
+        // One snapshot for metadata, liquidation and share rows, so entries cannot mix database
+        // states. Released before any signing.
+        let locals: HashMap<ValidatorIndex, ValidatorMetadata> = {
+            let state = self.database.state();
+            state
+                .metadata()
+                .get_all_by(committee_id)
+                .filter_map(|validator| {
+                    let index = validator.index.filter(|i| decided_indices.contains(i))?;
+                    let cluster = state.clusters().get_by(&validator.cluster_id)?;
+                    if cluster.liquidated {
+                        return None;
+                    }
+                    // Without a share row this operator cannot sign for the validator, and counting
+                    // it would leave the committee batch permanently short.
+                    state.shares().get_by(&validator.public_key)?;
+                    Some((index, validator.clone()))
+                })
+                .collect()
+        };
+
+        let epoch = slot.epoch(E::slots_per_epoch());
+        let aggregate_domain = self.get_domain(epoch, Domain::AggregateAndProof);
+        let contribution_domain = self.get_domain(epoch, Domain::ContributionAndProof);
+
+        let mut aggregates = HashMap::new();
+        for decided_aggregator in decided_data.aggregators.iter() {
+            let Some(validator) = locals.get(&decided_aggregator.validator_index) else {
+                continue;
+            };
+            let request = match Self::resolve_decided_aggregate(
+                decided_data,
+                decided_aggregator,
+                validator,
+                slot,
+                aggregate_domain,
+            ) {
+                Ok(request) => request,
+                Err(e) => {
+                    debug!(
+                        validator_index = ?decided_aggregator.validator_index,
+                        error = e,
+                        "Skipping decided aggregate"
+                    );
+                    continue;
+                }
+            };
+            match aggregates.entry(decided_aggregator.validator_index) {
+                Entry::Vacant(vacant) => {
+                    vacant.insert(request);
+                }
+                Entry::Occupied(kept) if kept.get().signing_root != request.signing_root => warn!(
+                    validator_index = ?decided_aggregator.validator_index,
+                    "Decided value contains conflicting aggregate roots for one validator, \
+                     signing the first"
+                ),
+                Entry::Occupied(_) => {}
+            }
+        }
+
+        let mut contributions = HashMap::new();
+        for decided_contributor in decided_data.contributors.iter() {
+            let Some(validator) = locals.get(&decided_contributor.validator_index) else {
+                continue;
+            };
+            let request = match Self::resolve_decided_contribution(
+                decided_data,
+                decided_contributor,
+                validator,
+                slot,
+                contribution_domain,
+            ) {
+                Ok(request) => request,
+                Err(e) => {
+                    debug!(
+                        validator_index = ?decided_contributor.validator_index,
+                        subcommittee_index = decided_contributor.committee_index,
+                        error = e,
+                        "Skipping decided contribution"
+                    );
+                    continue;
+                }
+            };
+            match contributions.entry((
+                decided_contributor.validator_index,
+                decided_contributor.committee_index,
+            )) {
+                Entry::Vacant(vacant) => {
+                    vacant.insert(request);
+                }
+                Entry::Occupied(kept) if kept.get().signing_root != request.signing_root => warn!(
+                    validator_index = ?decided_contributor.validator_index,
+                    subcommittee_index = decided_contributor.committee_index,
+                    "Decided value contains conflicting contribution roots for one identity, \
+                     signing the first"
+                ),
+                Entry::Occupied(_) => {}
+            }
+        }
+
+        DecidedWorklist {
+            aggregates,
+            contributions,
+        }
+    }
+
+    /// Resolve one decided aggregator entry into a signable `AggregateAndProof`.
+    ///
+    /// Finds the matching committee index, decodes the aggregate attestation from SSZ, and binds
+    /// the decoded slot to the duty slot. The signing domain comes from the duty slot's epoch,
+    /// matching the beacon spec (domain at the epoch of `aggregate.data.slot`) and go-ssv's
+    /// expected roots.
+    fn resolve_decided_aggregate(
+        decided_data: &AggregatorCommitteeConsensusData<E>,
+        decided_aggregator: &AssignedAggregator,
+        validator: &ValidatorMetadata,
+        slot: Slot,
+        domain_hash: Hash256,
+    ) -> Result<SigningRequest<AggregateAndProof<E>>, String> {
+        let aggregator_index = decided_aggregator.validator_index.0 as u64;
+
+        let committee_index = decided_aggregator.committee_index;
+
+        // Find the position of this committee index in decided data
+        let decided_aggregate_idx = decided_data
+            .aggregator_committee_indexes
+            .iter()
+            .position(|&idx| idx == committee_index)
+            .ok_or("Committee index not found in decided data")?;
+
+        let decided_aggregate_bytes = decided_data
+            .aggregated_attestations
+            .get(decided_aggregate_idx)
+            .ok_or("Aggregate attestation bytes not found in decided data")?;
+
+        // Decode based on fork version
+        let decided_aggregate = if decided_data.version < DataVersion::from(ForkName::Electra) {
+            AttestationBase::from_ssz_bytes(decided_aggregate_bytes)
+                .map(Attestation::Base)
+                .map_err(|e| format!("Failed to decode decided aggregate: {e:?}"))?
+        } else {
+            AttestationElectra::from_ssz_bytes(decided_aggregate_bytes)
+                .map(Attestation::Electra)
+                .map_err(|e| format!("Failed to decode decided aggregate: {e:?}"))?
+        };
+
+        let aggregate_slot = decided_aggregate.data().slot;
+        if aggregate_slot != slot {
+            return Err(format!(
+                "Decided aggregate slot {aggregate_slot} does not match duty slot {slot}"
+            ));
+        }
+
+        let decided_selection_proof =
+            SelectionProof::from(decided_aggregator.selection_proof.clone());
+
+        let message = AggregateAndProof::from_attestation(
+            aggregator_index,
+            decided_aggregate,
+            decided_selection_proof,
+        );
+
+        Ok(SigningRequest {
+            validator: validator.clone(),
+            signing_root: message.signing_root(domain_hash),
+            duty_data: message,
+        })
+    }
+
+    /// Resolve one decided contributor entry into a signable `ContributionAndProof`.
+    fn resolve_decided_contribution(
+        decided_data: &AggregatorCommitteeConsensusData<E>,
+        decided_contributor: &AssignedAggregator,
+        validator: &ValidatorMetadata,
+        slot: Slot,
+        domain_hash: Hash256,
+    ) -> Result<SigningRequest<ContributionAndProof<E>>, String> {
+        let subcommittee_index = decided_contributor.committee_index;
+
+        // Find the contribution for this subcommittee
+        let decided_contribution = decided_data
+            .sync_committee_contributions
+            .iter()
+            .find(|c| c.subcommittee_index == subcommittee_index)
+            .ok_or(
+                "Contribution not in consensus data - likely filtered due to beacon API failure",
+            )?;
+        if decided_contribution.slot != slot {
+            return Err(format!(
+                "Decided contribution slot {} does not match duty slot {slot}",
+                decided_contribution.slot
+            ));
+        }
+
+        let message = ContributionAndProof {
+            aggregator_index: decided_contributor.validator_index.0 as u64,
+            contribution: decided_contribution.clone(),
+            selection_proof: decided_contributor.selection_proof.clone(),
+        };
+
+        Ok(SigningRequest {
+            validator: validator.clone(),
+            signing_root: message.signing_root(domain_hash),
+            duty_data: message,
+        })
+    }
+}

--- a/anchor/validator_store/src/aggregator_post_consensus.rs
+++ b/anchor/validator_store/src/aggregator_post_consensus.rs
@@ -2,14 +2,20 @@
 //!
 //! One QBFT decision carries both attestation aggregates and sync contributions for an SSV
 //! committee, and the operator must emit exactly one committee partial-signature message per
-//! `(committee, slot)` covering everything it can sign. Lighthouse asks for signatures through two
-//! independent callbacks, one per object class, so neither callback can own that message: whichever
-//! one fires, the other class still has to be signed (issue #1227).
+//! `(committee, slot)` covering everything it can sign. The decided value drives both what gets
+//! signed and what gets published: Anchor owns Boole+ aggregate publication outright, through
+//! the metadata service's publisher, because the protocol's unit of agreement is the decided
+//! value and no local Lighthouse view is part of it. (Lighthouse's duty snapshot in particular
+//! is cloned before slot-start selection proofs finish, so routing publication through it would
+//! silently skip late-installed proofs.) Contributions are returned through a Lighthouse
+//! callback that may or may not fire (issue #1227), so no callback can own the committee
+//! message either.
 //!
-//! The signing set is therefore a property of the duty, not of any callback. The slot pipeline
-//! starts one execution per committee when it publishes the decided value at 2/3 slot, and the
-//! callbacks only look up their own results. This is the ssv-spec-normative shape, where the
-//! decided value drives what gets signed and local state only filters.
+//! The signing set is therefore a property of the duty, not of any consumer. The slot pipeline
+//! starts one execution per committee when it publishes the decided value at 2/3 slot; the
+//! contributions callback and the aggregate publisher only look up their own results. This is
+//! the ssv-spec-normative shape, where the decided value drives what gets signed and local state
+//! only filters.
 
 use std::{
     collections::{HashMap, HashSet, hash_map::Entry},
@@ -20,8 +26,9 @@ use std::{
 use bls::Signature;
 use database::{NonUniqueIndex, UniqueIndex};
 use futures::{
-    FutureExt,
+    FutureExt, StreamExt,
     future::{BoxFuture, Shared},
+    stream::FuturesUnordered,
 };
 use qbft_manager::ConsensusDecider;
 use slot_clock::SlotClock;
@@ -33,15 +40,15 @@ use ssv_types::{
 };
 use ssz::Decode;
 use tokio::time::Instant;
-use tracing::{debug, error, warn};
+use tracing::{Instrument, debug, error, info, info_span, warn};
 use types::{
     AggregateAndProof, Attestation, AttestationBase, AttestationElectra, ContributionAndProof,
-    Domain, EthSpec, ForkName, Hash256, SelectionProof, SignedRoot, Slot,
+    Domain, EthSpec, ForkName, Hash256, SelectionProof, SignedAggregateAndProof, SignedRoot, Slot,
 };
 
 use crate::{
     AggregationAssignments, AnchorValidatorStore, CollectionMode, Error, SigningRequest,
-    SpecificError,
+    SpecificError, metrics,
 };
 
 /// Epochs to retain finished `AggregatorCommittee` post-consensus executions.
@@ -66,10 +73,14 @@ pub(crate) struct PreparedRoot<M> {
     pub(crate) signature: SharedResult<Signature>,
 }
 
-/// Everything this operator signs for one decided `AggregatorCommittee` round, keyed by the
-/// identities the Lighthouse callbacks look up: validator index for aggregates,
-/// `(validator index, subcommittee index)` for contributions.
+/// Everything this operator signs for one decided `AggregatorCommittee` round, keyed by signing
+/// identity: validator index for aggregates (read by the aggregate publisher),
+/// `(validator index, subcommittee index)` for contributions (read by the Lighthouse callback).
 pub(crate) struct AggregatorPostConsensusOutcome<E: EthSpec> {
+    /// Fork the decided value's SSZ payloads were decoded under (its `DataVersion`). The
+    /// publisher derives its HTTP endpoint choice and fork header from this, so they cannot
+    /// diverge from the payload variant of the decided aggregates.
+    pub(crate) fork_name: ForkName,
     pub(crate) aggregates: HashMap<ValidatorIndex, PreparedRoot<AggregateAndProof<E>>>,
     pub(crate) contributions: HashMap<(ValidatorIndex, u64), PreparedRoot<ContributionAndProof<E>>>,
 }
@@ -96,21 +107,131 @@ async fn join_detached_task<R>(
     .ok_or_else(post_consensus_aborted)
 }
 
+/// Await one decided root's threshold signature under the deadline and publish it on quorum,
+/// one publish call per aggregate.
+///
+/// Both publish arms reproduce the per-aggregate log Lighthouse emits on its pre-Boole path;
+/// operator pipelines key on `type="aggregated"`.
+async fn publish_one_root<E: EthSpec, F, Fut>(
+    slot: Slot,
+    fork_name: ForkName,
+    deadline: Instant,
+    root: &PreparedRoot<AggregateAndProof<E>>,
+    publish: &F,
+) where
+    F: Fn(ForkName, SignedAggregateAndProof<E>) -> Fut,
+    Fut: Future<Output = Result<(), String>>,
+{
+    let signature = match tokio::time::timeout_at(deadline, root.signature.clone()).await {
+        Ok(Ok(signature)) => signature,
+        // `collect_signature` failures are also logged by the detached signing task, but a task
+        // that died without a result (spawn refused, executor exit, panic) is only visible here,
+        // so carry the error into the warn.
+        Ok(Err(e)) => {
+            warn!(
+                pubkey = ?root.request.validator.public_key,
+                %slot,
+                error = ?e,
+                "Missing signature, skipping aggregate"
+            );
+            validator_metrics::inc_counter_vec(
+                &validator_metrics::SIGNED_AGGREGATES_TOTAL,
+                &[metrics::OTHER_ERROR],
+            );
+            metrics::inc_publish_result(metrics::NO_SIGNATURES);
+            return;
+        }
+        // Deadline expired before this root's quorum; only this root is withheld. Labelled
+        // `timeout` to match the committee-level join arm, now that expiry is distinguishable
+        // from a collection failure.
+        Err(_) => {
+            warn!(
+                pubkey = ?root.request.validator.public_key,
+                %slot,
+                "Missing signature, skipping aggregate"
+            );
+            validator_metrics::inc_counter_vec(
+                &validator_metrics::SIGNED_AGGREGATES_TOTAL,
+                &[metrics::TIMEOUT],
+            );
+            metrics::inc_publish_result(metrics::NO_SIGNATURES);
+            return;
+        }
+    };
+
+    let message = root.request.duty_data.clone();
+    debug!(
+        aggregator_index = message.aggregator_index(),
+        data = ?message.aggregate().data(),
+        num_set_aggregation_bits = message.aggregate().num_set_aggregation_bits(),
+        "Signed AggregateAndProof (Boole+ committee consensus)"
+    );
+    validator_metrics::inc_counter_vec(
+        &validator_metrics::SIGNED_AGGREGATES_TOTAL,
+        &[validator_metrics::SUCCESS],
+    );
+    let signed = SignedAggregateAndProof::from_aggregate_and_proof(message, signature);
+
+    let aggregator = signed.message().aggregator_index();
+    let attestation = signed.message().aggregate();
+    let signatures = attestation.num_set_aggregation_bits();
+    let head_block = format!("{:?}", attestation.data().beacon_block_root);
+    let committee_index = attestation.committee_index();
+
+    let result = publish(fork_name, signed)
+        .instrument(info_span!("publish_aggregate", aggregator))
+        .await;
+    match result {
+        Ok(()) => {
+            info!(
+                aggregator,
+                signatures,
+                head_block,
+                committee_index,
+                slot = slot.as_u64(),
+                "type" = "aggregated",
+                "Successfully published attestation"
+            );
+            metrics::inc_publish_result(validator_metrics::SUCCESS);
+        }
+        Err(e) => {
+            error!(
+                error = %e,
+                aggregator,
+                committee_index,
+                slot = slot.as_u64(),
+                "type" = "aggregated",
+                "Failed to publish attestation"
+            );
+            metrics::inc_publish_result(metrics::HTTP_ERROR);
+        }
+    }
+}
+
 impl<T: SlotClock + 'static, E: EthSpec, C: ConsensusDecider<E> + 'static>
     AnchorValidatorStore<T, E, C>
 {
-    /// Start one post-consensus execution per committee in freshly built assignments.
+    /// Start one post-consensus execution per committee in freshly built assignments, returning
+    /// the executions newly registered by this call.
     ///
     /// This is the only place executions are created. Callbacks look results up and never start
     /// work, so exactly one committee message per `(committee, slot)` holds by construction rather
     /// than by locking. Called from `update_aggregation_assignments` before the watch channel is
     /// published, so any consumer that can observe the assignments can also observe the execution.
     ///
-    /// Pre-Boole there is no consensus data and this is a no-op.
+    /// The returned handles feed the metadata service's aggregate publisher. Returning only the
+    /// vacant insertions gives the publisher the same exactly-once property as the executions
+    /// themselves: a repeated call for one `(committee, slot)` registers nothing and therefore
+    /// publishes nothing twice. Both properties are scoped to the process lifetime and to the
+    /// retention window below: after an entry is pruned, only a slot clock stepping backwards
+    /// past the window could present its `(committee, slot)` again, and that would re-register.
+    ///
+    /// Pre-Boole there is no consensus data and this is a no-op returning no executions.
+    #[must_use = "dropping the returned executions disables Boole+ aggregate publication"]
     pub(crate) fn start_aggregator_post_consensus(
         self: &Arc<Self>,
         assignments: &AggregationAssignments<E>,
-    ) {
+    ) -> Vec<(CommitteeId, AggregatorPostConsensusShared<E>)> {
         let slot = assignments.slot;
         let mut executions = self.aggregator_post_consensus.lock();
 
@@ -118,6 +239,7 @@ impl<T: SlotClock + 'static, E: EthSpec, C: ConsensusDecider<E> + 'static>
             slot.saturating_sub(AGGREGATOR_POST_CONSENSUS_RETAIN_EPOCHS * E::slots_per_epoch());
         executions.retain(|(_, execution_slot), _| *execution_slot >= cutoff);
 
+        let mut new_executions = Vec::new();
         for (&committee_id, decided_data) in &assignments.consensus_data_by_ssv_committee {
             // Vacant-only, so registration is idempotent. Overwriting would spawn a second QBFT
             // round and a second set of detached signing tasks while the first set kept running,
@@ -128,22 +250,144 @@ impl<T: SlotClock + 'static, E: EthSpec, C: ConsensusDecider<E> + 'static>
             if let Entry::Vacant(vacant) = executions.entry((committee_id, slot)) {
                 let store = Arc::clone(self);
                 let decided_data = Arc::clone(decided_data);
-                vacant.insert(self.spawn_shared("aggregator_post_consensus", async move {
+                let execution = self.spawn_shared("aggregator_post_consensus", async move {
                     store
                         .run_aggregator_post_consensus(committee_id, slot, decided_data)
                         .await
-                }));
+                });
+                vacant.insert(execution.clone());
+                new_executions.push((committee_id, execution));
             }
         }
+        new_executions
     }
 
-    /// Join the post-consensus execution for `(committee, slot)`, returning the outcome and the
-    /// deadline that bounded the join, for the caller to reuse when draining its own roots.
+    /// Join one committee's execution under the shared deadline, returning the outcome and the
+    /// deadline for the caller to reuse when draining its own roots.
     ///
     /// The single deadline (one slot past the duty slot's end) is an anti-hang backstop, not a
     /// duty-freshness bound: QBFT `SlotTime` rounds legitimately decide after the slot ends and
     /// reconstruction needs a network round trip after that, so bounding at slot end would discard
     /// results decided in contended rounds.
+    async fn join_execution(
+        &self,
+        slot: Slot,
+        execution: AggregatorPostConsensusShared<E>,
+    ) -> Result<(Instant, Arc<AggregatorPostConsensusOutcome<E>>), Error> {
+        let deadline = self.get_instant_in_slot(slot, self.spec.get_slot_duration() * 2)?;
+        let outcome = tokio::time::timeout_at(deadline, execution)
+            .await
+            .map_err(|_| Error::SpecificError(SpecificError::Timeout))?
+            .map_err(|e| (*e).clone())?;
+
+        Ok((deadline, outcome))
+    }
+
+    /// Join one committee's post-consensus execution and publish each decided aggregate this
+    /// operator signed as soon as its threshold signature reconstructs.
+    ///
+    /// This backs [`Self::publish_decided_aggregates`], which owns Boole+ aggregate publication:
+    /// Lighthouse's aggregate callback returns an empty batch at Boole+, because its duty
+    /// snapshot is cloned before slot-start selection proofs finish, silently skipping any proof
+    /// installed after the clone. The publisher works from the decided value instead, so
+    /// publication does not depend on Lighthouse's snapshot timing.
+    ///
+    /// Takes the execution handle directly rather than re-entering the assignments watch channel,
+    /// so a late-polled publisher cannot observe `AggregatorInfoSlotPassed` for an execution that
+    /// still exists in the retention map.
+    async fn publish_committee_aggregates<F, Fut>(
+        &self,
+        committee_id: CommitteeId,
+        slot: Slot,
+        execution: AggregatorPostConsensusShared<E>,
+        publish: &F,
+    ) where
+        F: Fn(ForkName, SignedAggregateAndProof<E>) -> Fut,
+        Fut: Future<Output = Result<(), String>>,
+    {
+        let (deadline, outcome) = match self.join_execution(slot, execution).await {
+            Ok(joined) => joined,
+            Err(e) => {
+                warn!(
+                    ?committee_id,
+                    %slot,
+                    error = ?e,
+                    "Aggregator post-consensus failed, no aggregates to publish"
+                );
+                // Keeps the Lighthouse-era signing counter alive for dashboards keyed on it. The
+                // per-aggregate count is unknowable before the outcome resolves, so failures
+                // count once per committee, an undercount but not silence.
+                let label = match e {
+                    Error::SpecificError(SpecificError::Timeout) => metrics::TIMEOUT,
+                    _ => metrics::OTHER_ERROR,
+                };
+                validator_metrics::inc_counter_vec(
+                    &validator_metrics::SIGNED_AGGREGATES_TOTAL,
+                    &[label],
+                );
+                metrics::inc_publish_result(metrics::CONSENSUS_ERROR);
+                return;
+            }
+        };
+
+        // A decided value can legitimately hold contributions only; nothing to publish then.
+        if outcome.aggregates.is_empty() {
+            debug!(?committee_id, %slot, "Decided worklist holds no aggregates");
+            metrics::inc_publish_result(metrics::NO_AGGREGATES);
+            return;
+        }
+
+        // Each root publishes independently under the shared deadline, so a root that never
+        // reaches quorum withholds only itself and never delays a sibling's POST.
+        let mut roots: FuturesUnordered<_> = outcome
+            .aggregates
+            .values()
+            .map(|root| publish_one_root(slot, outcome.fork_name, deadline, root, publish))
+            .collect();
+        while roots.next().await.is_some() {}
+    }
+
+    /// Resolve each committee's decided aggregates and hand each signed aggregate to `publish`
+    /// the moment its threshold signature reconstructs, one publish call per aggregate. This is
+    /// go-ssv's publication shape at the reference pin: a bad aggregate cannot fail a sibling's
+    /// POST, and a no-quorum root cannot delay its committee's other aggregates.
+    ///
+    /// This is the authoritative Boole+ aggregate publication driver, spawned per slot by the
+    /// metadata service with the executions its assignment update newly registered. Generic over
+    /// the publish operation so tests (in `testing/aggregator_post_consensus.rs`) can inject a
+    /// recorder instead of an HTTP client. Each committee runs as one `FuturesUnordered` entry
+    /// and each of its roots as another inside it, so committees and roots are all mutually
+    /// independent.
+    ///
+    /// Owns every `AGGREGATOR_COMMITTEE_PUBLISH_TOTAL` increment, together with
+    /// [`publish_one_root`]: `consensus_error` and `no_aggregates` count committees (those
+    /// failures occur before per-root work exists), while `success`, `http_error`, and
+    /// `no_signatures` count individual aggregates.
+    ///
+    /// The fork handed to `publish` is the one the decided value's payloads were decoded under,
+    /// so the closure's endpoint choice always matches the payload variant.
+    pub(crate) async fn publish_decided_aggregates<F, Fut>(
+        &self,
+        slot: Slot,
+        executions: Vec<(CommitteeId, AggregatorPostConsensusShared<E>)>,
+        publish: F,
+    ) where
+        F: Fn(ForkName, SignedAggregateAndProof<E>) -> Fut,
+        Fut: Future<Output = Result<(), String>>,
+    {
+        let publish = &publish;
+        let mut pending: FuturesUnordered<_> = executions
+            .into_iter()
+            .map(|(committee_id, execution)| {
+                self.publish_committee_aggregates(committee_id, slot, execution, publish)
+            })
+            .collect();
+
+        while pending.next().await.is_some() {}
+    }
+
+    /// Join the post-consensus execution for `(committee, slot)`, returning the outcome and the
+    /// deadline that bounded the join, for the caller to reuse when draining its own roots.
     pub(crate) async fn post_consensus_outcome(
         &self,
         committee_id: CommitteeId,
@@ -160,13 +404,7 @@ impl<T: SlotClock + 'static, E: EthSpec, C: ConsensusDecider<E> + 'static>
             .cloned()
             .ok_or(Error::SpecificError(SpecificError::ConsensusDataNotFound))?;
 
-        let deadline = self.get_instant_in_slot(slot, self.spec.get_slot_duration() * 2)?;
-        let outcome = tokio::time::timeout_at(deadline, execution)
-            .await
-            .map_err(|_| Error::SpecificError(SpecificError::Timeout))?
-            .map_err(|e| (*e).clone())?;
-
-        Ok((deadline, outcome))
+        self.join_execution(slot, execution).await
     }
 
     /// Spawn `fut` detached and hand out a `Shared` view of its result.
@@ -198,6 +436,7 @@ impl<T: SlotClock + 'static, E: EthSpec, C: ConsensusDecider<E> + 'static>
                 "No active cluster for committee, skipping aggregator post-consensus"
             );
             return Ok(Arc::new(AggregatorPostConsensusOutcome {
+                fork_name: ForkName::from(our_consensus_data.version),
                 aggregates: HashMap::new(),
                 contributions: HashMap::new(),
             }));
@@ -228,6 +467,7 @@ impl<T: SlotClock + 'static, E: EthSpec, C: ConsensusDecider<E> + 'static>
         };
 
         Ok(Arc::new(AggregatorPostConsensusOutcome {
+            fork_name: ForkName::from(decided_data.version),
             aggregates: self.prepare_roots(worklist.aggregates, &collection_mode, &cluster, slot),
             contributions: self.prepare_roots(
                 worklist.contributions,

--- a/anchor/validator_store/src/lib.rs
+++ b/anchor/validator_store/src/lib.rs
@@ -37,7 +37,7 @@ use qbft_manager::{
 use safe_arith::{ArithError, SafeArith};
 use signature_collector::{
     CollectionError, SignatureCollecting, SignatureMetadata, SignatureRequester,
-    SyncSelectionProofDescriptor, ValidatorSigningData,
+    SyncCommitteeBatchEntry, ValidatorSigningData,
 };
 use slashing_protection::{CheckSlashability, NotSafe, Safe, SlashingDatabase};
 use slot_clock::SlotClock;
@@ -613,7 +613,7 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> AnchorValidator
         slot: Slot,
         callback_subnet: SyncSubnetId,
         position_counts: &HashMap<SyncSubnetId, usize>,
-    ) -> Result<Vec<SyncSelectionProofDescriptor>, SyncSelectionProofAssignmentError> {
+    ) -> Result<Vec<SyncCommitteeBatchEntry>, SyncSelectionProofAssignmentError> {
         if position_counts.is_empty() {
             return Err(SyncSelectionProofAssignmentError::Empty);
         }
@@ -651,10 +651,10 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> AnchorValidator
 
         let mut descriptor = Vec::with_capacity(position_counts.len());
         for (&subnet_id, &position_count) in position_counts {
-            descriptor.push(SyncSelectionProofDescriptor {
+            descriptor.push(SyncCommitteeBatchEntry {
                 subnet_id,
                 signing_root: self.compute_sync_selection_root(slot, subnet_id.into()),
-                position_count,
+                multiplicity: position_count,
             });
         }
 
@@ -1380,31 +1380,32 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> AnchorValidator
             let data = Contributions::<E>::from_ssz_bytes(&data.data_ssz)
                 .map_err(|e| Error::from(SpecificError::InvalidQbftData(e)))?;
 
-            let data = data
-                .into_iter()
-                .map(Contribution::from)
-                .find(|data| data.contribution.subcommittee_index == subcommittee_index)
-                .ok_or(SpecificError::NoDataAgreed)?;
+            let domain_hash = self.get_domain(epoch, Domain::ContributionAndProof);
+            let PreparedSyncContributionBatch {
+                callback_message: message,
+                callback_signing_root: signing_root,
+                descriptor,
+            } = prepare_decided_sync_contributions(
+                data,
+                SyncSubnetId::new(subcommittee_index),
+                aggregator_index,
+                domain_hash,
+            )?;
 
             debug!(
-                slot = %data.contribution.slot,
-                block_root = ?data.contribution.beacon_block_root,
-                subcommittee_index = data.contribution.subcommittee_index,
-                num_set_aggregation_bits = data.contribution.aggregation_bits.num_set_bits(),
+                slot = %message.contribution.slot,
+                block_root = ?message.contribution.beacon_block_root,
+                subcommittee_index = message.contribution.subcommittee_index,
+                num_set_aggregation_bits = message.contribution.aggregation_bits.num_set_bits(),
                 "Decided on Contribution to sign"
             );
 
-            let domain_hash = self.get_domain(epoch, Domain::ContributionAndProof);
-            let message = ContributionAndProof {
-                aggregator_index,
-                contribution: data.contribution,
-                selection_proof: data.selection_proof_sig,
-            };
-            let signing_root = message.signing_root(domain_hash);
+            let collection_mode =
+                sync_committee_collection_mode(SyncSubnetId::new(subcommittee_index), descriptor);
             self.collect_signature(
                 PartialSignatureKind::PostConsensus,
                 Role::SyncCommittee,
-                CollectionMode::SingleValidator,
+                collection_mode,
                 &validator,
                 &cluster,
                 signing_root,
@@ -2080,14 +2081,73 @@ pub struct ContributionAndProofSigningData<E: EthSpec> {
     selection_proof: SyncSelectionProof,
 }
 
+struct PreparedSyncContributionBatch<E: EthSpec> {
+    callback_message: ContributionAndProof<E>,
+    callback_signing_root: Hash256,
+    descriptor: Vec<SyncCommitteeBatchEntry>,
+}
+
+/// Prepares the exact decided sync contribution root multiset for every Lighthouse callback.
+fn prepare_decided_sync_contributions<E: EthSpec>(
+    contributions: Contributions<E>,
+    callback_subnet: SyncSubnetId,
+    aggregator_index: u64,
+    domain_hash: Hash256,
+) -> Result<PreparedSyncContributionBatch<E>, SpecificError> {
+    let mut callback = None;
+    let mut descriptor = Vec::with_capacity(contributions.len());
+
+    for contribution in contributions.into_iter().map(Contribution::from) {
+        let subnet_id = SyncSubnetId::new(contribution.contribution.subcommittee_index);
+        let message = ContributionAndProof {
+            aggregator_index,
+            contribution: contribution.contribution,
+            selection_proof: contribution.selection_proof_sig,
+        };
+        let signing_root = message.signing_root(domain_hash);
+
+        if callback.is_none() && subnet_id == callback_subnet {
+            callback = Some((message, signing_root));
+        }
+        descriptor.push(SyncCommitteeBatchEntry {
+            subnet_id,
+            signing_root,
+            multiplicity: 1,
+        });
+    }
+
+    let (callback_message, callback_signing_root) = callback.ok_or(SpecificError::NoDataAgreed)?;
+
+    descriptor.sort_unstable_by_key(|entry| (u64::from(entry.subnet_id), entry.signing_root));
+
+    let mut collapsed: Vec<SyncCommitteeBatchEntry> = Vec::with_capacity(descriptor.len());
+    for entry in descriptor {
+        match collapsed.last_mut() {
+            Some(previous)
+                if previous.subnet_id == entry.subnet_id
+                    && previous.signing_root == entry.signing_root =>
+            {
+                previous.multiplicity += entry.multiplicity;
+            }
+            _ => collapsed.push(entry),
+        }
+    }
+
+    Ok(PreparedSyncContributionBatch {
+        callback_message,
+        callback_signing_root,
+        descriptor: collapsed,
+    })
+}
+
 #[derive(Clone)]
 enum CollectionMode {
     SingleValidator,
     SingleValidatorBatch {
         /// Subnet requested by the current Lighthouse callback.
         subnet_id: SyncSubnetId,
-        /// Canonical descriptor for every unique subnet assigned to this validator and slot.
-        descriptor: Vec<SyncSelectionProofDescriptor>,
+        /// Canonical descriptor for every unique subnet and signing root pair in this batch.
+        descriptor: Vec<SyncCommitteeBatchEntry>,
     },
     Committee {
         /// The number of validator partial signatures this operator batches locally into the
@@ -2097,6 +2157,25 @@ enum CollectionMode {
         /// message.
         base_hash: Hash256,
     },
+}
+
+fn sync_committee_collection_mode(
+    callback_subnet: SyncSubnetId,
+    descriptor: Vec<SyncCommitteeBatchEntry>,
+) -> CollectionMode {
+    if descriptor
+        .iter()
+        .map(|entry| entry.multiplicity)
+        .sum::<usize>()
+        == 1
+    {
+        CollectionMode::SingleValidator
+    } else {
+        CollectionMode::SingleValidatorBatch {
+            subnet_id: callback_subnet,
+            descriptor,
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -2884,13 +2963,11 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> ValidatorStore
                             },
                         )?;
 
+                    let collection_mode = sync_committee_collection_mode(subnet_id, descriptor);
                     self.collect_signature(
                         PartialSignatureKind::ContributionProofs,
                         Role::SyncCommittee,
-                        CollectionMode::SingleValidatorBatch {
-                            subnet_id,
-                            descriptor,
-                        },
+                        collection_mode,
                         &validator,
                         &cluster,
                         signing_root,

--- a/anchor/validator_store/src/lib.rs
+++ b/anchor/validator_store/src/lib.rs
@@ -1,3 +1,4 @@
+mod aggregator_post_consensus;
 mod instrumentation;
 pub mod metadata_service;
 mod metrics;
@@ -17,7 +18,7 @@ use database::{NetworkDatabase, NonUniqueIndex, UniqueIndex};
 use eth2::types::{BlockContents, BlockContentsTuple, FullBlockContents, PublishBlockRequest};
 use fork::{Fork, ForkSchedule};
 use futures::{
-    Stream,
+    Stream, StreamExt,
     future::{Either, join_all},
     stream,
     stream::FuturesUnordered,
@@ -46,7 +47,7 @@ use ssv_types::{
     consensus::{
         AggregatorCommitteeConsensusData, AggregatorCommitteeDataValidator, BEACON_ROLE_AGGREGATOR,
         BEACON_ROLE_PROPOSER, BEACON_ROLE_SYNC_COMMITTEE_CONTRIBUTION, BeaconVote,
-        BeaconVoteValidator, Contribution, ContributionWrapper, Contributions, DataVersion,
+        BeaconVoteValidator, Contribution, ContributionWrapper, Contributions,
         ProposerConsensusData, ProposerConsensusDataValidator, QbftData, SelectionProofBatchId,
         ValidatorDuty,
     },
@@ -65,13 +66,12 @@ use tokio::{
 use tracing::{Instrument, Span, debug, error, field, info, info_span, trace, warn};
 use types::{
     AbstractExecPayload, Address, AggregateAndProof, AggregateAndProofBase,
-    AggregateAndProofElectra, Attestation, AttestationBase, AttestationElectra, BeaconBlock,
-    BeaconBlockRef, BlindedPayload, ChainSpec, ContributionAndProof, Domain, Epoch, EthSpec,
-    ExecutionPayloadEnvelope, ForkName, FullPayload, Graffiti, Hash256, PayloadAttestationData,
-    PayloadAttestationMessage, ProposerPreferences, SelectionProof, SignedAggregateAndProof,
-    SignedBeaconBlock, SignedBlindedBeaconBlock, SignedContributionAndProof,
-    SignedExecutionPayloadEnvelope, SignedProposerPreferences, SignedRoot,
-    SignedValidatorRegistrationData, SignedVoluntaryExit, Slot, SlotData,
+    AggregateAndProofElectra, Attestation, BeaconBlock, BeaconBlockRef, BlindedPayload, ChainSpec,
+    ContributionAndProof, Domain, Epoch, EthSpec, ExecutionPayloadEnvelope, ForkName, FullPayload,
+    Graffiti, Hash256, PayloadAttestationData, PayloadAttestationMessage, ProposerPreferences,
+    SelectionProof, SignedAggregateAndProof, SignedBeaconBlock, SignedBlindedBeaconBlock,
+    SignedContributionAndProof, SignedExecutionPayloadEnvelope, SignedProposerPreferences,
+    SignedRoot, SignedValidatorRegistrationData, SignedVoluntaryExit, Slot, SlotData,
     SyncAggregatorSelectionData, SyncCommitteeContribution, SyncCommitteeMessage,
     SyncSelectionProof, SyncSubnetId, ValidatorRegistrationData, VoluntaryExit,
 };
@@ -81,6 +81,8 @@ use validator_store::{
     Error as ValidatorStoreError, ProposalData, SignedBlock, SyncMessageToSign, UnsignedBlock,
     ValidatorStore,
 };
+
+use crate::aggregator_post_consensus::AggregatorPostConsensusShared;
 
 /// Number of epochs of slashing protection history to keep.
 ///
@@ -102,6 +104,7 @@ const SYNC_COMMITTEE_CONTRIBUTION_LOG_NAME: &str = "sync committee contribution"
 ///
 /// The shared fields (`validator`, `signing_root`) drive `collect_prepared_signatures`,
 /// while `duty_data` carries duty-specific context needed by the assembly step.
+#[derive(Clone)]
 struct SigningRequest<T> {
     validator: ValidatorMetadata,
     signing_root: Hash256,
@@ -109,21 +112,68 @@ struct SigningRequest<T> {
 }
 
 impl<T> SigningRequest<T> {
-    /// Look up this validator's collected signature, consuming the request.
+    /// Look up this request's collected signature, consuming the request.
     ///
     /// Returns `Ok((duty_data, signature))` on success, or `Err(pubkey)` if
     /// the validator index is missing or no signature was collected.
-    fn resolve(
-        self,
-        signatures: &HashMap<ValidatorIndex, Signature>,
-    ) -> Result<(T, Signature), PublicKeyBytes> {
+    ///
+    /// Keyed by `(index, root)` rather than index alone because one validator can hold several
+    /// distinct roots in a single batch (an `AggregatorCommittee` duty allows one aggregate plus
+    /// one contribution per subcommittee).
+    fn resolve(self, signatures: &CollectedSignatures) -> Result<(T, Signature), PublicKeyBytes> {
         let sig = self
             .validator
             .index
-            .and_then(|idx| signatures.get(&idx).cloned())
+            .and_then(|idx| signatures.get(&(idx, self.signing_root)).cloned())
             .ok_or(self.validator.public_key)?;
         Ok((self.duty_data, sig))
     }
+}
+
+/// Signatures collected for one committee batch, keyed by the request that produced each.
+type CollectedSignatures = HashMap<(ValidatorIndex, Hash256), Signature>;
+
+/// Drive signature collection to completion, keeping each result as it resolves.
+///
+/// Results are taken one at a time rather than as a group so that a root which never reaches
+/// quorum withholds only itself. `deadline`, when set, bounds the wait and leaves the roots still
+/// outstanding out of the returned map; callers surface those through `SigningRequest::resolve`
+/// failing for the affected request.
+async fn drain_signatures<F, E>(
+    mut pending: FuturesUnordered<F>,
+    deadline: Option<Instant>,
+) -> CollectedSignatures
+where
+    F: Future<Output = (ValidatorIndex, Hash256, Result<Signature, E>)>,
+    E: Debug,
+{
+    let mut signatures = HashMap::with_capacity(pending.len());
+    let collect = async {
+        while let Some((index, signing_root, result)) = pending.next().await {
+            match result {
+                Ok(signature) => {
+                    signatures.insert((index, signing_root), signature);
+                }
+                Err(e) => {
+                    error!(?index, ?signing_root, error = ?e, "Failed to collect signature");
+                }
+            }
+        }
+    };
+
+    match deadline {
+        Some(deadline) => {
+            if tokio::time::timeout_at(deadline, collect).await.is_err() {
+                warn!(
+                    unresolved = pending.len(),
+                    "Deadline passed before every signature resolved"
+                );
+            }
+        }
+        None => collect.await,
+    }
+
+    signatures
 }
 
 /// Handle committee signing errors with consistent timeout/failure metrics.
@@ -193,6 +243,16 @@ pub struct AnchorValidatorStore<
     strict_mfp: bool,
     is_synced: watch::Receiver<bool>,
     task_executor: TaskExecutor,
+    /// Once-only post-consensus signing executions for `AggregatorCommittee` duties (Boole+).
+    ///
+    /// One entry per `(committee, slot)`, registered by the slot pipeline in
+    /// [`Self::update_aggregation_assignments`] before those assignments are published, and only
+    /// when the entry is vacant. That registration is the single writer, so the complete decided
+    /// worklist is signed and batched exactly once no matter which Lighthouse callbacks fire, in
+    /// what order, or whether their futures are dropped. Callbacks only read this map as a
+    /// detached `Shared` future; they never start work.
+    aggregator_post_consensus:
+        Mutex<HashMap<(CommitteeId, Slot), AggregatorPostConsensusShared<E>>>,
 }
 
 /// How far into `slot` the clock currently is, or `None` if the clock cannot answer.
@@ -352,6 +412,7 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> AnchorValidator
             strict_mfp,
             is_synced,
             task_executor,
+            aggregator_post_consensus: Mutex::new(HashMap::new()),
         })
     }
 
@@ -461,13 +522,13 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> AnchorValidator
         validator_partial_signature_batch_size: usize,
         data_hash: Hash256,
         prepared: &[SigningRequest<D>],
-    ) -> Result<HashMap<ValidatorIndex, Signature>, Error> {
+    ) -> Result<CollectedSignatures, Error> {
         let collection_mode = CollectionMode::Committee {
             validator_partial_signature_batch_size,
             base_hash: data_hash,
         };
 
-        let futures: Vec<_> = prepared
+        let pending: FuturesUnordered<_> = prepared
             .iter()
             .filter_map(|item| {
                 let index = item.validator.index?;
@@ -484,45 +545,27 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> AnchorValidator
                             slot,
                         )
                         .await;
-                    (index, result)
+                    (index, item.signing_root, result)
                 })
             })
             .collect();
 
-        let results = join_all(futures).await;
-
-        let mut signatures = HashMap::with_capacity(results.len());
-        for (index, result) in results {
-            match result {
-                Ok(sig) => {
-                    signatures.insert(index, sig);
-                }
-                Err(e) => {
-                    error!(?index, error = ?e, "Failed to collect signature for validator");
-                }
-            }
-        }
-
-        Ok(signatures)
+        Ok(drain_signatures(pending, None).await)
     }
 
     /// Run `AggregatorCommittee` QBFT consensus for a committee at 2/3 slot.
     ///
-    /// Shared by `sign_committee_aggregate_and_proofs` and
-    /// `sign_committee_sync_committee_contributions`.
-    async fn run_aggregator_committee_consensus(
+    /// Called once per `(committee, slot)` by the post-consensus execution in
+    /// [`crate::aggregator_post_consensus`], which supplies the value this operator proposes.
+    pub(crate) async fn run_aggregator_committee_consensus(
         &self,
         committee_id: CommitteeId,
         slot: Slot,
         cluster: &Cluster,
-        metric_label: &str,
+        our_consensus_data: &AggregatorCommitteeConsensusData<E>,
     ) -> Result<AggregatorCommitteeConsensusData<E>, Error> {
-        let aggregation_assignments = self.get_aggregation_assignments(slot).await?;
-        let our_consensus_data = aggregation_assignments
-            .get_consensus_data(&committee_id)
-            .ok_or(Error::SpecificError(SpecificError::ConsensusDataNotFound))?;
-
-        let timer = metrics::start_timer_vec(&metrics::CONSENSUS_TIMES, &[metric_label]);
+        let timer =
+            metrics::start_timer_vec(&metrics::CONSENSUS_TIMES, &[metrics::AGGREGATOR_COMMITTEE]);
         let timeout_mode = TimeoutMode::SlotTime {
             instance_start_time: self
                 .get_instant_in_slot(slot, self.spec.get_slot_duration() * 2 / 3)?,
@@ -535,7 +578,7 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> AnchorValidator
                     committee: committee_id,
                     instance_height: slot.as_usize().into(),
                 },
-                (*our_consensus_data).clone(),
+                our_consensus_data.clone(),
                 Box::new(AggregatorCommitteeDataValidator::new()),
                 timeout_mode,
                 &cluster.cluster_members,
@@ -914,8 +957,8 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> AnchorValidator
     /// Get aggregator voting assignments, waiting if not yet available for this slot.
     ///
     /// This method waits until `AggregationAssignments` for the requested slot becomes available.
-    /// Called by `sign_committee_aggregate_and_proofs` and
-    /// `produce_signed_contribution_and_proof_boole` at 2/3 slot.
+    /// Called by `run_aggregator_post_consensus` (via `run_aggregator_committee_consensus`)
+    /// at 2/3 slot.
     ///
     /// Returns an error if the requested slot has already passed or if the watch channel is closed.
     pub async fn get_aggregation_assignments(
@@ -949,7 +992,12 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> AnchorValidator
     /// This publishes the `AggregationAssignments` to all subscribers via the watch channel.
     /// At 2/3 slot, selection proofs have been computed by Lighthouse, so
     /// `DutyAndProof.selection_proof.is_some()` accurately indicates `is_aggregator`.
-    pub fn update_aggregation_assignments(&self, info: AggregationAssignments<E>) {
+    ///
+    /// It also starts each Boole+ committee's post-consensus signing execution, before publishing,
+    /// so that every consumer able to observe these assignments can also observe the execution they
+    /// belong to. See [`crate::aggregator_post_consensus`].
+    pub fn update_aggregation_assignments(self: &Arc<Self>, info: AggregationAssignments<E>) {
+        self.start_aggregator_post_consensus(&info);
         self.aggregation_assignments_tx
             .send_replace(Some(Arc::new(info)));
     }
@@ -1363,16 +1411,15 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> AnchorValidator
         .await
     }
 
-    /// Boole+ committee-based contribution signing: single QBFT consensus per committee,
-    /// batch signature collection for all contributors.
+    /// Boole+ committee-based contribution signing: join the per-`(committee, slot)`
+    /// post-consensus execution and return the requested contributions from its outcome.
     ///
-    /// Cannot use `collect_prepared_signatures` because a validator in multiple subcommittees
-    /// needs multiple signatures with different signing roots, but that helper deduplicates
-    /// by `ValidatorIndex`. Uses `collect_signature` directly instead.
+    /// The execution signs the complete decided worklist (both object classes) regardless of
+    /// which Lighthouse callbacks fire; this callback only filters. See
+    /// [`crate::aggregator_post_consensus`].
     async fn sign_committee_sync_committee_contributions(
         &self,
         committee_id: CommitteeId,
-        cluster: Cluster,
         contributions: Vec<(ValidatorMetadata, ContributionToSign<E>)>,
     ) -> Result<Vec<SignedContributionAndProof<E>>, Error> {
         let Some((_, first)) = contributions.first() else {
@@ -1380,31 +1427,49 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> AnchorValidator
             return Ok(vec![]);
         };
         let slot = first.contribution.slot;
-        let epoch = slot.epoch(E::slots_per_epoch());
 
-        let decided_data = self
-            .run_aggregator_committee_consensus(
-                committee_id,
-                slot,
-                &cluster,
-                metrics::SYNC_CONTRIBUTION_AND_PROOF,
-            )
-            .await?;
+        let (deadline, outcome) = self.post_consensus_outcome(committee_id, slot).await?;
 
-        let domain_hash = self.get_domain(epoch, Domain::ContributionAndProof);
-
-        // Prepare all validators: find each in decided data, build ContributionAndProof
-        // (metadata already resolved by `group_by_committee`)
-        let mut prepared: Vec<SigningRequest<ContributionAndProof<E>>> =
-            Vec::with_capacity(contributions.len());
-
+        // Select this callback's own identities out of the shared outcome. The execution signs the
+        // whole decided value, so anything missing here is an entry the cluster did not decide on.
+        let mut prepared = Vec::with_capacity(contributions.len());
+        let pending = FuturesUnordered::new();
         for (validator, contrib) in &contributions {
-            let validator_index = match validator.index {
-                Some(idx) => idx,
-                None => {
-                    debug!(
-                        pubkey = ?contrib.aggregator_pubkey,
-                        "Validator missing index, skipping contribution"
+            let root = validator.index.and_then(|index| {
+                outcome
+                    .contributions
+                    .get(&(index, contrib.contribution.subcommittee_index))
+                    .map(|root| (index, root))
+            });
+            let Some((index, root)) = root else {
+                debug!(
+                    pubkey = ?contrib.aggregator_pubkey,
+                    subcommittee_index = contrib.contribution.subcommittee_index,
+                    "Requested contribution not in the decided worklist, skipping due to \
+                     divergent operator views"
+                );
+                validator_metrics::inc_counter_vec(
+                    &validator_metrics::SIGNED_SYNC_COMMITTEE_CONTRIBUTIONS_TOTAL,
+                    &[metrics::OTHER_ERROR],
+                );
+                continue;
+            };
+            let signing_root = root.request.signing_root;
+            let signature = root.signature.clone();
+            pending.push(async move { (index, signing_root, signature.await) });
+            prepared.push(root.request.clone());
+        }
+
+        let signatures = drain_signatures(pending, Some(deadline)).await;
+
+        let mut results = Vec::with_capacity(prepared.len());
+        for request in prepared {
+            let (message, signature) = match request.resolve(&signatures) {
+                Ok(resolved) => resolved,
+                Err(pubkey) => {
+                    warn!(
+                        ?pubkey,
+                        "Missing signature, skipping sync committee contribution"
                     );
                     validator_metrics::inc_counter_vec(
                         &validator_metrics::SIGNED_SYNC_COMMITTEE_CONTRIBUTIONS_TOTAL,
@@ -1414,118 +1479,19 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> AnchorValidator
                 }
             };
 
-            let subcommittee_index = contrib.contribution.subcommittee_index;
-
-            // Find this validator+subcommittee in the decided data
-            let Some(decided_contributor) = decided_data.contributors.iter().find(|c| {
-                c.validator_index == validator_index && c.committee_index == subcommittee_index
-            }) else {
-                debug!(
-                    ?validator_index,
-                    subcommittee_index,
-                    "Validator not in decided data, skipping due to divergent operator views"
-                );
-                validator_metrics::inc_counter_vec(
-                    &validator_metrics::SIGNED_SYNC_COMMITTEE_CONTRIBUTIONS_TOTAL,
-                    &[metrics::OTHER_ERROR],
-                );
-                continue;
-            };
-
-            // Find the contribution for this subcommittee
-            let Some(decided_contribution) = decided_data
-                .sync_committee_contributions
-                .iter()
-                .find(|c| c.subcommittee_index == subcommittee_index)
-            else {
-                debug!(
-                    subcommittee_index,
-                    pubkey = ?contrib.aggregator_pubkey,
-                    "Contribution not in consensus data - likely filtered due to beacon API failure"
-                );
-                validator_metrics::inc_counter_vec(
-                    &validator_metrics::SIGNED_SYNC_COMMITTEE_CONTRIBUTIONS_TOTAL,
-                    &[metrics::OTHER_ERROR],
-                );
-                continue;
-            };
-
-            let message = ContributionAndProof {
-                aggregator_index: contrib.aggregator_index,
-                contribution: decided_contribution.clone(),
-                selection_proof: decided_contributor.selection_proof.clone(),
-            };
-
-            let signing_root = message.signing_root(domain_hash);
-            prepared.push(SigningRequest {
-                validator: validator.clone(),
-                signing_root,
-                duty_data: message,
-            });
-        }
-
-        // Collect signatures — using `collect_signature` directly because a validator in
-        // multiple subcommittees produces multiple `SigningRequest`s with different signing
-        // roots, which `collect_prepared_signatures` cannot handle (it deduplicates by
-        // `ValidatorIndex`).
-        let committee_validator_indices = self.get_committee_validator_indices(&committee_id);
-        let validator_partial_signature_batch_size = decided_data
-            .post_consensus_signature_count(|idx| committee_validator_indices.contains(idx));
-        let data_hash = decided_data.hash();
-        let collection_mode = CollectionMode::Committee {
-            validator_partial_signature_batch_size,
-            base_hash: data_hash,
-        };
-
-        let sig_futures: Vec<_> = prepared
-            .iter()
-            .map(|req| {
-                self.collect_signature(
-                    PartialSignatureKind::PostConsensus,
-                    Role::AggregatorCommittee,
-                    collection_mode.clone(),
-                    &req.validator,
-                    &cluster,
-                    req.signing_root,
-                    slot,
-                )
-            })
-            .collect();
-
-        let signature_results = join_all(sig_futures).await;
-
-        // Assemble results
-        let mut results = Vec::with_capacity(prepared.len());
-        for (req, sig_result) in prepared.into_iter().zip(signature_results) {
-            match sig_result {
-                Ok(signature) => {
-                    let message = req.duty_data;
-                    debug!(
-                        aggregator_index = ?message.aggregator_index,
-                        slot = %message.contribution.slot,
-                        block_root = ?message.contribution.beacon_block_root,
-                        subcommittee_index = message.contribution.subcommittee_index,
-                        num_set_aggregation_bits = message.contribution.aggregation_bits.num_set_bits(),
-                        "Signed ContributionAndProof (Boole+ committee consensus)"
-                    );
-                    validator_metrics::inc_counter_vec(
-                        &validator_metrics::SIGNED_SYNC_COMMITTEE_CONTRIBUTIONS_TOTAL,
-                        &[validator_metrics::SUCCESS],
-                    );
-                    results.push(SignedContributionAndProof { message, signature });
-                }
-                Err(e) => {
-                    error!(
-                        pubkey = ?req.validator.public_key,
-                        error = ?e,
-                        "Failed to collect signature for sync contribution"
-                    );
-                    validator_metrics::inc_counter_vec(
-                        &validator_metrics::SIGNED_SYNC_COMMITTEE_CONTRIBUTIONS_TOTAL,
-                        &[metrics::OTHER_ERROR],
-                    );
-                }
-            }
+            debug!(
+                aggregator_index = ?message.aggregator_index,
+                slot = %message.contribution.slot,
+                block_root = ?message.contribution.beacon_block_root,
+                subcommittee_index = message.contribution.subcommittee_index,
+                num_set_aggregation_bits = message.contribution.aggregation_bits.num_set_bits(),
+                "Signed ContributionAndProof (Boole+ committee consensus)"
+            );
+            validator_metrics::inc_counter_vec(
+                &validator_metrics::SIGNED_SYNC_COMMITTEE_CONTRIBUTIONS_TOTAL,
+                &[validator_metrics::SUCCESS],
+            );
+            results.push(SignedContributionAndProof { message, signature });
         }
 
         Ok(results)
@@ -1764,73 +1730,15 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> AnchorValidator
         Ok(results)
     }
 
-    /// Resolve a single validator's aggregate from decided consensus data.
+    /// Boole+ committee-based aggregate signing: join the per-`(committee, slot)`
+    /// post-consensus execution and return the requested aggregates from its outcome.
     ///
-    /// Looks up the aggregator in decided data, finds the matching committee index,
-    /// decodes the aggregate attestation from SSZ, and builds an `AggregateAndProof`.
-    fn resolve_decided_aggregate(
-        decided_data: &AggregatorCommitteeConsensusData<E>,
-        validator: ValidatorMetadata,
-        agg: &AggregateToSign<E>,
-        domain_hash: Hash256,
-    ) -> Result<SigningRequest<(u64, AggregateAndProof<E>)>, String> {
-        let validator_index = validator.index.ok_or("Validator missing index")?;
-
-        // Find this validator in the decided data
-        let decided_aggregator = decided_data
-            .aggregators
-            .iter()
-            .find(|a| a.validator_index == validator_index)
-            .ok_or("Validator not in decided data")?;
-
-        let committee_index = decided_aggregator.committee_index;
-
-        // Find the position of this committee index in decided data
-        let decided_aggregate_idx = decided_data
-            .aggregator_committee_indexes
-            .iter()
-            .position(|&idx| idx == committee_index)
-            .ok_or("Committee index not found in decided data")?;
-
-        let decided_aggregate_bytes = decided_data
-            .aggregated_attestations
-            .get(decided_aggregate_idx)
-            .ok_or("Aggregate attestation bytes not found in decided data")?;
-
-        // Decode based on fork version
-        let decided_aggregate = if decided_data.version < DataVersion::from(ForkName::Electra) {
-            AttestationBase::from_ssz_bytes(decided_aggregate_bytes)
-                .map(Attestation::Base)
-                .map_err(|e| format!("Failed to decode decided aggregate: {e:?}"))?
-        } else {
-            AttestationElectra::from_ssz_bytes(decided_aggregate_bytes)
-                .map(Attestation::Electra)
-                .map_err(|e| format!("Failed to decode decided aggregate: {e:?}"))?
-        };
-
-        let decided_selection_proof =
-            SelectionProof::from(decided_aggregator.selection_proof.clone());
-
-        let message = AggregateAndProof::from_attestation(
-            agg.aggregator_index,
-            decided_aggregate,
-            decided_selection_proof,
-        );
-
-        let signing_root = message.signing_root(domain_hash);
-        Ok(SigningRequest {
-            validator,
-            signing_root,
-            duty_data: (agg.aggregator_index, message),
-        })
-    }
-
-    /// Boole+ committee-based aggregate signing: single QBFT consensus per committee,
-    /// batch signature collection for all aggregators.
+    /// The execution signs the complete decided worklist (both object classes) regardless of
+    /// which Lighthouse callbacks fire; this callback only filters. See
+    /// [`crate::aggregator_post_consensus`].
     async fn sign_committee_aggregate_and_proofs(
         &self,
         committee_id: CommitteeId,
-        cluster: Cluster,
         aggregates: Vec<(ValidatorMetadata, AggregateToSign<E>)>,
     ) -> Result<Vec<SignedAggregateAndProof<E>>, Error> {
         let Some((_, first)) = aggregates.first() else {
@@ -1838,62 +1746,43 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> AnchorValidator
             return Ok(vec![]);
         };
         let slot = first.aggregate.data().slot;
-        let signing_epoch = first.aggregate.data().target.epoch;
 
-        let decided_data = self
-            .run_aggregator_committee_consensus(
-                committee_id,
-                slot,
-                &cluster,
-                metrics::AGGREGATE_AND_PROOF,
-            )
-            .await?;
+        let (deadline, outcome) = self.post_consensus_outcome(committee_id, slot).await?;
 
-        let domain_hash = self.get_domain(signing_epoch, Domain::AggregateAndProof);
-
-        // Prepare all validators: find each in decided data, decode aggregate, build message
-        // (metadata already resolved by `group_by_committee`)
-        let mut prepared: Vec<SigningRequest<(u64, AggregateAndProof<E>)>> =
-            Vec::with_capacity(aggregates.len());
-
-        for (validator, agg) in aggregates {
-            match Self::resolve_decided_aggregate(&decided_data, validator, &agg, domain_hash) {
-                Ok(request) => prepared.push(request),
-                Err(e) => {
-                    debug!(pubkey = ?agg.pubkey, error = e, "Skipping aggregate");
-                    validator_metrics::inc_counter_vec(
-                        &validator_metrics::SIGNED_AGGREGATES_TOTAL,
-                        &[metrics::OTHER_ERROR],
-                    );
-                }
-            }
+        // Select this callback's own identities out of the shared outcome. The execution signs the
+        // whole decided value, so anything missing here is an entry the cluster did not decide on.
+        let mut prepared = Vec::with_capacity(aggregates.len());
+        let pending = FuturesUnordered::new();
+        for (validator, agg) in &aggregates {
+            let root = validator
+                .index
+                .and_then(|index| outcome.aggregates.get(&index).map(|root| (index, root)));
+            let Some((index, root)) = root else {
+                debug!(
+                    pubkey = ?agg.pubkey,
+                    "Requested aggregate not in the decided worklist, skipping due to divergent \
+                     operator views"
+                );
+                validator_metrics::inc_counter_vec(
+                    &validator_metrics::SIGNED_AGGREGATES_TOTAL,
+                    &[metrics::OTHER_ERROR],
+                );
+                continue;
+            };
+            let signing_root = root.request.signing_root;
+            let signature = root.signature.clone();
+            pending.push(async move { (index, signing_root, signature.await) });
+            prepared.push(root.request.clone());
         }
 
-        // Collect signatures and assemble results
-        let committee_validator_indices = self.get_committee_validator_indices(&committee_id);
-        let validator_partial_signature_batch_size = decided_data
-            .post_consensus_signature_count(|idx| committee_validator_indices.contains(idx));
-
-        let signatures = self
-            .collect_prepared_signatures(
-                Role::AggregatorCommittee,
-                slot,
-                &cluster,
-                validator_partial_signature_batch_size,
-                decided_data.hash(),
-                &prepared,
-            )
-            .await?;
+        let signatures = drain_signatures(pending, Some(deadline)).await;
 
         let mut results = Vec::with_capacity(prepared.len());
-        for req in prepared {
-            let ((aggregator_index, message), signature) = match req.resolve(&signatures) {
+        for request in prepared {
+            let (message, signature) = match request.resolve(&signatures) {
                 Ok(resolved) => resolved,
                 Err(pubkey) => {
-                    warn!(
-                        ?pubkey,
-                        "Missing validator index or signature for aggregator, skipping"
-                    );
+                    warn!(?pubkey, "Missing signature, skipping aggregate");
                     validator_metrics::inc_counter_vec(
                         &validator_metrics::SIGNED_AGGREGATES_TOTAL,
                         &[metrics::OTHER_ERROR],
@@ -1903,7 +1792,7 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> AnchorValidator
             };
 
             debug!(
-                ?aggregator_index,
+                aggregator_index = message.aggregator_index(),
                 data = ?message.aggregate().data(),
                 num_set_aggregation_bits = message.aggregate().num_set_aggregation_bits(),
                 "Signed AggregateAndProof (Boole+ committee consensus)"
@@ -2351,6 +2240,9 @@ pub enum SpecificError {
     ContributionNotInConsensus(u64),
     /// This validator not found in consensus data (Boole+)
     ValidatorNotInConsensus(ValidatorIndex),
+    /// The detached `AggregatorCommittee` post-consensus execution died before producing a
+    /// result (executor shutdown, spawn refusal, or task panic)
+    PostConsensusAborted,
 }
 
 impl From<CollectionError> for SpecificError {
@@ -2822,18 +2714,14 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> ValidatorStore
 
             let committee_futures: FuturesUnordered<_> = committee_mapping
                 .into_iter()
-                .map(|(committee_id, (cluster, aggregates))| {
+                .map(|(committee_id, (_cluster, aggregates))| {
                     let this = Arc::clone(self);
                     async move {
                         run_committee_signing(
                             committee_id,
                             aggregates.len(),
                             &validator_metrics::SIGNED_AGGREGATES_TOTAL,
-                            this.sign_committee_aggregate_and_proofs(
-                                committee_id,
-                                cluster,
-                                aggregates,
-                            ),
+                            this.sign_committee_aggregate_and_proofs(committee_id, aggregates),
                         )
                         .await
                     }
@@ -3146,7 +3034,7 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> ValidatorStore
 
             let committee_futures: FuturesUnordered<_> = committee_mapping
                 .into_iter()
-                .map(|(committee_id, (cluster, contributions))| {
+                .map(|(committee_id, (_cluster, contributions))| {
                     let this = Arc::clone(self);
                     async move {
                         run_committee_signing(
@@ -3155,7 +3043,6 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> ValidatorStore
                             &validator_metrics::SIGNED_SYNC_COMMITTEE_CONTRIBUTIONS_TOTAL,
                             this.sign_committee_sync_committee_contributions(
                                 committee_id,
-                                cluster,
                                 contributions,
                             ),
                         )

--- a/anchor/validator_store/src/lib.rs
+++ b/anchor/validator_store/src/lib.rs
@@ -248,9 +248,10 @@ pub struct AnchorValidatorStore<
     /// One entry per `(committee, slot)`, registered by the slot pipeline in
     /// [`Self::update_aggregation_assignments`] before those assignments are published, and only
     /// when the entry is vacant. That registration is the single writer, so the complete decided
-    /// worklist is signed and batched exactly once no matter which Lighthouse callbacks fire, in
-    /// what order, or whether their futures are dropped. Callbacks only read this map as a
-    /// detached `Shared` future; they never start work.
+    /// worklist is signed and batched exactly once no matter which consumers run, in what order,
+    /// or whether their futures are dropped. Consumers (the contributions callback via this map,
+    /// the aggregate publisher via the handles registration returns) only read detached `Shared`
+    /// futures; they never start work.
     aggregator_post_consensus:
         Mutex<HashMap<(CommitteeId, Slot), AggregatorPostConsensusShared<E>>>,
 }
@@ -996,10 +997,19 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> AnchorValidator
     /// It also starts each Boole+ committee's post-consensus signing execution, before publishing,
     /// so that every consumer able to observe these assignments can also observe the execution they
     /// belong to. See [`crate::aggregator_post_consensus`].
-    pub fn update_aggregation_assignments(self: &Arc<Self>, info: AggregationAssignments<E>) {
-        self.start_aggregator_post_consensus(&info);
+    ///
+    /// Returns the executions newly registered by this call, for the caller to hand to the
+    /// aggregate publisher. Only vacant insertions are returned, so repeated calls for one slot
+    /// cannot register a second publisher for the same `(committee, slot)`.
+    #[must_use = "dropping the returned executions disables Boole+ aggregate publication"]
+    pub(crate) fn update_aggregation_assignments(
+        self: &Arc<Self>,
+        info: AggregationAssignments<E>,
+    ) -> Vec<(CommitteeId, AggregatorPostConsensusShared<E>)> {
+        let new_executions = self.start_aggregator_post_consensus(&info);
         self.aggregation_assignments_tx
             .send_replace(Some(Arc::new(info)));
+        new_executions
     }
 
     /// Return [`SpecificError::Timeout`] if the given future does not complete at `delay` into the
@@ -1725,85 +1735,6 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> AnchorValidator
             }
 
             results.push((validator_index, attestation, pubkey));
-        }
-
-        Ok(results)
-    }
-
-    /// Boole+ committee-based aggregate signing: join the per-`(committee, slot)`
-    /// post-consensus execution and return the requested aggregates from its outcome.
-    ///
-    /// The execution signs the complete decided worklist (both object classes) regardless of
-    /// which Lighthouse callbacks fire; this callback only filters. See
-    /// [`crate::aggregator_post_consensus`].
-    async fn sign_committee_aggregate_and_proofs(
-        &self,
-        committee_id: CommitteeId,
-        aggregates: Vec<(ValidatorMetadata, AggregateToSign<E>)>,
-    ) -> Result<Vec<SignedAggregateAndProof<E>>, Error> {
-        let Some((_, first)) = aggregates.first() else {
-            warn!("sign_committee_aggregate_and_proofs called with empty aggregates");
-            return Ok(vec![]);
-        };
-        let slot = first.aggregate.data().slot;
-
-        let (deadline, outcome) = self.post_consensus_outcome(committee_id, slot).await?;
-
-        // Select this callback's own identities out of the shared outcome. The execution signs the
-        // whole decided value, so anything missing here is an entry the cluster did not decide on.
-        let mut prepared = Vec::with_capacity(aggregates.len());
-        let pending = FuturesUnordered::new();
-        for (validator, agg) in &aggregates {
-            let root = validator
-                .index
-                .and_then(|index| outcome.aggregates.get(&index).map(|root| (index, root)));
-            let Some((index, root)) = root else {
-                debug!(
-                    pubkey = ?agg.pubkey,
-                    "Requested aggregate not in the decided worklist, skipping due to divergent \
-                     operator views"
-                );
-                validator_metrics::inc_counter_vec(
-                    &validator_metrics::SIGNED_AGGREGATES_TOTAL,
-                    &[metrics::OTHER_ERROR],
-                );
-                continue;
-            };
-            let signing_root = root.request.signing_root;
-            let signature = root.signature.clone();
-            pending.push(async move { (index, signing_root, signature.await) });
-            prepared.push(root.request.clone());
-        }
-
-        let signatures = drain_signatures(pending, Some(deadline)).await;
-
-        let mut results = Vec::with_capacity(prepared.len());
-        for request in prepared {
-            let (message, signature) = match request.resolve(&signatures) {
-                Ok(resolved) => resolved,
-                Err(pubkey) => {
-                    warn!(?pubkey, "Missing signature, skipping aggregate");
-                    validator_metrics::inc_counter_vec(
-                        &validator_metrics::SIGNED_AGGREGATES_TOTAL,
-                        &[metrics::OTHER_ERROR],
-                    );
-                    continue;
-                }
-            };
-
-            debug!(
-                aggregator_index = message.aggregator_index(),
-                data = ?message.aggregate().data(),
-                num_set_aggregation_bits = message.aggregate().num_set_aggregation_bits(),
-                "Signed AggregateAndProof (Boole+ committee consensus)"
-            );
-            validator_metrics::inc_counter_vec(
-                &validator_metrics::SIGNED_AGGREGATES_TOTAL,
-                &[validator_metrics::SUCCESS],
-            );
-            results.push(SignedAggregateAndProof::from_aggregate_and_proof(
-                message, signature,
-            ));
         }
 
         Ok(results)
@@ -2698,49 +2629,45 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> ValidatorStore
         self: &Arc<Self>,
         aggregates: Vec<AggregateToSign<E>>,
     ) -> impl Stream<Item = Result<Vec<SignedAggregateAndProof<E>>, Error>> + Send {
-        // Early return for empty input — no fork to determine, nothing to sign
-        let Some(first) = aggregates.first() else {
-            return Either::Right(FuturesUnordered::new());
-        };
+        let this = Arc::clone(self);
+        stream::once(async move {
+            let publish_via_lighthouse = aggregates.first().is_some_and(|first| {
+                this.fork_schedule
+                    .active_fork(first.aggregate.data().target.epoch)
+                    < Fork::Boole
+            });
 
-        if self
-            .fork_schedule
-            .active_fork(first.aggregate.data().target.epoch)
-            >= Fork::Boole
-        {
-            // Boole+: group by committee, stream per committee via FuturesUnordered
-            let _span = info_span!("sign_aggregate_and_proofs").entered();
-            let committee_mapping = self.group_by_committee(aggregates, |a| a.pubkey);
+            if !publish_via_lighthouse {
+                // Boole+ (or empty input): hand Lighthouse an empty batch, which its publish loop
+                // drops silently. Publication ownership lives with the metadata service's
+                // aggregate publisher, which signs and publishes the decided worklist regardless
+                // of whether Lighthouse's duty snapshot saw the selection proofs in time. See
+                // [`crate::aggregator_post_consensus`].
+                if let Some(first) = aggregates.first() {
+                    // Lighthouse's request set is its snapshot's view of who aggregates; the
+                    // publisher only ever sees the decided view. Logging the request set here
+                    // keeps divergent operator views diagnosable by comparing the two.
+                    debug!(
+                        slot = %first.aggregate.data().slot,
+                        requested = aggregates.len(),
+                        aggregators = ?aggregates
+                            .iter()
+                            .map(|agg| agg.aggregator_index)
+                            .collect::<Vec<_>>(),
+                        "Deferring Lighthouse-requested aggregates to the decided-value publisher"
+                    );
+                }
+                return Ok(Vec::new());
+            }
 
-            let committee_futures: FuturesUnordered<_> = committee_mapping
-                .into_iter()
-                .map(|(committee_id, (_cluster, aggregates))| {
-                    let this = Arc::clone(self);
-                    async move {
-                        run_committee_signing(
-                            committee_id,
-                            aggregates.len(),
-                            &validator_metrics::SIGNED_AGGREGATES_TOTAL,
-                            this.sign_committee_aggregate_and_proofs(committee_id, aggregates),
-                        )
-                        .await
-                    }
-                })
-                .collect();
-
-            Either::Right(committee_futures)
-        } else {
-            // Pre-Boole: per-validator processing, no committee grouping needed
-            let this = Arc::clone(self);
-            Either::Left(stream::once(async move {
-                let futures = aggregates.into_iter().map(|agg| {
-                    let this = Arc::clone(&this);
-                    async move { this.sign_single_aggregate_and_proof(agg).await }
-                });
-                let results = join_all(futures).await;
-                Ok(results.into_iter().filter_map(|r| r.ok()).collect())
-            }))
-        }
+            // Pre-Boole: per-validator processing, Lighthouse publishes the results
+            let futures = aggregates.into_iter().map(|agg| {
+                let this = Arc::clone(&this);
+                async move { this.sign_single_aggregate_and_proof(agg).await }
+            });
+            let results = join_all(futures).await;
+            Ok(results.into_iter().filter_map(|r| r.ok()).collect())
+        })
     }
 
     async fn produce_selection_proof(

--- a/anchor/validator_store/src/lib.rs
+++ b/anchor/validator_store/src/lib.rs
@@ -136,43 +136,24 @@ type CollectedSignatures = HashMap<(ValidatorIndex, Hash256), Signature>;
 /// Drive signature collection to completion, keeping each result as it resolves.
 ///
 /// Results are taken one at a time rather than as a group so that a root which never reaches
-/// quorum withholds only itself. `deadline`, when set, bounds the wait and leaves the roots still
-/// outstanding out of the returned map; callers surface those through `SigningRequest::resolve`
-/// failing for the affected request.
-async fn drain_signatures<F, E>(
-    mut pending: FuturesUnordered<F>,
-    deadline: Option<Instant>,
-) -> CollectedSignatures
+/// quorum withholds only itself; callers surface missing roots through
+/// `SigningRequest::resolve` failing for the affected request.
+async fn drain_signatures<F, E>(mut pending: FuturesUnordered<F>) -> CollectedSignatures
 where
     F: Future<Output = (ValidatorIndex, Hash256, Result<Signature, E>)>,
     E: Debug,
 {
     let mut signatures = HashMap::with_capacity(pending.len());
-    let collect = async {
-        while let Some((index, signing_root, result)) = pending.next().await {
-            match result {
-                Ok(signature) => {
-                    signatures.insert((index, signing_root), signature);
-                }
-                Err(e) => {
-                    error!(?index, ?signing_root, error = ?e, "Failed to collect signature");
-                }
+    while let Some((index, signing_root, result)) = pending.next().await {
+        match result {
+            Ok(signature) => {
+                signatures.insert((index, signing_root), signature);
+            }
+            Err(e) => {
+                error!(?index, ?signing_root, error = ?e, "Failed to collect signature");
             }
         }
-    };
-
-    match deadline {
-        Some(deadline) => {
-            if tokio::time::timeout_at(deadline, collect).await.is_err() {
-                warn!(
-                    unresolved = pending.len(),
-                    "Deadline passed before every signature resolved"
-                );
-            }
-        }
-        None => collect.await,
     }
-
     signatures
 }
 
@@ -243,17 +224,16 @@ pub struct AnchorValidatorStore<
     strict_mfp: bool,
     is_synced: watch::Receiver<bool>,
     task_executor: TaskExecutor,
-    /// Once-only post-consensus signing executions for `AggregatorCommittee` duties (Boole+).
+    /// `(committee, slot)` keys whose Boole+ `AggregatorCommittee` post-consensus execution has
+    /// already been started.
     ///
-    /// One entry per `(committee, slot)`, registered by the slot pipeline in
-    /// [`Self::update_aggregation_assignments`] before those assignments are published, and only
-    /// when the entry is vacant. That registration is the single writer, so the complete decided
-    /// worklist is signed and batched exactly once no matter which consumers run, in what order,
-    /// or whether their futures are dropped. Consumers (the contributions callback via this map,
-    /// the aggregate publisher via the handles registration returns) only read detached `Shared`
-    /// futures; they never start work.
-    aggregator_post_consensus:
-        Mutex<HashMap<(CommitteeId, Slot), AggregatorPostConsensusShared<E>>>,
+    /// Registered by the slot pipeline in [`Self::update_aggregation_assignments`] before those
+    /// assignments are published, first-insert-only. That registration is the single writer, so
+    /// the complete decided worklist is signed and batched exactly once no matter how often the
+    /// pipeline runs. The execution handles themselves travel to their sole consumer (the
+    /// metadata service's publisher) through the registration's return value; this set only
+    /// provides registration idempotence across the retention window.
+    aggregator_post_consensus: Mutex<HashSet<(CommitteeId, Slot)>>,
 }
 
 /// How far into `slot` the clock currently is, or `None` if the clock cannot answer.
@@ -413,7 +393,7 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> AnchorValidator
             strict_mfp,
             is_synced,
             task_executor,
-            aggregator_post_consensus: Mutex::new(HashMap::new()),
+            aggregator_post_consensus: Mutex::new(HashSet::new()),
         })
     }
 
@@ -551,7 +531,7 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> AnchorValidator
             })
             .collect();
 
-        Ok(drain_signatures(pending, None).await)
+        Ok(drain_signatures(pending).await)
     }
 
     /// Run `AggregatorCommittee` QBFT consensus for a committee at 2/3 slot.
@@ -1422,90 +1402,16 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> AnchorValidator
         .await
     }
 
-    /// Boole+ committee-based contribution signing: join the per-`(committee, slot)`
-    /// post-consensus execution and return the requested contributions from its outcome.
+    /// Whether Lighthouse's callbacks own publication of aggregator-committee duties at `epoch`.
     ///
-    /// The execution signs the complete decided worklist (both object classes) regardless of
-    /// which Lighthouse callbacks fire; this callback only filters. See
-    /// [`crate::aggregator_post_consensus`].
-    async fn sign_committee_sync_committee_contributions(
-        &self,
-        committee_id: CommitteeId,
-        contributions: Vec<(ValidatorMetadata, ContributionToSign<E>)>,
-    ) -> Result<Vec<SignedContributionAndProof<E>>, Error> {
-        let Some((_, first)) = contributions.first() else {
-            warn!("sign_committee_sync_committee_contributions called with empty contributions");
-            return Ok(vec![]);
-        };
-        let slot = first.contribution.slot;
-
-        let (deadline, outcome) = self.post_consensus_outcome(committee_id, slot).await?;
-
-        // Select this callback's own identities out of the shared outcome. The execution signs the
-        // whole decided value, so anything missing here is an entry the cluster did not decide on.
-        let mut prepared = Vec::with_capacity(contributions.len());
-        let pending = FuturesUnordered::new();
-        for (validator, contrib) in &contributions {
-            let root = validator.index.and_then(|index| {
-                outcome
-                    .contributions
-                    .get(&(index, contrib.contribution.subcommittee_index))
-                    .map(|root| (index, root))
-            });
-            let Some((index, root)) = root else {
-                debug!(
-                    pubkey = ?contrib.aggregator_pubkey,
-                    subcommittee_index = contrib.contribution.subcommittee_index,
-                    "Requested contribution not in the decided worklist, skipping due to \
-                     divergent operator views"
-                );
-                validator_metrics::inc_counter_vec(
-                    &validator_metrics::SIGNED_SYNC_COMMITTEE_CONTRIBUTIONS_TOTAL,
-                    &[metrics::OTHER_ERROR],
-                );
-                continue;
-            };
-            let signing_root = root.request.signing_root;
-            let signature = root.signature.clone();
-            pending.push(async move { (index, signing_root, signature.await) });
-            prepared.push(root.request.clone());
-        }
-
-        let signatures = drain_signatures(pending, Some(deadline)).await;
-
-        let mut results = Vec::with_capacity(prepared.len());
-        for request in prepared {
-            let (message, signature) = match request.resolve(&signatures) {
-                Ok(resolved) => resolved,
-                Err(pubkey) => {
-                    warn!(
-                        ?pubkey,
-                        "Missing signature, skipping sync committee contribution"
-                    );
-                    validator_metrics::inc_counter_vec(
-                        &validator_metrics::SIGNED_SYNC_COMMITTEE_CONTRIBUTIONS_TOTAL,
-                        &[metrics::OTHER_ERROR],
-                    );
-                    continue;
-                }
-            };
-
-            debug!(
-                aggregator_index = ?message.aggregator_index,
-                slot = %message.contribution.slot,
-                block_root = ?message.contribution.beacon_block_root,
-                subcommittee_index = message.contribution.subcommittee_index,
-                num_set_aggregation_bits = message.contribution.aggregation_bits.num_set_bits(),
-                "Signed ContributionAndProof (Boole+ committee consensus)"
-            );
-            validator_metrics::inc_counter_vec(
-                &validator_metrics::SIGNED_SYNC_COMMITTEE_CONTRIBUTIONS_TOTAL,
-                &[validator_metrics::SUCCESS],
-            );
-            results.push(SignedContributionAndProof { message, signature });
-        }
-
-        Ok(results)
+    /// Pre-Boole they do; from Boole the metadata service's publisher owns both classes
+    /// (aggregates and sync contributions) and the callbacks return empty batches. This is the
+    /// exact complement of the publisher's registration gate (consensus data is only built for
+    /// Boole+ slots), so exactly one path publishes for any duty. Both callbacks derive `epoch`
+    /// from the duty's own payload (the aggregate's target epoch, the contribution's slot),
+    /// which equal the duty slot's epoch by construction.
+    pub(crate) fn lighthouse_owns_publication(&self, epoch: Epoch) -> bool {
+        self.fork_schedule.active_fork(epoch) < Fork::Boole
     }
 
     /// Sign sync committee messages for all validators in a single SSV committee.
@@ -2242,8 +2148,6 @@ pub enum SpecificError {
         slot: Slot,
         reason: SyncSelectionProofAssignmentError,
     },
-    /// Pre-built consensus data not found for this committee (Boole+)
-    ConsensusDataNotFound,
     /// This committee's aggregate not found in consensus data (Boole+)
     AggregateNotInConsensus(u64),
     /// This subcommittee's contribution not found in consensus data (Boole+)
@@ -2710,32 +2614,30 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> ValidatorStore
     ) -> impl Stream<Item = Result<Vec<SignedAggregateAndProof<E>>, Error>> + Send {
         let this = Arc::clone(self);
         stream::once(async move {
-            let publish_via_lighthouse = aggregates.first().is_some_and(|first| {
-                this.fork_schedule
-                    .active_fork(first.aggregate.data().target.epoch)
-                    < Fork::Boole
-            });
+            // Empty input: nothing to sign and no fork to determine.
+            let Some(first) = aggregates.first() else {
+                return Ok(Vec::new());
+            };
 
-            if !publish_via_lighthouse {
-                // Boole+ (or empty input): hand Lighthouse an empty batch, which its publish loop
-                // drops silently. Publication ownership lives with the metadata service's
-                // aggregate publisher, which signs and publishes the decided worklist regardless
-                // of whether Lighthouse's duty snapshot saw the selection proofs in time. See
+            if !this.lighthouse_owns_publication(first.aggregate.data().target.epoch) {
+                // Boole+: hand Lighthouse an empty batch, which its publish loop drops silently.
+                // Publication ownership lives with the metadata service's publisher, which signs
+                // and publishes the decided worklist regardless of whether Lighthouse's duty
+                // snapshot saw the selection proofs in time. See
                 // [`crate::aggregator_post_consensus`].
-                if let Some(first) = aggregates.first() {
-                    // Lighthouse's request set is its snapshot's view of who aggregates; the
-                    // publisher only ever sees the decided view. Logging the request set here
-                    // keeps divergent operator views diagnosable by comparing the two.
-                    debug!(
-                        slot = %first.aggregate.data().slot,
-                        requested = aggregates.len(),
-                        aggregators = ?aggregates
-                            .iter()
-                            .map(|agg| agg.aggregator_index)
-                            .collect::<Vec<_>>(),
-                        "Deferring Lighthouse-requested aggregates to the decided-value publisher"
-                    );
-                }
+                //
+                // Lighthouse's request set is its snapshot's view of who aggregates; the
+                // publisher only ever sees the decided view. Logging the request set here keeps
+                // divergent operator views diagnosable by comparing the two.
+                debug!(
+                    slot = %first.aggregate.data().slot,
+                    requested = aggregates.len(),
+                    aggregators = ?aggregates
+                        .iter()
+                        .map(|agg| agg.aggregator_index)
+                        .collect::<Vec<_>>(),
+                    "Deferring Lighthouse-requested aggregates to the decided-value publisher"
+                );
                 return Ok(Vec::new());
             }
 
@@ -3024,50 +2926,48 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> ValidatorStore
         self: &Arc<Self>,
         contributions: Vec<ContributionToSign<E>>,
     ) -> impl Stream<Item = Result<Vec<SignedContributionAndProof<E>>, Error>> + Send {
-        // Early return for empty input — no fork to determine, nothing to sign
-        let Some(first) = contributions.first() else {
-            return Either::Right(FuturesUnordered::new());
-        };
+        let this = Arc::clone(self);
+        stream::once(async move {
+            // Empty input: nothing to sign and no fork to determine.
+            let Some(first) = contributions.first() else {
+                return Ok(Vec::new());
+            };
 
-        let epoch = first.contribution.slot.epoch(E::slots_per_epoch());
+            if !this
+                .lighthouse_owns_publication(first.contribution.slot.epoch(E::slots_per_epoch()))
+            {
+                // Boole+: hand Lighthouse an empty batch, which its publish loop drops silently.
+                // Publication ownership lives with the metadata service's publisher, which signs
+                // and publishes the decided worklist regardless of whether Lighthouse's duty
+                // snapshot saw the sync selection proofs in time. See
+                // [`crate::aggregator_post_consensus`].
+                //
+                // Lighthouse's request set is its snapshot's view of who aggregates; the
+                // publisher only ever sees the decided view. Logging the request set here keeps
+                // divergent operator views diagnosable by comparing the two.
+                debug!(
+                    slot = %first.contribution.slot,
+                    // Lighthouse requests contributions per subnet, so one call is one subnet;
+                    // the publisher's logs key on subcommittee index, and this field is the join.
+                    subnet = first.contribution.subcommittee_index,
+                    requested = contributions.len(),
+                    aggregators = ?contributions
+                        .iter()
+                        .map(|contrib| contrib.aggregator_index)
+                        .collect::<Vec<_>>(),
+                    "Deferring Lighthouse-requested contributions to the decided-value publisher"
+                );
+                return Ok(Vec::new());
+            }
 
-        if self.fork_schedule.active_fork(epoch) >= Fork::Boole {
-            // Boole+: group by committee, stream per committee via FuturesUnordered
-            let _span = info_span!("sign_sync_committee_contributions").entered();
-            let committee_mapping = self.group_by_committee(contributions, |c| c.aggregator_pubkey);
-
-            let committee_futures: FuturesUnordered<_> = committee_mapping
-                .into_iter()
-                .map(|(committee_id, (_cluster, contributions))| {
-                    let this = Arc::clone(self);
-                    async move {
-                        run_committee_signing(
-                            committee_id,
-                            contributions.len(),
-                            &validator_metrics::SIGNED_SYNC_COMMITTEE_CONTRIBUTIONS_TOTAL,
-                            this.sign_committee_sync_committee_contributions(
-                                committee_id,
-                                contributions,
-                            ),
-                        )
-                        .await
-                    }
-                })
-                .collect();
-
-            Either::Right(committee_futures)
-        } else {
-            // Pre-Boole: per-validator processing, no committee grouping needed
-            let this = Arc::clone(self);
-            Either::Left(stream::once(async move {
-                let futures = contributions.into_iter().map(|contrib| {
-                    let this = Arc::clone(&this);
-                    async move { this.sign_single_sync_committee_contribution(contrib).await }
-                });
-                let results = join_all(futures).await;
-                Ok(results.into_iter().filter_map(|r| r.ok()).collect())
-            }))
-        }
+            // Pre-Boole: per-validator processing, Lighthouse publishes the results
+            let futures = contributions.into_iter().map(|contrib| {
+                let this = Arc::clone(&this);
+                async move { this.sign_single_sync_committee_contribution(contrib).await }
+            });
+            let results = join_all(futures).await;
+            Ok(results.into_iter().filter_map(|r| r.ok()).collect())
+        })
     }
 
     // stolen from lighthouse

--- a/anchor/validator_store/src/lib.rs
+++ b/anchor/validator_store/src/lib.rs
@@ -1,3 +1,4 @@
+mod aggregator_post_consensus;
 mod instrumentation;
 pub mod metadata_service;
 mod metrics;
@@ -17,7 +18,7 @@ use database::{NetworkDatabase, NonUniqueIndex, UniqueIndex};
 use eth2::types::{BlockContents, BlockContentsTuple, FullBlockContents, PublishBlockRequest};
 use fork::{Fork, ForkSchedule};
 use futures::{
-    Stream,
+    Stream, StreamExt,
     future::{Either, join_all},
     stream,
     stream::FuturesUnordered,
@@ -36,7 +37,7 @@ use qbft_manager::{
 use safe_arith::{ArithError, SafeArith};
 use signature_collector::{
     CollectionError, SignatureCollecting, SignatureMetadata, SignatureRequester,
-    SyncSelectionProofDescriptor, ValidatorSigningData,
+    SyncCommitteeBatchEntry, ValidatorSigningData,
 };
 use slashing_protection::{CheckSlashability, NotSafe, Safe, SlashingDatabase};
 use slot_clock::SlotClock;
@@ -65,15 +66,15 @@ use tokio::{
 };
 use tracing::{Instrument, Span, debug, error, field, info, info_span, trace, warn};
 use types::{
-    AbstractExecPayload, Address, AggregateAndProof, Attestation, BeaconBlock, BeaconBlockRef,
-    BlindedPayload, ChainSpec, Checkpoint, ContributionAndProof, Domain, Epoch, EthSpec,
-    ExecutionPayloadEnvelope, ForkName, FullPayload, Graffiti, Hash256, PayloadAttestationData,
-    PayloadAttestationMessage, ProposerPreferences, SelectionProof, SignedAggregateAndProof,
-    SignedBeaconBlock, SignedBlindedBeaconBlock, SignedContributionAndProof,
-    SignedExecutionPayloadEnvelope, SignedProposerPreferences, SignedRoot,
-    SignedValidatorRegistrationData, SignedVoluntaryExit, SingleAttestation, Slot, SlotData,
-    SyncAggregatorSelectionData, SyncCommitteeContribution, SyncCommitteeMessage,
-    SyncSelectionProof, SyncSubnetId, ValidatorRegistrationData, VoluntaryExit,
+    AbstractExecPayload, Address, AggregateAndProof, BeaconBlock, BeaconBlockRef, BlindedPayload,
+    ChainSpec, Checkpoint, ContributionAndProof, Domain, Epoch, EthSpec, ExecutionPayloadEnvelope,
+    ForkName, FullPayload, Graffiti, Hash256, PayloadAttestationData, PayloadAttestationMessage,
+    ProposerPreferences, SelectionProof, SignedAggregateAndProof, SignedBeaconBlock,
+    SignedBlindedBeaconBlock, SignedContributionAndProof, SignedExecutionPayloadEnvelope,
+    SignedProposerPreferences, SignedRoot, SignedValidatorRegistrationData, SignedVoluntaryExit,
+    SingleAttestation, Slot, SlotData, SyncAggregatorSelectionData, SyncCommitteeContribution,
+    SyncCommitteeMessage, SyncSelectionProof, SyncSubnetId, ValidatorRegistrationData,
+    VoluntaryExit,
 };
 use validator_metrics::IntCounterVec;
 use validator_store::{
@@ -82,7 +83,10 @@ use validator_store::{
     ValidatorStore,
 };
 
-use crate::instrumentation::CollectionFailureClass;
+use crate::{
+    aggregator_post_consensus::AggregatorPostConsensusShared,
+    instrumentation::CollectionFailureClass,
+};
 
 /// Number of epochs of slashing protection history to keep.
 ///
@@ -120,6 +124,7 @@ const PROPOSER_PREFERENCES_COLLECTION_TIMEOUT_SLOTS: u32 = 2;
 ///
 /// The shared fields (`validator`, `signing_root`) drive `collect_prepared_signatures`,
 /// while `duty_data` carries duty-specific context needed by the assembly step.
+#[derive(Clone)]
 struct SigningRequest<T> {
     validator: ValidatorMetadata,
     signing_root: Hash256,
@@ -139,21 +144,49 @@ struct DecidedVote {
 }
 
 impl<T> SigningRequest<T> {
-    /// Look up this validator's collected signature, consuming the request.
+    /// Look up this request's collected signature, consuming the request.
     ///
     /// Returns `Ok((duty_data, signature))` on success, or `Err(pubkey)` if
     /// the validator index is missing or no signature was collected.
-    fn resolve(
-        self,
-        signatures: &HashMap<ValidatorIndex, Signature>,
-    ) -> Result<(T, Signature), PublicKeyBytes> {
+    ///
+    /// Keyed by `(index, root)` rather than index alone because one validator can hold several
+    /// distinct roots in a single batch (an `AggregatorCommittee` duty allows one aggregate plus
+    /// one contribution per subcommittee).
+    fn resolve(self, signatures: &CollectedSignatures) -> Result<(T, Signature), PublicKeyBytes> {
         let sig = self
             .validator
             .index
-            .and_then(|idx| signatures.get(&idx).cloned())
+            .and_then(|idx| signatures.get(&(idx, self.signing_root)).cloned())
             .ok_or(self.validator.public_key)?;
         Ok((self.duty_data, sig))
     }
+}
+
+/// Signatures collected for one committee batch, keyed by the request that produced each.
+type CollectedSignatures = HashMap<(ValidatorIndex, Hash256), Signature>;
+
+/// Drive signature collection to completion, keeping each result as it resolves.
+///
+/// Results are taken one at a time rather than as a group so that a root which never reaches
+/// quorum withholds only itself; callers surface missing roots through
+/// `SigningRequest::resolve` failing for the affected request.
+async fn drain_signatures<F, E>(mut pending: FuturesUnordered<F>) -> CollectedSignatures
+where
+    F: Future<Output = (ValidatorIndex, Hash256, Result<Signature, E>)>,
+    E: Debug,
+{
+    let mut signatures = HashMap::with_capacity(pending.len());
+    while let Some((index, signing_root, result)) = pending.next().await {
+        match result {
+            Ok(signature) => {
+                signatures.insert((index, signing_root), signature);
+            }
+            Err(e) => {
+                error!(?index, ?signing_root, error = ?e, "Failed to collect signature");
+            }
+        }
+    }
+    signatures
 }
 
 /// Handle committee signing errors with consistent timeout/failure metrics.
@@ -225,6 +258,16 @@ pub struct AnchorValidatorStore<
     strict_mfp: bool,
     is_synced: watch::Receiver<bool>,
     task_executor: TaskExecutor,
+    /// `(committee, slot)` keys whose Boole+ `AggregatorCommittee` post-consensus execution has
+    /// already been started.
+    ///
+    /// Registered by the slot pipeline in [`Self::update_aggregation_assignments`] before those
+    /// assignments are published, first-insert-only. That registration is the single writer, so
+    /// the complete decided worklist is signed and batched exactly once no matter how often the
+    /// pipeline runs. The execution handles themselves travel to their sole consumer (the
+    /// metadata service's publisher) through the registration's return value; this set only
+    /// provides registration idempotence across the retention window.
+    aggregator_post_consensus: Mutex<HashSet<(CommitteeId, Slot)>>,
 }
 
 /// How far into `slot` the clock currently is, or `None` if the clock cannot answer.
@@ -422,6 +465,7 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> AnchorValidator
             strict_mfp,
             is_synced,
             task_executor,
+            aggregator_post_consensus: Mutex::new(HashSet::new()),
         })
     }
 
@@ -531,13 +575,13 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> AnchorValidator
         validator_partial_signature_batch_size: usize,
         data_hash: Hash256,
         prepared: &[SigningRequest<D>],
-    ) -> Result<HashMap<ValidatorIndex, Signature>, Error> {
+    ) -> Result<CollectedSignatures, Error> {
         let collection_mode = CollectionMode::Committee {
             validator_partial_signature_batch_size,
             base_hash: data_hash,
         };
 
-        let futures: Vec<_> = prepared
+        let pending: FuturesUnordered<_> = prepared
             .iter()
             .filter_map(|item| {
                 let index = item.validator.index?;
@@ -554,45 +598,27 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> AnchorValidator
                             slot,
                         )
                         .await;
-                    (index, result)
+                    (index, item.signing_root, result)
                 })
             })
             .collect();
 
-        let results = join_all(futures).await;
-
-        let mut signatures = HashMap::with_capacity(results.len());
-        for (index, result) in results {
-            match result {
-                Ok(sig) => {
-                    signatures.insert(index, sig);
-                }
-                Err(e) => {
-                    error!(?index, error = ?e, "Failed to collect signature for validator");
-                }
-            }
-        }
-
-        Ok(signatures)
+        Ok(drain_signatures(pending).await)
     }
 
     /// Run `AggregatorCommittee` QBFT consensus for a committee at 2/3 slot.
     ///
-    /// Shared by `sign_committee_aggregate_and_proofs` and
-    /// `sign_committee_sync_committee_contributions`.
-    async fn run_aggregator_committee_consensus(
+    /// Called once per `(committee, slot)` by the post-consensus execution in
+    /// [`crate::aggregator_post_consensus`], which supplies the value this operator proposes.
+    pub(crate) async fn run_aggregator_committee_consensus(
         &self,
         committee_id: CommitteeId,
         slot: Slot,
         cluster: &Cluster,
-        metric_label: &str,
+        our_consensus_data: &AggregatorCommitteeConsensusData<E>,
     ) -> Result<AggregatorCommitteeConsensusData<E>, Error> {
-        let aggregation_assignments = self.get_aggregation_assignments(slot).await?;
-        let our_consensus_data = aggregation_assignments
-            .get_consensus_data(&committee_id)
-            .ok_or(Error::SpecificError(SpecificError::ConsensusDataNotFound))?;
-
-        let timer = metrics::start_timer_vec(&metrics::CONSENSUS_TIMES, &[metric_label]);
+        let timer =
+            metrics::start_timer_vec(&metrics::CONSENSUS_TIMES, &[metrics::AGGREGATOR_COMMITTEE]);
         let timeout_mode = TimeoutMode::SlotTime {
             round_deadline_origin: self
                 .get_instant_in_slot(slot, self.spec.get_slot_duration() * 2 / 3)?,
@@ -605,7 +631,7 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> AnchorValidator
                     committee: committee_id,
                     instance_height: slot.as_usize().into(),
                 },
-                (*our_consensus_data).clone(),
+                our_consensus_data.clone(),
                 Box::new(AggregatorCommitteeDataValidator::new()),
                 timeout_mode,
                 &cluster.cluster_members,
@@ -639,7 +665,7 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> AnchorValidator
         slot: Slot,
         callback_subnet: SyncSubnetId,
         position_counts: &HashMap<SyncSubnetId, usize>,
-    ) -> Result<Vec<SyncSelectionProofDescriptor>, SyncSelectionProofAssignmentError> {
+    ) -> Result<Vec<SyncCommitteeBatchEntry>, SyncSelectionProofAssignmentError> {
         if position_counts.is_empty() {
             return Err(SyncSelectionProofAssignmentError::Empty);
         }
@@ -677,10 +703,10 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> AnchorValidator
 
         let mut descriptor = Vec::with_capacity(position_counts.len());
         for (&subnet_id, &position_count) in position_counts {
-            descriptor.push(SyncSelectionProofDescriptor {
+            descriptor.push(SyncCommitteeBatchEntry {
                 subnet_id,
                 signing_root: self.compute_sync_selection_root(slot, subnet_id.into()),
-                position_count,
+                multiplicity: position_count,
             });
         }
 
@@ -1098,8 +1124,8 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> AnchorValidator
     /// Get aggregator voting assignments, waiting if not yet available for this slot.
     ///
     /// This method waits until `AggregationAssignments` for the requested slot becomes available.
-    /// Called by `sign_committee_aggregate_and_proofs` and
-    /// `produce_signed_contribution_and_proof_boole` at 2/3 slot.
+    /// Called by `run_aggregator_post_consensus` (via `run_aggregator_committee_consensus`)
+    /// at 2/3 slot.
     ///
     /// Returns an error if the requested slot has already passed or if the watch channel is closed.
     pub async fn get_aggregation_assignments(
@@ -1133,9 +1159,23 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> AnchorValidator
     /// This publishes the `AggregationAssignments` to all subscribers via the watch channel.
     /// At 2/3 slot, selection proofs have been computed by Lighthouse, so
     /// `DutyAndProof.selection_proof.is_some()` accurately indicates `is_aggregator`.
-    pub fn update_aggregation_assignments(&self, info: AggregationAssignments<E>) {
+    ///
+    /// It also starts each Boole+ committee's post-consensus signing execution, before publishing,
+    /// so that every consumer able to observe these assignments can also observe the execution they
+    /// belong to. See [`crate::aggregator_post_consensus`].
+    ///
+    /// Returns the executions newly registered by this call, for the caller to hand to the
+    /// aggregate publisher. Only vacant insertions are returned, so repeated calls for one slot
+    /// cannot register a second publisher for the same `(committee, slot)`.
+    #[must_use = "dropping the returned executions disables Boole+ aggregate publication"]
+    pub(crate) fn update_aggregation_assignments(
+        self: &Arc<Self>,
+        info: AggregationAssignments<E>,
+    ) -> Vec<(CommitteeId, AggregatorPostConsensusShared<E>)> {
+        let new_executions = self.start_aggregator_post_consensus(&info);
         self.aggregation_assignments_tx
             .send_replace(Some(Arc::new(info)));
+        new_executions
     }
 
     /// Return [`SpecificError::Timeout`] if the given future does not complete at `delay` into the
@@ -1625,31 +1665,32 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> AnchorValidator
             let data = Contributions::<E>::from_ssz_bytes(&data.data_ssz)
                 .map_err(|e| Error::from(SpecificError::InvalidQbftData(e)))?;
 
-            let data = data
-                .into_iter()
-                .map(Contribution::from)
-                .find(|data| data.contribution.subcommittee_index == subcommittee_index)
-                .ok_or(SpecificError::NoDataAgreed)?;
+            let domain_hash = self.get_domain(epoch, Domain::ContributionAndProof);
+            let PreparedSyncContributionBatch {
+                callback_message: message,
+                callback_signing_root: signing_root,
+                descriptor,
+            } = prepare_decided_sync_contributions(
+                data,
+                SyncSubnetId::new(subcommittee_index),
+                aggregator_index,
+                domain_hash,
+            )?;
 
             debug!(
-                slot = %data.contribution.slot,
-                block_root = ?data.contribution.beacon_block_root,
-                subcommittee_index = data.contribution.subcommittee_index,
-                num_set_aggregation_bits = data.contribution.aggregation_bits.num_set_bits(),
+                slot = %message.contribution.slot,
+                block_root = ?message.contribution.beacon_block_root,
+                subcommittee_index = message.contribution.subcommittee_index,
+                num_set_aggregation_bits = message.contribution.aggregation_bits.num_set_bits(),
                 "Decided on Contribution to sign"
             );
 
-            let domain_hash = self.get_domain(epoch, Domain::ContributionAndProof);
-            let message = ContributionAndProof {
-                aggregator_index,
-                contribution: data.contribution,
-                selection_proof: data.selection_proof_sig,
-            };
-            let signing_root = message.signing_root(domain_hash);
+            let collection_mode =
+                sync_committee_collection_mode(SyncSubnetId::new(subcommittee_index), descriptor);
             self.collect_signature(
                 PartialSignatureKind::PostConsensus,
                 Role::SyncCommittee,
-                CollectionMode::SingleValidator,
+                collection_mode,
                 &validator,
                 &cluster,
                 signing_root,
@@ -1666,172 +1707,16 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> AnchorValidator
         .await
     }
 
-    /// Boole+ committee-based contribution signing: single QBFT consensus per committee,
-    /// batch signature collection for all contributors.
+    /// Whether Lighthouse's callbacks own publication of aggregator-committee duties at `epoch`.
     ///
-    /// Cannot use `collect_prepared_signatures` because a validator in multiple subcommittees
-    /// needs multiple signatures with different signing roots, but that helper deduplicates
-    /// by `ValidatorIndex`. Uses `collect_signature` directly instead.
-    async fn sign_committee_sync_committee_contributions(
-        &self,
-        committee_id: CommitteeId,
-        cluster: Cluster,
-        contributions: Vec<(ValidatorMetadata, ContributionToSign<E>)>,
-    ) -> Result<Vec<SignedContributionAndProof<E>>, Error> {
-        let Some((_, first)) = contributions.first() else {
-            warn!("sign_committee_sync_committee_contributions called with empty contributions");
-            return Ok(vec![]);
-        };
-        let slot = first.contribution.slot;
-        let epoch = slot.epoch(E::slots_per_epoch());
-
-        let decided_data = self
-            .run_aggregator_committee_consensus(
-                committee_id,
-                slot,
-                &cluster,
-                metrics::SYNC_CONTRIBUTION_AND_PROOF,
-            )
-            .await?;
-
-        let domain_hash = self.get_domain(epoch, Domain::ContributionAndProof);
-
-        // Prepare all validators: find each in decided data, build ContributionAndProof
-        // (metadata already resolved by `group_by_committee`)
-        let mut prepared: Vec<SigningRequest<ContributionAndProof<E>>> =
-            Vec::with_capacity(contributions.len());
-
-        for (validator, contrib) in &contributions {
-            let validator_index = match validator.index {
-                Some(idx) => idx,
-                None => {
-                    debug!(
-                        pubkey = ?contrib.aggregator_pubkey,
-                        "Validator missing index, skipping contribution"
-                    );
-                    validator_metrics::inc_counter_vec(
-                        &validator_metrics::SIGNED_SYNC_COMMITTEE_CONTRIBUTIONS_TOTAL,
-                        &[metrics::OTHER_ERROR],
-                    );
-                    continue;
-                }
-            };
-
-            let subcommittee_index = contrib.contribution.subcommittee_index;
-
-            // Find this validator+subcommittee in the decided data
-            let Some(decided_contributor) = decided_data.contributors.iter().find(|c| {
-                c.validator_index == validator_index && c.committee_index == subcommittee_index
-            }) else {
-                debug!(
-                    ?validator_index,
-                    subcommittee_index,
-                    "Validator not in decided data, skipping due to divergent operator views"
-                );
-                validator_metrics::inc_counter_vec(
-                    &validator_metrics::SIGNED_SYNC_COMMITTEE_CONTRIBUTIONS_TOTAL,
-                    &[metrics::OTHER_ERROR],
-                );
-                continue;
-            };
-
-            // Find the contribution for this subcommittee
-            let Some(decided_contribution) = decided_data
-                .sync_committee_contributions
-                .iter()
-                .find(|c| c.subcommittee_index == subcommittee_index)
-            else {
-                debug!(
-                    subcommittee_index,
-                    pubkey = ?contrib.aggregator_pubkey,
-                    "Contribution not in consensus data - likely filtered due to beacon API failure"
-                );
-                validator_metrics::inc_counter_vec(
-                    &validator_metrics::SIGNED_SYNC_COMMITTEE_CONTRIBUTIONS_TOTAL,
-                    &[metrics::OTHER_ERROR],
-                );
-                continue;
-            };
-
-            let message = ContributionAndProof {
-                aggregator_index: contrib.aggregator_index,
-                contribution: decided_contribution.clone(),
-                selection_proof: decided_contributor.selection_proof.clone(),
-            };
-
-            let signing_root = message.signing_root(domain_hash);
-            prepared.push(SigningRequest {
-                validator: validator.clone(),
-                signing_root,
-                duty_data: message,
-            });
-        }
-
-        // Collect signatures — using `collect_signature` directly because a validator in
-        // multiple subcommittees produces multiple `SigningRequest`s with different signing
-        // roots, which `collect_prepared_signatures` cannot handle (it deduplicates by
-        // `ValidatorIndex`).
-        let committee_validator_indices = self.get_committee_validator_indices(&committee_id);
-        let validator_partial_signature_batch_size = decided_data
-            .post_consensus_signature_count(|idx| committee_validator_indices.contains(idx));
-        let data_hash = decided_data.hash();
-        let collection_mode = CollectionMode::Committee {
-            validator_partial_signature_batch_size,
-            base_hash: data_hash,
-        };
-
-        let sig_futures: Vec<_> = prepared
-            .iter()
-            .map(|req| {
-                self.collect_signature(
-                    PartialSignatureKind::PostConsensus,
-                    Role::AggregatorCommittee,
-                    collection_mode.clone(),
-                    &req.validator,
-                    &cluster,
-                    req.signing_root,
-                    slot,
-                )
-            })
-            .collect();
-
-        let signature_results = join_all(sig_futures).await;
-
-        // Assemble results
-        let mut results = Vec::with_capacity(prepared.len());
-        for (req, sig_result) in prepared.into_iter().zip(signature_results) {
-            match sig_result {
-                Ok(signature) => {
-                    let message = req.duty_data;
-                    debug!(
-                        aggregator_index = ?message.aggregator_index,
-                        slot = %message.contribution.slot,
-                        block_root = ?message.contribution.beacon_block_root,
-                        subcommittee_index = message.contribution.subcommittee_index,
-                        num_set_aggregation_bits = message.contribution.aggregation_bits.num_set_bits(),
-                        "Signed ContributionAndProof (Boole+ committee consensus)"
-                    );
-                    validator_metrics::inc_counter_vec(
-                        &validator_metrics::SIGNED_SYNC_COMMITTEE_CONTRIBUTIONS_TOTAL,
-                        &[validator_metrics::SUCCESS],
-                    );
-                    results.push(SignedContributionAndProof { message, signature });
-                }
-                Err(e) => {
-                    error!(
-                        pubkey = ?req.validator.public_key,
-                        error = ?e,
-                        "Failed to collect signature for sync contribution"
-                    );
-                    validator_metrics::inc_counter_vec(
-                        &validator_metrics::SIGNED_SYNC_COMMITTEE_CONTRIBUTIONS_TOTAL,
-                        &[metrics::OTHER_ERROR],
-                    );
-                }
-            }
-        }
-
-        Ok(results)
+    /// Pre-Boole they do; from Boole the metadata service's publisher owns both classes
+    /// (aggregates and sync contributions) and the callbacks return empty batches. This is the
+    /// exact complement of the publisher's registration gate (consensus data is only built for
+    /// Boole+ slots), so exactly one path publishes for any duty. Both callbacks derive `epoch`
+    /// from the duty's own payload (the aggregate's target epoch, the contribution's slot),
+    /// which equal the duty slot's epoch by construction.
+    pub(crate) fn lighthouse_owns_publication(&self, epoch: Epoch) -> bool {
+        self.fork_schedule.active_fork(epoch) < Fork::Boole
     }
 
     /// Run the shared committee beacon-vote consensus with fork-correct data and timing.
@@ -2147,158 +2032,6 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> AnchorValidator
                     signature: AggregateSignature::from(&signature),
                 },
                 att.pubkey,
-            ));
-        }
-
-        Ok(results)
-    }
-
-    /// Resolve a single validator's aggregate from decided consensus data.
-    ///
-    /// Looks up the aggregator in decided data, finds the matching committee index,
-    /// decodes the aggregate attestation from SSZ, and builds an `AggregateAndProof`.
-    fn resolve_decided_aggregate(
-        decided_data: &AggregatorCommitteeConsensusData<E>,
-        validator: ValidatorMetadata,
-        agg: &AggregateToSign<E>,
-        domain_hash: Hash256,
-    ) -> Result<SigningRequest<(u64, AggregateAndProof<E>)>, String> {
-        let validator_index = validator.index.ok_or("Validator missing index")?;
-
-        // Find this validator in the decided data
-        let decided_aggregator = decided_data
-            .aggregators
-            .iter()
-            .find(|a| a.validator_index == validator_index)
-            .ok_or("Validator not in decided data")?;
-
-        let committee_index = decided_aggregator.committee_index;
-
-        // Find the position of this committee index in decided data
-        let decided_aggregate_idx = decided_data
-            .aggregator_committee_indexes
-            .iter()
-            .position(|&idx| idx == committee_index)
-            .ok_or("Committee index not found in decided data")?;
-
-        let decided_aggregate_bytes = decided_data
-            .aggregated_attestations
-            .get(decided_aggregate_idx)
-            .ok_or("Aggregate attestation bytes not found in decided data")?;
-
-        // Decode with the shape the decided version selects (Gloas merkleizes progressively,
-        // so the shape drives the signing root computed below).
-        let decided_aggregate: Attestation<E> = decided_data
-            .version
-            .decode_attestation(decided_aggregate_bytes)
-            .map_err(|e| format!("Failed to decode decided aggregate: {e}"))?;
-
-        let decided_selection_proof =
-            SelectionProof::from(decided_aggregator.selection_proof.clone());
-
-        let message = AggregateAndProof::from_attestation(
-            agg.aggregator_index,
-            decided_aggregate,
-            decided_selection_proof,
-        );
-
-        let signing_root = message.signing_root(domain_hash);
-        Ok(SigningRequest {
-            validator,
-            signing_root,
-            duty_data: (agg.aggregator_index, message),
-        })
-    }
-
-    /// Boole+ committee-based aggregate signing: single QBFT consensus per committee,
-    /// batch signature collection for all aggregators.
-    async fn sign_committee_aggregate_and_proofs(
-        &self,
-        committee_id: CommitteeId,
-        cluster: Cluster,
-        aggregates: Vec<(ValidatorMetadata, AggregateToSign<E>)>,
-    ) -> Result<Vec<SignedAggregateAndProof<E>>, Error> {
-        let Some((_, first)) = aggregates.first() else {
-            warn!("sign_committee_aggregate_and_proofs called with empty aggregates");
-            return Ok(vec![]);
-        };
-        let slot = first.aggregate.data().slot;
-        let signing_epoch = first.aggregate.data().target.epoch;
-
-        let decided_data = self
-            .run_aggregator_committee_consensus(
-                committee_id,
-                slot,
-                &cluster,
-                metrics::AGGREGATE_AND_PROOF,
-            )
-            .await?;
-
-        let domain_hash = self.get_domain(signing_epoch, Domain::AggregateAndProof);
-
-        // Prepare all validators: find each in decided data, decode aggregate, build message
-        // (metadata already resolved by `group_by_committee`)
-        let mut prepared: Vec<SigningRequest<(u64, AggregateAndProof<E>)>> =
-            Vec::with_capacity(aggregates.len());
-
-        for (validator, agg) in aggregates {
-            match Self::resolve_decided_aggregate(&decided_data, validator, &agg, domain_hash) {
-                Ok(request) => prepared.push(request),
-                Err(e) => {
-                    debug!(pubkey = ?agg.pubkey, error = e, "Skipping aggregate");
-                    validator_metrics::inc_counter_vec(
-                        &validator_metrics::SIGNED_AGGREGATES_TOTAL,
-                        &[metrics::OTHER_ERROR],
-                    );
-                }
-            }
-        }
-
-        // Collect signatures and assemble results
-        let committee_validator_indices = self.get_committee_validator_indices(&committee_id);
-        let validator_partial_signature_batch_size = decided_data
-            .post_consensus_signature_count(|idx| committee_validator_indices.contains(idx));
-
-        let signatures = self
-            .collect_prepared_signatures(
-                Role::AggregatorCommittee,
-                slot,
-                &cluster,
-                validator_partial_signature_batch_size,
-                decided_data.hash(),
-                &prepared,
-            )
-            .await?;
-
-        let mut results = Vec::with_capacity(prepared.len());
-        for req in prepared {
-            let ((aggregator_index, message), signature) = match req.resolve(&signatures) {
-                Ok(resolved) => resolved,
-                Err(pubkey) => {
-                    warn!(
-                        ?pubkey,
-                        "Missing validator index or signature for aggregator, skipping"
-                    );
-                    validator_metrics::inc_counter_vec(
-                        &validator_metrics::SIGNED_AGGREGATES_TOTAL,
-                        &[metrics::OTHER_ERROR],
-                    );
-                    continue;
-                }
-            };
-
-            debug!(
-                ?aggregator_index,
-                data = ?message.aggregate().data(),
-                num_set_aggregation_bits = message.aggregate().num_set_aggregation_bits(),
-                "Signed AggregateAndProof (Boole+ committee consensus)"
-            );
-            validator_metrics::inc_counter_vec(
-                &validator_metrics::SIGNED_AGGREGATES_TOTAL,
-                &[validator_metrics::SUCCESS],
-            );
-            results.push(SignedAggregateAndProof::from_aggregate_and_proof(
-                message, signature,
             ));
         }
 
@@ -2912,14 +2645,73 @@ pub struct ContributionAndProofSigningData<E: EthSpec> {
     selection_proof: SyncSelectionProof,
 }
 
+struct PreparedSyncContributionBatch<E: EthSpec> {
+    callback_message: ContributionAndProof<E>,
+    callback_signing_root: Hash256,
+    descriptor: Vec<SyncCommitteeBatchEntry>,
+}
+
+/// Prepares the exact decided sync contribution root multiset for every Lighthouse callback.
+fn prepare_decided_sync_contributions<E: EthSpec>(
+    contributions: Contributions<E>,
+    callback_subnet: SyncSubnetId,
+    aggregator_index: u64,
+    domain_hash: Hash256,
+) -> Result<PreparedSyncContributionBatch<E>, SpecificError> {
+    let mut callback = None;
+    let mut descriptor = Vec::with_capacity(contributions.len());
+
+    for contribution in contributions.into_iter().map(Contribution::from) {
+        let subnet_id = SyncSubnetId::new(contribution.contribution.subcommittee_index);
+        let message = ContributionAndProof {
+            aggregator_index,
+            contribution: contribution.contribution,
+            selection_proof: contribution.selection_proof_sig,
+        };
+        let signing_root = message.signing_root(domain_hash);
+
+        if callback.is_none() && subnet_id == callback_subnet {
+            callback = Some((message, signing_root));
+        }
+        descriptor.push(SyncCommitteeBatchEntry {
+            subnet_id,
+            signing_root,
+            multiplicity: 1,
+        });
+    }
+
+    let (callback_message, callback_signing_root) = callback.ok_or(SpecificError::NoDataAgreed)?;
+
+    descriptor.sort_unstable_by_key(|entry| (u64::from(entry.subnet_id), entry.signing_root));
+
+    let mut collapsed: Vec<SyncCommitteeBatchEntry> = Vec::with_capacity(descriptor.len());
+    for entry in descriptor {
+        match collapsed.last_mut() {
+            Some(previous)
+                if previous.subnet_id == entry.subnet_id
+                    && previous.signing_root == entry.signing_root =>
+            {
+                previous.multiplicity += entry.multiplicity;
+            }
+            _ => collapsed.push(entry),
+        }
+    }
+
+    Ok(PreparedSyncContributionBatch {
+        callback_message,
+        callback_signing_root,
+        descriptor: collapsed,
+    })
+}
+
 #[derive(Clone)]
 enum CollectionMode {
     SingleValidator,
     SingleValidatorBatch {
         /// Subnet requested by the current Lighthouse callback.
         subnet_id: SyncSubnetId,
-        /// Canonical descriptor for every unique subnet assigned to this validator and slot.
-        descriptor: Vec<SyncSelectionProofDescriptor>,
+        /// Canonical descriptor for every unique subnet and signing root pair in this batch.
+        descriptor: Vec<SyncCommitteeBatchEntry>,
     },
     Committee {
         /// The number of validator partial signatures this operator batches locally into the
@@ -2939,6 +2731,25 @@ pub struct DecidedRootConflict {
     pub slot: Slot,
     pub existing_root: Hash256,
     pub new_root: Hash256,
+}
+
+fn sync_committee_collection_mode(
+    callback_subnet: SyncSubnetId,
+    descriptor: Vec<SyncCommitteeBatchEntry>,
+) -> CollectionMode {
+    if descriptor
+        .iter()
+        .map(|entry| entry.multiplicity)
+        .sum::<usize>()
+        == 1
+    {
+        CollectionMode::SingleValidator
+    } else {
+        CollectionMode::SingleValidatorBatch {
+            subnet_id: callback_subnet,
+            descriptor,
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -3057,6 +2868,9 @@ pub enum SpecificError {
         local_root: Hash256,
         decided_root: Hash256,
     },
+    /// The detached `AggregatorCommittee` post-consensus execution died before producing a
+    /// result (executor shutdown, spawn refusal, or task panic)
+    PostConsensusAborted,
 }
 
 impl From<CollectionError> for SpecificError {
@@ -3529,53 +3343,43 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> ValidatorStore
         self: &Arc<Self>,
         aggregates: Vec<AggregateToSign<E>>,
     ) -> impl Stream<Item = Result<Vec<SignedAggregateAndProof<E>>, Error>> + Send {
-        // Early return for empty input — no fork to determine, nothing to sign
-        let Some(first) = aggregates.first() else {
-            return Either::Right(FuturesUnordered::new());
-        };
+        let this = Arc::clone(self);
+        stream::once(async move {
+            // Empty input: nothing to sign and no fork to determine.
+            let Some(first) = aggregates.first() else {
+                return Ok(Vec::new());
+            };
 
-        if self
-            .fork_schedule
-            .active_fork(first.aggregate.data().target.epoch)
-            >= Fork::Boole
-        {
-            // Boole+: group by committee, stream per committee via FuturesUnordered
-            let _span = info_span!("sign_aggregate_and_proofs").entered();
-            let committee_mapping = self.group_by_committee(aggregates, |a| a.pubkey);
+            if !this.lighthouse_owns_publication(first.aggregate.data().target.epoch) {
+                // Boole+: hand Lighthouse an empty batch, which its publish loop drops silently.
+                // Publication ownership lives with the metadata service's publisher, which signs
+                // and publishes the decided worklist regardless of whether Lighthouse's duty
+                // snapshot saw the selection proofs in time. See
+                // [`crate::aggregator_post_consensus`].
+                //
+                // Lighthouse's request set is its snapshot's view of who aggregates; the
+                // publisher only ever sees the decided view. Logging the request set here keeps
+                // divergent operator views diagnosable by comparing the two.
+                debug!(
+                    slot = %first.aggregate.data().slot,
+                    requested = aggregates.len(),
+                    aggregators = ?aggregates
+                        .iter()
+                        .map(|agg| agg.aggregator_index)
+                        .collect::<Vec<_>>(),
+                    "Deferring Lighthouse-requested aggregates to the decided-value publisher"
+                );
+                return Ok(Vec::new());
+            }
 
-            let committee_futures: FuturesUnordered<_> = committee_mapping
-                .into_iter()
-                .map(|(committee_id, (cluster, aggregates))| {
-                    let this = Arc::clone(self);
-                    async move {
-                        run_committee_signing(
-                            committee_id,
-                            aggregates.len(),
-                            &validator_metrics::SIGNED_AGGREGATES_TOTAL,
-                            this.sign_committee_aggregate_and_proofs(
-                                committee_id,
-                                cluster,
-                                aggregates,
-                            ),
-                        )
-                        .await
-                    }
-                })
-                .collect();
-
-            Either::Right(committee_futures)
-        } else {
-            // Pre-Boole: per-validator processing, no committee grouping needed
-            let this = Arc::clone(self);
-            Either::Left(stream::once(async move {
-                let futures = aggregates.into_iter().map(|agg| {
-                    let this = Arc::clone(&this);
-                    async move { this.sign_single_aggregate_and_proof(agg).await }
-                });
-                let results = join_all(futures).await;
-                Ok(results.into_iter().filter_map(|r| r.ok()).collect())
-            }))
-        }
+            // Pre-Boole: per-validator processing, Lighthouse publishes the results
+            let futures = aggregates.into_iter().map(|agg| {
+                let this = Arc::clone(&this);
+                async move { this.sign_single_aggregate_and_proof(agg).await }
+            });
+            let results = join_all(futures).await;
+            Ok(results.into_iter().filter_map(|r| r.ok()).collect())
+        })
     }
 
     async fn produce_selection_proof(
@@ -3792,13 +3596,11 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> ValidatorStore
                             },
                         )?;
 
+                    let collection_mode = sync_committee_collection_mode(subnet_id, descriptor);
                     self.collect_signature(
                         PartialSignatureKind::ContributionProofs,
                         Role::SyncCommittee,
-                        CollectionMode::SingleValidatorBatch {
-                            subnet_id,
-                            descriptor,
-                        },
+                        collection_mode,
                         &validator,
                         &cluster,
                         signing_root,
@@ -3855,51 +3657,48 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> ValidatorStore
         self: &Arc<Self>,
         contributions: Vec<ContributionToSign<E>>,
     ) -> impl Stream<Item = Result<Vec<SignedContributionAndProof<E>>, Error>> + Send {
-        // Early return for empty input — no fork to determine, nothing to sign
-        let Some(first) = contributions.first() else {
-            return Either::Right(FuturesUnordered::new());
-        };
+        let this = Arc::clone(self);
+        stream::once(async move {
+            // Empty input: nothing to sign and no fork to determine.
+            let Some(first) = contributions.first() else {
+                return Ok(Vec::new());
+            };
 
-        let epoch = first.contribution.slot.epoch(E::slots_per_epoch());
+            if !this
+                .lighthouse_owns_publication(first.contribution.slot.epoch(E::slots_per_epoch()))
+            {
+                // Boole+: hand Lighthouse an empty batch, which its publish loop drops silently.
+                // Publication ownership lives with the metadata service's publisher, which signs
+                // and publishes the decided worklist regardless of whether Lighthouse's duty
+                // snapshot saw the sync selection proofs in time. See
+                // [`crate::aggregator_post_consensus`].
+                //
+                // Lighthouse's request set is its snapshot's view of who aggregates; the
+                // publisher only ever sees the decided view. Logging the request set here keeps
+                // divergent operator views diagnosable by comparing the two.
+                debug!(
+                    slot = %first.contribution.slot,
+                    // Lighthouse requests contributions per subnet, so one call is one subnet;
+                    // the publisher's logs key on subcommittee index, and this field is the join.
+                    subnet = first.contribution.subcommittee_index,
+                    requested = contributions.len(),
+                    aggregators = ?contributions
+                        .iter()
+                        .map(|contrib| contrib.aggregator_index)
+                        .collect::<Vec<_>>(),
+                    "Deferring Lighthouse-requested contributions to the decided-value publisher"
+                );
+                return Ok(Vec::new());
+            }
 
-        if self.fork_schedule.active_fork(epoch) >= Fork::Boole {
-            // Boole+: group by committee, stream per committee via FuturesUnordered
-            let _span = info_span!("sign_sync_committee_contributions").entered();
-            let committee_mapping = self.group_by_committee(contributions, |c| c.aggregator_pubkey);
-
-            let committee_futures: FuturesUnordered<_> = committee_mapping
-                .into_iter()
-                .map(|(committee_id, (cluster, contributions))| {
-                    let this = Arc::clone(self);
-                    async move {
-                        run_committee_signing(
-                            committee_id,
-                            contributions.len(),
-                            &validator_metrics::SIGNED_SYNC_COMMITTEE_CONTRIBUTIONS_TOTAL,
-                            this.sign_committee_sync_committee_contributions(
-                                committee_id,
-                                cluster,
-                                contributions,
-                            ),
-                        )
-                        .await
-                    }
-                })
-                .collect();
-
-            Either::Right(committee_futures)
-        } else {
-            // Pre-Boole: per-validator processing, no committee grouping needed
-            let this = Arc::clone(self);
-            Either::Left(stream::once(async move {
-                let futures = contributions.into_iter().map(|contrib| {
-                    let this = Arc::clone(&this);
-                    async move { this.sign_single_sync_committee_contribution(contrib).await }
-                });
-                let results = join_all(futures).await;
-                Ok(results.into_iter().filter_map(|r| r.ok()).collect())
-            }))
-        }
+            // Pre-Boole: per-validator processing, Lighthouse publishes the results
+            let futures = contributions.into_iter().map(|contrib| {
+                let this = Arc::clone(&this);
+                async move { this.sign_single_sync_committee_contribution(contrib).await }
+            });
+            let results = join_all(futures).await;
+            Ok(results.into_iter().filter_map(|r| r.ok()).collect())
+        })
     }
 
     // stolen from lighthouse

--- a/anchor/validator_store/src/metadata_service.rs
+++ b/anchor/validator_store/src/metadata_service.rs
@@ -63,6 +63,19 @@ const WAD_SOFT_TIMEOUT: Duration = Duration::from_secs(1);
 const WAD_HARD_TIMEOUT: Duration = Duration::from_secs(3);
 const BLOCK_SLOT_LOOKUP_TIMEOUT: Duration = Duration::from_millis(500);
 
+/// Publish `VotingAssignments` this long after the slot boundary.
+///
+/// The boundary sleep runs on the monotonic timer but the slot is read from the
+/// wall clock, and the two drift apart by a few milliseconds over a full-slot
+/// sleep. A wake landing marginally before the boundary would read the previous
+/// slot, republish it, and skip the new one (issue #1223). This margin absorbs
+/// that drift. 50 ms mirrors the message validator's `CLOCK_ERROR_TOLERANCE`,
+/// the clock error the SSV network already budgets for between nodes. Nothing
+/// consumes the assignments this early: the soonest consumers are the
+/// selection-proof flows (deadline 2/3 slot) and the voting-context build
+/// (triggered no earlier than a head event).
+const VOTING_ASSIGNMENTS_PUBLISH_DELAY: Duration = Duration::from_millis(50);
+
 /// Builds each validator's per-subnet position counts from raw sync committee positions.
 fn build_sync_validator_assignments<E, I, P>(
     duties: I,
@@ -194,6 +207,24 @@ async fn wait_for_head_event<T: SlotClock>(
     }
 }
 
+/// Drive `publish` once per slot, shortly after each slot boundary.
+///
+/// The delay past the boundary is what makes this correct: sleeping exactly to
+/// the boundary lets a marginally early timer wake read the previous slot,
+/// republish it, and skip the new one (issue #1223). See
+/// [`VOTING_ASSIGNMENTS_PUBLISH_DELAY`].
+async fn run_slot_start_publisher<T: SlotClock>(slot_clock: T, mut publish: impl FnMut()) {
+    loop {
+        if let Some(duration_to_next_slot) = slot_clock.duration_to_next_slot() {
+            sleep(duration_to_next_slot + VOTING_ASSIGNMENTS_PUBLISH_DELAY).await;
+            publish();
+        } else {
+            error!("Failed to read slot clock");
+            sleep(slot_clock.slot_duration()).await;
+        }
+    }
+}
+
 impl<E: EthSpec, T: SlotClock + 'static> MetadataService<E, T> {
     #[expect(clippy::too_many_arguments)]
     pub fn new(
@@ -245,21 +276,13 @@ impl<E: EthSpec, T: SlotClock + 'static> MetadataService<E, T> {
         let self_clone_phase1 = self.clone();
         executor.spawn(
             async move {
-                loop {
-                    if let Some(duration_to_next_slot) =
-                        self_clone_phase1.slot_clock.duration_to_next_slot()
-                    {
-                        // Sleep until slot start
-                        sleep(duration_to_next_slot).await;
-
-                        if let Err(err) = self_clone_phase1.update_voting_assignments() {
-                            error!(err, "Failed to update validator voting assignments");
-                        }
-                    } else {
-                        error!("Failed to read slot clock");
-                        sleep(slot_duration).await;
+                let slot_clock = self_clone_phase1.slot_clock.clone();
+                run_slot_start_publisher(slot_clock, move || {
+                    if let Err(err) = self_clone_phase1.update_voting_assignments() {
+                        error!(err, "Failed to update validator voting assignments");
                     }
-                }
+                })
+                .await
             },
             "voting_assignments_service",
         );
@@ -2524,5 +2547,105 @@ mod tests {
         };
 
         assert!(!from_head_event);
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════════════════
+    // Slot start publisher tests
+    //
+    // The virtual tokio timer stands in for the monotonic timer the publisher sleeps on,
+    // and the manual slot clock stands in for the wall clock it reads slots from. Driving
+    // them separately is what lets these tests reproduce the drift between the two.
+    // ═══════════════════════════════════════════════════════════════════════════════════
+
+    use parking_lot::Mutex;
+
+    const SLOT_DURATION: Duration = Duration::from_secs(SLOT_DURATION_SECS);
+    /// How far the wall clock trails the virtual timer when the boundary sleep wakes. The
+    /// drift observed in issue #1223 was 1 ms to 5 ms.
+    const WALL_CLOCK_LAG: Duration = Duration::from_millis(3);
+    /// Slot boundaries crossed by `publishes_each_slot_exactly_once`.
+    const LOCKSTEP_SLOTS: u64 = 3;
+
+    /// Spawn the publisher, recording the slot its clock reads at each publish. Production
+    /// reads the slot inside `update_voting_assignments`, so the recorded slot is the one
+    /// that would have been published.
+    async fn spawn_slot_start_publisher(slot_clock: &ManualSlotClock) -> Arc<Mutex<Vec<Slot>>> {
+        let published = Arc::new(Mutex::new(Vec::new()));
+        let publish_clock = slot_clock.clone();
+        let recorded = published.clone();
+        tokio::spawn(run_slot_start_publisher(slot_clock.clone(), move || {
+            let slot = publish_clock.now().expect("manual slot clock is readable");
+            recorded.lock().push(slot);
+        }));
+        // Let the publisher arm its first sleep before either clock moves.
+        tokio::task::yield_now().await;
+        published
+    }
+
+    /// Advance the virtual timer, giving a sleep that expires within the step a scheduling
+    /// round to run. `tokio::time::advance` only wakes the sleeper, it does not poll it, so
+    /// without the extra round the publish would be observed a step late.
+    async fn advance_virtual_time(duration: Duration) {
+        tokio::time::advance(duration).await;
+        tokio::task::yield_now().await;
+    }
+
+    /// Move the wall clock and the virtual timer forward by the same amount. The wall clock
+    /// moves first so a timer firing within the step reads the time the step ends at.
+    async fn advance_in_lockstep(slot_clock: &ManualSlotClock, duration: Duration) {
+        slot_clock.advance_time(duration);
+        advance_virtual_time(duration).await;
+    }
+
+    /// Regression test for issue #1223.
+    ///
+    /// A boundary sleep that wakes a few milliseconds before the wall clock reaches the
+    /// slot boundary used to republish the previous slot, and the next iteration then slept
+    /// past the new slot entirely, so waiters on it saw `MetadataSlotPassed`. The publish
+    /// offset has to hold the publish back until the wall clock has crossed.
+    #[tokio::test(start_paused = true)]
+    async fn early_wake_still_publishes_the_new_slot() {
+        // Arrange: publisher armed at the start of TEST_SLOT.
+        let slot_clock = make_test_slot_clock();
+        let published = spawn_slot_start_publisher(&slot_clock).await;
+
+        // Act: fire the boundary sleep with the wall clock still short of the boundary.
+        slot_clock.advance_time(SLOT_DURATION - WALL_CLOCK_LAG);
+        advance_virtual_time(SLOT_DURATION).await;
+
+        assert!(
+            published.lock().is_empty(),
+            "publishing at the early wake would read slot {TEST_SLOT} again"
+        );
+
+        // The wall clock crosses the boundary within the publish offset.
+        advance_in_lockstep(&slot_clock, VOTING_ASSIGNMENTS_PUBLISH_DELAY).await;
+
+        // Assert: the new slot is published once, and the previous slot is not repeated.
+        assert_eq!(
+            published.lock().as_slice(),
+            [Slot::new(TEST_SLOT + 1)],
+            "an early wake must still publish the new slot exactly once"
+        );
+    }
+
+    /// Without drift, every slot boundary produces exactly one publish for that slot.
+    #[tokio::test(start_paused = true)]
+    async fn publishes_each_slot_exactly_once() {
+        // Arrange: publisher armed at the start of TEST_SLOT.
+        let slot_clock = make_test_slot_clock();
+        let published = spawn_slot_start_publisher(&slot_clock).await;
+
+        // Act: settle onto the publish offset, then cross one boundary per step.
+        advance_in_lockstep(&slot_clock, VOTING_ASSIGNMENTS_PUBLISH_DELAY).await;
+        for _ in 0..LOCKSTEP_SLOTS {
+            advance_in_lockstep(&slot_clock, SLOT_DURATION).await;
+        }
+
+        // Assert: one publish per boundary, slots strictly increasing by one.
+        let expected: Vec<Slot> = (1..=LOCKSTEP_SLOTS)
+            .map(|offset| Slot::new(TEST_SLOT + offset))
+            .collect();
+        assert_eq!(published.lock().as_slice(), expected);
     }
 }

--- a/anchor/validator_store/src/metadata_service.rs
+++ b/anchor/validator_store/src/metadata_service.rs
@@ -10,7 +10,6 @@ use eth2::{
     BeaconNodeHttpClient,
     types::{BlockId, SyncContributionData},
 };
-use fork::{Fork, ForkSchedule};
 use futures::stream::{FuturesUnordered, StreamExt};
 use slot_clock::SlotClock;
 use ssv_types::{
@@ -28,7 +27,7 @@ use tracing::{Instrument, debug, error, info, info_span, trace, warn};
 use tree_hash::TreeHash;
 use types::{
     Attestation, AttestationData, ChainSpec, EthSpec, ForkName, Hash256, SignedAggregateAndProof,
-    Slot, SyncCommitteeContribution, SyncSelectionProof, SyncSubnetId,
+    SignedContributionAndProof, Slot, SyncCommitteeContribution, SyncSelectionProof, SyncSubnetId,
 };
 use validator_services::duties_service::{DutiesService, DutyAndProof};
 
@@ -178,7 +177,6 @@ pub struct MetadataService<E: EthSpec, T: SlotClock + 'static> {
     beacon_nodes: Arc<BeaconNodeFallback<T>>,
     executor: TaskExecutor,
     spec: Arc<ChainSpec>,
-    fork_schedule: Arc<ForkSchedule>,
     weighted_attestation_data: bool,
 }
 
@@ -226,7 +224,6 @@ async fn run_slot_start_publisher<T: SlotClock>(slot_clock: T, mut publish: impl
 }
 
 impl<E: EthSpec, T: SlotClock + 'static> MetadataService<E, T> {
-    #[expect(clippy::too_many_arguments)]
     pub fn new(
         duties_service: Arc<DutiesService<AnchorValidatorStore<T, E>, T>>,
         validator_store: Arc<AnchorValidatorStore<T, E>>,
@@ -234,7 +231,6 @@ impl<E: EthSpec, T: SlotClock + 'static> MetadataService<E, T> {
         beacon_nodes: Arc<BeaconNodeFallback<T>>,
         executor: TaskExecutor,
         spec: Arc<ChainSpec>,
-        fork_schedule: Arc<ForkSchedule>,
         weighted_attestation_data: bool,
     ) -> Self {
         Self {
@@ -244,7 +240,6 @@ impl<E: EthSpec, T: SlotClock + 'static> MetadataService<E, T> {
             beacon_nodes,
             executor,
             spec,
-            fork_schedule,
             weighted_attestation_data,
         }
     }
@@ -642,8 +637,13 @@ impl<E: EthSpec, T: SlotClock + 'static> MetadataService<E, T> {
         // ═══════════════════════════════════════════════════════════════════════
         let epoch = slot.epoch(E::slots_per_epoch());
 
+        // The exact complement of the Lighthouse callback gates by construction: consensus data
+        // (and therefore the publisher) exists precisely when Lighthouse does not own
+        // publication.
         let consensus_data_by_ssv_committee =
-            if self.fork_schedule.active_fork(epoch) >= Fork::Boole {
+            if self.validator_store.lighthouse_owns_publication(epoch) {
+                HashMap::new()
+            } else {
                 self.build_consensus_data_for_all_committees(
                     slot,
                     attesters_by_ssv_committee,
@@ -652,8 +652,6 @@ impl<E: EthSpec, T: SlotClock + 'static> MetadataService<E, T> {
                     all_subnet_ids,
                 )
                 .await?
-            } else {
-                HashMap::new()
             };
 
         let aggregator_info = AggregationAssignments {
@@ -674,19 +672,20 @@ impl<E: EthSpec, T: SlotClock + 'static> MetadataService<E, T> {
 
     /// Spawn the detached publisher for this slot's newly registered post-consensus executions.
     ///
-    /// The publisher owns Boole+ aggregate publication: the Lighthouse aggregate callback returns
-    /// an empty batch at Boole+ because its duty snapshot is cloned before slot-start selection
-    /// proofs finish, so aggregates the snapshot never saw would otherwise be silently dropped.
-    /// Contributions are unaffected (sync selection proofs are precomputed a slot ahead) and stay
-    /// on the Lighthouse publish path.
+    /// The publisher owns Boole+ publication of aggregates and sync contributions: the Lighthouse
+    /// callbacks return empty batches at Boole+ because their duty snapshots are cloned before
+    /// slot-start selection proofs finish, so roots the snapshots never saw would otherwise be
+    /// silently dropped. (Anchor's sync selection proofs are NOT precomputed a slot ahead: its
+    /// one-slot Lighthouse lookahead config starts slot N's proof signing at slot N's boundary,
+    /// in the same slot-start partial-signature batch as the attestation proofs.)
     ///
     /// Exactly-once: `new_executions` holds only vacant registrations, so a repeated Phase 3 run
     /// for one slot cannot spawn a second publisher for the same `(committee, slot)`.
     ///
     /// The publisher is implicitly Boole-gated (consensus data exists only for Boole+ slots),
-    /// while the empty Lighthouse callback gates on the aggregate's target epoch. The two agree
-    /// because `attestation.data.target.epoch` equals the slot's own epoch by construction, which
-    /// is what rules out both paths publishing for one duty.
+    /// while the empty Lighthouse callbacks gate on the duty's epoch. The two agree because
+    /// `attestation.data.target.epoch` and `contribution.slot`'s epoch equal the slot's own epoch
+    /// by construction, which is what rules out both paths publishing for one duty.
     fn spawn_aggregate_publisher(
         &self,
         slot: Slot,
@@ -702,9 +701,12 @@ impl<E: EthSpec, T: SlotClock + 'static> MetadataService<E, T> {
         self.executor.spawn(
             async move {
                 validator_store
-                    .publish_decided_aggregates(slot, new_executions, |fork_name, signed| {
-                        post_aggregate(&beacon_nodes, fork_name, signed)
-                    })
+                    .publish_decided_aggregates(
+                        slot,
+                        new_executions,
+                        |fork_name, signed| post_aggregate(&beacon_nodes, fork_name, signed),
+                        |signed| post_contribution(&beacon_nodes, signed),
+                    )
                     .await;
             },
             "aggregator_committee_publisher",
@@ -1475,6 +1477,27 @@ async fn post_aggregate<T: SlotClock + 'static, E: EthSpec>(
                         .post_validator_aggregate_and_proof_v1(signed)
                         .await
                 }
+            }
+        })
+        .await
+        .map_err(|e| format!("{e}"))
+}
+
+/// POST one signed sync contribution, matching go-ssv's publication shape at the reference pin
+/// (one contribution per request, published as soon as its quorum lands). Endpoint policy mirrors
+/// Lighthouse's at the pin: `first_success` across the beacon nodes; the endpoint takes no fork
+/// header.
+async fn post_contribution<T: SlotClock + 'static, E: EthSpec>(
+    beacon_nodes: &BeaconNodeFallback<T>,
+    signed: SignedContributionAndProof<E>,
+) -> Result<(), String> {
+    beacon_nodes
+        .first_success(|beacon_node| {
+            let signed = std::slice::from_ref(&signed);
+            async move {
+                beacon_node
+                    .post_validator_contribution_and_proofs(signed)
+                    .await
             }
         })
         .await

--- a/anchor/validator_store/src/metadata_service.rs
+++ b/anchor/validator_store/src/metadata_service.rs
@@ -27,14 +27,14 @@ use tokio::{
 use tracing::{Instrument, debug, error, info, info_span, trace, warn};
 use tree_hash::TreeHash;
 use types::{
-    Attestation, AttestationData, ChainSpec, EthSpec, ForkName, Hash256, Slot,
-    SyncCommitteeContribution, SyncSelectionProof, SyncSubnetId,
+    Attestation, AttestationData, ChainSpec, EthSpec, ForkName, Hash256, SignedAggregateAndProof,
+    Slot, SyncCommitteeContribution, SyncSelectionProof, SyncSubnetId,
 };
 use validator_services::duties_service::{DutiesService, DutyAndProof};
 
 use crate::{
     AggregationAssignments, AnchorValidatorStore, ContributionWaiter, VotingAssignments,
-    VotingContext, metrics,
+    VotingContext, aggregator_post_consensus::AggregatorPostConsensusShared, metrics,
 };
 
 /// Data for sync committee aggregators.
@@ -640,11 +640,52 @@ impl<E: EthSpec, T: SlotClock + 'static> MetadataService<E, T> {
             consensus_data_by_ssv_committee,
         };
 
-        self.validator_store
+        let new_executions = self
+            .validator_store
             .update_aggregation_assignments(aggregator_info);
+        self.spawn_aggregate_publisher(slot, new_executions);
 
         trace!(%slot, "Published AggregationAssignments at 2/3 slot");
         Ok(())
+    }
+
+    /// Spawn the detached publisher for this slot's newly registered post-consensus executions.
+    ///
+    /// The publisher owns Boole+ aggregate publication: the Lighthouse aggregate callback returns
+    /// an empty batch at Boole+ because its duty snapshot is cloned before slot-start selection
+    /// proofs finish, so aggregates the snapshot never saw would otherwise be silently dropped.
+    /// Contributions are unaffected (sync selection proofs are precomputed a slot ahead) and stay
+    /// on the Lighthouse publish path.
+    ///
+    /// Exactly-once: `new_executions` holds only vacant registrations, so a repeated Phase 3 run
+    /// for one slot cannot spawn a second publisher for the same `(committee, slot)`.
+    ///
+    /// The publisher is implicitly Boole-gated (consensus data exists only for Boole+ slots),
+    /// while the empty Lighthouse callback gates on the aggregate's target epoch. The two agree
+    /// because `attestation.data.target.epoch` equals the slot's own epoch by construction, which
+    /// is what rules out both paths publishing for one duty.
+    fn spawn_aggregate_publisher(
+        &self,
+        slot: Slot,
+        new_executions: Vec<(CommitteeId, AggregatorPostConsensusShared<E>)>,
+    ) {
+        if new_executions.is_empty() {
+            return;
+        }
+
+        let validator_store = self.validator_store.clone();
+        let beacon_nodes = self.beacon_nodes.clone();
+
+        self.executor.spawn(
+            async move {
+                validator_store
+                    .publish_decided_aggregates(slot, new_executions, |fork_name, signed| {
+                        post_aggregate(&beacon_nodes, fork_name, signed)
+                    })
+                    .await;
+            },
+            "aggregator_committee_publisher",
+        );
     }
 
     /// Build `AggregatorCommitteeConsensusData` for each committee that has aggregators.
@@ -1379,6 +1420,42 @@ pub fn filter_contributors_with_contributions<E: EthSpec>(
     contributors_with_roots.retain(|(_, contrib)| {
         sync_contributions.contains_key(&SyncSubnetId::new(contrib.committee_index))
     });
+}
+
+/// POST one signed aggregate, matching go-ssv's publication shape at the reference pin (one
+/// aggregate per request, published as soon as its quorum lands). Endpoint policy mirrors
+/// Lighthouse's at the pin: `first_success` across the beacon nodes (which makes two passes
+/// over the candidate list before giving up), v2 with the fork header for Electra+ aggregates,
+/// v1 otherwise.
+///
+/// `fork_name` is the fork the aggregate's payload was decoded under (the decided value's
+/// `DataVersion`), so the endpoint and fork header cannot diverge from the payload variant.
+async fn post_aggregate<T: SlotClock + 'static, E: EthSpec>(
+    beacon_nodes: &BeaconNodeFallback<T>,
+    fork_name: ForkName,
+    signed: SignedAggregateAndProof<E>,
+) -> Result<(), String> {
+    beacon_nodes
+        .first_success(|beacon_node| {
+            let signed = std::slice::from_ref(&signed);
+            async move {
+                let _timer = validator_metrics::start_timer_vec(
+                    &validator_metrics::ATTESTATION_SERVICE_TIMES,
+                    &[validator_metrics::AGGREGATES_HTTP_POST],
+                );
+                if fork_name.electra_enabled() {
+                    beacon_node
+                        .post_validator_aggregate_and_proof_v2(signed, fork_name)
+                        .await
+                } else {
+                    beacon_node
+                        .post_validator_aggregate_and_proof_v1(signed)
+                        .await
+                }
+            }
+        })
+        .await
+        .map_err(|e| format!("{e}"))
 }
 
 #[cfg(test)]

--- a/anchor/validator_store/src/metadata_service.rs
+++ b/anchor/validator_store/src/metadata_service.rs
@@ -10,7 +10,6 @@ use eth2::{
     BeaconNodeHttpClient,
     types::{BlockId, SyncContributionData},
 };
-use fork::{Fork, ForkSchedule};
 use futures::stream::{FuturesUnordered, StreamExt};
 use slot_clock::SlotClock;
 use ssv_types::{
@@ -30,14 +29,14 @@ use tokio::{
 use tracing::{Instrument, debug, error, info, info_span, trace, warn};
 use tree_hash::TreeHash;
 use types::{
-    Attestation, AttestationData, ChainSpec, EthSpec, ForkName, Hash256, Slot,
-    SyncCommitteeContribution, SyncSelectionProof, SyncSubnetId,
+    Attestation, AttestationData, ChainSpec, EthSpec, ForkName, Hash256, SignedAggregateAndProof,
+    SignedContributionAndProof, Slot, SyncCommitteeContribution, SyncSelectionProof, SyncSubnetId,
 };
 use validator_services::duties_service::{DutiesService, DutyAndProof};
 
 use crate::{
     AggregationAssignments, AnchorValidatorStore, ContributionWaiter, SlotVote, VotingAssignments,
-    VotingContext, metrics,
+    VotingContext, aggregator_post_consensus::AggregatorPostConsensusShared, metrics,
 };
 
 /// Data for sync committee aggregators.
@@ -92,6 +91,19 @@ const BEACON_API_FETCH_TIMEOUT: Duration = Duration::from_secs(2);
 const WAD_SOFT_TIMEOUT: Duration = Duration::from_secs(1);
 const WAD_HARD_TIMEOUT: Duration = Duration::from_secs(3);
 const BLOCK_SLOT_LOOKUP_TIMEOUT: Duration = Duration::from_millis(500);
+
+/// Publish `VotingAssignments` this long after the slot boundary.
+///
+/// The boundary sleep runs on the monotonic timer but the slot is read from the
+/// wall clock, and the two drift apart by a few milliseconds over a full-slot
+/// sleep. A wake landing marginally before the boundary would read the previous
+/// slot, republish it, and skip the new one (issue #1223). This margin absorbs
+/// that drift. 50 ms mirrors the message validator's `CLOCK_ERROR_TOLERANCE`,
+/// the clock error the SSV network already budgets for between nodes. Nothing
+/// consumes the assignments this early: the soonest consumers are the
+/// selection-proof flows (deadline 2/3 slot) and the voting-context build
+/// (triggered no earlier than a head event).
+const VOTING_ASSIGNMENTS_PUBLISH_DELAY: Duration = Duration::from_millis(50);
 
 /// Builds each validator's per-subnet position counts from raw sync committee positions.
 fn build_sync_validator_assignments<E, I, P>(
@@ -263,7 +275,6 @@ pub struct MetadataService<E: EthSpec, T: SlotClock + 'static> {
     beacon_nodes: Arc<BeaconNodeFallback<T>>,
     executor: TaskExecutor,
     spec: Arc<ChainSpec>,
-    fork_schedule: Arc<ForkSchedule>,
     weighted_attestation_data: bool,
 }
 
@@ -292,8 +303,25 @@ async fn wait_for_head_event<T: SlotClock>(
     }
 }
 
+/// Drive `publish` once per slot, shortly after each slot boundary.
+///
+/// The delay past the boundary is what makes this correct: sleeping exactly to
+/// the boundary lets a marginally early timer wake read the previous slot,
+/// republish it, and skip the new one (issue #1223). See
+/// [`VOTING_ASSIGNMENTS_PUBLISH_DELAY`].
+async fn run_slot_start_publisher<T: SlotClock>(slot_clock: T, mut publish: impl FnMut()) {
+    loop {
+        if let Some(duration_to_next_slot) = slot_clock.duration_to_next_slot() {
+            sleep(duration_to_next_slot + VOTING_ASSIGNMENTS_PUBLISH_DELAY).await;
+            publish();
+        } else {
+            error!("Failed to read slot clock");
+            sleep(slot_clock.slot_duration()).await;
+        }
+    }
+}
+
 impl<E: EthSpec, T: SlotClock + 'static> MetadataService<E, T> {
-    #[expect(clippy::too_many_arguments)]
     pub fn new(
         duties_service: Arc<DutiesService<AnchorValidatorStore<T, E>, T>>,
         validator_store: Arc<AnchorValidatorStore<T, E>>,
@@ -301,7 +329,6 @@ impl<E: EthSpec, T: SlotClock + 'static> MetadataService<E, T> {
         beacon_nodes: Arc<BeaconNodeFallback<T>>,
         executor: TaskExecutor,
         spec: Arc<ChainSpec>,
-        fork_schedule: Arc<ForkSchedule>,
         weighted_attestation_data: bool,
     ) -> Self {
         Self {
@@ -311,7 +338,6 @@ impl<E: EthSpec, T: SlotClock + 'static> MetadataService<E, T> {
             beacon_nodes,
             executor,
             spec,
-            fork_schedule,
             weighted_attestation_data,
         }
     }
@@ -343,21 +369,13 @@ impl<E: EthSpec, T: SlotClock + 'static> MetadataService<E, T> {
         let self_clone_phase1 = self.clone();
         executor.spawn(
             async move {
-                loop {
-                    if let Some(duration_to_next_slot) =
-                        self_clone_phase1.slot_clock.duration_to_next_slot()
-                    {
-                        // Sleep until slot start
-                        sleep(duration_to_next_slot).await;
-
-                        if let Err(err) = self_clone_phase1.update_voting_assignments() {
-                            error!(err, "Failed to update validator voting assignments");
-                        }
-                    } else {
-                        error!("Failed to read slot clock");
-                        sleep(slot_duration).await;
+                let slot_clock = self_clone_phase1.slot_clock.clone();
+                run_slot_start_publisher(slot_clock, move || {
+                    if let Err(err) = self_clone_phase1.update_voting_assignments() {
+                        error!(err, "Failed to update validator voting assignments");
                     }
-                }
+                })
+                .await
             },
             "voting_assignments_service",
         );
@@ -713,16 +731,19 @@ impl<E: EthSpec, T: SlotClock + 'static> MetadataService<E, T> {
         // ═══════════════════════════════════════════════════════════════════════
         let epoch = slot.epoch(E::slots_per_epoch());
 
+        // The exact complement of the Lighthouse callback gates by construction: consensus data
+        // (and therefore the publisher) exists precisely when Lighthouse does not own
+        // publication.
         let consensus_data_by_ssv_committee =
-            if self.fork_schedule.active_fork(epoch) >= Fork::Boole {
+            if self.validator_store.lighthouse_owns_publication(epoch) {
+                HashMap::new()
+            } else {
                 self.build_consensus_data_for_all_committees(
                     slot,
                     attesters_by_ssv_committee,
                     sync_by_ssv_committee,
                 )
                 .await?
-            } else {
-                HashMap::new()
             };
 
         let aggregator_info = AggregationAssignments {
@@ -732,8 +753,10 @@ impl<E: EthSpec, T: SlotClock + 'static> MetadataService<E, T> {
             consensus_data_by_ssv_committee,
         };
 
-        self.validator_store
+        let new_executions = self
+            .validator_store
             .update_aggregation_assignments(aggregator_info);
+        self.spawn_aggregate_publisher(slot, new_executions);
 
         trace!(%slot, "Published AggregationAssignments at 2/3 slot");
         Ok(())
@@ -785,6 +808,49 @@ impl<E: EthSpec, T: SlotClock + 'static> MetadataService<E, T> {
             aggregate_attestation_keys,
             sync_contribution_keys,
         }
+    }
+
+    /// Spawn the detached publisher for this slot's newly registered post-consensus executions.
+    ///
+    /// The publisher owns Boole+ publication of aggregates and sync contributions: the Lighthouse
+    /// callbacks return empty batches at Boole+ because their duty snapshots are cloned before
+    /// slot-start selection proofs finish, so roots the snapshots never saw would otherwise be
+    /// silently dropped. (Anchor's sync selection proofs are NOT precomputed a slot ahead: its
+    /// one-slot Lighthouse lookahead config starts slot N's proof signing at slot N's boundary,
+    /// in the same slot-start partial-signature batch as the attestation proofs.)
+    ///
+    /// Exactly-once: `new_executions` holds only vacant registrations, so a repeated Phase 3 run
+    /// for one slot cannot spawn a second publisher for the same `(committee, slot)`.
+    ///
+    /// The publisher is implicitly Boole-gated (consensus data exists only for Boole+ slots),
+    /// while the empty Lighthouse callbacks gate on the duty's epoch. The two agree because
+    /// `attestation.data.target.epoch` and `contribution.slot`'s epoch equal the slot's own epoch
+    /// by construction, which is what rules out both paths publishing for one duty.
+    fn spawn_aggregate_publisher(
+        &self,
+        slot: Slot,
+        new_executions: Vec<(CommitteeId, AggregatorPostConsensusShared<E>)>,
+    ) {
+        if new_executions.is_empty() {
+            return;
+        }
+
+        let validator_store = self.validator_store.clone();
+        let beacon_nodes = self.beacon_nodes.clone();
+
+        self.executor.spawn(
+            async move {
+                validator_store
+                    .publish_decided_aggregates(
+                        slot,
+                        new_executions,
+                        |fork_name, signed| post_aggregate(&beacon_nodes, fork_name, signed),
+                        |signed| post_contribution(&beacon_nodes, signed),
+                    )
+                    .await;
+            },
+            "aggregator_committee_publisher",
+        );
     }
 
     /// Build `AggregatorCommitteeConsensusData` for each committee that has aggregators.
@@ -1489,6 +1555,63 @@ pub fn sort_contributors_by_signing_root_then_validator_index(
             .cmp(root_b)
             .then_with(|| contrib_a.validator_index.cmp(&contrib_b.validator_index))
     });
+}
+
+/// POST one signed aggregate, matching go-ssv's publication shape at the reference pin (one
+/// aggregate per request, published as soon as its quorum lands). Endpoint policy mirrors
+/// Lighthouse's at the pin: `first_success` across the beacon nodes (which makes two passes
+/// over the candidate list before giving up), v2 with the fork header for Electra+ aggregates,
+/// v1 otherwise.
+///
+/// `fork_name` is the fork the aggregate's payload was decoded under (the decided value's
+/// `DataVersion`), so the endpoint and fork header cannot diverge from the payload variant.
+async fn post_aggregate<T: SlotClock + 'static, E: EthSpec>(
+    beacon_nodes: &BeaconNodeFallback<T>,
+    fork_name: ForkName,
+    signed: SignedAggregateAndProof<E>,
+) -> Result<(), String> {
+    beacon_nodes
+        .first_success(|beacon_node| {
+            let signed = std::slice::from_ref(&signed);
+            async move {
+                let _timer = validator_metrics::start_timer_vec(
+                    &validator_metrics::ATTESTATION_SERVICE_TIMES,
+                    &[validator_metrics::AGGREGATES_HTTP_POST],
+                );
+                if fork_name.electra_enabled() {
+                    beacon_node
+                        .post_validator_aggregate_and_proof_v2(signed, fork_name)
+                        .await
+                } else {
+                    beacon_node
+                        .post_validator_aggregate_and_proof_v1(signed)
+                        .await
+                }
+            }
+        })
+        .await
+        .map_err(|e| format!("{e}"))
+}
+
+/// POST one signed sync contribution, matching go-ssv's publication shape at the reference pin
+/// (one contribution per request, published as soon as its quorum lands). Endpoint policy mirrors
+/// Lighthouse's at the pin: `first_success` across the beacon nodes; the endpoint takes no fork
+/// header.
+async fn post_contribution<T: SlotClock + 'static, E: EthSpec>(
+    beacon_nodes: &BeaconNodeFallback<T>,
+    signed: SignedContributionAndProof<E>,
+) -> Result<(), String> {
+    beacon_nodes
+        .first_success(|beacon_node| {
+            let signed = std::slice::from_ref(&signed);
+            async move {
+                beacon_node
+                    .post_validator_contribution_and_proofs(signed)
+                    .await
+            }
+        })
+        .await
+        .map_err(|e| format!("{e}"))
 }
 
 #[cfg(test)]
@@ -2791,5 +2914,105 @@ mod tests {
         };
 
         assert!(!from_head_event);
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════════════════
+    // Slot start publisher tests
+    //
+    // The virtual tokio timer stands in for the monotonic timer the publisher sleeps on,
+    // and the manual slot clock stands in for the wall clock it reads slots from. Driving
+    // them separately is what lets these tests reproduce the drift between the two.
+    // ═══════════════════════════════════════════════════════════════════════════════════
+
+    use parking_lot::Mutex;
+
+    const SLOT_DURATION: Duration = Duration::from_secs(SLOT_DURATION_SECS);
+    /// How far the wall clock trails the virtual timer when the boundary sleep wakes. The
+    /// drift observed in issue #1223 was 1 ms to 5 ms.
+    const WALL_CLOCK_LAG: Duration = Duration::from_millis(3);
+    /// Slot boundaries crossed by `publishes_each_slot_exactly_once`.
+    const LOCKSTEP_SLOTS: u64 = 3;
+
+    /// Spawn the publisher, recording the slot its clock reads at each publish. Production
+    /// reads the slot inside `update_voting_assignments`, so the recorded slot is the one
+    /// that would have been published.
+    async fn spawn_slot_start_publisher(slot_clock: &ManualSlotClock) -> Arc<Mutex<Vec<Slot>>> {
+        let published = Arc::new(Mutex::new(Vec::new()));
+        let publish_clock = slot_clock.clone();
+        let recorded = published.clone();
+        tokio::spawn(run_slot_start_publisher(slot_clock.clone(), move || {
+            let slot = publish_clock.now().expect("manual slot clock is readable");
+            recorded.lock().push(slot);
+        }));
+        // Let the publisher arm its first sleep before either clock moves.
+        tokio::task::yield_now().await;
+        published
+    }
+
+    /// Advance the virtual timer, giving a sleep that expires within the step a scheduling
+    /// round to run. `tokio::time::advance` only wakes the sleeper, it does not poll it, so
+    /// without the extra round the publish would be observed a step late.
+    async fn advance_virtual_time(duration: Duration) {
+        tokio::time::advance(duration).await;
+        tokio::task::yield_now().await;
+    }
+
+    /// Move the wall clock and the virtual timer forward by the same amount. The wall clock
+    /// moves first so a timer firing within the step reads the time the step ends at.
+    async fn advance_in_lockstep(slot_clock: &ManualSlotClock, duration: Duration) {
+        slot_clock.advance_time(duration);
+        advance_virtual_time(duration).await;
+    }
+
+    /// Regression test for issue #1223.
+    ///
+    /// A boundary sleep that wakes a few milliseconds before the wall clock reaches the
+    /// slot boundary used to republish the previous slot, and the next iteration then slept
+    /// past the new slot entirely, so waiters on it saw `MetadataSlotPassed`. The publish
+    /// offset has to hold the publish back until the wall clock has crossed.
+    #[tokio::test(start_paused = true)]
+    async fn early_wake_still_publishes_the_new_slot() {
+        // Arrange: publisher armed at the start of TEST_SLOT.
+        let slot_clock = make_test_slot_clock();
+        let published = spawn_slot_start_publisher(&slot_clock).await;
+
+        // Act: fire the boundary sleep with the wall clock still short of the boundary.
+        slot_clock.advance_time(SLOT_DURATION - WALL_CLOCK_LAG);
+        advance_virtual_time(SLOT_DURATION).await;
+
+        assert!(
+            published.lock().is_empty(),
+            "publishing at the early wake would read slot {TEST_SLOT} again"
+        );
+
+        // The wall clock crosses the boundary within the publish offset.
+        advance_in_lockstep(&slot_clock, VOTING_ASSIGNMENTS_PUBLISH_DELAY).await;
+
+        // Assert: the new slot is published once, and the previous slot is not repeated.
+        assert_eq!(
+            published.lock().as_slice(),
+            [Slot::new(TEST_SLOT + 1)],
+            "an early wake must still publish the new slot exactly once"
+        );
+    }
+
+    /// Without drift, every slot boundary produces exactly one publish for that slot.
+    #[tokio::test(start_paused = true)]
+    async fn publishes_each_slot_exactly_once() {
+        // Arrange: publisher armed at the start of TEST_SLOT.
+        let slot_clock = make_test_slot_clock();
+        let published = spawn_slot_start_publisher(&slot_clock).await;
+
+        // Act: settle onto the publish offset, then cross one boundary per step.
+        advance_in_lockstep(&slot_clock, VOTING_ASSIGNMENTS_PUBLISH_DELAY).await;
+        for _ in 0..LOCKSTEP_SLOTS {
+            advance_in_lockstep(&slot_clock, SLOT_DURATION).await;
+        }
+
+        // Assert: one publish per boundary, slots strictly increasing by one.
+        let expected: Vec<Slot> = (1..=LOCKSTEP_SLOTS)
+            .map(|offset| Slot::new(TEST_SLOT + offset))
+            .collect();
+        assert_eq!(published.lock().as_slice(), expected);
     }
 }

--- a/anchor/validator_store/src/metrics.rs
+++ b/anchor/validator_store/src/metrics.rs
@@ -3,6 +3,7 @@ use std::sync::LazyLock;
 pub use metrics::*;
 
 pub const AGGREGATE_AND_PROOF: &str = "aggregate_and_proof";
+pub const AGGREGATOR_COMMITTEE: &str = "aggregator_committee";
 pub const BLOCK: &str = "block";
 pub const BEACON_VOTE: &str = "beacon_vote";
 pub const SYNC_CONTRIBUTION_AND_PROOF: &str = "sync_contribution_and_proof";

--- a/anchor/validator_store/src/metrics.rs
+++ b/anchor/validator_store/src/metrics.rs
@@ -3,6 +3,7 @@ use std::sync::LazyLock;
 pub use metrics::*;
 
 pub const AGGREGATE_AND_PROOF: &str = "aggregate_and_proof";
+pub const AGGREGATOR_COMMITTEE: &str = "aggregator_committee";
 pub const BLOCK: &str = "block";
 pub const BEACON_VOTE: &str = "beacon_vote";
 pub const SYNC_CONTRIBUTION_AND_PROOF: &str = "sync_contribution_and_proof";
@@ -169,6 +170,34 @@ pub static AGGREGATOR_COMMITTEE_FETCH_SUCCESS: LazyLock<Result<IntCounterVec>> =
             &["type", "status"],
         )
     });
+
+// Labels for `AGGREGATOR_COMMITTEE_PUBLISH_TOTAL` (`success` is `validator_metrics::SUCCESS`).
+pub const CONSENSUS_ERROR: &str = "consensus_error";
+pub const HTTP_ERROR: &str = "http_error";
+pub const NO_AGGREGATES: &str = "no_aggregates";
+pub const NO_SIGNATURES: &str = "no_signatures";
+
+/// Aggregate-class outcomes of the Boole+ publisher. `consensus_error` (outcome failed or timed
+/// out) and `no_aggregates` (decided worklist held no aggregates) count committees, since those
+/// failures occur before any per-root work exists. `success` and `http_error` (per publish
+/// attempt) and `no_signatures` (root missed signature quorum in time) count individual
+/// aggregates, matching go-ssv's one-POST-per-aggregate accounting. The publisher's sync
+/// contribution outcomes are deliberately excluded: they keep the Lighthouse-era
+/// `SIGNED_SYNC_COMMITTEE_CONTRIBUTIONS_TOTAL` accounting and per-publish logs instead. All
+/// increments live in `AnchorValidatorStore::publish_decided_aggregates` and its
+/// per-committee/per-root helpers in `aggregator_post_consensus.rs`.
+pub static AGGREGATOR_COMMITTEE_PUBLISH_TOTAL: LazyLock<Result<IntCounterVec>> =
+    LazyLock::new(|| {
+        try_create_int_counter_vec(
+            "anchor_aggregator_committee_publish_total",
+            "Boole+ aggregate publisher outcomes (committee-level errors, per-aggregate results)",
+            &["result"],
+        )
+    });
+
+pub fn inc_publish_result(result: &str) {
+    inc_counter_vec(&AGGREGATOR_COMMITTEE_PUBLISH_TOTAL, &[result]);
+}
 
 // ═══════════════════════════════════════════════════════════════════════════════
 // Weighted Attestation Data (WAD) metrics

--- a/anchor/validator_store/src/metrics.rs
+++ b/anchor/validator_store/src/metrics.rs
@@ -148,13 +148,15 @@ pub const HTTP_ERROR: &str = "http_error";
 pub const NO_AGGREGATES: &str = "no_aggregates";
 pub const NO_SIGNATURES: &str = "no_signatures";
 
-/// Outcomes of the Boole+ aggregate publisher. `consensus_error` (outcome failed or timed out)
-/// and `no_aggregates` (decided worklist held contributions only) count committees, since those
+/// Aggregate-class outcomes of the Boole+ publisher. `consensus_error` (outcome failed or timed
+/// out) and `no_aggregates` (decided worklist held no aggregates) count committees, since those
 /// failures occur before any per-root work exists. `success` and `http_error` (per publish
 /// attempt) and `no_signatures` (root missed signature quorum in time) count individual
-/// aggregates, matching go-ssv's one-POST-per-aggregate accounting. All increments live in
-/// `AnchorValidatorStore::publish_decided_aggregates` and its per-committee/per-root helpers in
-/// `aggregator_post_consensus.rs`.
+/// aggregates, matching go-ssv's one-POST-per-aggregate accounting. The publisher's sync
+/// contribution outcomes are deliberately excluded: they keep the Lighthouse-era
+/// `SIGNED_SYNC_COMMITTEE_CONTRIBUTIONS_TOTAL` accounting and per-publish logs instead. All
+/// increments live in `AnchorValidatorStore::publish_decided_aggregates` and its
+/// per-committee/per-root helpers in `aggregator_post_consensus.rs`.
 pub static AGGREGATOR_COMMITTEE_PUBLISH_TOTAL: LazyLock<Result<IntCounterVec>> =
     LazyLock::new(|| {
         try_create_int_counter_vec(

--- a/anchor/validator_store/src/metrics.rs
+++ b/anchor/validator_store/src/metrics.rs
@@ -142,6 +142,32 @@ pub static AGGREGATOR_COMMITTEE_FETCH_SUCCESS: LazyLock<Result<IntCounterVec>> =
         )
     });
 
+// Labels for `AGGREGATOR_COMMITTEE_PUBLISH_TOTAL` (`success` is `validator_metrics::SUCCESS`).
+pub const CONSENSUS_ERROR: &str = "consensus_error";
+pub const HTTP_ERROR: &str = "http_error";
+pub const NO_AGGREGATES: &str = "no_aggregates";
+pub const NO_SIGNATURES: &str = "no_signatures";
+
+/// Outcomes of the Boole+ aggregate publisher. `consensus_error` (outcome failed or timed out)
+/// and `no_aggregates` (decided worklist held contributions only) count committees, since those
+/// failures occur before any per-root work exists. `success` and `http_error` (per publish
+/// attempt) and `no_signatures` (root missed signature quorum in time) count individual
+/// aggregates, matching go-ssv's one-POST-per-aggregate accounting. All increments live in
+/// `AnchorValidatorStore::publish_decided_aggregates` and its per-committee/per-root helpers in
+/// `aggregator_post_consensus.rs`.
+pub static AGGREGATOR_COMMITTEE_PUBLISH_TOTAL: LazyLock<Result<IntCounterVec>> =
+    LazyLock::new(|| {
+        try_create_int_counter_vec(
+            "anchor_aggregator_committee_publish_total",
+            "Boole+ aggregate publisher outcomes (committee-level errors, per-aggregate results)",
+            &["result"],
+        )
+    });
+
+pub fn inc_publish_result(result: &str) {
+    inc_counter_vec(&AGGREGATOR_COMMITTEE_PUBLISH_TOTAL, &[result]);
+}
+
 // ═══════════════════════════════════════════════════════════════════════════════
 // Weighted Attestation Data (WAD) metrics
 // ═══════════════════════════════════════════════════════════════════════════════

--- a/anchor/validator_store/src/testing/aggregator_post_consensus.rs
+++ b/anchor/validator_store/src/testing/aggregator_post_consensus.rs
@@ -1,0 +1,1510 @@
+//! Integration tests for the Boole+ `AggregatorCommittee` post-consensus execution.
+//!
+//! One QBFT decision carries both attestation aggregates and sync contributions. The
+//! per-`(committee, slot)` execution signs the complete decided worklist regardless of which
+//! Lighthouse callbacks fire. These tests pin the regression from issue #1227: a callback of one
+//! class must still produce the partial signatures for the other class, so the shared committee
+//! batch never stalls below its expected size.
+//!
+//! Both classes are read out the same way: Anchor publishes aggregates and contributions itself
+//! from the decided value, one publish call per root, so `publish_decided_aggregates` is the
+//! only reader and both Lighthouse callbacks return nothing (see `testing/committee_aggregate.rs`
+//! and `testing/committee_contribution.rs` for the callback contract).
+//!
+//! The worklist tasks are detached, so captured `sign_and_collect` calls arrive
+//! asynchronously; assertions on capture counts poll with a deadline and then let the
+//! captures settle before asserting exact counts.
+
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+    time::Duration,
+};
+
+use bls::{AggregateSignature, FixedBytesExtended, PublicKeyBytes, Signature};
+use futures::FutureExt;
+use parking_lot::Mutex;
+use signature_collector::SignatureRequester;
+use ssv_types::{
+    CommitteeId, OperatorId, ValidatorIndex, ValidatorMetadata,
+    consensus::{AggregatorCommitteeConsensusData, AssignedAggregator, DataVersion, QbftData},
+    msgid::Role,
+    partial_sig::PartialSignatureKind,
+};
+use ssz::Encode;
+use ssz_types::VariableList;
+use types::{
+    AttestationBase, AttestationData, AttestationElectra, Checkpoint, Epoch, ForkName, Hash256,
+    MainnetEthSpec, Slot, SyncCommitteeContribution,
+};
+
+use super::common::*;
+use crate::{
+    Error, SpecificError, aggregator_post_consensus::AggregatorPostConsensusShared, metrics,
+};
+
+/// One committee's decided value, as the slot pipeline publishes it.
+type DecidedData = AggregatorCommitteeConsensusData<MainnetEthSpec>;
+/// A handle on one `(committee, slot)` post-consensus execution, as handed to the publisher.
+type Execution = AggregatorPostConsensusShared<MainnetEthSpec>;
+
+const COMMITTEE_OPERATOR_IDS: [OperatorId; 4] =
+    [OperatorId(1), OperatorId(2), OperatorId(3), OperatorId(4)];
+const OUR_OPERATOR_ID: OperatorId = OperatorId(1);
+
+const COMMITTEE_INDEX: usize = 0;
+const STARTING_VALIDATOR_INDEX: usize = 0;
+const AGGREGATE_VALIDATOR_IDX: usize = 0;
+const CONTRIBUTOR_VALIDATOR_IDX: usize = 1;
+const MIXED_COMMITTEE_VALIDATOR_COUNT: usize = 2;
+const SINGLE_VALIDATOR_COUNT: usize = 1;
+/// Position of the only validator in single-validator fixtures.
+const SOLE_VALIDATOR_IDX: usize = 0;
+
+const BEACON_COMMITTEE_INDEX: u64 = 0;
+const CONFLICTING_BEACON_COMMITTEE_INDEX: u64 = 1;
+const CONTRIBUTION_SUBCOMMITTEES: [u64; 2] = [0, 1];
+const ALL_SUBCOMMITTEES: [u64; 4] = [0, 1, 2, 3];
+
+/// Decided validator indices with no local metadata, so the worklist filters them out.
+const FOREIGN_AGGREGATOR_INDEX: usize = 900;
+const FOREIGN_CONTRIBUTOR_INDEX: usize = 901;
+
+/// One aggregate root plus one contribution root per subcommittee in the standard mixed
+/// decided value.
+const MIXED_WORKLIST_SIZE: usize = 1 + CONTRIBUTION_SUBCOMMITTEES.len();
+
+/// A clock position past the publisher's deadline for `TEST_SLOT` (one slot past that slot's end),
+/// so deadline tests reach the timeout without sleeping two real slots.
+const PAST_PUBLISH_DEADLINE_SECS: u64 = (TEST_SLOT + 3) * SLOT_DURATION_SECS;
+
+/// A clock position strictly between the two per-root deadlines for `TEST_SLOT`: past the
+/// contribution deadline (that slot's end) and before the aggregate deadline (one slot later).
+/// Tests of the per-class asymmetry sit here, where the two classes must behave differently.
+const BETWEEN_CLASS_DEADLINES_SECS: u64 =
+    (TEST_SLOT + 1) * SLOT_DURATION_SECS + SLOT_DURATION_SECS / 2;
+
+/// Long enough that a publisher which is going to finish has finished, short enough to keep the
+/// asymmetry test fast. Only used to prove a publisher is still waiting.
+const STILL_WAITING_PROBE: Duration = Duration::from_millis(500);
+
+const CAPTURE_TIMEOUT: Duration = Duration::from_secs(2);
+const CAPTURE_POLL_INTERVAL: Duration = Duration::from_millis(10);
+/// Extra wait after the expected capture count is reached, to catch spurious extra captures.
+const SETTLE_DELAY: Duration = Duration::from_millis(200);
+
+// ==================== Fixture ====================
+
+/// One committee plus the identifiers needed to seed decided values for it.
+///
+/// The harness owns its `CommitteeSetup`s privately, so the committee ID and validator
+/// metadata are captured before handing the setup over.
+struct AggregatorCommitteeFixture {
+    harness: ValidatorStoreTestHarness,
+    committee_id: CommitteeId,
+}
+
+impl AggregatorCommitteeFixture {
+    fn new(validator_count: usize) -> Self {
+        let setup = create_committee_setup(
+            &COMMITTEE_OPERATOR_IDS,
+            validator_count,
+            STARTING_VALIDATOR_INDEX,
+        );
+        let committee_id = setup.cluster.committee_id();
+        let harness = ValidatorStoreTestHarness::new(vec![setup], OUR_OPERATOR_ID);
+        Self {
+            harness,
+            committee_id,
+        }
+    }
+
+    fn validator_metadata(&self, position: usize) -> ValidatorMetadata {
+        self.harness.validator_metadata(COMMITTEE_INDEX, position)
+    }
+
+    fn validator_index(&self, position: usize) -> ValidatorIndex {
+        self.validator_metadata(position)
+            .index
+            .expect("test validator should have an index")
+    }
+
+    fn pubkey(&self, position: usize) -> PublicKeyBytes {
+        self.validator_metadata(position).public_key
+    }
+
+    /// Seeds `AggregationAssignments` at `TEST_SLOT` with the given consensus data for this
+    /// committee. The mock decider echoes the proposal, so this is also the decided value.
+    fn seed_decided_value(&self, data: DecidedData) -> Arc<DecidedData> {
+        let data = Arc::new(data);
+        self.publish_decided_value(Arc::clone(&data));
+        data
+    }
+
+    /// Publishes `data` as this committee's decided value at `TEST_SLOT`, returning the executions
+    /// newly registered by the publish. This is what the slot pipeline hands to the aggregate
+    /// publisher, so a republish of the same slot returns nothing.
+    fn publish_decided_value(&self, data: Arc<DecidedData>) -> Vec<(CommitteeId, Execution)> {
+        self.harness
+            .publish_decided_values(HashMap::from([(self.committee_id, data)]))
+    }
+
+    /// Seeds `AggregationAssignments` at `TEST_SLOT` without consensus data for any committee, so
+    /// no execution is registered. Returns the (empty) set of executions the publish registered.
+    fn seed_assignments_without_consensus_data(&self) -> Vec<(CommitteeId, Execution)> {
+        self.harness.publish_decided_values(HashMap::new())
+    }
+
+    /// The standard mixed decided value: one aggregate for the aggregate validator plus one
+    /// contribution per subcommittee in [`CONTRIBUTION_SUBCOMMITTEES`] for the contributor.
+    fn mixed_decided_data(&self) -> DecidedData {
+        let aggregator = self.validator_index(AGGREGATE_VALIDATOR_IDX);
+        let contributor = self.validator_index(CONTRIBUTOR_VALIDATOR_IDX);
+        build_decided_data(
+            &[(aggregator, BEACON_COMMITTEE_INDEX)],
+            &[
+                (contributor, CONTRIBUTION_SUBCOMMITTEES[0]),
+                (contributor, CONTRIBUTION_SUBCOMMITTEES[1]),
+            ],
+        )
+    }
+
+    /// Seeds the standard mixed decided value.
+    fn seed_mixed_decided_value(&self) -> Arc<DecidedData> {
+        self.seed_decided_value(self.mixed_decided_data())
+    }
+
+    /// Seeds the standard mixed decided value and returns the single execution it registers,
+    /// for tests that also read the aggregate side through the publisher.
+    fn seed_mixed_decided_value_with_execution(&self) -> (Arc<DecidedData>, Execution) {
+        self.seed_decided_value_with_execution(self.mixed_decided_data())
+    }
+
+    /// Seeds `data` and returns the single execution it registers.
+    fn seed_decided_value_with_execution(
+        &self,
+        data: DecidedData,
+    ) -> (Arc<DecidedData>, Execution) {
+        let data = Arc::new(data);
+        let mut new_executions = self.publish_decided_value(Arc::clone(&data));
+        assert_eq!(
+            new_executions.len(),
+            1,
+            "seeding one committee should register exactly one execution"
+        );
+        let (committee_id, execution) = new_executions.pop().expect("execution should exist");
+        assert_eq!(committee_id, self.committee_id);
+        (data, execution)
+    }
+
+    /// Runs the publisher over this committee's execution with always-succeeding recording
+    /// closures, returning one entry per publish call of either class.
+    async fn run_publisher(&self, execution: Execution) -> RecordedPublishes {
+        run_recording_publisher(&self.harness, vec![(self.committee_id, execution)], |_| {
+            Ok(())
+        })
+        .await
+    }
+
+    /// The aggregator index the standard mixed decided value publishes.
+    fn expected_aggregator_index(&self) -> u64 {
+        self.harness
+            .aggregator_index(COMMITTEE_INDEX, AGGREGATE_VALIDATOR_IDX)
+    }
+}
+
+// ==================== Decided value construction ====================
+
+fn assigned(validator_index: ValidatorIndex, committee_index: u64) -> AssignedAggregator {
+    AssignedAggregator {
+        validator_index,
+        selection_proof: Signature::empty(),
+        committee_index,
+    }
+}
+
+/// The `AttestationData` shared by the aggregate payload builders, at `TEST_SLOT`.
+fn test_attestation_data(index: u64) -> AttestationData {
+    AttestationData {
+        slot: Slot::new(TEST_SLOT),
+        index,
+        beacon_block_root: Hash256::zero(),
+        source: Checkpoint {
+            epoch: Epoch::new(0),
+            root: Hash256::zero(),
+        },
+        target: Checkpoint {
+            epoch: Epoch::new(0),
+            root: Hash256::zero(),
+        },
+    }
+}
+
+/// An aggregate attestation payload at `TEST_SLOT`, in the pre-Electra shape. Distinct
+/// `committee_index` values produce distinct signing roots.
+fn test_aggregate_attestation(committee_index: u64) -> AttestationBase<MainnetEthSpec> {
+    AttestationBase {
+        aggregation_bits: ssz_types::BitList::with_capacity(128).expect("bitlist should be valid"),
+        data: test_attestation_data(committee_index),
+        signature: AggregateSignature::infinity(),
+    }
+}
+
+/// An aggregate attestation payload at `TEST_SLOT`, in the Electra+ shape: the committee moves
+/// from `data.index` to `committee_bits`. Distinct `committee_index` values produce distinct
+/// signing roots.
+fn test_aggregate_attestation_electra(committee_index: u64) -> AttestationElectra<MainnetEthSpec> {
+    let mut committee_bits = ssz_types::BitVector::new();
+    committee_bits
+        .set(committee_index as usize, true)
+        .expect("committee bit should be in range");
+    AttestationElectra {
+        aggregation_bits: ssz_types::BitList::with_capacity(128).expect("bitlist should be valid"),
+        data: test_attestation_data(0),
+        signature: AggregateSignature::infinity(),
+        committee_bits,
+    }
+}
+
+/// SSZ payload bytes for one decided aggregate, in the shape `fork` decodes.
+fn aggregate_payload_bytes(fork: ForkName, committee_index: u64) -> Vec<u8> {
+    if fork >= ForkName::Electra {
+        test_aggregate_attestation_electra(committee_index).as_ssz_bytes()
+    } else {
+        test_aggregate_attestation(committee_index).as_ssz_bytes()
+    }
+}
+
+/// A sync contribution at `TEST_SLOT`. Distinct `subcommittee_index` values produce distinct
+/// signing roots.
+fn test_contribution(subcommittee_index: u64) -> SyncCommitteeContribution<MainnetEthSpec> {
+    SyncCommitteeContribution {
+        slot: Slot::new(TEST_SLOT),
+        beacon_block_root: Hash256::zero(),
+        subcommittee_index,
+        aggregation_bits: Default::default(),
+        signature: AggregateSignature::infinity(),
+    }
+}
+
+/// Fork the standard decided values are built at; [`build_decided_data`] uses it.
+const DEFAULT_DECIDED_FORK: ForkName = ForkName::Deneb;
+
+/// Builds an `AggregatorCommitteeConsensusData` at [`DEFAULT_DECIDED_FORK`] from decided entries.
+fn build_decided_data(
+    aggregators: &[(ValidatorIndex, u64)],
+    contributors: &[(ValidatorIndex, u64)],
+) -> AggregatorCommitteeConsensusData<MainnetEthSpec> {
+    build_decided_data_at_fork(DEFAULT_DECIDED_FORK, aggregators, contributors)
+}
+
+/// Builds an `AggregatorCommitteeConsensusData` decided at `fork` from decided entries.
+///
+/// `aggregators` and `contributors` are `(validator_index, committee_index)` pairs; the
+/// attestation and contribution payload lists are derived from them (one payload per unique
+/// index), with each attestation payload in the shape `fork` decodes.
+fn build_decided_data_at_fork(
+    fork: ForkName,
+    aggregators: &[(ValidatorIndex, u64)],
+    contributors: &[(ValidatorIndex, u64)],
+) -> AggregatorCommitteeConsensusData<MainnetEthSpec> {
+    // One payload per unique committee/subcommittee index, in first-seen order.
+    let mut aggregate_committee_indexes: Vec<u64> = Vec::new();
+    for &(_, committee_index) in aggregators {
+        if !aggregate_committee_indexes.contains(&committee_index) {
+            aggregate_committee_indexes.push(committee_index);
+        }
+    }
+    let mut contribution_subcommittees: Vec<u64> = Vec::new();
+    for &(_, subcommittee_index) in contributors {
+        if !contribution_subcommittees.contains(&subcommittee_index) {
+            contribution_subcommittees.push(subcommittee_index);
+        }
+    }
+    let aggregators: Vec<_> = aggregators
+        .iter()
+        .map(|&(validator_index, committee_index)| assigned(validator_index, committee_index))
+        .collect();
+    let aggregated_attestations: Vec<_> = aggregate_committee_indexes
+        .iter()
+        .map(|&committee_index| {
+            VariableList::new(aggregate_payload_bytes(fork, committee_index))
+                .expect("attestation bytes should fit")
+        })
+        .collect();
+    let contributors: Vec<_> = contributors
+        .iter()
+        .map(|&(validator_index, subcommittee_index)| assigned(validator_index, subcommittee_index))
+        .collect();
+    let sync_committee_contributions: Vec<_> = contribution_subcommittees
+        .iter()
+        .map(|&subcommittee_index| test_contribution(subcommittee_index))
+        .collect();
+
+    AggregatorCommitteeConsensusData {
+        version: DataVersion::from(fork),
+        aggregators: VariableList::new(aggregators).expect("aggregator list should be valid"),
+        aggregator_committee_indexes: VariableList::new(aggregate_committee_indexes)
+            .expect("committee indexes should be valid"),
+        aggregated_attestations: VariableList::new(aggregated_attestations)
+            .expect("aggregated attestations should be valid"),
+        contributors: VariableList::new(contributors).expect("contributor list should be valid"),
+        sync_committee_contributions: VariableList::new(sync_committee_contributions)
+            .expect("contributions should be valid"),
+    }
+}
+
+// ==================== Recording publisher ====================
+
+/// Fork and aggregator index of one aggregate publish call made by the recording closure.
+type RecordedPublish = (ForkName, u64);
+/// Aggregator index and subcommittee index of one contribution publish call.
+type RecordedContribution = (u64, u64);
+
+/// Every publish call the recording publisher made, one entry per call, by class.
+#[derive(Debug, Default, PartialEq)]
+struct RecordedPublishes {
+    aggregates: Vec<RecordedPublish>,
+    contributions: Vec<RecordedContribution>,
+}
+
+/// Runs the publisher over `executions` with recording publish closures, returning one entry per
+/// publish call of either class.
+///
+/// The aggregate recorder captures the `ForkName` each call receives, so tests can pin that it
+/// matches the decided value's `DataVersion`. `outcome` decides each call's publish result from
+/// its aggregator index (for both classes), so a test can fail one root's publish without
+/// depending on the order roots finish in. The returned calls are sorted for the same reason.
+async fn run_recording_publisher(
+    harness: &ValidatorStoreTestHarness,
+    executions: Vec<(CommitteeId, Execution)>,
+    outcome: impl Fn(u64) -> Result<(), String>,
+) -> RecordedPublishes {
+    let aggregates: Arc<Mutex<Vec<RecordedPublish>>> = Arc::new(Mutex::new(Vec::new()));
+    let contributions: Arc<Mutex<Vec<RecordedContribution>>> = Arc::new(Mutex::new(Vec::new()));
+    let outcome = &outcome;
+    harness
+        .validator_store
+        .publish_decided_aggregates(
+            Slot::new(TEST_SLOT),
+            executions,
+            |fork_name, signed| {
+                let aggregates = Arc::clone(&aggregates);
+                async move {
+                    let aggregator = signed.message().aggregator_index();
+                    let result = outcome(aggregator);
+                    aggregates.lock().push((fork_name, aggregator));
+                    result
+                }
+            },
+            |signed| {
+                let contributions = Arc::clone(&contributions);
+                async move {
+                    let aggregator = signed.message.aggregator_index;
+                    let result = outcome(aggregator);
+                    contributions
+                        .lock()
+                        .push((aggregator, signed.message.contribution.subcommittee_index));
+                    result
+                }
+            },
+        )
+        .await;
+
+    let mut aggregates = aggregates.lock().clone();
+    aggregates.sort_by_key(|&(_, aggregator)| aggregator);
+    let mut contributions = contributions.lock().clone();
+    contributions.sort_unstable();
+    RecordedPublishes {
+        aggregates,
+        contributions,
+    }
+}
+
+/// Serializes the tests that mutate and assert deltas on the `consensus_error`, `no_aggregates`,
+/// and `no_signatures` publish outcome labels, so one test's increments cannot land inside
+/// another's before/after window. `success` and `http_error` have no delta assertions, so tests
+/// touching only those labels stay unserialized.
+static PUBLISH_METRIC_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
+/// Current value of one `AGGREGATOR_COMMITTEE_PUBLISH_TOTAL` label.
+///
+/// The counters are process-global: a test asserting a delta must hold [`PUBLISH_METRIC_LOCK`],
+/// together with every test that increments the same label.
+fn publish_result_count(label: &str) -> u64 {
+    metrics::AGGREGATOR_COMMITTEE_PUBLISH_TOTAL
+        .as_ref()
+        .expect("the publish outcome metric should be created")
+        .with_label_values(&[label])
+        .get()
+}
+
+/// Current value of one `SIGNED_SYNC_COMMITTEE_CONTRIBUTIONS_TOTAL` label, under the same
+/// [`PUBLISH_METRIC_LOCK`] discipline as [`publish_result_count`].
+fn contribution_signing_count(label: &str) -> u64 {
+    validator_metrics::SIGNED_SYNC_COMMITTEE_CONTRIBUTIONS_TOTAL
+        .as_ref()
+        .expect("the contribution signing metric should be created")
+        .with_label_values(&[label])
+        .get()
+}
+
+// ==================== Capture assertions ====================
+
+/// The committee-requester view of one captured `sign_and_collect` call.
+struct CapturedCommitteeCall {
+    pubkey: PublicKeyBytes,
+    signing_root: Hash256,
+    batch_size: usize,
+    base_hash: Hash256,
+}
+
+/// Snapshots the captured calls, asserting every call is an `AggregatorCommittee`
+/// post-consensus call with a `Committee` requester.
+fn committee_calls(harness: &ValidatorStoreTestHarness) -> Vec<CapturedCommitteeCall> {
+    harness
+        .captured_calls
+        .lock()
+        .iter()
+        .map(|call| {
+            assert_eq!(call.metadata.role, Role::AggregatorCommittee);
+            assert_eq!(call.metadata.kind, PartialSignatureKind::PostConsensus);
+            assert_eq!(call.metadata.slot, Slot::new(TEST_SLOT));
+            match &call.requester {
+                SignatureRequester::Committee {
+                    validator_partial_signature_batch_size,
+                    base_hash,
+                } => CapturedCommitteeCall {
+                    pubkey: call.validator_pubkey,
+                    signing_root: call.signing_root,
+                    batch_size: *validator_partial_signature_batch_size,
+                    base_hash: *base_hash,
+                },
+                other => panic!("expected SignatureRequester::Committee, got: {other:?}"),
+            }
+        })
+        .collect()
+}
+
+/// Asserts every call shares the expected local batch size and decided-value batch identity.
+fn assert_batch_identity(
+    calls: &[CapturedCommitteeCall],
+    expected_batch_size: usize,
+    expected_base_hash: Hash256,
+) {
+    for call in calls {
+        assert_eq!(
+            call.batch_size, expected_batch_size,
+            "every root should join the same local committee batch"
+        );
+        assert_eq!(
+            call.base_hash, expected_base_hash,
+            "every root should carry the decided-value hash as its batch identity"
+        );
+    }
+}
+
+fn distinct_roots(calls: &[CapturedCommitteeCall]) -> HashSet<Hash256> {
+    calls.iter().map(|call| call.signing_root).collect()
+}
+
+fn calls_for_pubkey(calls: &[CapturedCommitteeCall], pubkey: PublicKeyBytes) -> usize {
+    calls.iter().filter(|call| call.pubkey == pubkey).count()
+}
+
+/// Polls until at least `expected` calls were captured, panicking after [`CAPTURE_TIMEOUT`].
+///
+/// The worklist signing tasks are detached, so captures arrive asynchronously relative to the
+/// Lighthouse callback futures.
+async fn wait_for_captured_calls(harness: &ValidatorStoreTestHarness, expected: usize) {
+    let deadline = tokio::time::Instant::now() + CAPTURE_TIMEOUT;
+    loop {
+        let count = harness.captured_calls.lock().len();
+        if count >= expected {
+            return;
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "expected {expected} captured sign_and_collect calls within {CAPTURE_TIMEOUT:?}, \
+             got {count}"
+        );
+        tokio::time::sleep(CAPTURE_POLL_INTERVAL).await;
+    }
+}
+
+/// Waits for `expected` captures, then lets stragglers settle and asserts the count is exact.
+async fn assert_captured_calls_settle_at(harness: &ValidatorStoreTestHarness, expected: usize) {
+    wait_for_captured_calls(harness, expected).await;
+    tokio::time::sleep(SETTLE_DELAY).await;
+    let count = harness.captured_calls.lock().len();
+    assert_eq!(
+        count, expected,
+        "capture count should settle at exactly {expected}"
+    );
+}
+
+/// Unwraps a single-committee stream result into its signed batch.
+fn single_batch<T>(results: Vec<Result<Vec<T>, Error>>) -> Vec<T> {
+    assert_eq!(results.len(), 1, "expected one committee stream item");
+    results
+        .into_iter()
+        .next()
+        .expect("committee stream item should exist")
+        .expect("committee signing should succeed")
+}
+
+// ==================== Complete-worklist tests ====================
+
+/// The publisher takes both classes from the decided value while both Lighthouse callbacks
+/// return empty batches.
+///
+/// This pins the design the module rests on: which callbacks fire has no influence on what is
+/// signed or published. The execution signs the complete mixed worklist into one committee
+/// batch, and the publisher is the single POSTer for aggregates and contributions alike.
+#[tokio::test(flavor = "multi_thread")]
+async fn publisher_takes_both_classes_while_the_callbacks_return_empty() {
+    // Arrange
+    let fixture = AggregatorCommitteeFixture::new(MIXED_COMMITTEE_VALIDATOR_COUNT);
+    let (decided, execution) = fixture.seed_mixed_decided_value_with_execution();
+    let aggregates = vec![
+        fixture
+            .harness
+            .create_aggregate(COMMITTEE_INDEX, AGGREGATE_VALIDATOR_IDX),
+    ];
+    let contributions = CONTRIBUTION_SUBCOMMITTEES
+        .iter()
+        .map(|&subcommittee| {
+            fixture.harness.create_contribution(
+                COMMITTEE_INDEX,
+                CONTRIBUTOR_VALIDATOR_IDX,
+                subcommittee,
+            )
+        })
+        .collect();
+
+    // Act: both callbacks fire, then the publisher reads the same execution.
+    let aggregate_results = fixture.harness.collect_aggregates(aggregates).await;
+    let contribution_results = fixture.harness.collect_contributions(contributions).await;
+    let published = fixture.run_publisher(execution).await;
+
+    // Assert: Lighthouse gets nothing to publish on either path.
+    assert!(
+        single_batch(aggregate_results).is_empty(),
+        "the aggregate callback must hand Lighthouse an empty batch at Boole+"
+    );
+    assert!(
+        single_batch(contribution_results).is_empty(),
+        "the contribution callback must hand Lighthouse an empty batch at Boole+"
+    );
+
+    // Anchor publishes the full decided worklist itself.
+    let contributor = *fixture.validator_index(CONTRIBUTOR_VALIDATOR_IDX) as u64;
+    assert_eq!(
+        published,
+        RecordedPublishes {
+            aggregates: vec![(DEFAULT_DECIDED_FORK, fixture.expected_aggregator_index())],
+            contributions: vec![
+                (contributor, CONTRIBUTION_SUBCOMMITTEES[0]),
+                (contributor, CONTRIBUTION_SUBCOMMITTEES[1]),
+            ],
+        },
+        "the publisher should publish the decided aggregate and both decided contributions"
+    );
+
+    // The worklist was signed exactly once, into one committee batch.
+    assert_captured_calls_settle_at(&fixture.harness, MIXED_WORKLIST_SIZE).await;
+    let calls = committee_calls(&fixture.harness);
+    assert_eq!(
+        distinct_roots(&calls).len(),
+        MIXED_WORKLIST_SIZE,
+        "aggregate and per-subcommittee contribution roots must stay distinct"
+    );
+    assert_batch_identity(&calls, MIXED_WORKLIST_SIZE, decided.hash());
+    assert_eq!(
+        calls_for_pubkey(&calls, fixture.pubkey(AGGREGATE_VALIDATOR_IDX)),
+        1,
+        "the decided aggregate must be signed without an aggregate callback"
+    );
+    assert_eq!(
+        calls_for_pubkey(&calls, fixture.pubkey(CONTRIBUTOR_VALIDATOR_IDX)),
+        CONTRIBUTION_SUBCOMMITTEES.len(),
+        "the contributor must sign one root per subcommittee"
+    );
+}
+
+/// The slot pipeline signs the complete decided worklist with no Lighthouse callback involved.
+///
+/// This is the property the whole design rests on: what gets signed is a function of the decided
+/// value alone, so a class Lighthouse never asks about can no longer leave the committee batch
+/// short of its expected size.
+#[tokio::test(flavor = "multi_thread")]
+async fn decided_worklist_is_signed_without_any_callback() {
+    // Arrange and act: publishing the assignments is the entire trigger.
+    let fixture = AggregatorCommitteeFixture::new(MIXED_COMMITTEE_VALIDATOR_COUNT);
+    let decided = fixture.seed_mixed_decided_value();
+
+    // Assert: every decided root of both classes was submitted to one correctly sized batch.
+    assert_captured_calls_settle_at(&fixture.harness, MIXED_WORKLIST_SIZE).await;
+    let calls = committee_calls(&fixture.harness);
+    assert_eq!(
+        distinct_roots(&calls).len(),
+        MIXED_WORKLIST_SIZE,
+        "both object classes must be signed without either callback firing"
+    );
+    assert_batch_identity(&calls, MIXED_WORKLIST_SIZE, decided.hash());
+}
+
+/// Republishing assignments for a slot must not register a second execution.
+///
+/// Registration is the single writer that makes "exactly one committee message per
+/// `(committee, slot)`" true. If a republish overwrote the entry it would spawn a second QBFT
+/// round and a second set of detached signing tasks while the first set kept running, putting two
+/// post-consensus messages on the wire for one slot, which peers reject with a gossip penalty.
+#[tokio::test(flavor = "multi_thread")]
+async fn republished_assignments_do_not_resubmit() {
+    // Arrange: let the first publish fully submit its worklist.
+    let fixture = AggregatorCommitteeFixture::new(MIXED_COMMITTEE_VALIDATOR_COUNT);
+    let decided = fixture.seed_mixed_decided_value();
+    assert_captured_calls_settle_at(&fixture.harness, MIXED_WORKLIST_SIZE).await;
+
+    // Act: publish the same slot again.
+    fixture.seed_mixed_decided_value();
+
+    // Assert: still exactly one submission of the worklist, not two.
+    assert_captured_calls_settle_at(&fixture.harness, MIXED_WORKLIST_SIZE).await;
+    let calls = committee_calls(&fixture.harness);
+    assert_eq!(
+        distinct_roots(&calls).len(),
+        MIXED_WORKLIST_SIZE,
+        "a republish must not resubmit the worklist"
+    );
+    assert_batch_identity(&calls, MIXED_WORKLIST_SIZE, decided.hash());
+}
+
+/// A publisher that joins after the worklist has already been signed still publishes both
+/// classes from the resolved execution, without re-running consensus or duplicating signatures.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_late_publisher_publishes_both_classes_from_the_resolved_execution() {
+    // Arrange: let the detached execution finish the complete worklist first.
+    let fixture = AggregatorCommitteeFixture::new(MIXED_COMMITTEE_VALIDATOR_COUNT);
+    let (decided, execution) = fixture.seed_mixed_decided_value_with_execution();
+    assert_captured_calls_settle_at(&fixture.harness, MIXED_WORKLIST_SIZE).await;
+    let calls = committee_calls(&fixture.harness);
+    assert_batch_identity(&calls, MIXED_WORKLIST_SIZE, decided.hash());
+
+    // Act: the publisher joins the finished execution.
+    let published = fixture.run_publisher(execution).await;
+
+    // Assert: it publishes the full decided worklist.
+    let contributor = *fixture.validator_index(CONTRIBUTOR_VALIDATOR_IDX) as u64;
+    assert_eq!(
+        published,
+        RecordedPublishes {
+            aggregates: vec![(DEFAULT_DECIDED_FORK, fixture.expected_aggregator_index())],
+            contributions: vec![
+                (contributor, CONTRIBUTION_SUBCOMMITTEES[0]),
+                (contributor, CONTRIBUTION_SUBCOMMITTEES[1]),
+            ],
+        },
+        "a late publisher should publish from the resolved execution"
+    );
+
+    // Still no duplicate captures after the late read.
+    tokio::time::sleep(SETTLE_DELAY).await;
+    assert_eq!(
+        fixture.harness.captured_calls.lock().len(),
+        MIXED_WORKLIST_SIZE
+    );
+}
+
+/// One validator owning an aggregate plus contributions in all four subcommittees keeps five
+/// distinct signing roots in one five-entry batch, and the publisher assembles one POST per
+/// `(validator, subcommittee)` identity.
+#[tokio::test(flavor = "multi_thread")]
+async fn multi_root_validator_keeps_distinct_roots() {
+    // Arrange
+    const EXPECTED_WORKLIST_SIZE: usize = 1 + ALL_SUBCOMMITTEES.len();
+    let fixture = AggregatorCommitteeFixture::new(SINGLE_VALIDATOR_COUNT);
+    let validator = fixture.validator_index(AGGREGATE_VALIDATOR_IDX);
+    let contributors: Vec<_> = ALL_SUBCOMMITTEES
+        .iter()
+        .map(|&subcommittee| (validator, subcommittee))
+        .collect();
+    let (decided, execution) = fixture.seed_decided_value_with_execution(build_decided_data(
+        &[(validator, BEACON_COMMITTEE_INDEX)],
+        &contributors,
+    ));
+
+    // Act
+    let published = fixture.run_publisher(execution).await;
+
+    // Assert: one aggregate POST plus one contribution POST per subcommittee.
+    assert_eq!(
+        published,
+        RecordedPublishes {
+            aggregates: vec![(DEFAULT_DECIDED_FORK, fixture.expected_aggregator_index())],
+            contributions: ALL_SUBCOMMITTEES
+                .iter()
+                .map(|&subcommittee| (*validator as u64, subcommittee))
+                .collect(),
+        },
+        "each (validator, subcommittee) identity should publish its own contribution"
+    );
+    assert_captured_calls_settle_at(&fixture.harness, EXPECTED_WORKLIST_SIZE).await;
+    let calls = committee_calls(&fixture.harness);
+    assert_eq!(
+        distinct_roots(&calls).len(),
+        EXPECTED_WORKLIST_SIZE,
+        "one validator's aggregate and four contribution roots must stay distinct"
+    );
+    assert_batch_identity(&calls, EXPECTED_WORKLIST_SIZE, decided.hash());
+    assert_eq!(
+        calls_for_pubkey(&calls, fixture.pubkey(AGGREGATE_VALIDATOR_IDX)),
+        EXPECTED_WORKLIST_SIZE
+    );
+}
+
+// ==================== Divergent-view and normalization tests ====================
+
+/// Exact duplicate decided entries collapse to one worklist entry each, so the batch size
+/// reflects the deduplicated union and each identity publishes once.
+#[tokio::test(flavor = "multi_thread")]
+async fn duplicate_decided_entries_normalized() {
+    // Arrange: the same aggregator entry twice and the same contributor entry twice.
+    const EXPECTED_DEDUPED_SIZE: usize = 2;
+    let fixture = AggregatorCommitteeFixture::new(MIXED_COMMITTEE_VALIDATOR_COUNT);
+    let aggregator = fixture.validator_index(AGGREGATE_VALIDATOR_IDX);
+    let contributor = fixture.validator_index(CONTRIBUTOR_VALIDATOR_IDX);
+    let (decided, execution) = fixture.seed_decided_value_with_execution(build_decided_data(
+        &[
+            (aggregator, BEACON_COMMITTEE_INDEX),
+            (aggregator, BEACON_COMMITTEE_INDEX),
+        ],
+        &[
+            (contributor, CONTRIBUTION_SUBCOMMITTEES[0]),
+            (contributor, CONTRIBUTION_SUBCOMMITTEES[0]),
+        ],
+    ));
+
+    // Act
+    let published = fixture.run_publisher(execution).await;
+
+    // Assert
+    assert_eq!(
+        published,
+        RecordedPublishes {
+            aggregates: vec![(DEFAULT_DECIDED_FORK, fixture.expected_aggregator_index())],
+            contributions: vec![(*contributor as u64, CONTRIBUTION_SUBCOMMITTEES[0])],
+        },
+        "duplicate decided entries must publish once per identity"
+    );
+    assert_captured_calls_settle_at(&fixture.harness, EXPECTED_DEDUPED_SIZE).await;
+    let calls = committee_calls(&fixture.harness);
+    assert_eq!(
+        distinct_roots(&calls).len(),
+        EXPECTED_DEDUPED_SIZE,
+        "duplicates must collapse to one entry per (validator, signing_root)"
+    );
+    assert_batch_identity(&calls, EXPECTED_DEDUPED_SIZE, decided.hash());
+}
+
+/// Conflicting aggregate roots for one validator sign only the first, keeping that validator
+/// within the receivers' per-validator root cap while unrelated entries are unaffected.
+#[tokio::test(flavor = "multi_thread")]
+async fn conflicting_aggregate_roots_sign_only_the_first() {
+    // Arrange: the aggregator appears twice with different committee indexes, each resolving
+    // to a different attestation payload and therefore a different signing root.
+    const EXPECTED_SIGNED_SIZE: usize = 2;
+    let fixture = AggregatorCommitteeFixture::new(MIXED_COMMITTEE_VALIDATOR_COUNT);
+    let aggregator = fixture.validator_index(AGGREGATE_VALIDATOR_IDX);
+    let contributor = fixture.validator_index(CONTRIBUTOR_VALIDATOR_IDX);
+    let decided = fixture.seed_decided_value(build_decided_data(
+        &[
+            (aggregator, BEACON_COMMITTEE_INDEX),
+            (aggregator, CONFLICTING_BEACON_COMMITTEE_INDEX),
+        ],
+        &[(contributor, CONTRIBUTION_SUBCOMMITTEES[0])],
+    ));
+
+    // Assert: exactly one of the conflicting aggregates is signed, the contribution is
+    // unaffected, and the batch counts both.
+    assert_captured_calls_settle_at(&fixture.harness, EXPECTED_SIGNED_SIZE).await;
+    let calls = committee_calls(&fixture.harness);
+    assert_eq!(
+        calls_for_pubkey(&calls, fixture.pubkey(AGGREGATE_VALIDATOR_IDX)),
+        1,
+        "a validator with conflicting decided aggregate roots must sign exactly one of them"
+    );
+    assert_eq!(
+        calls_for_pubkey(&calls, fixture.pubkey(CONTRIBUTOR_VALIDATOR_IDX)),
+        1,
+        "the unrelated contribution must be unaffected by the malformed aggregate entries"
+    );
+    assert_eq!(
+        distinct_roots(&calls).len(),
+        EXPECTED_SIGNED_SIZE,
+        "each signed identity contributes exactly one distinct root"
+    );
+    assert_batch_identity(&calls, EXPECTED_SIGNED_SIZE, decided.hash());
+}
+
+// ==================== Empty and error path tests ====================
+
+/// A decided value naming only validators this operator has no metadata for produces an empty
+/// worklist: the publisher has nothing to publish in either class, counts the committee under
+/// `no_aggregates`, and no signature is ever collected.
+#[tokio::test(flavor = "multi_thread")]
+async fn empty_worklist_publishes_nothing() {
+    let _metric_guard = PUBLISH_METRIC_LOCK.lock().await;
+    // Arrange: the decided entries reference foreign validator indices only.
+    let fixture = AggregatorCommitteeFixture::new(SINGLE_VALIDATOR_COUNT);
+    let (_, execution) = fixture.seed_decided_value_with_execution(build_decided_data(
+        &[(
+            ValidatorIndex(FOREIGN_AGGREGATOR_INDEX),
+            BEACON_COMMITTEE_INDEX,
+        )],
+        &[(
+            ValidatorIndex(FOREIGN_CONTRIBUTOR_INDEX),
+            CONTRIBUTION_SUBCOMMITTEES[0],
+        )],
+    ));
+    let no_aggregates_before = publish_result_count(metrics::NO_AGGREGATES);
+
+    // Act
+    let published = fixture.run_publisher(execution).await;
+
+    // Assert: nothing to publish in either class, nothing signed.
+    assert_eq!(
+        published,
+        RecordedPublishes::default(),
+        "no locally signable decided entry means no publish call of either class"
+    );
+    assert_eq!(
+        publish_result_count(metrics::NO_AGGREGATES),
+        no_aggregates_before + 1,
+        "the publisher should count the aggregate-free committee under `no_aggregates`"
+    );
+    assert_captured_calls_settle_at(&fixture.harness, 0).await;
+}
+
+/// Missing consensus data for the committee registers no execution: the publisher gets no
+/// handle and nothing is signed.
+#[tokio::test(flavor = "multi_thread")]
+async fn consensus_data_missing_registers_no_execution() {
+    // Arrange: assignments exist for the slot, but carry no consensus data for any committee.
+    let fixture = AggregatorCommitteeFixture::new(MIXED_COMMITTEE_VALIDATOR_COUNT);
+    let executions = fixture.seed_assignments_without_consensus_data();
+
+    // Assert: nothing is handed to the publisher, and no signature collection is attempted.
+    assert!(
+        executions.is_empty(),
+        "a committee with no decided value must not register a publisher handle"
+    );
+    assert_captured_calls_settle_at(&fixture.harness, 0).await;
+}
+
+/// Decided payloads whose slot does not match the duty slot are excluded from the worklist, so
+/// the batch settles at the surviving count instead of stalling.
+#[tokio::test(flavor = "multi_thread")]
+async fn slot_mismatched_decided_payloads_are_excluded() {
+    // Arrange: the standard mixed decided value, but both contribution payloads carry the
+    // wrong slot; only the aggregate survives slot binding.
+    let fixture = AggregatorCommitteeFixture::new(MIXED_COMMITTEE_VALIDATOR_COUNT);
+    let aggregator = fixture.validator_index(AGGREGATE_VALIDATOR_IDX);
+    let contributor = fixture.validator_index(CONTRIBUTOR_VALIDATOR_IDX);
+    let mut decided = build_decided_data(
+        &[(aggregator, BEACON_COMMITTEE_INDEX)],
+        &[
+            (contributor, CONTRIBUTION_SUBCOMMITTEES[0]),
+            (contributor, CONTRIBUTION_SUBCOMMITTEES[1]),
+        ],
+    );
+    for contribution in decided.sync_committee_contributions.iter_mut() {
+        contribution.slot = Slot::new(TEST_SLOT + 1);
+    }
+    let (_, execution) = fixture.seed_decided_value_with_execution(decided);
+
+    // Act
+    let published = fixture.run_publisher(execution).await;
+
+    // Assert: the mismatched contributions are excluded from the worklist and never published,
+    // while the aggregate still gets signed and published with a batch sized to the survivors.
+    assert_eq!(
+        published,
+        RecordedPublishes {
+            aggregates: vec![(DEFAULT_DECIDED_FORK, fixture.expected_aggregator_index())],
+            contributions: vec![],
+        },
+        "slot-mismatched contributions should not be published"
+    );
+    const EXPECTED_SURVIVOR_COUNT: usize = 1;
+    assert_captured_calls_settle_at(&fixture.harness, EXPECTED_SURVIVOR_COUNT).await;
+    let calls = committee_calls(&fixture.harness);
+    assert_eq!(
+        calls[0].pubkey,
+        fixture.pubkey(AGGREGATE_VALIDATOR_IDX),
+        "the surviving entry should be the aggregate"
+    );
+    assert_eq!(
+        calls[0].batch_size, EXPECTED_SURVIVOR_COUNT,
+        "the batch size should count only surviving entries"
+    );
+}
+
+// ==================== Publisher registration tests ====================
+
+/// Registration is first-insert-only, so a `(committee, slot)` yields its publisher handle
+/// exactly once.
+///
+/// The handle is what makes the publisher run, so a second handle for one slot would post the
+/// same aggregates to the beacon node twice.
+#[tokio::test(flavor = "multi_thread")]
+async fn start_aggregator_post_consensus_returns_only_first_insertions() {
+    // Arrange
+    let fixture = AggregatorCommitteeFixture::new(MIXED_COMMITTEE_VALIDATOR_COUNT);
+    let decided = Arc::new(fixture.mixed_decided_data());
+
+    // Act: publish the same slot's assignments twice.
+    let first = fixture.publish_decided_value(Arc::clone(&decided));
+    let second = fixture.publish_decided_value(decided);
+
+    // Assert
+    assert_eq!(
+        first.len(),
+        1,
+        "the first publish should register this committee's execution"
+    );
+    assert_eq!(first[0].0, fixture.committee_id);
+    assert!(
+        second.is_empty(),
+        "a republish must not hand out a second publisher handle"
+    );
+    assert_eq!(
+        fixture
+            .harness
+            .validator_store
+            .aggregator_post_consensus
+            .lock()
+            .len(),
+        1,
+        "the retention map should hold exactly one execution for the slot"
+    );
+}
+
+// ==================== Publisher consensus-failure tests ====================
+
+/// A failed execution publishes nothing and is counted as a consensus error rather than
+/// propagating the error.
+#[tokio::test(flavor = "multi_thread")]
+async fn publisher_counts_a_failed_execution_as_a_consensus_error() {
+    let _metric_guard = PUBLISH_METRIC_LOCK.lock().await;
+    // Arrange: an execution that resolves to an error, as a lost QBFT round would.
+    let fixture = AggregatorCommitteeFixture::new(SINGLE_VALIDATOR_COUNT);
+    let execution: Execution = async {
+        Err(Arc::new(Error::SpecificError(
+            SpecificError::PostConsensusAborted,
+        )))
+    }
+    .boxed()
+    .shared();
+    let consensus_error_before = publish_result_count(metrics::CONSENSUS_ERROR);
+    let contribution_errors_before = contribution_signing_count(metrics::OTHER_ERROR);
+
+    // Act
+    let published = fixture.run_publisher(execution).await;
+
+    // Assert
+    assert_eq!(
+        published,
+        RecordedPublishes::default(),
+        "a failed execution should publish nothing"
+    );
+    assert_eq!(
+        publish_result_count(metrics::CONSENSUS_ERROR),
+        consensus_error_before + 1,
+        "the publisher should count the failed committee under `consensus_error`"
+    );
+    assert_eq!(
+        contribution_signing_count(metrics::OTHER_ERROR),
+        contribution_errors_before + 1,
+        "a failed committee round should count once on the contribution signing counter too, \
+         keeping the only contribution failure signal non-silent"
+    );
+}
+
+/// An execution that never decides is bounded by the two-slot deadline instead of hanging, and
+/// the timeout is counted as a consensus error.
+///
+/// The harness clock is moved past that deadline first, so the bound is asserted without sleeping
+/// two real slots.
+#[tokio::test(flavor = "multi_thread")]
+async fn publisher_counts_a_consensus_error_once_the_deadline_passes() {
+    let _metric_guard = PUBLISH_METRIC_LOCK.lock().await;
+    // Arrange
+    let fixture = AggregatorCommitteeFixture::new(SINGLE_VALIDATOR_COUNT);
+    fixture
+        .harness
+        .slot_clock
+        .set_current_time(Duration::from_secs(PAST_PUBLISH_DEADLINE_SECS));
+    let execution: Execution = futures::future::pending().boxed().shared();
+    let consensus_error_before = publish_result_count(metrics::CONSENSUS_ERROR);
+
+    // Act
+    let published = tokio::time::timeout(STREAM_TIMEOUT, fixture.run_publisher(execution))
+        .await
+        .expect("the publisher must not outlive the two-slot deadline");
+
+    // Assert
+    assert_eq!(
+        published,
+        RecordedPublishes::default(),
+        "an undecided execution should publish nothing"
+    );
+    assert_eq!(
+        publish_result_count(metrics::CONSENSUS_ERROR),
+        consensus_error_before + 1,
+        "the publisher should count the timed-out committee under `consensus_error`"
+    );
+}
+
+// ==================== Publisher tests ====================
+
+/// Distinct operator sets give distinct `CommitteeId`s, so one harness can hold several committees
+/// with different decided values.
+const PUBLISHER_OPERATOR_SETS: [[OperatorId; 4]; 3] = [
+    [OperatorId(1), OperatorId(2), OperatorId(3), OperatorId(4)],
+    [OperatorId(1), OperatorId(5), OperatorId(6), OperatorId(7)],
+    [OperatorId(1), OperatorId(8), OperatorId(9), OperatorId(10)],
+];
+/// Validator index space per publisher committee, so an aggregator index identifies its committee.
+const PUBLISHER_INDEX_STRIDE: usize = 100;
+/// Committee positions in [`PublisherFixture`], named by the role they play in the tests.
+const FIRST_AGGREGATE_COMMITTEE: usize = 0;
+const CONTRIBUTIONS_ONLY_COMMITTEE: usize = 1;
+const SECOND_AGGREGATE_COMMITTEE: usize = 2;
+
+/// Several single-validator committees in one harness, for the publisher's per-committee fan-out.
+struct PublisherFixture {
+    harness: ValidatorStoreTestHarness,
+    committee_ids: Vec<CommitteeId>,
+}
+
+impl PublisherFixture {
+    fn new() -> Self {
+        let setups: Vec<_> = PUBLISHER_OPERATOR_SETS
+            .iter()
+            .enumerate()
+            .map(|(position, operator_ids)| {
+                create_committee_setup(
+                    operator_ids,
+                    SINGLE_VALIDATOR_COUNT,
+                    (position + 1) * PUBLISHER_INDEX_STRIDE,
+                )
+            })
+            .collect();
+        let committee_ids = setups
+            .iter()
+            .map(|setup| setup.cluster.committee_id())
+            .collect();
+        Self {
+            harness: ValidatorStoreTestHarness::new(setups, OUR_OPERATOR_ID),
+            committee_ids,
+        }
+    }
+
+    fn validator_index(&self, committee: usize) -> ValidatorIndex {
+        self.harness
+            .validator_metadata(committee, SOLE_VALIDATOR_IDX)
+            .index
+            .expect("test validator should have an index")
+    }
+
+    fn aggregator_index(&self, committee: usize) -> u64 {
+        self.harness.aggregator_index(committee, SOLE_VALIDATOR_IDX)
+    }
+
+    /// A decided value holding this committee's single aggregate.
+    fn aggregate_only(&self, committee: usize) -> DecidedData {
+        self.aggregate_only_at_fork(committee, DEFAULT_DECIDED_FORK)
+    }
+
+    /// [`Self::aggregate_only`] decided at `fork`, with the payload in that fork's shape.
+    fn aggregate_only_at_fork(&self, committee: usize, fork: ForkName) -> DecidedData {
+        build_decided_data_at_fork(
+            fork,
+            &[(self.validator_index(committee), BEACON_COMMITTEE_INDEX)],
+            &[],
+        )
+    }
+
+    /// A decided value holding one contribution and no aggregate.
+    fn contributions_only(&self, committee: usize) -> DecidedData {
+        build_decided_data(
+            &[],
+            &[(
+                self.validator_index(committee),
+                CONTRIBUTION_SUBCOMMITTEES[0],
+            )],
+        )
+    }
+
+    /// Publishes one decided value per named committee at `TEST_SLOT`, returning the executions
+    /// the slot pipeline hands to the publisher.
+    fn publish(
+        &self,
+        decided_by_committee: Vec<(usize, DecidedData)>,
+    ) -> Vec<(CommitteeId, Execution)> {
+        self.harness.publish_decided_values(
+            decided_by_committee
+                .into_iter()
+                .map(|(committee, data)| (self.committee_ids[committee], Arc::new(data)))
+                .collect(),
+        )
+    }
+
+    /// [`run_recording_publisher`] over this fixture's harness.
+    async fn run_publisher(
+        &self,
+        executions: Vec<(CommitteeId, Execution)>,
+        outcome: impl Fn(u64) -> Result<(), String>,
+    ) -> RecordedPublishes {
+        run_recording_publisher(&self.harness, executions, outcome).await
+    }
+}
+
+/// Every decided root is published exactly once, whichever class it belongs to: a
+/// contributions-only committee publishes its contribution rather than being discarded, and it
+/// is the one counted under `no_aggregates`.
+///
+/// The discard was the pre-#1260 behavior, when contributions still rode Lighthouse's publish
+/// path; with the Lighthouse callback inert, the publisher is the only POSTer for both classes.
+#[tokio::test(flavor = "multi_thread")]
+async fn publish_decided_aggregates_publishes_each_committees_decided_worklist_once() {
+    let _metric_guard = PUBLISH_METRIC_LOCK.lock().await;
+    // Arrange
+    let fixture = PublisherFixture::new();
+    let executions = fixture.publish(vec![
+        (
+            FIRST_AGGREGATE_COMMITTEE,
+            fixture.aggregate_only(FIRST_AGGREGATE_COMMITTEE),
+        ),
+        (
+            CONTRIBUTIONS_ONLY_COMMITTEE,
+            fixture.contributions_only(CONTRIBUTIONS_ONLY_COMMITTEE),
+        ),
+        (
+            SECOND_AGGREGATE_COMMITTEE,
+            fixture.aggregate_only(SECOND_AGGREGATE_COMMITTEE),
+        ),
+    ]);
+    assert_eq!(
+        executions.len(),
+        PUBLISHER_OPERATOR_SETS.len(),
+        "each committee should register one execution"
+    );
+    let no_aggregates_before = publish_result_count(metrics::NO_AGGREGATES);
+
+    // Act
+    let published = fixture.run_publisher(executions, |_| Ok(())).await;
+
+    // Assert: one publish call per decided root, each aggregate carrying its committee's
+    // aggregator and the decided value's fork, the contribution carrying its identity.
+    assert_eq!(
+        published,
+        RecordedPublishes {
+            aggregates: vec![
+                (
+                    DEFAULT_DECIDED_FORK,
+                    fixture.aggregator_index(FIRST_AGGREGATE_COMMITTEE),
+                ),
+                (
+                    DEFAULT_DECIDED_FORK,
+                    fixture.aggregator_index(SECOND_AGGREGATE_COMMITTEE),
+                ),
+            ],
+            contributions: vec![(
+                fixture.aggregator_index(CONTRIBUTIONS_ONLY_COMMITTEE),
+                CONTRIBUTION_SUBCOMMITTEES[0],
+            )],
+        },
+        "committees publish their decided roots once each, contributions included"
+    );
+    assert_eq!(
+        publish_result_count(metrics::NO_AGGREGATES),
+        no_aggregates_before + 1,
+        "the contributions-only committee should still count once under `no_aggregates`"
+    );
+}
+
+/// A publish failure is contained to its own aggregate: it neither panics nor stops the other
+/// committees' aggregates from being published.
+#[tokio::test(flavor = "multi_thread")]
+async fn publish_decided_aggregates_survives_a_failing_publish() {
+    // Arrange: all three committees decide an aggregate.
+    let fixture = PublisherFixture::new();
+    let executions = fixture.publish(
+        (0..PUBLISHER_OPERATOR_SETS.len())
+            .map(|committee| (committee, fixture.aggregate_only(committee)))
+            .collect(),
+    );
+    let failing_aggregator = fixture.aggregator_index(FIRST_AGGREGATE_COMMITTEE);
+
+    // Act: the first committee's POST fails, keyed by aggregator index so the outcome does not
+    // depend on which committee resolves first.
+    let published = fixture
+        .run_publisher(executions, |aggregator| {
+            if aggregator == failing_aggregator {
+                Err("beacon node unavailable".to_string())
+            } else {
+                Ok(())
+            }
+        })
+        .await;
+
+    // Assert: every committee's aggregate was still attempted.
+    assert_eq!(
+        published.aggregates,
+        (0..PUBLISHER_OPERATOR_SETS.len())
+            .map(|committee| (DEFAULT_DECIDED_FORK, fixture.aggregator_index(committee)))
+            .collect::<Vec<_>>(),
+        "a failing publish must not withhold the other committees' aggregates"
+    );
+}
+
+/// A committee that decided an aggregate whose root never reached signature quorum publishes
+/// nothing, and the root is counted under `no_signatures`.
+///
+/// This is a third outcome, distinct from `consensus_error` (the round itself failed) and
+/// `no_aggregates` (the decided value held none): consensus succeeded and there was something to
+/// sign, but no signature came back. The publisher counts each such root under its own label, so
+/// the three cases stay separable on a dashboard instead of collapsing into one.
+#[tokio::test(flavor = "multi_thread")]
+async fn publish_decided_aggregates_skips_a_committee_whose_roots_never_reach_quorum() {
+    let _metric_guard = PUBLISH_METRIC_LOCK.lock().await;
+    // Arrange: signature collection fails before the decided value is published, so the
+    // committee's only aggregate root resolves to an error.
+    let fixture = PublisherFixture::new();
+    fixture.harness.fail_signature_collection();
+    let executions = fixture.publish(vec![(
+        FIRST_AGGREGATE_COMMITTEE,
+        fixture.aggregate_only(FIRST_AGGREGATE_COMMITTEE),
+    )]);
+    let no_signatures_before = publish_result_count(metrics::NO_SIGNATURES);
+
+    // Act
+    let published = fixture.run_publisher(executions, |_| Ok(())).await;
+
+    // Assert: the publish closure was never invoked, and the root was counted under its label.
+    assert_eq!(
+        published,
+        RecordedPublishes::default(),
+        "the publisher must not invoke the publish closure for a root without quorum"
+    );
+    assert_eq!(
+        publish_result_count(metrics::NO_SIGNATURES),
+        no_signatures_before + 1,
+        "each decided root without quorum should count once under `no_signatures`; this \
+         committee decided exactly one root"
+    );
+}
+
+/// Two decided aggregate roots in one committee where exactly one misses signature quorum: the
+/// surviving root is still published, and only the missing root is counted under
+/// `no_signatures`.
+///
+/// This per-root independence is the point of the per-root publisher: under the batch shape a
+/// committee published all-or-nothing, so one quorum miss could withhold a signed sibling.
+#[tokio::test(flavor = "multi_thread")]
+async fn publish_decided_aggregates_publishes_the_surviving_root_when_a_sibling_misses_quorum() {
+    let _metric_guard = PUBLISH_METRIC_LOCK.lock().await;
+    // Arrange: both validators aggregate distinct roots, and signature collection fails only for
+    // the second validator. The fail mode is set before seeding, since the detached worklist
+    // tasks start collecting at publish.
+    const SURVIVING_VALIDATOR_IDX: usize = 0;
+    const FAILING_VALIDATOR_IDX: usize = 1;
+    let fixture = AggregatorCommitteeFixture::new(MIXED_COMMITTEE_VALIDATOR_COUNT);
+    fixture
+        .harness
+        .fail_signature_collection_for(fixture.pubkey(FAILING_VALIDATOR_IDX));
+    let (_, execution) = fixture.seed_decided_value_with_execution(build_decided_data(
+        &[
+            (
+                fixture.validator_index(SURVIVING_VALIDATOR_IDX),
+                BEACON_COMMITTEE_INDEX,
+            ),
+            (
+                fixture.validator_index(FAILING_VALIDATOR_IDX),
+                CONFLICTING_BEACON_COMMITTEE_INDEX,
+            ),
+        ],
+        &[],
+    ));
+    let no_signatures_before = publish_result_count(metrics::NO_SIGNATURES);
+
+    // Act
+    let published = fixture.run_publisher(execution).await;
+
+    // Assert: exactly the surviving root was published, exactly the missing one was counted.
+    assert_eq!(
+        published.aggregates,
+        vec![(
+            DEFAULT_DECIDED_FORK,
+            fixture
+                .harness
+                .aggregator_index(COMMITTEE_INDEX, SURVIVING_VALIDATOR_IDX),
+        )],
+        "a sibling's quorum miss must not withhold the surviving root's publish call"
+    );
+    assert_eq!(
+        publish_result_count(metrics::NO_SIGNATURES),
+        no_signatures_before + 1,
+        "only the root that missed quorum should count under `no_signatures`"
+    );
+}
+
+/// The fork handed to the publish closure is the decided value's `DataVersion` fork, not any
+/// local default: an Electra-decided value reaches the closure as `ForkName::Electra`.
+///
+/// The closure derives its publish endpoint and fork header from this argument, so binding it to
+/// the decided version is what keeps the endpoint from diverging from the payload variant.
+#[tokio::test(flavor = "multi_thread")]
+async fn publish_decided_aggregates_hands_the_decided_versions_fork_to_the_closure() {
+    // Arrange: one committee decides an Electra-versioned value with an Electra-shaped payload.
+    let fixture = PublisherFixture::new();
+    let executions = fixture.publish(vec![(
+        FIRST_AGGREGATE_COMMITTEE,
+        fixture.aggregate_only_at_fork(FIRST_AGGREGATE_COMMITTEE, ForkName::Electra),
+    )]);
+
+    // Act
+    let published = fixture.run_publisher(executions, |_| Ok(())).await;
+
+    // Assert
+    assert_eq!(
+        published.aggregates,
+        vec![(
+            ForkName::Electra,
+            fixture.aggregator_index(FIRST_AGGREGATE_COMMITTEE),
+        )],
+        "the publish closure must receive the fork named by the decided value's DataVersion"
+    );
+}
+
+/// The two classes carry different deadlines, and the difference is load-bearing: a beacon node
+/// accepts a contribution only during its own slot, while aggregates stay acceptable for about an
+/// epoch. So contributions stop waiting for quorum at slot end and aggregates keep waiting.
+///
+/// The clock sits between the two deadlines and signature collection never resolves, so the two
+/// classes must diverge: the contribution roots give up immediately and count `timeout`, while the
+/// aggregate root is still waiting when the probe expires. A refactor that collapsed both classes
+/// onto one deadline would fail this test in one direction or the other.
+#[tokio::test(flavor = "multi_thread")]
+async fn contributions_stop_at_slot_end_while_aggregates_keep_waiting() {
+    let _metric_guard = PUBLISH_METRIC_LOCK.lock().await;
+    // Arrange: a mixed decided value whose roots never reach quorum, with the clock past the
+    // contribution deadline (this slot's end) but before the aggregate deadline (a slot later).
+    let fixture = AggregatorCommitteeFixture::new(MIXED_COMMITTEE_VALIDATOR_COUNT);
+    fixture.harness.hang_signature_collection();
+    let (_, execution) = fixture.seed_mixed_decided_value_with_execution();
+    fixture
+        .harness
+        .slot_clock
+        .set_current_time(Duration::from_secs(BETWEEN_CLASS_DEADLINES_SECS));
+    let contribution_timeouts_before = contribution_signing_count(metrics::TIMEOUT);
+    let no_signatures_before = publish_result_count(metrics::NO_SIGNATURES);
+
+    // Act: the publisher cannot finish while the aggregate root is still within its deadline.
+    let outcome = tokio::time::timeout(STILL_WAITING_PROBE, fixture.run_publisher(execution)).await;
+
+    // Assert: the aggregate is still waiting past this slot's end.
+    assert!(
+        outcome.is_err(),
+        "the aggregate root must keep waiting past slot end; it stays publishable for about an \
+         epoch, so bounding it here would discard a recoverable duty"
+    );
+
+    // The contributions already gave up, counted under the class's own signing counter.
+    assert_eq!(
+        contribution_signing_count(metrics::TIMEOUT),
+        contribution_timeouts_before + CONTRIBUTION_SUBCOMMITTEES.len() as u64,
+        "each contribution root past slot end should count once under `timeout`"
+    );
+    assert_eq!(
+        publish_result_count(metrics::NO_SIGNATURES),
+        no_signatures_before,
+        "contribution outcomes must stay out of the aggregate-only publish counter"
+    );
+}
+
+/// A failing contribution POST is contained to its own root: the sibling aggregate still
+/// publishes and the drain still completes.
+///
+/// The aggregate side of this is covered by
+/// `publish_decided_aggregates_survives_a_failing_publish`; this is the contribution half, which
+/// the two-class publisher made reachable.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_failing_contribution_post_does_not_withhold_the_sibling_aggregate() {
+    // Arrange: every contribution POST fails, keyed by the contributor's aggregator index so the
+    // outcome does not depend on which root resolves first.
+    let fixture = AggregatorCommitteeFixture::new(MIXED_COMMITTEE_VALIDATOR_COUNT);
+    let (_, execution) = fixture.seed_mixed_decided_value_with_execution();
+    let failing_contributor = *fixture.validator_index(CONTRIBUTOR_VALIDATOR_IDX) as u64;
+
+    // Act
+    let published = run_recording_publisher(
+        &fixture.harness,
+        vec![(fixture.committee_id, execution)],
+        |aggregator| {
+            if aggregator == failing_contributor {
+                Err("beacon node rejected the contribution".to_string())
+            } else {
+                Ok(())
+            }
+        },
+    )
+    .await;
+
+    // Assert: both contributions were still attempted, and the aggregate published regardless.
+    assert_eq!(
+        published,
+        RecordedPublishes {
+            aggregates: vec![(DEFAULT_DECIDED_FORK, fixture.expected_aggregator_index())],
+            contributions: vec![
+                (failing_contributor, CONTRIBUTION_SUBCOMMITTEES[0]),
+                (failing_contributor, CONTRIBUTION_SUBCOMMITTEES[1]),
+            ],
+        },
+        "a failing contribution POST must not withhold its sibling aggregate or its own sibling \
+         contribution"
+    );
+}
+
+/// Cross-class independence inside one committee: a contribution root that misses signature
+/// quorum withholds only itself, and the sibling aggregate is still published.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_contributions_quorum_miss_does_not_withhold_the_sibling_aggregate() {
+    // Serialized: the failing contribution roots increment the contribution signing counter's
+    // `other_error` label, which the failed-execution test asserts a delta on.
+    let _metric_guard = PUBLISH_METRIC_LOCK.lock().await;
+    // Arrange: a mixed decided value where only the contributor's signature collection fails.
+    // The fail mode is set before seeding, since the detached worklist tasks start collecting at
+    // publish.
+    let fixture = AggregatorCommitteeFixture::new(MIXED_COMMITTEE_VALIDATOR_COUNT);
+    fixture
+        .harness
+        .fail_signature_collection_for(fixture.pubkey(CONTRIBUTOR_VALIDATOR_IDX));
+    let (_, execution) = fixture.seed_mixed_decided_value_with_execution();
+
+    // Act
+    let published = fixture.run_publisher(execution).await;
+
+    // Assert: the aggregate publishes, the failed contributions publish nothing.
+    assert_eq!(
+        published,
+        RecordedPublishes {
+            aggregates: vec![(DEFAULT_DECIDED_FORK, fixture.expected_aggregator_index())],
+            contributions: vec![],
+        },
+        "a contribution quorum miss must not withhold the sibling aggregate's publish call"
+    );
+}

--- a/anchor/validator_store/src/testing/aggregator_post_consensus.rs
+++ b/anchor/validator_store/src/testing/aggregator_post_consensus.rs
@@ -1,0 +1,925 @@
+//! Integration tests for the Boole+ `AggregatorCommittee` post-consensus execution.
+//!
+//! One QBFT decision carries both attestation aggregates and sync contributions. The
+//! per-`(committee, slot)` execution signs the complete decided worklist regardless of which
+//! Lighthouse callbacks fire; the callbacks only filter the shared outcome down to their own
+//! requested items. These tests pin the regression from issue #1227: a callback of one class
+//! must still produce the partial signatures for the other class, so the shared committee
+//! batch never stalls below its expected size.
+//!
+//! The worklist tasks are detached, so captured `sign_and_collect` calls arrive
+//! asynchronously; assertions on capture counts poll with a deadline and then let the
+//! captures settle before asserting exact counts.
+
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+    time::Duration,
+};
+
+use bls::{AggregateSignature, FixedBytesExtended, PublicKeyBytes, Signature};
+use futures::StreamExt;
+use signature_collector::SignatureRequester;
+use ssv_types::{
+    CommitteeId, OperatorId, ValidatorIndex, ValidatorMetadata,
+    consensus::{AggregatorCommitteeConsensusData, AssignedAggregator, DataVersion, QbftData},
+    msgid::Role,
+    partial_sig::PartialSignatureKind,
+};
+use ssz::Encode;
+use ssz_types::VariableList;
+use types::{
+    AttestationBase, AttestationData, Checkpoint, Epoch, ForkName, Hash256, MainnetEthSpec,
+    SignedAggregateAndProof, SignedContributionAndProof, Slot, SyncCommitteeContribution,
+    SyncSelectionProof,
+};
+use validator_store::{ContributionToSign, ValidatorStore};
+
+use super::common::*;
+use crate::{AggregationAssignments, Error};
+
+type SignAggregatesResult = Vec<Result<Vec<SignedAggregateAndProof<MainnetEthSpec>>, Error>>;
+type SignContributionsResult = Vec<Result<Vec<SignedContributionAndProof<MainnetEthSpec>>, Error>>;
+
+const COMMITTEE_OPERATOR_IDS: [OperatorId; 4] =
+    [OperatorId(1), OperatorId(2), OperatorId(3), OperatorId(4)];
+const OUR_OPERATOR_ID: OperatorId = OperatorId(1);
+
+const COMMITTEE_INDEX: usize = 0;
+const STARTING_VALIDATOR_INDEX: usize = 0;
+const AGGREGATE_VALIDATOR_IDX: usize = 0;
+const CONTRIBUTOR_VALIDATOR_IDX: usize = 1;
+const MIXED_COMMITTEE_VALIDATOR_COUNT: usize = 2;
+const SINGLE_VALIDATOR_COUNT: usize = 1;
+/// Position of the only validator in single-validator fixtures.
+const SOLE_VALIDATOR_IDX: usize = 0;
+
+const BEACON_COMMITTEE_INDEX: u64 = 0;
+const CONFLICTING_BEACON_COMMITTEE_INDEX: u64 = 1;
+const CONTRIBUTION_SUBCOMMITTEES: [u64; 2] = [0, 1];
+const ALL_SUBCOMMITTEES: [u64; 4] = [0, 1, 2, 3];
+const MISSING_SUBCOMMITTEE_INDEX: u64 = 2;
+
+/// Decided validator indices with no local metadata, so the worklist filters them out.
+const FOREIGN_AGGREGATOR_INDEX: usize = 900;
+const FOREIGN_CONTRIBUTOR_INDEX: usize = 901;
+
+/// One aggregate root plus one contribution root per subcommittee in the standard mixed
+/// decided value.
+const MIXED_WORKLIST_SIZE: usize = 1 + CONTRIBUTION_SUBCOMMITTEES.len();
+
+const CAPTURE_TIMEOUT: Duration = Duration::from_secs(2);
+const CAPTURE_POLL_INTERVAL: Duration = Duration::from_millis(10);
+/// Extra wait after the expected capture count is reached, to catch spurious extra captures.
+const SETTLE_DELAY: Duration = Duration::from_millis(200);
+const STREAM_TIMEOUT: Duration = Duration::from_secs(5);
+
+// ==================== Fixture ====================
+
+/// One committee plus the identifiers needed to seed decided values for it.
+///
+/// The harness owns its `CommitteeSetup`s privately, so the committee ID and validator
+/// metadata are captured before handing the setup over.
+struct AggregatorCommitteeFixture {
+    harness: ValidatorStoreTestHarness,
+    committee_id: CommitteeId,
+}
+
+impl AggregatorCommitteeFixture {
+    fn new(validator_count: usize) -> Self {
+        let setup = create_committee_setup(
+            &COMMITTEE_OPERATOR_IDS,
+            validator_count,
+            STARTING_VALIDATOR_INDEX,
+        );
+        let committee_id = setup.cluster.committee_id();
+        let harness = ValidatorStoreTestHarness::new(vec![setup], OUR_OPERATOR_ID);
+        Self {
+            harness,
+            committee_id,
+        }
+    }
+
+    fn validator_metadata(&self, position: usize) -> ValidatorMetadata {
+        self.harness.validator_metadata(COMMITTEE_INDEX, position)
+    }
+
+    fn validator_index(&self, position: usize) -> ValidatorIndex {
+        self.validator_metadata(position)
+            .index
+            .expect("test validator should have an index")
+    }
+
+    fn pubkey(&self, position: usize) -> PublicKeyBytes {
+        self.validator_metadata(position).public_key
+    }
+
+    /// Seeds `AggregationAssignments` at `TEST_SLOT` with the given consensus data for this
+    /// committee. The mock decider echoes the proposal, so this is also the decided value.
+    fn seed_decided_value(
+        &self,
+        data: AggregatorCommitteeConsensusData<MainnetEthSpec>,
+    ) -> Arc<AggregatorCommitteeConsensusData<MainnetEthSpec>> {
+        let data = Arc::new(data);
+        self.harness
+            .validator_store
+            .update_aggregation_assignments(AggregationAssignments {
+                slot: Slot::new(TEST_SLOT),
+                aggregator_committees: HashMap::new(),
+                multi_sync_aggregators: HashMap::new(),
+                consensus_data_by_ssv_committee: HashMap::from([(
+                    self.committee_id,
+                    Arc::clone(&data),
+                )]),
+            });
+        data
+    }
+
+    /// Seeds `AggregationAssignments` at `TEST_SLOT` without consensus data for any committee, so
+    /// no execution is registered and the callbacks fail with `ConsensusDataNotFound`.
+    fn seed_assignments_without_consensus_data(&self) {
+        self.harness
+            .validator_store
+            .update_aggregation_assignments(AggregationAssignments {
+                slot: Slot::new(TEST_SLOT),
+                aggregator_committees: HashMap::new(),
+                multi_sync_aggregators: HashMap::new(),
+                consensus_data_by_ssv_committee: HashMap::new(),
+            });
+    }
+
+    /// Seeds the standard mixed decided value: one aggregate for the aggregate validator plus
+    /// one contribution per subcommittee in [`CONTRIBUTION_SUBCOMMITTEES`] for the contributor.
+    fn seed_mixed_decided_value(&self) -> Arc<AggregatorCommitteeConsensusData<MainnetEthSpec>> {
+        let aggregator = self.validator_index(AGGREGATE_VALIDATOR_IDX);
+        let contributor = self.validator_index(CONTRIBUTOR_VALIDATOR_IDX);
+        self.seed_decided_value(build_decided_data(
+            &[(aggregator, BEACON_COMMITTEE_INDEX)],
+            &[
+                (contributor, CONTRIBUTION_SUBCOMMITTEES[0]),
+                (contributor, CONTRIBUTION_SUBCOMMITTEES[1]),
+            ],
+        ))
+    }
+
+    fn create_contribution(
+        &self,
+        position: usize,
+        subcommittee_index: u64,
+    ) -> ContributionToSign<MainnetEthSpec> {
+        let validator = self.validator_metadata(position);
+        ContributionToSign {
+            aggregator_index: *validator
+                .index
+                .expect("test validator should have an index") as u64,
+            aggregator_pubkey: validator.public_key,
+            contribution: test_contribution(subcommittee_index),
+            selection_proof: SyncSelectionProof::from(Signature::empty()),
+        }
+    }
+
+    async fn collect_contributions(
+        &self,
+        contributions: Vec<ContributionToSign<MainnetEthSpec>>,
+    ) -> SignContributionsResult {
+        let stream = self
+            .harness
+            .validator_store
+            .sign_sync_committee_contributions(contributions);
+        tokio::time::timeout(STREAM_TIMEOUT, stream.collect())
+            .await
+            .expect("contribution callback should complete within the stream timeout")
+    }
+
+    async fn collect_aggregates(
+        &self,
+        aggregates: Vec<validator_store::AggregateToSign<MainnetEthSpec>>,
+    ) -> SignAggregatesResult {
+        let stream = self
+            .harness
+            .validator_store
+            .sign_aggregate_and_proofs(aggregates);
+        tokio::time::timeout(STREAM_TIMEOUT, stream.collect())
+            .await
+            .expect("aggregate callback should complete within the stream timeout")
+    }
+}
+
+// ==================== Decided value construction ====================
+
+fn assigned(validator_index: ValidatorIndex, committee_index: u64) -> AssignedAggregator {
+    AssignedAggregator {
+        validator_index,
+        selection_proof: Signature::empty(),
+        committee_index,
+    }
+}
+
+/// An aggregate attestation payload at `TEST_SLOT`. Distinct `committee_index` values produce
+/// distinct signing roots.
+fn test_aggregate_attestation(committee_index: u64) -> AttestationBase<MainnetEthSpec> {
+    AttestationBase {
+        aggregation_bits: ssz_types::BitList::with_capacity(128).expect("bitlist should be valid"),
+        data: AttestationData {
+            slot: Slot::new(TEST_SLOT),
+            index: committee_index,
+            beacon_block_root: Hash256::zero(),
+            source: Checkpoint {
+                epoch: Epoch::new(0),
+                root: Hash256::zero(),
+            },
+            target: Checkpoint {
+                epoch: Epoch::new(0),
+                root: Hash256::zero(),
+            },
+        },
+        signature: AggregateSignature::infinity(),
+    }
+}
+
+/// A sync contribution at `TEST_SLOT`. Distinct `subcommittee_index` values produce distinct
+/// signing roots.
+fn test_contribution(subcommittee_index: u64) -> SyncCommitteeContribution<MainnetEthSpec> {
+    SyncCommitteeContribution {
+        slot: Slot::new(TEST_SLOT),
+        beacon_block_root: Hash256::zero(),
+        subcommittee_index,
+        aggregation_bits: Default::default(),
+        signature: AggregateSignature::infinity(),
+    }
+}
+
+/// Builds an `AggregatorCommitteeConsensusData` from decided entries.
+///
+/// `aggregators` and `contributors` are `(validator_index, committee_index)` pairs; the
+/// attestation and contribution payload lists are derived from them (one payload per unique
+/// index).
+fn build_decided_data(
+    aggregators: &[(ValidatorIndex, u64)],
+    contributors: &[(ValidatorIndex, u64)],
+) -> AggregatorCommitteeConsensusData<MainnetEthSpec> {
+    // One payload per unique committee/subcommittee index, in first-seen order.
+    let mut aggregate_committee_indexes: Vec<u64> = Vec::new();
+    for &(_, committee_index) in aggregators {
+        if !aggregate_committee_indexes.contains(&committee_index) {
+            aggregate_committee_indexes.push(committee_index);
+        }
+    }
+    let mut contribution_subcommittees: Vec<u64> = Vec::new();
+    for &(_, subcommittee_index) in contributors {
+        if !contribution_subcommittees.contains(&subcommittee_index) {
+            contribution_subcommittees.push(subcommittee_index);
+        }
+    }
+    let aggregators: Vec<_> = aggregators
+        .iter()
+        .map(|&(validator_index, committee_index)| assigned(validator_index, committee_index))
+        .collect();
+    let aggregated_attestations: Vec<_> = aggregate_committee_indexes
+        .iter()
+        .map(|&committee_index| {
+            VariableList::new(test_aggregate_attestation(committee_index).as_ssz_bytes())
+                .expect("attestation bytes should fit")
+        })
+        .collect();
+    let contributors: Vec<_> = contributors
+        .iter()
+        .map(|&(validator_index, subcommittee_index)| assigned(validator_index, subcommittee_index))
+        .collect();
+    let sync_committee_contributions: Vec<_> = contribution_subcommittees
+        .iter()
+        .map(|&subcommittee_index| test_contribution(subcommittee_index))
+        .collect();
+
+    AggregatorCommitteeConsensusData {
+        version: DataVersion::from(ForkName::Deneb),
+        aggregators: VariableList::new(aggregators).expect("aggregator list should be valid"),
+        aggregator_committee_indexes: VariableList::new(aggregate_committee_indexes)
+            .expect("committee indexes should be valid"),
+        aggregated_attestations: VariableList::new(aggregated_attestations)
+            .expect("aggregated attestations should be valid"),
+        contributors: VariableList::new(contributors).expect("contributor list should be valid"),
+        sync_committee_contributions: VariableList::new(sync_committee_contributions)
+            .expect("contributions should be valid"),
+    }
+}
+
+// ==================== Capture assertions ====================
+
+/// The committee-requester view of one captured `sign_and_collect` call.
+struct CapturedCommitteeCall {
+    pubkey: PublicKeyBytes,
+    signing_root: Hash256,
+    batch_size: usize,
+    base_hash: Hash256,
+}
+
+/// Snapshots the captured calls, asserting every call is an `AggregatorCommittee`
+/// post-consensus call with a `Committee` requester.
+fn committee_calls(harness: &ValidatorStoreTestHarness) -> Vec<CapturedCommitteeCall> {
+    harness
+        .captured_calls
+        .lock()
+        .iter()
+        .map(|call| {
+            assert_eq!(call.metadata.role, Role::AggregatorCommittee);
+            assert_eq!(call.metadata.kind, PartialSignatureKind::PostConsensus);
+            assert_eq!(call.metadata.slot, Slot::new(TEST_SLOT));
+            match &call.requester {
+                SignatureRequester::Committee {
+                    validator_partial_signature_batch_size,
+                    base_hash,
+                } => CapturedCommitteeCall {
+                    pubkey: call.validator_pubkey,
+                    signing_root: call.signing_root,
+                    batch_size: *validator_partial_signature_batch_size,
+                    base_hash: *base_hash,
+                },
+                other => panic!("expected SignatureRequester::Committee, got: {other:?}"),
+            }
+        })
+        .collect()
+}
+
+/// Asserts every call shares the expected local batch size and decided-value batch identity.
+fn assert_batch_identity(
+    calls: &[CapturedCommitteeCall],
+    expected_batch_size: usize,
+    expected_base_hash: Hash256,
+) {
+    for call in calls {
+        assert_eq!(
+            call.batch_size, expected_batch_size,
+            "every root should join the same local committee batch"
+        );
+        assert_eq!(
+            call.base_hash, expected_base_hash,
+            "every root should carry the decided-value hash as its batch identity"
+        );
+    }
+}
+
+fn distinct_roots(calls: &[CapturedCommitteeCall]) -> HashSet<Hash256> {
+    calls.iter().map(|call| call.signing_root).collect()
+}
+
+fn calls_for_pubkey(calls: &[CapturedCommitteeCall], pubkey: PublicKeyBytes) -> usize {
+    calls.iter().filter(|call| call.pubkey == pubkey).count()
+}
+
+/// Polls until at least `expected` calls were captured, panicking after [`CAPTURE_TIMEOUT`].
+///
+/// The worklist signing tasks are detached, so captures arrive asynchronously relative to the
+/// Lighthouse callback futures.
+async fn wait_for_captured_calls(harness: &ValidatorStoreTestHarness, expected: usize) {
+    let deadline = tokio::time::Instant::now() + CAPTURE_TIMEOUT;
+    loop {
+        let count = harness.captured_calls.lock().len();
+        if count >= expected {
+            return;
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "expected {expected} captured sign_and_collect calls within {CAPTURE_TIMEOUT:?}, \
+             got {count}"
+        );
+        tokio::time::sleep(CAPTURE_POLL_INTERVAL).await;
+    }
+}
+
+/// Waits for `expected` captures, then lets stragglers settle and asserts the count is exact.
+async fn assert_captured_calls_settle_at(harness: &ValidatorStoreTestHarness, expected: usize) {
+    wait_for_captured_calls(harness, expected).await;
+    tokio::time::sleep(SETTLE_DELAY).await;
+    let count = harness.captured_calls.lock().len();
+    assert_eq!(
+        count, expected,
+        "capture count should settle at exactly {expected}"
+    );
+}
+
+/// Unwraps a single-committee stream result into its signed batch.
+fn single_batch<T>(results: Vec<Result<Vec<T>, Error>>) -> Vec<T> {
+    assert_eq!(results.len(), 1, "expected one committee stream item");
+    results
+        .into_iter()
+        .next()
+        .expect("committee stream item should exist")
+        .expect("committee signing should succeed")
+}
+
+// ==================== Complete-worklist tests ====================
+
+/// A contribution-only Lighthouse callback must still trigger signing of the decided
+/// aggregate: the detached execution signs the complete mixed worklist, and every root joins
+/// one three-entry committee batch keyed by the decided-value hash.
+#[tokio::test(flavor = "multi_thread")]
+async fn contribution_only_callback_signs_complete_mixed_worklist() {
+    // Arrange
+    let fixture = AggregatorCommitteeFixture::new(MIXED_COMMITTEE_VALIDATOR_COUNT);
+    let decided = fixture.seed_mixed_decided_value();
+    let contributions = CONTRIBUTION_SUBCOMMITTEES
+        .iter()
+        .map(|&subcommittee| fixture.create_contribution(CONTRIBUTOR_VALIDATOR_IDX, subcommittee))
+        .collect();
+
+    // Act: only the contribution callback fires.
+    let results = fixture.collect_contributions(contributions).await;
+
+    // Assert: the callback returns exactly its own two contributions.
+    let mut signed = single_batch(results);
+    signed.sort_by_key(|item| item.message.contribution.subcommittee_index);
+    assert_eq!(
+        signed.len(),
+        CONTRIBUTION_SUBCOMMITTEES.len(),
+        "the contribution callback should return only its requested contributions"
+    );
+    for (item, &subcommittee) in signed.iter().zip(CONTRIBUTION_SUBCOMMITTEES.iter()) {
+        assert_eq!(item.message.contribution.subcommittee_index, subcommittee);
+        assert_eq!(
+            item.message.aggregator_index,
+            *fixture.validator_index(CONTRIBUTOR_VALIDATOR_IDX) as u64
+        );
+    }
+
+    // The aggregate root is signed by a detached task even though no aggregate callback fired.
+    assert_captured_calls_settle_at(&fixture.harness, MIXED_WORKLIST_SIZE).await;
+    let calls = committee_calls(&fixture.harness);
+    assert_eq!(
+        distinct_roots(&calls).len(),
+        MIXED_WORKLIST_SIZE,
+        "aggregate and per-subcommittee contribution roots must stay distinct"
+    );
+    assert_batch_identity(&calls, MIXED_WORKLIST_SIZE, decided.hash());
+    assert_eq!(
+        calls_for_pubkey(&calls, fixture.pubkey(AGGREGATE_VALIDATOR_IDX)),
+        1,
+        "the decided aggregate must be signed without an aggregate callback"
+    );
+    assert_eq!(
+        calls_for_pubkey(&calls, fixture.pubkey(CONTRIBUTOR_VALIDATOR_IDX)),
+        CONTRIBUTION_SUBCOMMITTEES.len(),
+        "the contributor must sign one root per subcommittee"
+    );
+}
+
+/// The mirror case: an aggregate-only callback must still trigger signing of both decided
+/// contributions.
+#[tokio::test(flavor = "multi_thread")]
+async fn aggregate_only_callback_signs_complete_mixed_worklist() {
+    // Arrange
+    let fixture = AggregatorCommitteeFixture::new(MIXED_COMMITTEE_VALIDATOR_COUNT);
+    let decided = fixture.seed_mixed_decided_value();
+    let aggregates = vec![
+        fixture
+            .harness
+            .create_aggregate(COMMITTEE_INDEX, AGGREGATE_VALIDATOR_IDX),
+    ];
+
+    // Act: only the aggregate callback fires.
+    let results = fixture.collect_aggregates(aggregates).await;
+
+    // Assert: the callback returns exactly its own aggregate.
+    let signed = single_batch(results);
+    assert_eq!(
+        signed.len(),
+        1,
+        "the aggregate callback should return only its requested aggregate"
+    );
+
+    // Both contribution roots are signed by detached tasks without a contribution callback.
+    assert_captured_calls_settle_at(&fixture.harness, MIXED_WORKLIST_SIZE).await;
+    let calls = committee_calls(&fixture.harness);
+    assert_eq!(distinct_roots(&calls).len(), MIXED_WORKLIST_SIZE);
+    assert_batch_identity(&calls, MIXED_WORKLIST_SIZE, decided.hash());
+    assert_eq!(
+        calls_for_pubkey(&calls, fixture.pubkey(AGGREGATE_VALIDATOR_IDX)),
+        1
+    );
+    assert_eq!(
+        calls_for_pubkey(&calls, fixture.pubkey(CONTRIBUTOR_VALIDATOR_IDX)),
+        CONTRIBUTION_SUBCOMMITTEES.len(),
+        "the decided contributions must be signed without a contribution callback"
+    );
+}
+
+/// The slot pipeline signs the complete decided worklist with no Lighthouse callback involved.
+///
+/// This is the property the whole design rests on: what gets signed is a function of the decided
+/// value alone, so a class Lighthouse never asks about can no longer leave the committee batch
+/// short of its expected size.
+#[tokio::test(flavor = "multi_thread")]
+async fn decided_worklist_is_signed_without_any_callback() {
+    // Arrange and act: publishing the assignments is the entire trigger.
+    let fixture = AggregatorCommitteeFixture::new(MIXED_COMMITTEE_VALIDATOR_COUNT);
+    let decided = fixture.seed_mixed_decided_value();
+
+    // Assert: every decided root of both classes was submitted to one correctly sized batch.
+    assert_captured_calls_settle_at(&fixture.harness, MIXED_WORKLIST_SIZE).await;
+    let calls = committee_calls(&fixture.harness);
+    assert_eq!(
+        distinct_roots(&calls).len(),
+        MIXED_WORKLIST_SIZE,
+        "both object classes must be signed without either callback firing"
+    );
+    assert_batch_identity(&calls, MIXED_WORKLIST_SIZE, decided.hash());
+}
+
+/// Republishing assignments for a slot must not register a second execution.
+///
+/// Registration is the single writer that makes "exactly one committee message per
+/// `(committee, slot)`" true. If a republish overwrote the entry it would spawn a second QBFT
+/// round and a second set of detached signing tasks while the first set kept running, putting two
+/// post-consensus messages on the wire for one slot, which peers reject with a gossip penalty.
+#[tokio::test(flavor = "multi_thread")]
+async fn republished_assignments_do_not_resubmit() {
+    // Arrange: let the first publish fully submit its worklist.
+    let fixture = AggregatorCommitteeFixture::new(MIXED_COMMITTEE_VALIDATOR_COUNT);
+    let decided = fixture.seed_mixed_decided_value();
+    assert_captured_calls_settle_at(&fixture.harness, MIXED_WORKLIST_SIZE).await;
+
+    // Act: publish the same slot again.
+    fixture.seed_mixed_decided_value();
+
+    // Assert: still exactly one submission of the worklist, not two.
+    assert_captured_calls_settle_at(&fixture.harness, MIXED_WORKLIST_SIZE).await;
+    let calls = committee_calls(&fixture.harness);
+    assert_eq!(
+        distinct_roots(&calls).len(),
+        MIXED_WORKLIST_SIZE,
+        "a republish must not resubmit the worklist"
+    );
+    assert_batch_identity(&calls, MIXED_WORKLIST_SIZE, decided.hash());
+}
+
+/// Both callbacks read the same execution: neither re-runs consensus nor duplicates signatures,
+/// and each returns only its own items.
+#[tokio::test(flavor = "multi_thread")]
+async fn both_callbacks_share_one_execution() {
+    // Arrange
+    let fixture = AggregatorCommitteeFixture::new(MIXED_COMMITTEE_VALIDATOR_COUNT);
+    let decided = fixture.seed_mixed_decided_value();
+    let contributions = CONTRIBUTION_SUBCOMMITTEES
+        .iter()
+        .map(|&subcommittee| fixture.create_contribution(CONTRIBUTOR_VALIDATOR_IDX, subcommittee))
+        .collect();
+    let aggregates = vec![
+        fixture
+            .harness
+            .create_aggregate(COMMITTEE_INDEX, AGGREGATE_VALIDATOR_IDX),
+    ];
+
+    // Act: contribution callback first, then the aggregate callback joins the cached outcome.
+    let contribution_results = fixture.collect_contributions(contributions).await;
+    let aggregate_results = fixture.collect_aggregates(aggregates).await;
+
+    // Assert: each callback returned only its own items.
+    assert_eq!(
+        single_batch(contribution_results).len(),
+        CONTRIBUTION_SUBCOMMITTEES.len(),
+        "the contribution callback should return only its contributions"
+    );
+    assert_eq!(
+        single_batch(aggregate_results).len(),
+        1,
+        "the aggregate callback should return only its aggregate"
+    );
+
+    // The union is signed exactly once: no duplicate captures from the second callback.
+    assert_captured_calls_settle_at(&fixture.harness, MIXED_WORKLIST_SIZE).await;
+    let calls = committee_calls(&fixture.harness);
+    assert_eq!(distinct_roots(&calls).len(), MIXED_WORKLIST_SIZE);
+    assert_batch_identity(&calls, MIXED_WORKLIST_SIZE, decided.hash());
+}
+
+/// Dropping a callback future must not cancel the execution it is reading: the complete worklist
+/// is still signed, and a later callback still gets its items from the same execution.
+#[tokio::test(flavor = "multi_thread")]
+async fn dropped_callback_future_still_completes_worklist() {
+    // Arrange
+    let fixture = AggregatorCommitteeFixture::new(MIXED_COMMITTEE_VALIDATOR_COUNT);
+    let decided = fixture.seed_mixed_decided_value();
+    let contributions: Vec<_> = CONTRIBUTION_SUBCOMMITTEES
+        .iter()
+        .map(|&subcommittee| fixture.create_contribution(CONTRIBUTOR_VALIDATOR_IDX, subcommittee))
+        .collect();
+
+    // Act: poll the contribution callback once, then drop it. A zero timeout polls the inner
+    // future exactly once before the deadline elapses; if the callback happens to win the race the
+    // scenario degrades to the sequential case.
+    let stream = fixture
+        .harness
+        .validator_store
+        .sign_sync_committee_contributions(contributions);
+    let _ = tokio::time::timeout(Duration::ZERO, stream.collect::<SignContributionsResult>()).await;
+
+    // Assert: the detached execution still signs the complete worklist.
+    assert_captured_calls_settle_at(&fixture.harness, MIXED_WORKLIST_SIZE).await;
+    let calls = committee_calls(&fixture.harness);
+    assert_batch_identity(&calls, MIXED_WORKLIST_SIZE, decided.hash());
+
+    // A later aggregate callback joins the finished execution and gets its aggregate.
+    let aggregates = vec![
+        fixture
+            .harness
+            .create_aggregate(COMMITTEE_INDEX, AGGREGATE_VALIDATOR_IDX),
+    ];
+    let signed = single_batch(fixture.collect_aggregates(aggregates).await);
+    assert_eq!(
+        signed.len(),
+        1,
+        "a late aggregate callback should resolve from the cached execution"
+    );
+
+    // Still no duplicate captures after the late callback.
+    tokio::time::sleep(SETTLE_DELAY).await;
+    assert_eq!(
+        fixture.harness.captured_calls.lock().len(),
+        MIXED_WORKLIST_SIZE
+    );
+}
+
+/// One validator owning an aggregate plus contributions in all four subcommittees keeps five
+/// distinct signing roots in one five-entry batch.
+#[tokio::test(flavor = "multi_thread")]
+async fn multi_root_validator_keeps_distinct_roots() {
+    // Arrange
+    const EXPECTED_WORKLIST_SIZE: usize = 1 + ALL_SUBCOMMITTEES.len();
+    let fixture = AggregatorCommitteeFixture::new(SINGLE_VALIDATOR_COUNT);
+    let validator = fixture.validator_index(AGGREGATE_VALIDATOR_IDX);
+    let contributors: Vec<_> = ALL_SUBCOMMITTEES
+        .iter()
+        .map(|&subcommittee| (validator, subcommittee))
+        .collect();
+    let decided = fixture.seed_decided_value(build_decided_data(
+        &[(validator, BEACON_COMMITTEE_INDEX)],
+        &contributors,
+    ));
+    let contributions = ALL_SUBCOMMITTEES
+        .iter()
+        .map(|&subcommittee| fixture.create_contribution(SOLE_VALIDATOR_IDX, subcommittee))
+        .collect();
+
+    // Act
+    let results = fixture.collect_contributions(contributions).await;
+
+    // Assert
+    assert_eq!(single_batch(results).len(), ALL_SUBCOMMITTEES.len());
+    assert_captured_calls_settle_at(&fixture.harness, EXPECTED_WORKLIST_SIZE).await;
+    let calls = committee_calls(&fixture.harness);
+    assert_eq!(
+        distinct_roots(&calls).len(),
+        EXPECTED_WORKLIST_SIZE,
+        "one validator's aggregate and four contribution roots must stay distinct"
+    );
+    assert_batch_identity(&calls, EXPECTED_WORKLIST_SIZE, decided.hash());
+    assert_eq!(
+        calls_for_pubkey(&calls, fixture.pubkey(AGGREGATE_VALIDATOR_IDX)),
+        EXPECTED_WORKLIST_SIZE
+    );
+}
+
+// ==================== Divergent-view and normalization tests ====================
+
+/// A requested item absent from the decided value is skipped, while the other requested
+/// items succeed and the batch size counts only decided entries.
+#[tokio::test(flavor = "multi_thread")]
+async fn requested_item_missing_from_decided_value() {
+    // Arrange: the decided value covers subcommittees 0 and 1, but the callback also asks
+    // for subcommittee 2.
+    let fixture = AggregatorCommitteeFixture::new(MIXED_COMMITTEE_VALIDATOR_COUNT);
+    let decided = fixture.seed_mixed_decided_value();
+    let contributions = CONTRIBUTION_SUBCOMMITTEES
+        .iter()
+        .chain(std::iter::once(&MISSING_SUBCOMMITTEE_INDEX))
+        .map(|&subcommittee| fixture.create_contribution(CONTRIBUTOR_VALIDATOR_IDX, subcommittee))
+        .collect();
+
+    // Act
+    let results = fixture.collect_contributions(contributions).await;
+
+    // Assert: only the decided subcommittees come back.
+    let signed = single_batch(results);
+    let returned_subcommittees: HashSet<u64> = signed
+        .iter()
+        .map(|item| item.message.contribution.subcommittee_index)
+        .collect();
+    assert_eq!(
+        returned_subcommittees,
+        HashSet::from(CONTRIBUTION_SUBCOMMITTEES),
+        "the undecided subcommittee must be skipped, not signed"
+    );
+
+    // The batch covers the decided union only, without the missing item.
+    assert_captured_calls_settle_at(&fixture.harness, MIXED_WORKLIST_SIZE).await;
+    let calls = committee_calls(&fixture.harness);
+    assert_batch_identity(&calls, MIXED_WORKLIST_SIZE, decided.hash());
+}
+
+/// Exact duplicate decided entries collapse to one worklist entry each, so the batch size
+/// reflects the deduplicated union.
+#[tokio::test(flavor = "multi_thread")]
+async fn duplicate_decided_entries_normalized() {
+    // Arrange: the same aggregator entry twice and the same contributor entry twice.
+    const EXPECTED_DEDUPED_SIZE: usize = 2;
+    let fixture = AggregatorCommitteeFixture::new(MIXED_COMMITTEE_VALIDATOR_COUNT);
+    let aggregator = fixture.validator_index(AGGREGATE_VALIDATOR_IDX);
+    let contributor = fixture.validator_index(CONTRIBUTOR_VALIDATOR_IDX);
+    let decided = fixture.seed_decided_value(build_decided_data(
+        &[
+            (aggregator, BEACON_COMMITTEE_INDEX),
+            (aggregator, BEACON_COMMITTEE_INDEX),
+        ],
+        &[
+            (contributor, CONTRIBUTION_SUBCOMMITTEES[0]),
+            (contributor, CONTRIBUTION_SUBCOMMITTEES[0]),
+        ],
+    ));
+    let contributions =
+        vec![fixture.create_contribution(CONTRIBUTOR_VALIDATOR_IDX, CONTRIBUTION_SUBCOMMITTEES[0])];
+
+    // Act
+    let results = fixture.collect_contributions(contributions).await;
+
+    // Assert
+    assert_eq!(single_batch(results).len(), 1);
+    assert_captured_calls_settle_at(&fixture.harness, EXPECTED_DEDUPED_SIZE).await;
+    let calls = committee_calls(&fixture.harness);
+    assert_eq!(
+        distinct_roots(&calls).len(),
+        EXPECTED_DEDUPED_SIZE,
+        "duplicates must collapse to one entry per (validator, signing_root)"
+    );
+    assert_batch_identity(&calls, EXPECTED_DEDUPED_SIZE, decided.hash());
+}
+
+/// Conflicting aggregate roots for one validator sign only the first, keeping that validator
+/// within the receivers' per-validator root cap while unrelated entries are unaffected.
+#[tokio::test(flavor = "multi_thread")]
+async fn conflicting_aggregate_roots_sign_only_the_first() {
+    // Arrange: the aggregator appears twice with different committee indexes, each resolving
+    // to a different attestation payload and therefore a different signing root.
+    const EXPECTED_SIGNED_SIZE: usize = 2;
+    let fixture = AggregatorCommitteeFixture::new(MIXED_COMMITTEE_VALIDATOR_COUNT);
+    let aggregator = fixture.validator_index(AGGREGATE_VALIDATOR_IDX);
+    let contributor = fixture.validator_index(CONTRIBUTOR_VALIDATOR_IDX);
+    let decided = fixture.seed_decided_value(build_decided_data(
+        &[
+            (aggregator, BEACON_COMMITTEE_INDEX),
+            (aggregator, CONFLICTING_BEACON_COMMITTEE_INDEX),
+        ],
+        &[(contributor, CONTRIBUTION_SUBCOMMITTEES[0])],
+    ));
+    let contributions =
+        vec![fixture.create_contribution(CONTRIBUTOR_VALIDATOR_IDX, CONTRIBUTION_SUBCOMMITTEES[0])];
+
+    // Act
+    let results = fixture.collect_contributions(contributions).await;
+
+    // Assert: exactly one of the conflicting aggregates is signed, the contribution is
+    // unaffected, and the batch counts both.
+    assert_eq!(single_batch(results).len(), 1);
+    assert_captured_calls_settle_at(&fixture.harness, EXPECTED_SIGNED_SIZE).await;
+    let calls = committee_calls(&fixture.harness);
+    assert_eq!(
+        calls_for_pubkey(&calls, fixture.pubkey(AGGREGATE_VALIDATOR_IDX)),
+        1,
+        "a validator with conflicting decided aggregate roots must sign exactly one of them"
+    );
+    assert_eq!(
+        calls_for_pubkey(&calls, fixture.pubkey(CONTRIBUTOR_VALIDATOR_IDX)),
+        1,
+        "the unrelated contribution must be unaffected by the malformed aggregate entries"
+    );
+    assert_eq!(
+        distinct_roots(&calls).len(),
+        EXPECTED_SIGNED_SIZE,
+        "each signed identity contributes exactly one distinct root"
+    );
+    assert_batch_identity(&calls, EXPECTED_SIGNED_SIZE, decided.hash());
+}
+
+// ==================== Empty and error path tests ====================
+
+/// A decided value naming only validators this operator has no metadata for produces an empty
+/// worklist: the callbacks return empty batches and no signature is ever collected.
+#[tokio::test(flavor = "multi_thread")]
+async fn empty_worklist_returns_empty() {
+    // Arrange: the decided entries reference foreign validator indices, while the callbacks
+    // reference the local validator (required to pass committee grouping).
+    let fixture = AggregatorCommitteeFixture::new(SINGLE_VALIDATOR_COUNT);
+    fixture.seed_decided_value(build_decided_data(
+        &[(
+            ValidatorIndex(FOREIGN_AGGREGATOR_INDEX),
+            BEACON_COMMITTEE_INDEX,
+        )],
+        &[(
+            ValidatorIndex(FOREIGN_CONTRIBUTOR_INDEX),
+            CONTRIBUTION_SUBCOMMITTEES[0],
+        )],
+    ));
+    let aggregates = vec![
+        fixture
+            .harness
+            .create_aggregate(COMMITTEE_INDEX, AGGREGATE_VALIDATOR_IDX),
+    ];
+    let contributions =
+        vec![fixture.create_contribution(SOLE_VALIDATOR_IDX, CONTRIBUTION_SUBCOMMITTEES[0])];
+
+    // Act
+    let aggregate_results = fixture.collect_aggregates(aggregates).await;
+    let contribution_results = fixture.collect_contributions(contributions).await;
+
+    // Assert: both callbacks yield an empty batch and nothing is signed.
+    assert!(
+        single_batch(aggregate_results).is_empty(),
+        "no locally signable decided entry means an empty aggregate batch"
+    );
+    assert!(
+        single_batch(contribution_results).is_empty(),
+        "no locally signable decided entry means an empty contribution batch"
+    );
+    assert_captured_calls_settle_at(&fixture.harness, 0).await;
+}
+
+/// Missing consensus data for the committee fails the execution; the trait layer swallows the
+/// error into an empty batch (`run_committee_signing`) and nothing is signed.
+#[tokio::test(flavor = "multi_thread")]
+async fn consensus_data_missing_errors() {
+    // Arrange: assignments exist for the slot, but carry no consensus data for any committee,
+    // so the execution fails with `ConsensusDataNotFound`. (Seeding nothing at all would park
+    // the callbacks on the assignments watch channel instead of erroring.)
+    let fixture = AggregatorCommitteeFixture::new(MIXED_COMMITTEE_VALIDATOR_COUNT);
+    fixture.seed_assignments_without_consensus_data();
+    let aggregates = vec![
+        fixture
+            .harness
+            .create_aggregate(COMMITTEE_INDEX, AGGREGATE_VALIDATOR_IDX),
+    ];
+    let contributions =
+        vec![fixture.create_contribution(CONTRIBUTOR_VALIDATOR_IDX, CONTRIBUTION_SUBCOMMITTEES[0])];
+
+    // Act: both callback classes hit the same cached execution error.
+    let aggregate_results = fixture.collect_aggregates(aggregates).await;
+    let contribution_results = fixture.collect_contributions(contributions).await;
+
+    // Assert: `run_committee_signing` swallows the failure into one empty stream item per
+    // committee, and no signature collection is ever attempted.
+    assert!(
+        single_batch(aggregate_results).is_empty(),
+        "a failed execution should yield an empty aggregate batch"
+    );
+    assert!(
+        single_batch(contribution_results).is_empty(),
+        "a failed execution should yield an empty contribution batch"
+    );
+    assert_captured_calls_settle_at(&fixture.harness, 0).await;
+}
+
+/// Decided payloads whose slot does not match the duty slot are excluded from the worklist, so
+/// the batch settles at the surviving count instead of stalling.
+#[tokio::test(flavor = "multi_thread")]
+async fn slot_mismatched_decided_payloads_are_excluded() {
+    // Arrange: the standard mixed decided value, but both contribution payloads carry the
+    // wrong slot; only the aggregate survives slot binding.
+    let fixture = AggregatorCommitteeFixture::new(MIXED_COMMITTEE_VALIDATOR_COUNT);
+    let aggregator = fixture.validator_index(AGGREGATE_VALIDATOR_IDX);
+    let contributor = fixture.validator_index(CONTRIBUTOR_VALIDATOR_IDX);
+    let mut decided = build_decided_data(
+        &[(aggregator, BEACON_COMMITTEE_INDEX)],
+        &[
+            (contributor, CONTRIBUTION_SUBCOMMITTEES[0]),
+            (contributor, CONTRIBUTION_SUBCOMMITTEES[1]),
+        ],
+    );
+    for contribution in decided.sync_committee_contributions.iter_mut() {
+        contribution.slot = Slot::new(TEST_SLOT + 1);
+    }
+    fixture.seed_decided_value(decided);
+    let contributions = vec![
+        fixture.create_contribution(CONTRIBUTOR_VALIDATOR_IDX, CONTRIBUTION_SUBCOMMITTEES[0]),
+        fixture.create_contribution(CONTRIBUTOR_VALIDATOR_IDX, CONTRIBUTION_SUBCOMMITTEES[1]),
+    ];
+
+    // Act
+    let results = fixture.collect_contributions(contributions).await;
+
+    // Assert: the requested contributions resolve to nothing (their decided payloads were
+    // excluded), while the aggregate still gets signed with a batch sized to the survivors.
+    assert!(
+        single_batch(results).is_empty(),
+        "slot-mismatched contributions should not be returned"
+    );
+    const EXPECTED_SURVIVOR_COUNT: usize = 1;
+    assert_captured_calls_settle_at(&fixture.harness, EXPECTED_SURVIVOR_COUNT).await;
+    let calls = committee_calls(&fixture.harness);
+    assert_eq!(
+        calls[0].pubkey,
+        fixture.pubkey(AGGREGATE_VALIDATOR_IDX),
+        "the surviving entry should be the aggregate"
+    );
+    assert_eq!(
+        calls[0].batch_size, EXPECTED_SURVIVOR_COUNT,
+        "the batch size should count only surviving entries"
+    );
+}

--- a/anchor/validator_store/src/testing/aggregator_post_consensus.rs
+++ b/anchor/validator_store/src/testing/aggregator_post_consensus.rs
@@ -2,10 +2,14 @@
 //!
 //! One QBFT decision carries both attestation aggregates and sync contributions. The
 //! per-`(committee, slot)` execution signs the complete decided worklist regardless of which
-//! Lighthouse callbacks fire; the callbacks only filter the shared outcome down to their own
-//! requested items. These tests pin the regression from issue #1227: a callback of one class
-//! must still produce the partial signatures for the other class, so the shared committee
+//! Lighthouse callbacks fire. These tests pin the regression from issue #1227: a callback of one
+//! class must still produce the partial signatures for the other class, so the shared committee
 //! batch never stalls below its expected size.
+//!
+//! The two classes are read out differently. Contributions still go back through the Lighthouse
+//! callback, which filters the shared outcome down to its own requested items. Aggregates do not:
+//! Anchor publishes them itself from the decided value, one publish call per root, so
+//! `publish_decided_aggregates` is the reader and the aggregate callback returns nothing.
 //!
 //! The worklist tasks are detached, so captured `sign_and_collect` calls arrive
 //! asynchronously; assertions on capture counts poll with a deadline and then let the
@@ -18,7 +22,8 @@ use std::{
 };
 
 use bls::{AggregateSignature, FixedBytesExtended, PublicKeyBytes, Signature};
-use futures::StreamExt;
+use futures::{FutureExt, StreamExt};
+use parking_lot::Mutex;
 use signature_collector::SignatureRequester;
 use ssv_types::{
     CommitteeId, OperatorId, ValidatorIndex, ValidatorMetadata,
@@ -29,16 +34,22 @@ use ssv_types::{
 use ssz::Encode;
 use ssz_types::VariableList;
 use types::{
-    AttestationBase, AttestationData, Checkpoint, Epoch, ForkName, Hash256, MainnetEthSpec,
-    SignedAggregateAndProof, SignedContributionAndProof, Slot, SyncCommitteeContribution,
+    AttestationBase, AttestationData, AttestationElectra, Checkpoint, Epoch, ForkName, Hash256,
+    MainnetEthSpec, SignedContributionAndProof, Slot, SyncCommitteeContribution,
     SyncSelectionProof,
 };
 use validator_store::{ContributionToSign, ValidatorStore};
 
 use super::common::*;
-use crate::{AggregationAssignments, Error};
+use crate::{
+    Error, SpecificError, aggregator_post_consensus::AggregatorPostConsensusShared, metrics,
+};
 
-type SignAggregatesResult = Vec<Result<Vec<SignedAggregateAndProof<MainnetEthSpec>>, Error>>;
+/// One committee's decided value, as the slot pipeline publishes it.
+type DecidedData = AggregatorCommitteeConsensusData<MainnetEthSpec>;
+/// A handle on one `(committee, slot)` post-consensus execution, as handed to the publisher.
+type Execution = AggregatorPostConsensusShared<MainnetEthSpec>;
+
 type SignContributionsResult = Vec<Result<Vec<SignedContributionAndProof<MainnetEthSpec>>, Error>>;
 
 const COMMITTEE_OPERATOR_IDS: [OperatorId; 4] =
@@ -68,11 +79,14 @@ const FOREIGN_CONTRIBUTOR_INDEX: usize = 901;
 /// decided value.
 const MIXED_WORKLIST_SIZE: usize = 1 + CONTRIBUTION_SUBCOMMITTEES.len();
 
+/// A clock position past the publisher's deadline for `TEST_SLOT` (one slot past that slot's end),
+/// so deadline tests reach the timeout without sleeping two real slots.
+const PAST_PUBLISH_DEADLINE_SECS: u64 = (TEST_SLOT + 3) * SLOT_DURATION_SECS;
+
 const CAPTURE_TIMEOUT: Duration = Duration::from_secs(2);
 const CAPTURE_POLL_INTERVAL: Duration = Duration::from_millis(10);
 /// Extra wait after the expected capture count is reached, to catch spurious extra captures.
 const SETTLE_DELAY: Duration = Duration::from_millis(200);
-const STREAM_TIMEOUT: Duration = Duration::from_secs(5);
 
 // ==================== Fixture ====================
 
@@ -116,50 +130,82 @@ impl AggregatorCommitteeFixture {
 
     /// Seeds `AggregationAssignments` at `TEST_SLOT` with the given consensus data for this
     /// committee. The mock decider echoes the proposal, so this is also the decided value.
-    fn seed_decided_value(
-        &self,
-        data: AggregatorCommitteeConsensusData<MainnetEthSpec>,
-    ) -> Arc<AggregatorCommitteeConsensusData<MainnetEthSpec>> {
+    fn seed_decided_value(&self, data: DecidedData) -> Arc<DecidedData> {
         let data = Arc::new(data);
-        self.harness
-            .validator_store
-            .update_aggregation_assignments(AggregationAssignments {
-                slot: Slot::new(TEST_SLOT),
-                aggregator_committees: HashMap::new(),
-                multi_sync_aggregators: HashMap::new(),
-                consensus_data_by_ssv_committee: HashMap::from([(
-                    self.committee_id,
-                    Arc::clone(&data),
-                )]),
-            });
+        self.publish_decided_value(Arc::clone(&data));
         data
     }
 
-    /// Seeds `AggregationAssignments` at `TEST_SLOT` without consensus data for any committee, so
-    /// no execution is registered and the callbacks fail with `ConsensusDataNotFound`.
-    fn seed_assignments_without_consensus_data(&self) {
+    /// Publishes `data` as this committee's decided value at `TEST_SLOT`, returning the executions
+    /// newly registered by the publish. This is what the slot pipeline hands to the aggregate
+    /// publisher, so a republish of the same slot returns nothing.
+    fn publish_decided_value(&self, data: Arc<DecidedData>) -> Vec<(CommitteeId, Execution)> {
         self.harness
-            .validator_store
-            .update_aggregation_assignments(AggregationAssignments {
-                slot: Slot::new(TEST_SLOT),
-                aggregator_committees: HashMap::new(),
-                multi_sync_aggregators: HashMap::new(),
-                consensus_data_by_ssv_committee: HashMap::new(),
-            });
+            .publish_decided_values(HashMap::from([(self.committee_id, data)]))
     }
 
-    /// Seeds the standard mixed decided value: one aggregate for the aggregate validator plus
-    /// one contribution per subcommittee in [`CONTRIBUTION_SUBCOMMITTEES`] for the contributor.
-    fn seed_mixed_decided_value(&self) -> Arc<AggregatorCommitteeConsensusData<MainnetEthSpec>> {
+    /// Seeds `AggregationAssignments` at `TEST_SLOT` without consensus data for any committee, so
+    /// no execution is registered and the callbacks fail with `ConsensusDataNotFound`. Returns the
+    /// (empty) set of executions the publish registered.
+    fn seed_assignments_without_consensus_data(&self) -> Vec<(CommitteeId, Execution)> {
+        self.harness.publish_decided_values(HashMap::new())
+    }
+
+    /// The standard mixed decided value: one aggregate for the aggregate validator plus one
+    /// contribution per subcommittee in [`CONTRIBUTION_SUBCOMMITTEES`] for the contributor.
+    fn mixed_decided_data(&self) -> DecidedData {
         let aggregator = self.validator_index(AGGREGATE_VALIDATOR_IDX);
         let contributor = self.validator_index(CONTRIBUTOR_VALIDATOR_IDX);
-        self.seed_decided_value(build_decided_data(
+        build_decided_data(
             &[(aggregator, BEACON_COMMITTEE_INDEX)],
             &[
                 (contributor, CONTRIBUTION_SUBCOMMITTEES[0]),
                 (contributor, CONTRIBUTION_SUBCOMMITTEES[1]),
             ],
-        ))
+        )
+    }
+
+    /// Seeds the standard mixed decided value.
+    fn seed_mixed_decided_value(&self) -> Arc<DecidedData> {
+        self.seed_decided_value(self.mixed_decided_data())
+    }
+
+    /// Seeds the standard mixed decided value and returns the single execution it registers,
+    /// for tests that also read the aggregate side through the publisher.
+    fn seed_mixed_decided_value_with_execution(&self) -> (Arc<DecidedData>, Execution) {
+        self.seed_decided_value_with_execution(self.mixed_decided_data())
+    }
+
+    /// Seeds `data` and returns the single execution it registers.
+    fn seed_decided_value_with_execution(
+        &self,
+        data: DecidedData,
+    ) -> (Arc<DecidedData>, Execution) {
+        let data = Arc::new(data);
+        let mut new_executions = self.publish_decided_value(Arc::clone(&data));
+        assert_eq!(
+            new_executions.len(),
+            1,
+            "seeding one committee should register exactly one execution"
+        );
+        let (committee_id, execution) = new_executions.pop().expect("execution should exist");
+        assert_eq!(committee_id, self.committee_id);
+        (data, execution)
+    }
+
+    /// Runs the publisher over this committee's execution with an always-succeeding recording
+    /// closure, returning one `(fork, aggregator index)` entry per publish call.
+    async fn run_publisher(&self, execution: Execution) -> Vec<RecordedPublish> {
+        run_recording_publisher(&self.harness, vec![(self.committee_id, execution)], |_| {
+            Ok(())
+        })
+        .await
+    }
+
+    /// The aggregator index the standard mixed decided value publishes.
+    fn expected_aggregator_index(&self) -> u64 {
+        self.harness
+            .aggregator_index(COMMITTEE_INDEX, AGGREGATE_VALIDATOR_IDX)
     }
 
     fn create_contribution(
@@ -190,19 +236,6 @@ impl AggregatorCommitteeFixture {
             .await
             .expect("contribution callback should complete within the stream timeout")
     }
-
-    async fn collect_aggregates(
-        &self,
-        aggregates: Vec<validator_store::AggregateToSign<MainnetEthSpec>>,
-    ) -> SignAggregatesResult {
-        let stream = self
-            .harness
-            .validator_store
-            .sign_aggregate_and_proofs(aggregates);
-        tokio::time::timeout(STREAM_TIMEOUT, stream.collect())
-            .await
-            .expect("aggregate callback should complete within the stream timeout")
-    }
 }
 
 // ==================== Decided value construction ====================
@@ -215,25 +248,55 @@ fn assigned(validator_index: ValidatorIndex, committee_index: u64) -> AssignedAg
     }
 }
 
-/// An aggregate attestation payload at `TEST_SLOT`. Distinct `committee_index` values produce
-/// distinct signing roots.
+/// The `AttestationData` shared by the aggregate payload builders, at `TEST_SLOT`.
+fn test_attestation_data(index: u64) -> AttestationData {
+    AttestationData {
+        slot: Slot::new(TEST_SLOT),
+        index,
+        beacon_block_root: Hash256::zero(),
+        source: Checkpoint {
+            epoch: Epoch::new(0),
+            root: Hash256::zero(),
+        },
+        target: Checkpoint {
+            epoch: Epoch::new(0),
+            root: Hash256::zero(),
+        },
+    }
+}
+
+/// An aggregate attestation payload at `TEST_SLOT`, in the pre-Electra shape. Distinct
+/// `committee_index` values produce distinct signing roots.
 fn test_aggregate_attestation(committee_index: u64) -> AttestationBase<MainnetEthSpec> {
     AttestationBase {
         aggregation_bits: ssz_types::BitList::with_capacity(128).expect("bitlist should be valid"),
-        data: AttestationData {
-            slot: Slot::new(TEST_SLOT),
-            index: committee_index,
-            beacon_block_root: Hash256::zero(),
-            source: Checkpoint {
-                epoch: Epoch::new(0),
-                root: Hash256::zero(),
-            },
-            target: Checkpoint {
-                epoch: Epoch::new(0),
-                root: Hash256::zero(),
-            },
-        },
+        data: test_attestation_data(committee_index),
         signature: AggregateSignature::infinity(),
+    }
+}
+
+/// An aggregate attestation payload at `TEST_SLOT`, in the Electra+ shape: the committee moves
+/// from `data.index` to `committee_bits`. Distinct `committee_index` values produce distinct
+/// signing roots.
+fn test_aggregate_attestation_electra(committee_index: u64) -> AttestationElectra<MainnetEthSpec> {
+    let mut committee_bits = ssz_types::BitVector::new();
+    committee_bits
+        .set(committee_index as usize, true)
+        .expect("committee bit should be in range");
+    AttestationElectra {
+        aggregation_bits: ssz_types::BitList::with_capacity(128).expect("bitlist should be valid"),
+        data: test_attestation_data(0),
+        signature: AggregateSignature::infinity(),
+        committee_bits,
+    }
+}
+
+/// SSZ payload bytes for one decided aggregate, in the shape `fork` decodes.
+fn aggregate_payload_bytes(fork: ForkName, committee_index: u64) -> Vec<u8> {
+    if fork >= ForkName::Electra {
+        test_aggregate_attestation_electra(committee_index).as_ssz_bytes()
+    } else {
+        test_aggregate_attestation(committee_index).as_ssz_bytes()
     }
 }
 
@@ -249,12 +312,24 @@ fn test_contribution(subcommittee_index: u64) -> SyncCommitteeContribution<Mainn
     }
 }
 
-/// Builds an `AggregatorCommitteeConsensusData` from decided entries.
+/// Fork the standard decided values are built at; [`build_decided_data`] uses it.
+const DEFAULT_DECIDED_FORK: ForkName = ForkName::Deneb;
+
+/// Builds an `AggregatorCommitteeConsensusData` at [`DEFAULT_DECIDED_FORK`] from decided entries.
+fn build_decided_data(
+    aggregators: &[(ValidatorIndex, u64)],
+    contributors: &[(ValidatorIndex, u64)],
+) -> AggregatorCommitteeConsensusData<MainnetEthSpec> {
+    build_decided_data_at_fork(DEFAULT_DECIDED_FORK, aggregators, contributors)
+}
+
+/// Builds an `AggregatorCommitteeConsensusData` decided at `fork` from decided entries.
 ///
 /// `aggregators` and `contributors` are `(validator_index, committee_index)` pairs; the
 /// attestation and contribution payload lists are derived from them (one payload per unique
-/// index).
-fn build_decided_data(
+/// index), with each attestation payload in the shape `fork` decodes.
+fn build_decided_data_at_fork(
+    fork: ForkName,
     aggregators: &[(ValidatorIndex, u64)],
     contributors: &[(ValidatorIndex, u64)],
 ) -> AggregatorCommitteeConsensusData<MainnetEthSpec> {
@@ -278,7 +353,7 @@ fn build_decided_data(
     let aggregated_attestations: Vec<_> = aggregate_committee_indexes
         .iter()
         .map(|&committee_index| {
-            VariableList::new(test_aggregate_attestation(committee_index).as_ssz_bytes())
+            VariableList::new(aggregate_payload_bytes(fork, committee_index))
                 .expect("attestation bytes should fit")
         })
         .collect();
@@ -292,7 +367,7 @@ fn build_decided_data(
         .collect();
 
     AggregatorCommitteeConsensusData {
-        version: DataVersion::from(ForkName::Deneb),
+        version: DataVersion::from(fork),
         aggregators: VariableList::new(aggregators).expect("aggregator list should be valid"),
         aggregator_committee_indexes: VariableList::new(aggregate_committee_indexes)
             .expect("committee indexes should be valid"),
@@ -302,6 +377,61 @@ fn build_decided_data(
         sync_committee_contributions: VariableList::new(sync_committee_contributions)
             .expect("contributions should be valid"),
     }
+}
+
+// ==================== Recording publisher ====================
+
+/// Fork and aggregator index of one publish call made by the recording closure.
+type RecordedPublish = (ForkName, u64);
+
+/// Runs the publisher over `executions` with a recording publish closure, returning one
+/// `(fork, aggregator index)` entry per publish call.
+///
+/// The recorder captures the `ForkName` each call receives, so tests can pin that it matches the
+/// decided value's `DataVersion`. `outcome` decides each call's publish result from its
+/// aggregator index, so a test can fail one aggregate's publish without depending on the order
+/// roots finish in. The returned calls are sorted by aggregator index for the same reason.
+async fn run_recording_publisher(
+    harness: &ValidatorStoreTestHarness,
+    executions: Vec<(CommitteeId, Execution)>,
+    outcome: impl Fn(u64) -> Result<(), String>,
+) -> Vec<RecordedPublish> {
+    let recorded: Arc<Mutex<Vec<RecordedPublish>>> = Arc::new(Mutex::new(Vec::new()));
+    harness
+        .validator_store
+        .publish_decided_aggregates(Slot::new(TEST_SLOT), executions, |fork_name, signed| {
+            let recorded = Arc::clone(&recorded);
+            let outcome = &outcome;
+            async move {
+                let aggregator = signed.message().aggregator_index();
+                let result = outcome(aggregator);
+                recorded.lock().push((fork_name, aggregator));
+                result
+            }
+        })
+        .await;
+
+    let mut recorded = recorded.lock().clone();
+    recorded.sort_by_key(|&(_, aggregator)| aggregator);
+    recorded
+}
+
+/// Serializes the tests that mutate and assert deltas on the `consensus_error`, `no_aggregates`,
+/// and `no_signatures` publish outcome labels, so one test's increments cannot land inside
+/// another's before/after window. `success` and `http_error` have no delta assertions, so tests
+/// touching only those labels stay unserialized.
+static PUBLISH_METRIC_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
+/// Current value of one `AGGREGATOR_COMMITTEE_PUBLISH_TOTAL` label.
+///
+/// The counters are process-global: a test asserting a delta must hold [`PUBLISH_METRIC_LOCK`],
+/// together with every test that increments the same label.
+fn publish_result_count(label: &str) -> u64 {
+    metrics::AGGREGATOR_COMMITTEE_PUBLISH_TOTAL
+        .as_ref()
+        .expect("the publish outcome metric should be created")
+        .with_label_values(&[label])
+        .get()
 }
 
 // ==================== Capture assertions ====================
@@ -398,6 +528,16 @@ async fn assert_captured_calls_settle_at(harness: &ValidatorStoreTestHarness, ex
     );
 }
 
+/// Asserts the recording publisher made exactly one publish call per expected aggregator index,
+/// all at [`DEFAULT_DECIDED_FORK`].
+fn assert_published_aggregators(published: &[RecordedPublish], expected: &[u64], context: &str) {
+    let expected: Vec<RecordedPublish> = expected
+        .iter()
+        .map(|&aggregator| (DEFAULT_DECIDED_FORK, aggregator))
+        .collect();
+    assert_eq!(published, expected.as_slice(), "{context}");
+}
+
 /// Unwraps a single-committee stream result into its signed batch.
 fn single_batch<T>(results: Vec<Result<Vec<T>, Error>>) -> Vec<T> {
     assert_eq!(results.len(), 1, "expected one committee stream item");
@@ -463,28 +603,35 @@ async fn contribution_only_callback_signs_complete_mixed_worklist() {
     );
 }
 
-/// The mirror case: an aggregate-only callback must still trigger signing of both decided
-/// contributions.
+/// The mirror case, read through the publisher: the aggregate callback returns nothing, the
+/// publisher takes the decided aggregate, and the decided contributions are signed anyway.
+///
+/// The aggregate callback no longer joins the execution at all, so this is the test that the
+/// aggregate half of the worklist is complete: only the publisher can observe it.
 #[tokio::test(flavor = "multi_thread")]
-async fn aggregate_only_callback_signs_complete_mixed_worklist() {
+async fn publisher_takes_the_decided_aggregate_while_the_callback_returns_empty() {
     // Arrange
     let fixture = AggregatorCommitteeFixture::new(MIXED_COMMITTEE_VALIDATOR_COUNT);
-    let decided = fixture.seed_mixed_decided_value();
+    let (decided, execution) = fixture.seed_mixed_decided_value_with_execution();
     let aggregates = vec![
         fixture
             .harness
             .create_aggregate(COMMITTEE_INDEX, AGGREGATE_VALIDATOR_IDX),
     ];
 
-    // Act: only the aggregate callback fires.
-    let results = fixture.collect_aggregates(aggregates).await;
+    // Act: only the aggregate callback fires, and the publisher reads the same execution.
+    let results = fixture.harness.collect_aggregates(aggregates).await;
+    let published = fixture.run_publisher(execution).await;
 
-    // Assert: the callback returns exactly its own aggregate.
-    let signed = single_batch(results);
-    assert_eq!(
-        signed.len(),
-        1,
-        "the aggregate callback should return only its requested aggregate"
+    // Assert: Lighthouse gets nothing to publish, Anchor publishes the decided aggregate itself.
+    assert!(
+        single_batch(results).is_empty(),
+        "the aggregate callback must hand Lighthouse an empty batch at Boole+"
+    );
+    assert_published_aggregators(
+        &published,
+        &[fixture.expected_aggregator_index()],
+        "the publisher should publish the decided aggregate",
     );
 
     // Both contribution roots are signed by detached tasks without a contribution callback.
@@ -552,40 +699,35 @@ async fn republished_assignments_do_not_resubmit() {
     assert_batch_identity(&calls, MIXED_WORKLIST_SIZE, decided.hash());
 }
 
-/// Both callbacks read the same execution: neither re-runs consensus nor duplicates signatures,
-/// and each returns only its own items.
+/// The contribution callback and the publisher read the same execution: neither re-runs consensus
+/// nor duplicates signatures, and each takes only its own class of decided item.
 #[tokio::test(flavor = "multi_thread")]
-async fn both_callbacks_share_one_execution() {
+async fn contribution_callback_and_publisher_share_one_execution() {
     // Arrange
     let fixture = AggregatorCommitteeFixture::new(MIXED_COMMITTEE_VALIDATOR_COUNT);
-    let decided = fixture.seed_mixed_decided_value();
+    let (decided, execution) = fixture.seed_mixed_decided_value_with_execution();
     let contributions = CONTRIBUTION_SUBCOMMITTEES
         .iter()
         .map(|&subcommittee| fixture.create_contribution(CONTRIBUTOR_VALIDATOR_IDX, subcommittee))
         .collect();
-    let aggregates = vec![
-        fixture
-            .harness
-            .create_aggregate(COMMITTEE_INDEX, AGGREGATE_VALIDATOR_IDX),
-    ];
 
-    // Act: contribution callback first, then the aggregate callback joins the cached outcome.
+    // Act: contribution callback first, then the publisher joins the cached outcome.
     let contribution_results = fixture.collect_contributions(contributions).await;
-    let aggregate_results = fixture.collect_aggregates(aggregates).await;
+    let published = fixture.run_publisher(execution).await;
 
-    // Assert: each callback returned only its own items.
+    // Assert: each reader took only its own class.
     assert_eq!(
         single_batch(contribution_results).len(),
         CONTRIBUTION_SUBCOMMITTEES.len(),
         "the contribution callback should return only its contributions"
     );
-    assert_eq!(
-        single_batch(aggregate_results).len(),
-        1,
-        "the aggregate callback should return only its aggregate"
+    assert_published_aggregators(
+        &published,
+        &[fixture.expected_aggregator_index()],
+        "the publisher should publish only the decided aggregate",
     );
 
-    // The union is signed exactly once: no duplicate captures from the second callback.
+    // The union is signed exactly once: no duplicate captures from the second reader.
     assert_captured_calls_settle_at(&fixture.harness, MIXED_WORKLIST_SIZE).await;
     let calls = committee_calls(&fixture.harness);
     assert_eq!(distinct_roots(&calls).len(), MIXED_WORKLIST_SIZE);
@@ -593,12 +735,12 @@ async fn both_callbacks_share_one_execution() {
 }
 
 /// Dropping a callback future must not cancel the execution it is reading: the complete worklist
-/// is still signed, and a later callback still gets its items from the same execution.
+/// is still signed, and a later reader still gets its items from the same execution.
 #[tokio::test(flavor = "multi_thread")]
 async fn dropped_callback_future_still_completes_worklist() {
     // Arrange
     let fixture = AggregatorCommitteeFixture::new(MIXED_COMMITTEE_VALIDATOR_COUNT);
-    let decided = fixture.seed_mixed_decided_value();
+    let (decided, execution) = fixture.seed_mixed_decided_value_with_execution();
     let contributions: Vec<_> = CONTRIBUTION_SUBCOMMITTEES
         .iter()
         .map(|&subcommittee| fixture.create_contribution(CONTRIBUTOR_VALIDATOR_IDX, subcommittee))
@@ -618,20 +760,15 @@ async fn dropped_callback_future_still_completes_worklist() {
     let calls = committee_calls(&fixture.harness);
     assert_batch_identity(&calls, MIXED_WORKLIST_SIZE, decided.hash());
 
-    // A later aggregate callback joins the finished execution and gets its aggregate.
-    let aggregates = vec![
-        fixture
-            .harness
-            .create_aggregate(COMMITTEE_INDEX, AGGREGATE_VALIDATOR_IDX),
-    ];
-    let signed = single_batch(fixture.collect_aggregates(aggregates).await);
-    assert_eq!(
-        signed.len(),
-        1,
-        "a late aggregate callback should resolve from the cached execution"
+    // A late publisher joins the finished execution and gets the decided aggregate.
+    let published = fixture.run_publisher(execution).await;
+    assert_published_aggregators(
+        &published,
+        &[fixture.expected_aggregator_index()],
+        "a late publisher should publish from the cached execution",
     );
 
-    // Still no duplicate captures after the late callback.
+    // Still no duplicate captures after the late read.
     tokio::time::sleep(SETTLE_DELAY).await;
     assert_eq!(
         fixture.harness.captured_calls.lock().len(),
@@ -802,13 +939,15 @@ async fn conflicting_aggregate_roots_sign_only_the_first() {
 // ==================== Empty and error path tests ====================
 
 /// A decided value naming only validators this operator has no metadata for produces an empty
-/// worklist: the callbacks return empty batches and no signature is ever collected.
+/// worklist: the contribution callback returns an empty batch, the publisher has nothing to
+/// publish and counts the committee under `no_aggregates`, and no signature is ever collected.
 #[tokio::test(flavor = "multi_thread")]
 async fn empty_worklist_returns_empty() {
-    // Arrange: the decided entries reference foreign validator indices, while the callbacks
-    // reference the local validator (required to pass committee grouping).
+    let _metric_guard = PUBLISH_METRIC_LOCK.lock().await;
+    // Arrange: the decided entries reference foreign validator indices, while the callback
+    // references the local validator (required to pass committee grouping).
     let fixture = AggregatorCommitteeFixture::new(SINGLE_VALIDATOR_COUNT);
-    fixture.seed_decided_value(build_decided_data(
+    let (_, execution) = fixture.seed_decided_value_with_execution(build_decided_data(
         &[(
             ValidatorIndex(FOREIGN_AGGREGATOR_INDEX),
             BEACON_COMMITTEE_INDEX,
@@ -818,60 +957,55 @@ async fn empty_worklist_returns_empty() {
             CONTRIBUTION_SUBCOMMITTEES[0],
         )],
     ));
-    let aggregates = vec![
-        fixture
-            .harness
-            .create_aggregate(COMMITTEE_INDEX, AGGREGATE_VALIDATOR_IDX),
-    ];
     let contributions =
         vec![fixture.create_contribution(SOLE_VALIDATOR_IDX, CONTRIBUTION_SUBCOMMITTEES[0])];
+    let no_aggregates_before = publish_result_count(metrics::NO_AGGREGATES);
 
     // Act
-    let aggregate_results = fixture.collect_aggregates(aggregates).await;
     let contribution_results = fixture.collect_contributions(contributions).await;
+    let published = fixture.run_publisher(execution).await;
 
-    // Assert: both callbacks yield an empty batch and nothing is signed.
-    assert!(
-        single_batch(aggregate_results).is_empty(),
-        "no locally signable decided entry means an empty aggregate batch"
-    );
+    // Assert: nothing to return, nothing to publish, nothing signed.
     assert!(
         single_batch(contribution_results).is_empty(),
         "no locally signable decided entry means an empty contribution batch"
     );
+    assert!(
+        published.is_empty(),
+        "no locally signable decided aggregate means no publish call"
+    );
+    assert_eq!(
+        publish_result_count(metrics::NO_AGGREGATES),
+        no_aggregates_before + 1,
+        "the publisher should count the aggregate-free committee under `no_aggregates`"
+    );
     assert_captured_calls_settle_at(&fixture.harness, 0).await;
 }
 
-/// Missing consensus data for the committee fails the execution; the trait layer swallows the
-/// error into an empty batch (`run_committee_signing`) and nothing is signed.
+/// Missing consensus data for the committee registers no execution: the contribution callback
+/// fails with `ConsensusDataNotFound`, the publisher gets no handle, and nothing is signed.
 #[tokio::test(flavor = "multi_thread")]
 async fn consensus_data_missing_errors() {
     // Arrange: assignments exist for the slot, but carry no consensus data for any committee,
     // so the execution fails with `ConsensusDataNotFound`. (Seeding nothing at all would park
-    // the callbacks on the assignments watch channel instead of erroring.)
+    // the callback on the assignments watch channel instead of erroring.)
     let fixture = AggregatorCommitteeFixture::new(MIXED_COMMITTEE_VALIDATOR_COUNT);
-    fixture.seed_assignments_without_consensus_data();
-    let aggregates = vec![
-        fixture
-            .harness
-            .create_aggregate(COMMITTEE_INDEX, AGGREGATE_VALIDATOR_IDX),
-    ];
+    let executions = fixture.seed_assignments_without_consensus_data();
     let contributions =
         vec![fixture.create_contribution(CONTRIBUTOR_VALIDATOR_IDX, CONTRIBUTION_SUBCOMMITTEES[0])];
 
-    // Act: both callback classes hit the same cached execution error.
-    let aggregate_results = fixture.collect_aggregates(aggregates).await;
+    // Act
     let contribution_results = fixture.collect_contributions(contributions).await;
 
     // Assert: `run_committee_signing` swallows the failure into one empty stream item per
-    // committee, and no signature collection is ever attempted.
-    assert!(
-        single_batch(aggregate_results).is_empty(),
-        "a failed execution should yield an empty aggregate batch"
-    );
+    // committee, nothing is handed to the publisher, and no signature collection is attempted.
     assert!(
         single_batch(contribution_results).is_empty(),
         "a failed execution should yield an empty contribution batch"
+    );
+    assert!(
+        executions.is_empty(),
+        "a committee with no decided value must not register a publisher handle"
     );
     assert_captured_calls_settle_at(&fixture.harness, 0).await;
 }
@@ -921,5 +1055,421 @@ async fn slot_mismatched_decided_payloads_are_excluded() {
     assert_eq!(
         calls[0].batch_size, EXPECTED_SURVIVOR_COUNT,
         "the batch size should count only surviving entries"
+    );
+}
+
+// ==================== Publisher registration tests ====================
+
+/// Registration is vacant-only, so a `(committee, slot)` yields its publisher handle exactly once.
+///
+/// The handle is what makes the publisher run, so a second handle for one slot would post the
+/// same aggregates to the beacon node twice.
+#[tokio::test(flavor = "multi_thread")]
+async fn start_aggregator_post_consensus_returns_only_vacant_insertions() {
+    // Arrange
+    let fixture = AggregatorCommitteeFixture::new(MIXED_COMMITTEE_VALIDATOR_COUNT);
+    let decided = Arc::new(fixture.mixed_decided_data());
+
+    // Act: publish the same slot's assignments twice.
+    let first = fixture.publish_decided_value(Arc::clone(&decided));
+    let second = fixture.publish_decided_value(decided);
+
+    // Assert
+    assert_eq!(
+        first.len(),
+        1,
+        "the first publish should register this committee's execution"
+    );
+    assert_eq!(first[0].0, fixture.committee_id);
+    assert!(
+        second.is_empty(),
+        "a republish must not hand out a second publisher handle"
+    );
+    assert_eq!(
+        fixture
+            .harness
+            .validator_store
+            .aggregator_post_consensus
+            .lock()
+            .len(),
+        1,
+        "the retention map should hold exactly one execution for the slot"
+    );
+}
+
+// ==================== Publisher consensus-failure tests ====================
+
+/// A failed execution publishes nothing and is counted as a consensus error rather than
+/// propagating the error.
+#[tokio::test(flavor = "multi_thread")]
+async fn publisher_counts_a_failed_execution_as_a_consensus_error() {
+    let _metric_guard = PUBLISH_METRIC_LOCK.lock().await;
+    // Arrange: an execution that resolves to an error, as a lost QBFT round would.
+    let fixture = AggregatorCommitteeFixture::new(SINGLE_VALIDATOR_COUNT);
+    let execution: Execution = async {
+        Err(Arc::new(Error::SpecificError(
+            SpecificError::PostConsensusAborted,
+        )))
+    }
+    .boxed()
+    .shared();
+    let consensus_error_before = publish_result_count(metrics::CONSENSUS_ERROR);
+
+    // Act
+    let published = fixture.run_publisher(execution).await;
+
+    // Assert
+    assert!(
+        published.is_empty(),
+        "a failed execution should publish nothing"
+    );
+    assert_eq!(
+        publish_result_count(metrics::CONSENSUS_ERROR),
+        consensus_error_before + 1,
+        "the publisher should count the failed committee under `consensus_error`"
+    );
+}
+
+/// An execution that never decides is bounded by the two-slot deadline instead of hanging, and
+/// the timeout is counted as a consensus error.
+///
+/// The harness clock is moved past that deadline first, so the bound is asserted without sleeping
+/// two real slots.
+#[tokio::test(flavor = "multi_thread")]
+async fn publisher_counts_a_consensus_error_once_the_deadline_passes() {
+    let _metric_guard = PUBLISH_METRIC_LOCK.lock().await;
+    // Arrange
+    let fixture = AggregatorCommitteeFixture::new(SINGLE_VALIDATOR_COUNT);
+    fixture
+        .harness
+        .slot_clock
+        .set_current_time(Duration::from_secs(PAST_PUBLISH_DEADLINE_SECS));
+    let execution: Execution = futures::future::pending().boxed().shared();
+    let consensus_error_before = publish_result_count(metrics::CONSENSUS_ERROR);
+
+    // Act
+    let published = tokio::time::timeout(STREAM_TIMEOUT, fixture.run_publisher(execution))
+        .await
+        .expect("the publisher must not outlive the two-slot deadline");
+
+    // Assert
+    assert!(
+        published.is_empty(),
+        "an undecided execution should publish nothing"
+    );
+    assert_eq!(
+        publish_result_count(metrics::CONSENSUS_ERROR),
+        consensus_error_before + 1,
+        "the publisher should count the timed-out committee under `consensus_error`"
+    );
+}
+
+// ==================== Publisher tests ====================
+
+/// Distinct operator sets give distinct `CommitteeId`s, so one harness can hold several committees
+/// with different decided values.
+const PUBLISHER_OPERATOR_SETS: [[OperatorId; 4]; 3] = [
+    [OperatorId(1), OperatorId(2), OperatorId(3), OperatorId(4)],
+    [OperatorId(1), OperatorId(5), OperatorId(6), OperatorId(7)],
+    [OperatorId(1), OperatorId(8), OperatorId(9), OperatorId(10)],
+];
+/// Validator index space per publisher committee, so an aggregator index identifies its committee.
+const PUBLISHER_INDEX_STRIDE: usize = 100;
+/// Committee positions in [`PublisherFixture`], named by the role they play in the tests.
+const FIRST_AGGREGATE_COMMITTEE: usize = 0;
+const CONTRIBUTIONS_ONLY_COMMITTEE: usize = 1;
+const SECOND_AGGREGATE_COMMITTEE: usize = 2;
+
+/// Several single-validator committees in one harness, for the publisher's per-committee fan-out.
+struct PublisherFixture {
+    harness: ValidatorStoreTestHarness,
+    committee_ids: Vec<CommitteeId>,
+}
+
+impl PublisherFixture {
+    fn new() -> Self {
+        let setups: Vec<_> = PUBLISHER_OPERATOR_SETS
+            .iter()
+            .enumerate()
+            .map(|(position, operator_ids)| {
+                create_committee_setup(
+                    operator_ids,
+                    SINGLE_VALIDATOR_COUNT,
+                    (position + 1) * PUBLISHER_INDEX_STRIDE,
+                )
+            })
+            .collect();
+        let committee_ids = setups
+            .iter()
+            .map(|setup| setup.cluster.committee_id())
+            .collect();
+        Self {
+            harness: ValidatorStoreTestHarness::new(setups, OUR_OPERATOR_ID),
+            committee_ids,
+        }
+    }
+
+    fn validator_index(&self, committee: usize) -> ValidatorIndex {
+        self.harness
+            .validator_metadata(committee, SOLE_VALIDATOR_IDX)
+            .index
+            .expect("test validator should have an index")
+    }
+
+    fn aggregator_index(&self, committee: usize) -> u64 {
+        self.harness.aggregator_index(committee, SOLE_VALIDATOR_IDX)
+    }
+
+    /// A decided value holding this committee's single aggregate.
+    fn aggregate_only(&self, committee: usize) -> DecidedData {
+        self.aggregate_only_at_fork(committee, DEFAULT_DECIDED_FORK)
+    }
+
+    /// [`Self::aggregate_only`] decided at `fork`, with the payload in that fork's shape.
+    fn aggregate_only_at_fork(&self, committee: usize, fork: ForkName) -> DecidedData {
+        build_decided_data_at_fork(
+            fork,
+            &[(self.validator_index(committee), BEACON_COMMITTEE_INDEX)],
+            &[],
+        )
+    }
+
+    /// A decided value holding one contribution and no aggregate, which the publisher must skip.
+    fn contributions_only(&self, committee: usize) -> DecidedData {
+        build_decided_data(
+            &[],
+            &[(
+                self.validator_index(committee),
+                CONTRIBUTION_SUBCOMMITTEES[0],
+            )],
+        )
+    }
+
+    /// Publishes one decided value per named committee at `TEST_SLOT`, returning the executions
+    /// the slot pipeline hands to the publisher.
+    fn publish(
+        &self,
+        decided_by_committee: Vec<(usize, DecidedData)>,
+    ) -> Vec<(CommitteeId, Execution)> {
+        self.harness.publish_decided_values(
+            decided_by_committee
+                .into_iter()
+                .map(|(committee, data)| (self.committee_ids[committee], Arc::new(data)))
+                .collect(),
+        )
+    }
+
+    /// [`run_recording_publisher`] over this fixture's harness.
+    async fn run_publisher(
+        &self,
+        executions: Vec<(CommitteeId, Execution)>,
+        outcome: impl Fn(u64) -> Result<(), String>,
+    ) -> Vec<RecordedPublish> {
+        run_recording_publisher(&self.harness, executions, outcome).await
+    }
+}
+
+/// Every decided aggregate is published exactly once, and a committee whose decided value holds
+/// only contributions never reaches the publish call at all.
+///
+/// Contributions stay on Lighthouse's publish path, so a publish call for the contributions-only
+/// committee would be a pointless POST.
+#[tokio::test(flavor = "multi_thread")]
+async fn publish_decided_aggregates_publishes_each_committee_with_aggregates_once() {
+    let _metric_guard = PUBLISH_METRIC_LOCK.lock().await;
+    // Arrange
+    let fixture = PublisherFixture::new();
+    let executions = fixture.publish(vec![
+        (
+            FIRST_AGGREGATE_COMMITTEE,
+            fixture.aggregate_only(FIRST_AGGREGATE_COMMITTEE),
+        ),
+        (
+            CONTRIBUTIONS_ONLY_COMMITTEE,
+            fixture.contributions_only(CONTRIBUTIONS_ONLY_COMMITTEE),
+        ),
+        (
+            SECOND_AGGREGATE_COMMITTEE,
+            fixture.aggregate_only(SECOND_AGGREGATE_COMMITTEE),
+        ),
+    ]);
+    assert_eq!(
+        executions.len(),
+        PUBLISHER_OPERATOR_SETS.len(),
+        "each committee should register one execution"
+    );
+
+    // Act
+    let published = fixture.run_publisher(executions, |_| Ok(())).await;
+
+    // Assert: one publish call per decided aggregate, carrying its committee's aggregator and
+    // the decided value's fork.
+    assert_eq!(
+        published,
+        vec![
+            (
+                DEFAULT_DECIDED_FORK,
+                fixture.aggregator_index(FIRST_AGGREGATE_COMMITTEE),
+            ),
+            (
+                DEFAULT_DECIDED_FORK,
+                fixture.aggregator_index(SECOND_AGGREGATE_COMMITTEE),
+            ),
+        ],
+        "committees with decided aggregates publish once each, and the contributions-only \
+         committee never reaches the publish call"
+    );
+}
+
+/// A publish failure is contained to its own aggregate: it neither panics nor stops the other
+/// committees' aggregates from being published.
+#[tokio::test(flavor = "multi_thread")]
+async fn publish_decided_aggregates_survives_a_failing_publish() {
+    // Arrange: all three committees decide an aggregate.
+    let fixture = PublisherFixture::new();
+    let executions = fixture.publish(
+        (0..PUBLISHER_OPERATOR_SETS.len())
+            .map(|committee| (committee, fixture.aggregate_only(committee)))
+            .collect(),
+    );
+    let failing_aggregator = fixture.aggregator_index(FIRST_AGGREGATE_COMMITTEE);
+
+    // Act: the first committee's POST fails, keyed by aggregator index so the outcome does not
+    // depend on which committee resolves first.
+    let published = fixture
+        .run_publisher(executions, |aggregator| {
+            if aggregator == failing_aggregator {
+                Err("beacon node unavailable".to_string())
+            } else {
+                Ok(())
+            }
+        })
+        .await;
+
+    // Assert: every committee's aggregate was still attempted.
+    assert_eq!(
+        published,
+        (0..PUBLISHER_OPERATOR_SETS.len())
+            .map(|committee| (DEFAULT_DECIDED_FORK, fixture.aggregator_index(committee)))
+            .collect::<Vec<_>>(),
+        "a failing publish must not withhold the other committees' aggregates"
+    );
+}
+
+/// A committee that decided an aggregate whose root never reached signature quorum publishes
+/// nothing, and the root is counted under `no_signatures`.
+///
+/// This is a third outcome, distinct from `consensus_error` (the round itself failed) and
+/// `no_aggregates` (the decided value held none): consensus succeeded and there was something to
+/// sign, but no signature came back. The publisher counts each such root under its own label, so
+/// the three cases stay separable on a dashboard instead of collapsing into one.
+#[tokio::test(flavor = "multi_thread")]
+async fn publish_decided_aggregates_skips_a_committee_whose_roots_never_reach_quorum() {
+    let _metric_guard = PUBLISH_METRIC_LOCK.lock().await;
+    // Arrange: signature collection fails before the decided value is published, so the
+    // committee's only aggregate root resolves to an error.
+    let fixture = PublisherFixture::new();
+    fixture.harness.fail_signature_collection();
+    let executions = fixture.publish(vec![(
+        FIRST_AGGREGATE_COMMITTEE,
+        fixture.aggregate_only(FIRST_AGGREGATE_COMMITTEE),
+    )]);
+    let no_signatures_before = publish_result_count(metrics::NO_SIGNATURES);
+
+    // Act
+    let published = fixture.run_publisher(executions, |_| Ok(())).await;
+
+    // Assert: the publish closure was never invoked, and the root was counted under its label.
+    assert!(
+        published.is_empty(),
+        "the publisher must not invoke the publish closure for a root without quorum"
+    );
+    assert_eq!(
+        publish_result_count(metrics::NO_SIGNATURES),
+        no_signatures_before + 1,
+        "each decided root without quorum should count once under `no_signatures`; this \
+         committee decided exactly one root"
+    );
+}
+
+/// Two decided aggregate roots in one committee where exactly one misses signature quorum: the
+/// surviving root is still published, and only the missing root is counted under
+/// `no_signatures`.
+///
+/// This per-root independence is the point of the per-root publisher: under the batch shape a
+/// committee published all-or-nothing, so one quorum miss could withhold a signed sibling.
+#[tokio::test(flavor = "multi_thread")]
+async fn publish_decided_aggregates_publishes_the_surviving_root_when_a_sibling_misses_quorum() {
+    let _metric_guard = PUBLISH_METRIC_LOCK.lock().await;
+    // Arrange: both validators aggregate distinct roots, and signature collection fails only for
+    // the second validator. The fail mode is set before seeding, since the detached worklist
+    // tasks start collecting at publish.
+    const SURVIVING_VALIDATOR_IDX: usize = 0;
+    const FAILING_VALIDATOR_IDX: usize = 1;
+    let fixture = AggregatorCommitteeFixture::new(MIXED_COMMITTEE_VALIDATOR_COUNT);
+    fixture
+        .harness
+        .fail_signature_collection_for(fixture.pubkey(FAILING_VALIDATOR_IDX));
+    let (_, execution) = fixture.seed_decided_value_with_execution(build_decided_data(
+        &[
+            (
+                fixture.validator_index(SURVIVING_VALIDATOR_IDX),
+                BEACON_COMMITTEE_INDEX,
+            ),
+            (
+                fixture.validator_index(FAILING_VALIDATOR_IDX),
+                CONFLICTING_BEACON_COMMITTEE_INDEX,
+            ),
+        ],
+        &[],
+    ));
+    let no_signatures_before = publish_result_count(metrics::NO_SIGNATURES);
+
+    // Act
+    let published = fixture.run_publisher(execution).await;
+
+    // Assert: exactly the surviving root was published, exactly the missing one was counted.
+    assert_eq!(
+        published,
+        vec![(
+            DEFAULT_DECIDED_FORK,
+            fixture
+                .harness
+                .aggregator_index(COMMITTEE_INDEX, SURVIVING_VALIDATOR_IDX),
+        )],
+        "a sibling's quorum miss must not withhold the surviving root's publish call"
+    );
+    assert_eq!(
+        publish_result_count(metrics::NO_SIGNATURES),
+        no_signatures_before + 1,
+        "only the root that missed quorum should count under `no_signatures`"
+    );
+}
+
+/// The fork handed to the publish closure is the decided value's `DataVersion` fork, not any
+/// local default: an Electra-decided value reaches the closure as `ForkName::Electra`.
+///
+/// The closure derives its publish endpoint and fork header from this argument, so binding it to
+/// the decided version is what keeps the endpoint from diverging from the payload variant.
+#[tokio::test(flavor = "multi_thread")]
+async fn publish_decided_aggregates_hands_the_decided_versions_fork_to_the_closure() {
+    // Arrange: one committee decides an Electra-versioned value with an Electra-shaped payload.
+    let fixture = PublisherFixture::new();
+    let executions = fixture.publish(vec![(
+        FIRST_AGGREGATE_COMMITTEE,
+        fixture.aggregate_only_at_fork(FIRST_AGGREGATE_COMMITTEE, ForkName::Electra),
+    )]);
+
+    // Act
+    let published = fixture.run_publisher(executions, |_| Ok(())).await;
+
+    // Assert
+    assert_eq!(
+        published,
+        vec![(
+            ForkName::Electra,
+            fixture.aggregator_index(FIRST_AGGREGATE_COMMITTEE),
+        )],
+        "the publish closure must receive the fork named by the decided value's DataVersion"
     );
 }

--- a/anchor/validator_store/src/testing/aggregator_post_consensus.rs
+++ b/anchor/validator_store/src/testing/aggregator_post_consensus.rs
@@ -6,10 +6,10 @@
 //! class must still produce the partial signatures for the other class, so the shared committee
 //! batch never stalls below its expected size.
 //!
-//! The two classes are read out differently. Contributions still go back through the Lighthouse
-//! callback, which filters the shared outcome down to its own requested items. Aggregates do not:
-//! Anchor publishes them itself from the decided value, one publish call per root, so
-//! `publish_decided_aggregates` is the reader and the aggregate callback returns nothing.
+//! Both classes are read out the same way: Anchor publishes aggregates and contributions itself
+//! from the decided value, one publish call per root, so `publish_decided_aggregates` is the
+//! only reader and both Lighthouse callbacks return nothing (see `testing/committee_aggregate.rs`
+//! and `testing/committee_contribution.rs` for the callback contract).
 //!
 //! The worklist tasks are detached, so captured `sign_and_collect` calls arrive
 //! asynchronously; assertions on capture counts poll with a deadline and then let the
@@ -22,7 +22,7 @@ use std::{
 };
 
 use bls::{AggregateSignature, FixedBytesExtended, PublicKeyBytes, Signature};
-use futures::{FutureExt, StreamExt};
+use futures::FutureExt;
 use parking_lot::Mutex;
 use signature_collector::SignatureRequester;
 use ssv_types::{
@@ -35,10 +35,8 @@ use ssz::Encode;
 use ssz_types::VariableList;
 use types::{
     AttestationBase, AttestationData, AttestationElectra, Checkpoint, Epoch, ForkName, Hash256,
-    MainnetEthSpec, SignedContributionAndProof, Slot, SyncCommitteeContribution,
-    SyncSelectionProof,
+    MainnetEthSpec, Slot, SyncCommitteeContribution,
 };
-use validator_store::{ContributionToSign, ValidatorStore};
 
 use super::common::*;
 use crate::{
@@ -49,8 +47,6 @@ use crate::{
 type DecidedData = AggregatorCommitteeConsensusData<MainnetEthSpec>;
 /// A handle on one `(committee, slot)` post-consensus execution, as handed to the publisher.
 type Execution = AggregatorPostConsensusShared<MainnetEthSpec>;
-
-type SignContributionsResult = Vec<Result<Vec<SignedContributionAndProof<MainnetEthSpec>>, Error>>;
 
 const COMMITTEE_OPERATOR_IDS: [OperatorId; 4] =
     [OperatorId(1), OperatorId(2), OperatorId(3), OperatorId(4)];
@@ -69,7 +65,6 @@ const BEACON_COMMITTEE_INDEX: u64 = 0;
 const CONFLICTING_BEACON_COMMITTEE_INDEX: u64 = 1;
 const CONTRIBUTION_SUBCOMMITTEES: [u64; 2] = [0, 1];
 const ALL_SUBCOMMITTEES: [u64; 4] = [0, 1, 2, 3];
-const MISSING_SUBCOMMITTEE_INDEX: u64 = 2;
 
 /// Decided validator indices with no local metadata, so the worklist filters them out.
 const FOREIGN_AGGREGATOR_INDEX: usize = 900;
@@ -82,6 +77,16 @@ const MIXED_WORKLIST_SIZE: usize = 1 + CONTRIBUTION_SUBCOMMITTEES.len();
 /// A clock position past the publisher's deadline for `TEST_SLOT` (one slot past that slot's end),
 /// so deadline tests reach the timeout without sleeping two real slots.
 const PAST_PUBLISH_DEADLINE_SECS: u64 = (TEST_SLOT + 3) * SLOT_DURATION_SECS;
+
+/// A clock position strictly between the two per-root deadlines for `TEST_SLOT`: past the
+/// contribution deadline (that slot's end) and before the aggregate deadline (one slot later).
+/// Tests of the per-class asymmetry sit here, where the two classes must behave differently.
+const BETWEEN_CLASS_DEADLINES_SECS: u64 =
+    (TEST_SLOT + 1) * SLOT_DURATION_SECS + SLOT_DURATION_SECS / 2;
+
+/// Long enough that a publisher which is going to finish has finished, short enough to keep the
+/// asymmetry test fast. Only used to prove a publisher is still waiting.
+const STILL_WAITING_PROBE: Duration = Duration::from_millis(500);
 
 const CAPTURE_TIMEOUT: Duration = Duration::from_secs(2);
 const CAPTURE_POLL_INTERVAL: Duration = Duration::from_millis(10);
@@ -145,8 +150,7 @@ impl AggregatorCommitteeFixture {
     }
 
     /// Seeds `AggregationAssignments` at `TEST_SLOT` without consensus data for any committee, so
-    /// no execution is registered and the callbacks fail with `ConsensusDataNotFound`. Returns the
-    /// (empty) set of executions the publish registered.
+    /// no execution is registered. Returns the (empty) set of executions the publish registered.
     fn seed_assignments_without_consensus_data(&self) -> Vec<(CommitteeId, Execution)> {
         self.harness.publish_decided_values(HashMap::new())
     }
@@ -193,9 +197,9 @@ impl AggregatorCommitteeFixture {
         (data, execution)
     }
 
-    /// Runs the publisher over this committee's execution with an always-succeeding recording
-    /// closure, returning one `(fork, aggregator index)` entry per publish call.
-    async fn run_publisher(&self, execution: Execution) -> Vec<RecordedPublish> {
+    /// Runs the publisher over this committee's execution with always-succeeding recording
+    /// closures, returning one entry per publish call of either class.
+    async fn run_publisher(&self, execution: Execution) -> RecordedPublishes {
         run_recording_publisher(&self.harness, vec![(self.committee_id, execution)], |_| {
             Ok(())
         })
@@ -206,35 +210,6 @@ impl AggregatorCommitteeFixture {
     fn expected_aggregator_index(&self) -> u64 {
         self.harness
             .aggregator_index(COMMITTEE_INDEX, AGGREGATE_VALIDATOR_IDX)
-    }
-
-    fn create_contribution(
-        &self,
-        position: usize,
-        subcommittee_index: u64,
-    ) -> ContributionToSign<MainnetEthSpec> {
-        let validator = self.validator_metadata(position);
-        ContributionToSign {
-            aggregator_index: *validator
-                .index
-                .expect("test validator should have an index") as u64,
-            aggregator_pubkey: validator.public_key,
-            contribution: test_contribution(subcommittee_index),
-            selection_proof: SyncSelectionProof::from(Signature::empty()),
-        }
-    }
-
-    async fn collect_contributions(
-        &self,
-        contributions: Vec<ContributionToSign<MainnetEthSpec>>,
-    ) -> SignContributionsResult {
-        let stream = self
-            .harness
-            .validator_store
-            .sign_sync_committee_contributions(contributions);
-        tokio::time::timeout(STREAM_TIMEOUT, stream.collect())
-            .await
-            .expect("contribution callback should complete within the stream timeout")
     }
 }
 
@@ -381,39 +356,69 @@ fn build_decided_data_at_fork(
 
 // ==================== Recording publisher ====================
 
-/// Fork and aggregator index of one publish call made by the recording closure.
+/// Fork and aggregator index of one aggregate publish call made by the recording closure.
 type RecordedPublish = (ForkName, u64);
+/// Aggregator index and subcommittee index of one contribution publish call.
+type RecordedContribution = (u64, u64);
 
-/// Runs the publisher over `executions` with a recording publish closure, returning one
-/// `(fork, aggregator index)` entry per publish call.
+/// Every publish call the recording publisher made, one entry per call, by class.
+#[derive(Debug, Default, PartialEq)]
+struct RecordedPublishes {
+    aggregates: Vec<RecordedPublish>,
+    contributions: Vec<RecordedContribution>,
+}
+
+/// Runs the publisher over `executions` with recording publish closures, returning one entry per
+/// publish call of either class.
 ///
-/// The recorder captures the `ForkName` each call receives, so tests can pin that it matches the
-/// decided value's `DataVersion`. `outcome` decides each call's publish result from its
-/// aggregator index, so a test can fail one aggregate's publish without depending on the order
-/// roots finish in. The returned calls are sorted by aggregator index for the same reason.
+/// The aggregate recorder captures the `ForkName` each call receives, so tests can pin that it
+/// matches the decided value's `DataVersion`. `outcome` decides each call's publish result from
+/// its aggregator index (for both classes), so a test can fail one root's publish without
+/// depending on the order roots finish in. The returned calls are sorted for the same reason.
 async fn run_recording_publisher(
     harness: &ValidatorStoreTestHarness,
     executions: Vec<(CommitteeId, Execution)>,
     outcome: impl Fn(u64) -> Result<(), String>,
-) -> Vec<RecordedPublish> {
-    let recorded: Arc<Mutex<Vec<RecordedPublish>>> = Arc::new(Mutex::new(Vec::new()));
+) -> RecordedPublishes {
+    let aggregates: Arc<Mutex<Vec<RecordedPublish>>> = Arc::new(Mutex::new(Vec::new()));
+    let contributions: Arc<Mutex<Vec<RecordedContribution>>> = Arc::new(Mutex::new(Vec::new()));
+    let outcome = &outcome;
     harness
         .validator_store
-        .publish_decided_aggregates(Slot::new(TEST_SLOT), executions, |fork_name, signed| {
-            let recorded = Arc::clone(&recorded);
-            let outcome = &outcome;
-            async move {
-                let aggregator = signed.message().aggregator_index();
-                let result = outcome(aggregator);
-                recorded.lock().push((fork_name, aggregator));
-                result
-            }
-        })
+        .publish_decided_aggregates(
+            Slot::new(TEST_SLOT),
+            executions,
+            |fork_name, signed| {
+                let aggregates = Arc::clone(&aggregates);
+                async move {
+                    let aggregator = signed.message().aggregator_index();
+                    let result = outcome(aggregator);
+                    aggregates.lock().push((fork_name, aggregator));
+                    result
+                }
+            },
+            |signed| {
+                let contributions = Arc::clone(&contributions);
+                async move {
+                    let aggregator = signed.message.aggregator_index;
+                    let result = outcome(aggregator);
+                    contributions
+                        .lock()
+                        .push((aggregator, signed.message.contribution.subcommittee_index));
+                    result
+                }
+            },
+        )
         .await;
 
-    let mut recorded = recorded.lock().clone();
-    recorded.sort_by_key(|&(_, aggregator)| aggregator);
-    recorded
+    let mut aggregates = aggregates.lock().clone();
+    aggregates.sort_by_key(|&(_, aggregator)| aggregator);
+    let mut contributions = contributions.lock().clone();
+    contributions.sort_unstable();
+    RecordedPublishes {
+        aggregates,
+        contributions,
+    }
 }
 
 /// Serializes the tests that mutate and assert deltas on the `consensus_error`, `no_aggregates`,
@@ -430,6 +435,16 @@ fn publish_result_count(label: &str) -> u64 {
     metrics::AGGREGATOR_COMMITTEE_PUBLISH_TOTAL
         .as_ref()
         .expect("the publish outcome metric should be created")
+        .with_label_values(&[label])
+        .get()
+}
+
+/// Current value of one `SIGNED_SYNC_COMMITTEE_CONTRIBUTIONS_TOTAL` label, under the same
+/// [`PUBLISH_METRIC_LOCK`] discipline as [`publish_result_count`].
+fn contribution_signing_count(label: &str) -> u64 {
+    validator_metrics::SIGNED_SYNC_COMMITTEE_CONTRIBUTIONS_TOTAL
+        .as_ref()
+        .expect("the contribution signing metric should be created")
         .with_label_values(&[label])
         .get()
 }
@@ -528,16 +543,6 @@ async fn assert_captured_calls_settle_at(harness: &ValidatorStoreTestHarness, ex
     );
 }
 
-/// Asserts the recording publisher made exactly one publish call per expected aggregator index,
-/// all at [`DEFAULT_DECIDED_FORK`].
-fn assert_published_aggregators(published: &[RecordedPublish], expected: &[u64], context: &str) {
-    let expected: Vec<RecordedPublish> = expected
-        .iter()
-        .map(|&aggregator| (DEFAULT_DECIDED_FORK, aggregator))
-        .collect();
-    assert_eq!(published, expected.as_slice(), "{context}");
-}
-
 /// Unwraps a single-committee stream result into its signed batch.
 fn single_batch<T>(results: Vec<Result<Vec<T>, Error>>) -> Vec<T> {
     assert_eq!(results.len(), 1, "expected one committee stream item");
@@ -550,39 +555,63 @@ fn single_batch<T>(results: Vec<Result<Vec<T>, Error>>) -> Vec<T> {
 
 // ==================== Complete-worklist tests ====================
 
-/// A contribution-only Lighthouse callback must still trigger signing of the decided
-/// aggregate: the detached execution signs the complete mixed worklist, and every root joins
-/// one three-entry committee batch keyed by the decided-value hash.
+/// The publisher takes both classes from the decided value while both Lighthouse callbacks
+/// return empty batches.
+///
+/// This pins the design the module rests on: which callbacks fire has no influence on what is
+/// signed or published. The execution signs the complete mixed worklist into one committee
+/// batch, and the publisher is the single POSTer for aggregates and contributions alike.
 #[tokio::test(flavor = "multi_thread")]
-async fn contribution_only_callback_signs_complete_mixed_worklist() {
+async fn publisher_takes_both_classes_while_the_callbacks_return_empty() {
     // Arrange
     let fixture = AggregatorCommitteeFixture::new(MIXED_COMMITTEE_VALIDATOR_COUNT);
-    let decided = fixture.seed_mixed_decided_value();
+    let (decided, execution) = fixture.seed_mixed_decided_value_with_execution();
+    let aggregates = vec![
+        fixture
+            .harness
+            .create_aggregate(COMMITTEE_INDEX, AGGREGATE_VALIDATOR_IDX),
+    ];
     let contributions = CONTRIBUTION_SUBCOMMITTEES
         .iter()
-        .map(|&subcommittee| fixture.create_contribution(CONTRIBUTOR_VALIDATOR_IDX, subcommittee))
+        .map(|&subcommittee| {
+            fixture.harness.create_contribution(
+                COMMITTEE_INDEX,
+                CONTRIBUTOR_VALIDATOR_IDX,
+                subcommittee,
+            )
+        })
         .collect();
 
-    // Act: only the contribution callback fires.
-    let results = fixture.collect_contributions(contributions).await;
+    // Act: both callbacks fire, then the publisher reads the same execution.
+    let aggregate_results = fixture.harness.collect_aggregates(aggregates).await;
+    let contribution_results = fixture.harness.collect_contributions(contributions).await;
+    let published = fixture.run_publisher(execution).await;
 
-    // Assert: the callback returns exactly its own two contributions.
-    let mut signed = single_batch(results);
-    signed.sort_by_key(|item| item.message.contribution.subcommittee_index);
-    assert_eq!(
-        signed.len(),
-        CONTRIBUTION_SUBCOMMITTEES.len(),
-        "the contribution callback should return only its requested contributions"
+    // Assert: Lighthouse gets nothing to publish on either path.
+    assert!(
+        single_batch(aggregate_results).is_empty(),
+        "the aggregate callback must hand Lighthouse an empty batch at Boole+"
     );
-    for (item, &subcommittee) in signed.iter().zip(CONTRIBUTION_SUBCOMMITTEES.iter()) {
-        assert_eq!(item.message.contribution.subcommittee_index, subcommittee);
-        assert_eq!(
-            item.message.aggregator_index,
-            *fixture.validator_index(CONTRIBUTOR_VALIDATOR_IDX) as u64
-        );
-    }
+    assert!(
+        single_batch(contribution_results).is_empty(),
+        "the contribution callback must hand Lighthouse an empty batch at Boole+"
+    );
 
-    // The aggregate root is signed by a detached task even though no aggregate callback fired.
+    // Anchor publishes the full decided worklist itself.
+    let contributor = *fixture.validator_index(CONTRIBUTOR_VALIDATOR_IDX) as u64;
+    assert_eq!(
+        published,
+        RecordedPublishes {
+            aggregates: vec![(DEFAULT_DECIDED_FORK, fixture.expected_aggregator_index())],
+            contributions: vec![
+                (contributor, CONTRIBUTION_SUBCOMMITTEES[0]),
+                (contributor, CONTRIBUTION_SUBCOMMITTEES[1]),
+            ],
+        },
+        "the publisher should publish the decided aggregate and both decided contributions"
+    );
+
+    // The worklist was signed exactly once, into one committee batch.
     assert_captured_calls_settle_at(&fixture.harness, MIXED_WORKLIST_SIZE).await;
     let calls = committee_calls(&fixture.harness);
     assert_eq!(
@@ -600,53 +629,6 @@ async fn contribution_only_callback_signs_complete_mixed_worklist() {
         calls_for_pubkey(&calls, fixture.pubkey(CONTRIBUTOR_VALIDATOR_IDX)),
         CONTRIBUTION_SUBCOMMITTEES.len(),
         "the contributor must sign one root per subcommittee"
-    );
-}
-
-/// The mirror case, read through the publisher: the aggregate callback returns nothing, the
-/// publisher takes the decided aggregate, and the decided contributions are signed anyway.
-///
-/// The aggregate callback no longer joins the execution at all, so this is the test that the
-/// aggregate half of the worklist is complete: only the publisher can observe it.
-#[tokio::test(flavor = "multi_thread")]
-async fn publisher_takes_the_decided_aggregate_while_the_callback_returns_empty() {
-    // Arrange
-    let fixture = AggregatorCommitteeFixture::new(MIXED_COMMITTEE_VALIDATOR_COUNT);
-    let (decided, execution) = fixture.seed_mixed_decided_value_with_execution();
-    let aggregates = vec![
-        fixture
-            .harness
-            .create_aggregate(COMMITTEE_INDEX, AGGREGATE_VALIDATOR_IDX),
-    ];
-
-    // Act: only the aggregate callback fires, and the publisher reads the same execution.
-    let results = fixture.harness.collect_aggregates(aggregates).await;
-    let published = fixture.run_publisher(execution).await;
-
-    // Assert: Lighthouse gets nothing to publish, Anchor publishes the decided aggregate itself.
-    assert!(
-        single_batch(results).is_empty(),
-        "the aggregate callback must hand Lighthouse an empty batch at Boole+"
-    );
-    assert_published_aggregators(
-        &published,
-        &[fixture.expected_aggregator_index()],
-        "the publisher should publish the decided aggregate",
-    );
-
-    // Both contribution roots are signed by detached tasks without a contribution callback.
-    assert_captured_calls_settle_at(&fixture.harness, MIXED_WORKLIST_SIZE).await;
-    let calls = committee_calls(&fixture.harness);
-    assert_eq!(distinct_roots(&calls).len(), MIXED_WORKLIST_SIZE);
-    assert_batch_identity(&calls, MIXED_WORKLIST_SIZE, decided.hash());
-    assert_eq!(
-        calls_for_pubkey(&calls, fixture.pubkey(AGGREGATE_VALIDATOR_IDX)),
-        1
-    );
-    assert_eq!(
-        calls_for_pubkey(&calls, fixture.pubkey(CONTRIBUTOR_VALIDATOR_IDX)),
-        CONTRIBUTION_SUBCOMMITTEES.len(),
-        "the decided contributions must be signed without a contribution callback"
     );
 }
 
@@ -699,73 +681,32 @@ async fn republished_assignments_do_not_resubmit() {
     assert_batch_identity(&calls, MIXED_WORKLIST_SIZE, decided.hash());
 }
 
-/// The contribution callback and the publisher read the same execution: neither re-runs consensus
-/// nor duplicates signatures, and each takes only its own class of decided item.
+/// A publisher that joins after the worklist has already been signed still publishes both
+/// classes from the resolved execution, without re-running consensus or duplicating signatures.
 #[tokio::test(flavor = "multi_thread")]
-async fn contribution_callback_and_publisher_share_one_execution() {
-    // Arrange
+async fn a_late_publisher_publishes_both_classes_from_the_resolved_execution() {
+    // Arrange: let the detached execution finish the complete worklist first.
     let fixture = AggregatorCommitteeFixture::new(MIXED_COMMITTEE_VALIDATOR_COUNT);
     let (decided, execution) = fixture.seed_mixed_decided_value_with_execution();
-    let contributions = CONTRIBUTION_SUBCOMMITTEES
-        .iter()
-        .map(|&subcommittee| fixture.create_contribution(CONTRIBUTOR_VALIDATOR_IDX, subcommittee))
-        .collect();
+    assert_captured_calls_settle_at(&fixture.harness, MIXED_WORKLIST_SIZE).await;
+    let calls = committee_calls(&fixture.harness);
+    assert_batch_identity(&calls, MIXED_WORKLIST_SIZE, decided.hash());
 
-    // Act: contribution callback first, then the publisher joins the cached outcome.
-    let contribution_results = fixture.collect_contributions(contributions).await;
+    // Act: the publisher joins the finished execution.
     let published = fixture.run_publisher(execution).await;
 
-    // Assert: each reader took only its own class.
+    // Assert: it publishes the full decided worklist.
+    let contributor = *fixture.validator_index(CONTRIBUTOR_VALIDATOR_IDX) as u64;
     assert_eq!(
-        single_batch(contribution_results).len(),
-        CONTRIBUTION_SUBCOMMITTEES.len(),
-        "the contribution callback should return only its contributions"
-    );
-    assert_published_aggregators(
-        &published,
-        &[fixture.expected_aggregator_index()],
-        "the publisher should publish only the decided aggregate",
-    );
-
-    // The union is signed exactly once: no duplicate captures from the second reader.
-    assert_captured_calls_settle_at(&fixture.harness, MIXED_WORKLIST_SIZE).await;
-    let calls = committee_calls(&fixture.harness);
-    assert_eq!(distinct_roots(&calls).len(), MIXED_WORKLIST_SIZE);
-    assert_batch_identity(&calls, MIXED_WORKLIST_SIZE, decided.hash());
-}
-
-/// Dropping a callback future must not cancel the execution it is reading: the complete worklist
-/// is still signed, and a later reader still gets its items from the same execution.
-#[tokio::test(flavor = "multi_thread")]
-async fn dropped_callback_future_still_completes_worklist() {
-    // Arrange
-    let fixture = AggregatorCommitteeFixture::new(MIXED_COMMITTEE_VALIDATOR_COUNT);
-    let (decided, execution) = fixture.seed_mixed_decided_value_with_execution();
-    let contributions: Vec<_> = CONTRIBUTION_SUBCOMMITTEES
-        .iter()
-        .map(|&subcommittee| fixture.create_contribution(CONTRIBUTOR_VALIDATOR_IDX, subcommittee))
-        .collect();
-
-    // Act: poll the contribution callback once, then drop it. A zero timeout polls the inner
-    // future exactly once before the deadline elapses; if the callback happens to win the race the
-    // scenario degrades to the sequential case.
-    let stream = fixture
-        .harness
-        .validator_store
-        .sign_sync_committee_contributions(contributions);
-    let _ = tokio::time::timeout(Duration::ZERO, stream.collect::<SignContributionsResult>()).await;
-
-    // Assert: the detached execution still signs the complete worklist.
-    assert_captured_calls_settle_at(&fixture.harness, MIXED_WORKLIST_SIZE).await;
-    let calls = committee_calls(&fixture.harness);
-    assert_batch_identity(&calls, MIXED_WORKLIST_SIZE, decided.hash());
-
-    // A late publisher joins the finished execution and gets the decided aggregate.
-    let published = fixture.run_publisher(execution).await;
-    assert_published_aggregators(
-        &published,
-        &[fixture.expected_aggregator_index()],
-        "a late publisher should publish from the cached execution",
+        published,
+        RecordedPublishes {
+            aggregates: vec![(DEFAULT_DECIDED_FORK, fixture.expected_aggregator_index())],
+            contributions: vec![
+                (contributor, CONTRIBUTION_SUBCOMMITTEES[0]),
+                (contributor, CONTRIBUTION_SUBCOMMITTEES[1]),
+            ],
+        },
+        "a late publisher should publish from the resolved execution"
     );
 
     // Still no duplicate captures after the late read.
@@ -777,7 +718,8 @@ async fn dropped_callback_future_still_completes_worklist() {
 }
 
 /// One validator owning an aggregate plus contributions in all four subcommittees keeps five
-/// distinct signing roots in one five-entry batch.
+/// distinct signing roots in one five-entry batch, and the publisher assembles one POST per
+/// `(validator, subcommittee)` identity.
 #[tokio::test(flavor = "multi_thread")]
 async fn multi_root_validator_keeps_distinct_roots() {
     // Arrange
@@ -788,20 +730,26 @@ async fn multi_root_validator_keeps_distinct_roots() {
         .iter()
         .map(|&subcommittee| (validator, subcommittee))
         .collect();
-    let decided = fixture.seed_decided_value(build_decided_data(
+    let (decided, execution) = fixture.seed_decided_value_with_execution(build_decided_data(
         &[(validator, BEACON_COMMITTEE_INDEX)],
         &contributors,
     ));
-    let contributions = ALL_SUBCOMMITTEES
-        .iter()
-        .map(|&subcommittee| fixture.create_contribution(SOLE_VALIDATOR_IDX, subcommittee))
-        .collect();
 
     // Act
-    let results = fixture.collect_contributions(contributions).await;
+    let published = fixture.run_publisher(execution).await;
 
-    // Assert
-    assert_eq!(single_batch(results).len(), ALL_SUBCOMMITTEES.len());
+    // Assert: one aggregate POST plus one contribution POST per subcommittee.
+    assert_eq!(
+        published,
+        RecordedPublishes {
+            aggregates: vec![(DEFAULT_DECIDED_FORK, fixture.expected_aggregator_index())],
+            contributions: ALL_SUBCOMMITTEES
+                .iter()
+                .map(|&subcommittee| (*validator as u64, subcommittee))
+                .collect(),
+        },
+        "each (validator, subcommittee) identity should publish its own contribution"
+    );
     assert_captured_calls_settle_at(&fixture.harness, EXPECTED_WORKLIST_SIZE).await;
     let calls = committee_calls(&fixture.harness);
     assert_eq!(
@@ -818,43 +766,8 @@ async fn multi_root_validator_keeps_distinct_roots() {
 
 // ==================== Divergent-view and normalization tests ====================
 
-/// A requested item absent from the decided value is skipped, while the other requested
-/// items succeed and the batch size counts only decided entries.
-#[tokio::test(flavor = "multi_thread")]
-async fn requested_item_missing_from_decided_value() {
-    // Arrange: the decided value covers subcommittees 0 and 1, but the callback also asks
-    // for subcommittee 2.
-    let fixture = AggregatorCommitteeFixture::new(MIXED_COMMITTEE_VALIDATOR_COUNT);
-    let decided = fixture.seed_mixed_decided_value();
-    let contributions = CONTRIBUTION_SUBCOMMITTEES
-        .iter()
-        .chain(std::iter::once(&MISSING_SUBCOMMITTEE_INDEX))
-        .map(|&subcommittee| fixture.create_contribution(CONTRIBUTOR_VALIDATOR_IDX, subcommittee))
-        .collect();
-
-    // Act
-    let results = fixture.collect_contributions(contributions).await;
-
-    // Assert: only the decided subcommittees come back.
-    let signed = single_batch(results);
-    let returned_subcommittees: HashSet<u64> = signed
-        .iter()
-        .map(|item| item.message.contribution.subcommittee_index)
-        .collect();
-    assert_eq!(
-        returned_subcommittees,
-        HashSet::from(CONTRIBUTION_SUBCOMMITTEES),
-        "the undecided subcommittee must be skipped, not signed"
-    );
-
-    // The batch covers the decided union only, without the missing item.
-    assert_captured_calls_settle_at(&fixture.harness, MIXED_WORKLIST_SIZE).await;
-    let calls = committee_calls(&fixture.harness);
-    assert_batch_identity(&calls, MIXED_WORKLIST_SIZE, decided.hash());
-}
-
 /// Exact duplicate decided entries collapse to one worklist entry each, so the batch size
-/// reflects the deduplicated union.
+/// reflects the deduplicated union and each identity publishes once.
 #[tokio::test(flavor = "multi_thread")]
 async fn duplicate_decided_entries_normalized() {
     // Arrange: the same aggregator entry twice and the same contributor entry twice.
@@ -862,7 +775,7 @@ async fn duplicate_decided_entries_normalized() {
     let fixture = AggregatorCommitteeFixture::new(MIXED_COMMITTEE_VALIDATOR_COUNT);
     let aggregator = fixture.validator_index(AGGREGATE_VALIDATOR_IDX);
     let contributor = fixture.validator_index(CONTRIBUTOR_VALIDATOR_IDX);
-    let decided = fixture.seed_decided_value(build_decided_data(
+    let (decided, execution) = fixture.seed_decided_value_with_execution(build_decided_data(
         &[
             (aggregator, BEACON_COMMITTEE_INDEX),
             (aggregator, BEACON_COMMITTEE_INDEX),
@@ -872,14 +785,19 @@ async fn duplicate_decided_entries_normalized() {
             (contributor, CONTRIBUTION_SUBCOMMITTEES[0]),
         ],
     ));
-    let contributions =
-        vec![fixture.create_contribution(CONTRIBUTOR_VALIDATOR_IDX, CONTRIBUTION_SUBCOMMITTEES[0])];
 
     // Act
-    let results = fixture.collect_contributions(contributions).await;
+    let published = fixture.run_publisher(execution).await;
 
     // Assert
-    assert_eq!(single_batch(results).len(), 1);
+    assert_eq!(
+        published,
+        RecordedPublishes {
+            aggregates: vec![(DEFAULT_DECIDED_FORK, fixture.expected_aggregator_index())],
+            contributions: vec![(*contributor as u64, CONTRIBUTION_SUBCOMMITTEES[0])],
+        },
+        "duplicate decided entries must publish once per identity"
+    );
     assert_captured_calls_settle_at(&fixture.harness, EXPECTED_DEDUPED_SIZE).await;
     let calls = committee_calls(&fixture.harness);
     assert_eq!(
@@ -907,15 +825,9 @@ async fn conflicting_aggregate_roots_sign_only_the_first() {
         ],
         &[(contributor, CONTRIBUTION_SUBCOMMITTEES[0])],
     ));
-    let contributions =
-        vec![fixture.create_contribution(CONTRIBUTOR_VALIDATOR_IDX, CONTRIBUTION_SUBCOMMITTEES[0])];
-
-    // Act
-    let results = fixture.collect_contributions(contributions).await;
 
     // Assert: exactly one of the conflicting aggregates is signed, the contribution is
     // unaffected, and the batch counts both.
-    assert_eq!(single_batch(results).len(), 1);
     assert_captured_calls_settle_at(&fixture.harness, EXPECTED_SIGNED_SIZE).await;
     let calls = committee_calls(&fixture.harness);
     assert_eq!(
@@ -939,13 +851,12 @@ async fn conflicting_aggregate_roots_sign_only_the_first() {
 // ==================== Empty and error path tests ====================
 
 /// A decided value naming only validators this operator has no metadata for produces an empty
-/// worklist: the contribution callback returns an empty batch, the publisher has nothing to
-/// publish and counts the committee under `no_aggregates`, and no signature is ever collected.
+/// worklist: the publisher has nothing to publish in either class, counts the committee under
+/// `no_aggregates`, and no signature is ever collected.
 #[tokio::test(flavor = "multi_thread")]
-async fn empty_worklist_returns_empty() {
+async fn empty_worklist_publishes_nothing() {
     let _metric_guard = PUBLISH_METRIC_LOCK.lock().await;
-    // Arrange: the decided entries reference foreign validator indices, while the callback
-    // references the local validator (required to pass committee grouping).
+    // Arrange: the decided entries reference foreign validator indices only.
     let fixture = AggregatorCommitteeFixture::new(SINGLE_VALIDATOR_COUNT);
     let (_, execution) = fixture.seed_decided_value_with_execution(build_decided_data(
         &[(
@@ -957,22 +868,16 @@ async fn empty_worklist_returns_empty() {
             CONTRIBUTION_SUBCOMMITTEES[0],
         )],
     ));
-    let contributions =
-        vec![fixture.create_contribution(SOLE_VALIDATOR_IDX, CONTRIBUTION_SUBCOMMITTEES[0])];
     let no_aggregates_before = publish_result_count(metrics::NO_AGGREGATES);
 
     // Act
-    let contribution_results = fixture.collect_contributions(contributions).await;
     let published = fixture.run_publisher(execution).await;
 
-    // Assert: nothing to return, nothing to publish, nothing signed.
-    assert!(
-        single_batch(contribution_results).is_empty(),
-        "no locally signable decided entry means an empty contribution batch"
-    );
-    assert!(
-        published.is_empty(),
-        "no locally signable decided aggregate means no publish call"
+    // Assert: nothing to publish in either class, nothing signed.
+    assert_eq!(
+        published,
+        RecordedPublishes::default(),
+        "no locally signable decided entry means no publish call of either class"
     );
     assert_eq!(
         publish_result_count(metrics::NO_AGGREGATES),
@@ -982,27 +887,15 @@ async fn empty_worklist_returns_empty() {
     assert_captured_calls_settle_at(&fixture.harness, 0).await;
 }
 
-/// Missing consensus data for the committee registers no execution: the contribution callback
-/// fails with `ConsensusDataNotFound`, the publisher gets no handle, and nothing is signed.
+/// Missing consensus data for the committee registers no execution: the publisher gets no
+/// handle and nothing is signed.
 #[tokio::test(flavor = "multi_thread")]
-async fn consensus_data_missing_errors() {
-    // Arrange: assignments exist for the slot, but carry no consensus data for any committee,
-    // so the execution fails with `ConsensusDataNotFound`. (Seeding nothing at all would park
-    // the callback on the assignments watch channel instead of erroring.)
+async fn consensus_data_missing_registers_no_execution() {
+    // Arrange: assignments exist for the slot, but carry no consensus data for any committee.
     let fixture = AggregatorCommitteeFixture::new(MIXED_COMMITTEE_VALIDATOR_COUNT);
     let executions = fixture.seed_assignments_without_consensus_data();
-    let contributions =
-        vec![fixture.create_contribution(CONTRIBUTOR_VALIDATOR_IDX, CONTRIBUTION_SUBCOMMITTEES[0])];
 
-    // Act
-    let contribution_results = fixture.collect_contributions(contributions).await;
-
-    // Assert: `run_committee_signing` swallows the failure into one empty stream item per
-    // committee, nothing is handed to the publisher, and no signature collection is attempted.
-    assert!(
-        single_batch(contribution_results).is_empty(),
-        "a failed execution should yield an empty contribution batch"
-    );
+    // Assert: nothing is handed to the publisher, and no signature collection is attempted.
     assert!(
         executions.is_empty(),
         "a committee with no decided value must not register a publisher handle"
@@ -1029,20 +922,20 @@ async fn slot_mismatched_decided_payloads_are_excluded() {
     for contribution in decided.sync_committee_contributions.iter_mut() {
         contribution.slot = Slot::new(TEST_SLOT + 1);
     }
-    fixture.seed_decided_value(decided);
-    let contributions = vec![
-        fixture.create_contribution(CONTRIBUTOR_VALIDATOR_IDX, CONTRIBUTION_SUBCOMMITTEES[0]),
-        fixture.create_contribution(CONTRIBUTOR_VALIDATOR_IDX, CONTRIBUTION_SUBCOMMITTEES[1]),
-    ];
+    let (_, execution) = fixture.seed_decided_value_with_execution(decided);
 
     // Act
-    let results = fixture.collect_contributions(contributions).await;
+    let published = fixture.run_publisher(execution).await;
 
-    // Assert: the requested contributions resolve to nothing (their decided payloads were
-    // excluded), while the aggregate still gets signed with a batch sized to the survivors.
-    assert!(
-        single_batch(results).is_empty(),
-        "slot-mismatched contributions should not be returned"
+    // Assert: the mismatched contributions are excluded from the worklist and never published,
+    // while the aggregate still gets signed and published with a batch sized to the survivors.
+    assert_eq!(
+        published,
+        RecordedPublishes {
+            aggregates: vec![(DEFAULT_DECIDED_FORK, fixture.expected_aggregator_index())],
+            contributions: vec![],
+        },
+        "slot-mismatched contributions should not be published"
     );
     const EXPECTED_SURVIVOR_COUNT: usize = 1;
     assert_captured_calls_settle_at(&fixture.harness, EXPECTED_SURVIVOR_COUNT).await;
@@ -1060,12 +953,13 @@ async fn slot_mismatched_decided_payloads_are_excluded() {
 
 // ==================== Publisher registration tests ====================
 
-/// Registration is vacant-only, so a `(committee, slot)` yields its publisher handle exactly once.
+/// Registration is first-insert-only, so a `(committee, slot)` yields its publisher handle
+/// exactly once.
 ///
 /// The handle is what makes the publisher run, so a second handle for one slot would post the
 /// same aggregates to the beacon node twice.
 #[tokio::test(flavor = "multi_thread")]
-async fn start_aggregator_post_consensus_returns_only_vacant_insertions() {
+async fn start_aggregator_post_consensus_returns_only_first_insertions() {
     // Arrange
     let fixture = AggregatorCommitteeFixture::new(MIXED_COMMITTEE_VALIDATOR_COUNT);
     let decided = Arc::new(fixture.mixed_decided_data());
@@ -1114,19 +1008,27 @@ async fn publisher_counts_a_failed_execution_as_a_consensus_error() {
     .boxed()
     .shared();
     let consensus_error_before = publish_result_count(metrics::CONSENSUS_ERROR);
+    let contribution_errors_before = contribution_signing_count(metrics::OTHER_ERROR);
 
     // Act
     let published = fixture.run_publisher(execution).await;
 
     // Assert
-    assert!(
-        published.is_empty(),
+    assert_eq!(
+        published,
+        RecordedPublishes::default(),
         "a failed execution should publish nothing"
     );
     assert_eq!(
         publish_result_count(metrics::CONSENSUS_ERROR),
         consensus_error_before + 1,
         "the publisher should count the failed committee under `consensus_error`"
+    );
+    assert_eq!(
+        contribution_signing_count(metrics::OTHER_ERROR),
+        contribution_errors_before + 1,
+        "a failed committee round should count once on the contribution signing counter too, \
+         keeping the only contribution failure signal non-silent"
     );
 }
 
@@ -1153,8 +1055,9 @@ async fn publisher_counts_a_consensus_error_once_the_deadline_passes() {
         .expect("the publisher must not outlive the two-slot deadline");
 
     // Assert
-    assert!(
-        published.is_empty(),
+    assert_eq!(
+        published,
+        RecordedPublishes::default(),
         "an undecided execution should publish nothing"
     );
     assert_eq!(
@@ -1234,7 +1137,7 @@ impl PublisherFixture {
         )
     }
 
-    /// A decided value holding one contribution and no aggregate, which the publisher must skip.
+    /// A decided value holding one contribution and no aggregate.
     fn contributions_only(&self, committee: usize) -> DecidedData {
         build_decided_data(
             &[],
@@ -1264,18 +1167,19 @@ impl PublisherFixture {
         &self,
         executions: Vec<(CommitteeId, Execution)>,
         outcome: impl Fn(u64) -> Result<(), String>,
-    ) -> Vec<RecordedPublish> {
+    ) -> RecordedPublishes {
         run_recording_publisher(&self.harness, executions, outcome).await
     }
 }
 
-/// Every decided aggregate is published exactly once, and a committee whose decided value holds
-/// only contributions never reaches the publish call at all.
+/// Every decided root is published exactly once, whichever class it belongs to: a
+/// contributions-only committee publishes its contribution rather than being discarded, and it
+/// is the one counted under `no_aggregates`.
 ///
-/// Contributions stay on Lighthouse's publish path, so a publish call for the contributions-only
-/// committee would be a pointless POST.
+/// The discard was the pre-#1260 behavior, when contributions still rode Lighthouse's publish
+/// path; with the Lighthouse callback inert, the publisher is the only POSTer for both classes.
 #[tokio::test(flavor = "multi_thread")]
-async fn publish_decided_aggregates_publishes_each_committee_with_aggregates_once() {
+async fn publish_decided_aggregates_publishes_each_committees_decided_worklist_once() {
     let _metric_guard = PUBLISH_METRIC_LOCK.lock().await;
     // Arrange
     let fixture = PublisherFixture::new();
@@ -1298,26 +1202,37 @@ async fn publish_decided_aggregates_publishes_each_committee_with_aggregates_onc
         PUBLISHER_OPERATOR_SETS.len(),
         "each committee should register one execution"
     );
+    let no_aggregates_before = publish_result_count(metrics::NO_AGGREGATES);
 
     // Act
     let published = fixture.run_publisher(executions, |_| Ok(())).await;
 
-    // Assert: one publish call per decided aggregate, carrying its committee's aggregator and
-    // the decided value's fork.
+    // Assert: one publish call per decided root, each aggregate carrying its committee's
+    // aggregator and the decided value's fork, the contribution carrying its identity.
     assert_eq!(
         published,
-        vec![
-            (
-                DEFAULT_DECIDED_FORK,
-                fixture.aggregator_index(FIRST_AGGREGATE_COMMITTEE),
-            ),
-            (
-                DEFAULT_DECIDED_FORK,
-                fixture.aggregator_index(SECOND_AGGREGATE_COMMITTEE),
-            ),
-        ],
-        "committees with decided aggregates publish once each, and the contributions-only \
-         committee never reaches the publish call"
+        RecordedPublishes {
+            aggregates: vec![
+                (
+                    DEFAULT_DECIDED_FORK,
+                    fixture.aggregator_index(FIRST_AGGREGATE_COMMITTEE),
+                ),
+                (
+                    DEFAULT_DECIDED_FORK,
+                    fixture.aggregator_index(SECOND_AGGREGATE_COMMITTEE),
+                ),
+            ],
+            contributions: vec![(
+                fixture.aggregator_index(CONTRIBUTIONS_ONLY_COMMITTEE),
+                CONTRIBUTION_SUBCOMMITTEES[0],
+            )],
+        },
+        "committees publish their decided roots once each, contributions included"
+    );
+    assert_eq!(
+        publish_result_count(metrics::NO_AGGREGATES),
+        no_aggregates_before + 1,
+        "the contributions-only committee should still count once under `no_aggregates`"
     );
 }
 
@@ -1348,7 +1263,7 @@ async fn publish_decided_aggregates_survives_a_failing_publish() {
 
     // Assert: every committee's aggregate was still attempted.
     assert_eq!(
-        published,
+        published.aggregates,
         (0..PUBLISHER_OPERATOR_SETS.len())
             .map(|committee| (DEFAULT_DECIDED_FORK, fixture.aggregator_index(committee)))
             .collect::<Vec<_>>(),
@@ -1380,8 +1295,9 @@ async fn publish_decided_aggregates_skips_a_committee_whose_roots_never_reach_qu
     let published = fixture.run_publisher(executions, |_| Ok(())).await;
 
     // Assert: the publish closure was never invoked, and the root was counted under its label.
-    assert!(
-        published.is_empty(),
+    assert_eq!(
+        published,
+        RecordedPublishes::default(),
         "the publisher must not invoke the publish closure for a root without quorum"
     );
     assert_eq!(
@@ -1430,7 +1346,7 @@ async fn publish_decided_aggregates_publishes_the_surviving_root_when_a_sibling_
 
     // Assert: exactly the surviving root was published, exactly the missing one was counted.
     assert_eq!(
-        published,
+        published.aggregates,
         vec![(
             DEFAULT_DECIDED_FORK,
             fixture
@@ -1465,11 +1381,130 @@ async fn publish_decided_aggregates_hands_the_decided_versions_fork_to_the_closu
 
     // Assert
     assert_eq!(
-        published,
+        published.aggregates,
         vec![(
             ForkName::Electra,
             fixture.aggregator_index(FIRST_AGGREGATE_COMMITTEE),
         )],
         "the publish closure must receive the fork named by the decided value's DataVersion"
+    );
+}
+
+/// The two classes carry different deadlines, and the difference is load-bearing: a beacon node
+/// accepts a contribution only during its own slot, while aggregates stay acceptable for about an
+/// epoch. So contributions stop waiting for quorum at slot end and aggregates keep waiting.
+///
+/// The clock sits between the two deadlines and signature collection never resolves, so the two
+/// classes must diverge: the contribution roots give up immediately and count `timeout`, while the
+/// aggregate root is still waiting when the probe expires. A refactor that collapsed both classes
+/// onto one deadline would fail this test in one direction or the other.
+#[tokio::test(flavor = "multi_thread")]
+async fn contributions_stop_at_slot_end_while_aggregates_keep_waiting() {
+    let _metric_guard = PUBLISH_METRIC_LOCK.lock().await;
+    // Arrange: a mixed decided value whose roots never reach quorum, with the clock past the
+    // contribution deadline (this slot's end) but before the aggregate deadline (a slot later).
+    let fixture = AggregatorCommitteeFixture::new(MIXED_COMMITTEE_VALIDATOR_COUNT);
+    fixture.harness.hang_signature_collection();
+    let (_, execution) = fixture.seed_mixed_decided_value_with_execution();
+    fixture
+        .harness
+        .slot_clock
+        .set_current_time(Duration::from_secs(BETWEEN_CLASS_DEADLINES_SECS));
+    let contribution_timeouts_before = contribution_signing_count(metrics::TIMEOUT);
+    let no_signatures_before = publish_result_count(metrics::NO_SIGNATURES);
+
+    // Act: the publisher cannot finish while the aggregate root is still within its deadline.
+    let outcome = tokio::time::timeout(STILL_WAITING_PROBE, fixture.run_publisher(execution)).await;
+
+    // Assert: the aggregate is still waiting past this slot's end.
+    assert!(
+        outcome.is_err(),
+        "the aggregate root must keep waiting past slot end; it stays publishable for about an \
+         epoch, so bounding it here would discard a recoverable duty"
+    );
+
+    // The contributions already gave up, counted under the class's own signing counter.
+    assert_eq!(
+        contribution_signing_count(metrics::TIMEOUT),
+        contribution_timeouts_before + CONTRIBUTION_SUBCOMMITTEES.len() as u64,
+        "each contribution root past slot end should count once under `timeout`"
+    );
+    assert_eq!(
+        publish_result_count(metrics::NO_SIGNATURES),
+        no_signatures_before,
+        "contribution outcomes must stay out of the aggregate-only publish counter"
+    );
+}
+
+/// A failing contribution POST is contained to its own root: the sibling aggregate still
+/// publishes and the drain still completes.
+///
+/// The aggregate side of this is covered by
+/// `publish_decided_aggregates_survives_a_failing_publish`; this is the contribution half, which
+/// the two-class publisher made reachable.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_failing_contribution_post_does_not_withhold_the_sibling_aggregate() {
+    // Arrange: every contribution POST fails, keyed by the contributor's aggregator index so the
+    // outcome does not depend on which root resolves first.
+    let fixture = AggregatorCommitteeFixture::new(MIXED_COMMITTEE_VALIDATOR_COUNT);
+    let (_, execution) = fixture.seed_mixed_decided_value_with_execution();
+    let failing_contributor = *fixture.validator_index(CONTRIBUTOR_VALIDATOR_IDX) as u64;
+
+    // Act
+    let published = run_recording_publisher(
+        &fixture.harness,
+        vec![(fixture.committee_id, execution)],
+        |aggregator| {
+            if aggregator == failing_contributor {
+                Err("beacon node rejected the contribution".to_string())
+            } else {
+                Ok(())
+            }
+        },
+    )
+    .await;
+
+    // Assert: both contributions were still attempted, and the aggregate published regardless.
+    assert_eq!(
+        published,
+        RecordedPublishes {
+            aggregates: vec![(DEFAULT_DECIDED_FORK, fixture.expected_aggregator_index())],
+            contributions: vec![
+                (failing_contributor, CONTRIBUTION_SUBCOMMITTEES[0]),
+                (failing_contributor, CONTRIBUTION_SUBCOMMITTEES[1]),
+            ],
+        },
+        "a failing contribution POST must not withhold its sibling aggregate or its own sibling \
+         contribution"
+    );
+}
+
+/// Cross-class independence inside one committee: a contribution root that misses signature
+/// quorum withholds only itself, and the sibling aggregate is still published.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_contributions_quorum_miss_does_not_withhold_the_sibling_aggregate() {
+    // Serialized: the failing contribution roots increment the contribution signing counter's
+    // `other_error` label, which the failed-execution test asserts a delta on.
+    let _metric_guard = PUBLISH_METRIC_LOCK.lock().await;
+    // Arrange: a mixed decided value where only the contributor's signature collection fails.
+    // The fail mode is set before seeding, since the detached worklist tasks start collecting at
+    // publish.
+    let fixture = AggregatorCommitteeFixture::new(MIXED_COMMITTEE_VALIDATOR_COUNT);
+    fixture
+        .harness
+        .fail_signature_collection_for(fixture.pubkey(CONTRIBUTOR_VALIDATOR_IDX));
+    let (_, execution) = fixture.seed_mixed_decided_value_with_execution();
+
+    // Act
+    let published = fixture.run_publisher(execution).await;
+
+    // Assert: the aggregate publishes, the failed contributions publish nothing.
+    assert_eq!(
+        published,
+        RecordedPublishes {
+            aggregates: vec![(DEFAULT_DECIDED_FORK, fixture.expected_aggregator_index())],
+            contributions: vec![],
+        },
+        "a contribution quorum miss must not withhold the sibling aggregate's publish call"
     );
 }

--- a/anchor/validator_store/src/testing/committee_aggregate.rs
+++ b/anchor/validator_store/src/testing/committee_aggregate.rs
@@ -14,11 +14,6 @@ use ssv_types::{OperatorId, msgid::Role};
 
 use super::common::*;
 
-const PRIMARY_COMMITTEE_OPERATOR_IDS: [OperatorId; 4] =
-    [OperatorId(1), OperatorId(2), OperatorId(3), OperatorId(4)];
-const SECONDARY_COMMITTEE_OPERATOR_IDS: [OperatorId; 4] =
-    [OperatorId(1), OperatorId(5), OperatorId(6), OperatorId(7)];
-
 const OUR_OPERATOR_ID: OperatorId = OperatorId(1);
 const PRIMARY_COMMITTEE_INDEX: usize = 0;
 const SECONDARY_COMMITTEE_INDEX: usize = 1;
@@ -27,26 +22,6 @@ const SECOND_VALIDATOR_INDEX: usize = 1;
 
 const PRIMARY_COMMITTEE_VALIDATOR_COUNT: usize = 2;
 const SINGLE_VALIDATOR_COUNT: usize = 1;
-const PRIMARY_COMMITTEE_STARTING_VALIDATOR_INDEX: usize = 0;
-const SECONDARY_COMMITTEE_STARTING_VALIDATOR_INDEX: usize = 100;
-
-/// Asserts the stream yielded exactly one item and that item is an empty batch.
-///
-/// The empty batch is the Boole+ contract: Lighthouse's publish loop drops an empty result
-/// silently, which is what keeps Anchor the single publisher of committee aggregates.
-fn assert_single_empty_batch(results: SignAggregatesResult) {
-    assert_eq!(results.len(), 1, "expected exactly one stream item");
-    let batch = results
-        .into_iter()
-        .next()
-        .expect("stream item should exist")
-        .expect("the aggregate callback should not fail");
-    assert!(
-        batch.is_empty(),
-        "Lighthouse must receive nothing to publish at Boole+; the metadata service publishes \
-         committee aggregates from the decided value"
-    );
-}
 
 // ==================== Boole+ tests ====================
 
@@ -62,7 +37,7 @@ async fn sign_aggregate_and_proofs_empty_input_yields_one_empty_batch() {
     let results = harness.collect_aggregates(vec![]).await;
 
     // Assert
-    assert_single_empty_batch(results);
+    assert_single_empty_batch(results, "aggregates");
 }
 
 /// Boole+ yields one empty batch however many committees the request spans, without waiting on
@@ -91,7 +66,7 @@ async fn sign_aggregate_and_proofs_boole_yields_one_empty_batch_for_all_committe
     let results = harness.collect_aggregates(aggregates).await;
 
     // Assert
-    assert_single_empty_batch(results);
+    assert_single_empty_batch(results, "aggregates");
     assert!(
         harness.captured_calls.lock().is_empty(),
         "the callback must not collect signatures; signing belongs to the post-consensus execution"
@@ -150,20 +125,4 @@ async fn sign_aggregate_and_proofs_pre_boole_signs_each_validator() {
             "pre-Boole aggregates are collected per validator, not as a committee batch"
         );
     }
-}
-
-fn create_primary_committee_setup(num_validators: usize) -> CommitteeSetup {
-    create_committee_setup(
-        &PRIMARY_COMMITTEE_OPERATOR_IDS,
-        num_validators,
-        PRIMARY_COMMITTEE_STARTING_VALIDATOR_INDEX,
-    )
-}
-
-fn create_secondary_committee_setup(num_validators: usize) -> CommitteeSetup {
-    create_committee_setup(
-        &SECONDARY_COMMITTEE_OPERATOR_IDS,
-        num_validators,
-        SECONDARY_COMMITTEE_STARTING_VALIDATOR_INDEX,
-    )
 }

--- a/anchor/validator_store/src/testing/committee_aggregate.rs
+++ b/anchor/validator_store/src/testing/committee_aggregate.rs
@@ -1,21 +1,18 @@
-//! Integration tests for committee aggregate signing in `sign_aggregate_and_proofs()`.
-use std::time::Duration;
+//! Integration tests for `sign_aggregate_and_proofs()`.
+//!
+//! At Boole+ this Lighthouse callback is deliberately inert: Anchor is the authoritative publisher
+//! of committee aggregates, signing and posting the decided worklist itself (see
+//! [`crate::aggregator_post_consensus`]). Anything the callback returned would be published a
+//! second time by Lighthouse, so it hands back an empty batch. Pre-Boole is unchanged: the callback
+//! still signs per validator and Lighthouse still publishes the result.
 
-use futures::StreamExt;
+use std::collections::HashSet;
+
+use fork::Fork;
 use signature_collector::SignatureRequester;
-use ssv_types::OperatorId;
-use types::{MainnetEthSpec, SignedAggregateAndProof};
-use validator_store::ValidatorStore;
+use ssv_types::{OperatorId, msgid::Role};
 
 use super::common::*;
-use crate::Error;
-
-type SignAggregatesResult = Vec<Result<Vec<SignedAggregateAndProof<MainnetEthSpec>>, Error>>;
-
-const PRIMARY_COMMITTEE_OPERATOR_IDS: [OperatorId; 4] =
-    [OperatorId(1), OperatorId(2), OperatorId(3), OperatorId(4)];
-const SECONDARY_COMMITTEE_OPERATOR_IDS: [OperatorId; 4] =
-    [OperatorId(1), OperatorId(5), OperatorId(6), OperatorId(7)];
 
 const OUR_OPERATOR_ID: OperatorId = OperatorId(1);
 const PRIMARY_COMMITTEE_INDEX: usize = 0;
@@ -25,36 +22,33 @@ const SECOND_VALIDATOR_INDEX: usize = 1;
 
 const PRIMARY_COMMITTEE_VALIDATOR_COUNT: usize = 2;
 const SINGLE_VALIDATOR_COUNT: usize = 1;
-const PRIMARY_COMMITTEE_STARTING_VALIDATOR_INDEX: usize = 0;
-const SECONDARY_COMMITTEE_STARTING_VALIDATOR_INDEX: usize = 100;
 
-const NEXT_SLOT: u64 = TEST_SLOT + 1;
-const STREAM_ITEM_TIMEOUT: Duration = Duration::from_secs(5);
-const BLOCKED_STREAM_TIMEOUT: Duration = Duration::from_millis(500);
+// ==================== Boole+ tests ====================
 
-/// `sign_aggregate_and_proofs` with empty input yields zero stream items.
+/// Empty input yields the same single empty batch as any other Boole+ call: there is no fork to
+/// determine and nothing to publish either way.
 #[tokio::test(flavor = "multi_thread")]
-async fn sign_aggregate_and_proofs_empty_input() {
+async fn sign_aggregate_and_proofs_empty_input_yields_one_empty_batch() {
+    // Arrange
     let committee = create_primary_committee_setup(SINGLE_VALIDATOR_COUNT);
     let harness = ValidatorStoreTestHarness::new(vec![committee], OUR_OPERATOR_ID);
 
-    let results: SignAggregatesResult = harness
-        .validator_store
-        .sign_aggregate_and_proofs(vec![])
-        .collect()
-        .await;
+    // Act
+    let results = harness.collect_aggregates(vec![]).await;
 
-    assert!(
-        results.is_empty(),
-        "empty input should yield zero stream items"
-    );
+    // Assert
+    assert_single_empty_batch(results, "aggregates");
 }
 
-/// `sign_aggregate_and_proofs` groups aggregates by `CommitteeId`, runs consensus once per
-/// committee, collects one signature per validator, and streams one batch per committee.
+/// Boole+ yields one empty batch however many committees the request spans, without waiting on
+/// `AggregationAssignments` and without collecting any signature of its own.
+///
+/// The single item is the stream's completion signal, not a per-committee result: the callback no
+/// longer groups by committee, because it no longer produces anything Lighthouse could publish. It
+/// also no longer parks on the assignments watch channel, which is why nothing is seeded here.
 #[tokio::test(flavor = "multi_thread")]
-async fn sign_aggregate_and_proofs_produces_one_stream_item_per_committee() {
-    // Arrange
+async fn sign_aggregate_and_proofs_boole_yields_one_empty_batch_for_all_committees() {
+    // Arrange: two distinct committees, no assignments published for the slot at all.
     let committee_a = create_primary_committee_setup(PRIMARY_COMMITTEE_VALIDATOR_COUNT);
     let committee_b = create_secondary_committee_setup(SINGLE_VALIDATOR_COUNT);
     assert_ne!(
@@ -62,12 +56,6 @@ async fn sign_aggregate_and_proofs_produces_one_stream_item_per_committee() {
         committee_b.cluster.committee_id(),
     );
     let harness = ValidatorStoreTestHarness::new(vec![committee_a, committee_b], OUR_OPERATOR_ID);
-    // Seed aggregate assignments for both committees at TEST_SLOT so both committee batches can
-    // resolve their decided aggregate data.
-    harness.seed_aggregation_assignments_for_slot(
-        TEST_SLOT,
-        &[PRIMARY_COMMITTEE_INDEX, SECONDARY_COMMITTEE_INDEX],
-    );
     let aggregates = vec![
         harness.create_aggregate(PRIMARY_COMMITTEE_INDEX, FIRST_VALIDATOR_INDEX),
         harness.create_aggregate(PRIMARY_COMMITTEE_INDEX, SECOND_VALIDATOR_INDEX),
@@ -75,124 +63,66 @@ async fn sign_aggregate_and_proofs_produces_one_stream_item_per_committee() {
     ];
 
     // Act
-    let results: SignAggregatesResult = harness
-        .validator_store
-        .sign_aggregate_and_proofs(aggregates)
-        .collect()
-        .await;
+    let results = harness.collect_aggregates(aggregates).await;
 
     // Assert
-    assert_eq!(results.len(), 2, "expected one stream item per committee");
-    let all_signed: Vec<Vec<SignedAggregateAndProof<MainnetEthSpec>>> = results
-        .into_iter()
-        .map(|r| r.expect("each committee batch should succeed"))
-        .collect();
-    let total: usize = all_signed.iter().map(|batch| batch.len()).sum();
-    let expected_total = PRIMARY_COMMITTEE_VALIDATOR_COUNT + SINGLE_VALIDATOR_COUNT;
-    assert_eq!(
-        total, expected_total,
-        "expected {expected_total} total signed aggregates"
-    );
-
-    // We make one `sign_and_collect` call per validator.
-    // The committee requester stores the local batch size for that validator's committee:
-    // committee A has 2 validators, so it produces 2 calls, each with batch size 2;
-    // committee B has 1 validator, so it produces 1 call with batch size 1.
-    let captured = harness.captured_calls.lock();
-    assert_eq!(
-        captured.len(),
-        expected_total,
-        "expected {expected_total} sign_and_collect calls"
-    );
-    let batch_sizes: Vec<_> = captured
-        .iter()
-        .map(|call| match &call.requester {
-            SignatureRequester::Committee {
-                validator_partial_signature_batch_size,
-                ..
-            } => *validator_partial_signature_batch_size,
-            other => panic!("expected SignatureRequester::Committee, got: {other:?}"),
-        })
-        .collect();
-
-    let calls_with_batch_size = |batch_size: usize| {
-        batch_sizes
-            .iter()
-            .filter(|&&size| size == batch_size)
-            .count()
-    };
-    assert_eq!(
-        calls_with_batch_size(PRIMARY_COMMITTEE_VALIDATOR_COUNT),
-        PRIMARY_COMMITTEE_VALIDATOR_COUNT,
-        "committee A should make one call per validator, and each call should have batch size {}",
-        PRIMARY_COMMITTEE_VALIDATOR_COUNT,
-    );
-    assert_eq!(
-        calls_with_batch_size(SINGLE_VALIDATOR_COUNT),
-        SINGLE_VALIDATOR_COUNT,
-        "committee B should make one call for its only validator, and that call should have batch size {}",
-        SINGLE_VALIDATOR_COUNT,
+    assert_single_empty_batch(results, "aggregates");
+    assert!(
+        harness.captured_calls.lock().is_empty(),
+        "the callback must not collect signatures; signing belongs to the post-consensus execution"
     );
 }
 
-/// One committee blocked on missing `AggregationAssignments` must not stop another committee from
-/// producing its aggregate batch. This verifies that committee futures stay isolated.
-#[tokio::test(flavor = "current_thread", start_paused = true)]
-async fn sign_aggregate_and_proofs_failure_isolation() {
+// ==================== Pre-Boole tests ====================
+
+/// Pre-Boole the callback still signs one aggregate per validator and returns them for Lighthouse
+/// to publish. The empty-batch contract is Boole+ only.
+#[tokio::test(flavor = "multi_thread")]
+async fn sign_aggregate_and_proofs_pre_boole_signs_each_validator() {
     // Arrange
-    let committee_a = create_primary_committee_setup(SINGLE_VALIDATOR_COUNT);
-    let committee_b = create_secondary_committee_setup(SINGLE_VALIDATOR_COUNT);
-    let harness = ValidatorStoreTestHarness::new(vec![committee_a, committee_b], OUR_OPERATOR_ID);
-    // Only the primary committee gets aggregate assignments for TEST_SLOT.
-    harness.seed_aggregation_assignments_for_slot(TEST_SLOT, &[PRIMARY_COMMITTEE_INDEX]);
+    let committee = create_primary_committee_setup(PRIMARY_COMMITTEE_VALIDATOR_COUNT);
+    let harness =
+        ValidatorStoreTestHarness::new_with_fork(vec![committee], OUR_OPERATOR_ID, Fork::Alan);
     let aggregates = vec![
-        // Committee A uses TEST_SLOT and should complete.
         harness.create_aggregate(PRIMARY_COMMITTEE_INDEX, FIRST_VALIDATOR_INDEX),
-        // Committee B uses NEXT_SLOT, where no aggregate assignments were seeded, so it should
-        // stay blocked in the aggregate-assignment lookup.
-        harness.create_aggregate_at_slot(
-            SECONDARY_COMMITTEE_INDEX,
-            FIRST_VALIDATOR_INDEX,
-            NEXT_SLOT,
-        ),
+        harness.create_aggregate(PRIMARY_COMMITTEE_INDEX, SECOND_VALIDATOR_INDEX),
     ];
 
     // Act
-    let stream = harness
-        .validator_store
-        .sign_aggregate_and_proofs(aggregates);
-    tokio::pin!(stream);
-    let first = tokio::time::timeout(STREAM_ITEM_TIMEOUT, stream.next()).await;
-    let second = tokio::time::timeout(BLOCKED_STREAM_TIMEOUT, stream.next()).await;
+    let results = harness.collect_aggregates(aggregates).await;
 
-    // Assert
-    let first_item = first
-        .expect("first committee should complete within timeout")
-        .expect("stream should yield an item");
-    let signed = first_item.expect("first committee should succeed");
+    // Assert: one batch holding both validators' signed aggregates.
+    assert_eq!(results.len(), 1, "the pre-Boole path yields one batch");
+    let signed = results
+        .into_iter()
+        .next()
+        .expect("stream item should exist")
+        .expect("pre-Boole signing should succeed");
+    let signed_aggregators: HashSet<u64> = signed
+        .iter()
+        .map(|signed| signed.message().aggregator_index())
+        .collect();
+    let expected_aggregators: HashSet<u64> = [FIRST_VALIDATOR_INDEX, SECOND_VALIDATOR_INDEX]
+        .iter()
+        .map(|&position| harness.aggregator_index(PRIMARY_COMMITTEE_INDEX, position))
+        .collect();
     assert_eq!(
-        signed.len(),
-        1,
-        "successful committee should produce one signed item"
+        signed_aggregators, expected_aggregators,
+        "every requested validator should get a signed aggregate back"
     );
-    assert!(
-        second.is_err(),
-        "stuck committee should not produce a result"
+
+    // Signature collection is per validator, not batched into one committee message.
+    let captured = harness.captured_calls.lock();
+    assert_eq!(
+        captured.len(),
+        PRIMARY_COMMITTEE_VALIDATOR_COUNT,
+        "expected one sign_and_collect call per validator"
     );
-}
-
-fn create_primary_committee_setup(num_validators: usize) -> CommitteeSetup {
-    create_committee_setup(
-        &PRIMARY_COMMITTEE_OPERATOR_IDS,
-        num_validators,
-        PRIMARY_COMMITTEE_STARTING_VALIDATOR_INDEX,
-    )
-}
-
-fn create_secondary_committee_setup(num_validators: usize) -> CommitteeSetup {
-    create_committee_setup(
-        &SECONDARY_COMMITTEE_OPERATOR_IDS,
-        num_validators,
-        SECONDARY_COMMITTEE_STARTING_VALIDATOR_INDEX,
-    )
+    for call in captured.iter() {
+        assert_eq!(call.metadata.role, Role::Aggregator);
+        assert!(
+            matches!(call.requester, SignatureRequester::SingleValidator { .. }),
+            "pre-Boole aggregates are collected per validator, not as a committee batch"
+        );
+    }
 }

--- a/anchor/validator_store/src/testing/committee_aggregate.rs
+++ b/anchor/validator_store/src/testing/committee_aggregate.rs
@@ -1,16 +1,18 @@
-//! Integration tests for committee aggregate signing in `sign_aggregate_and_proofs()`.
-use std::time::Duration;
+//! Integration tests for `sign_aggregate_and_proofs()`.
+//!
+//! At Boole+ this Lighthouse callback is deliberately inert: Anchor is the authoritative publisher
+//! of committee aggregates, signing and posting the decided worklist itself (see
+//! [`crate::aggregator_post_consensus`]). Anything the callback returned would be published a
+//! second time by Lighthouse, so it hands back an empty batch. Pre-Boole is unchanged: the callback
+//! still signs per validator and Lighthouse still publishes the result.
 
-use futures::StreamExt;
+use std::collections::HashSet;
+
+use fork::Fork;
 use signature_collector::SignatureRequester;
-use ssv_types::OperatorId;
-use types::{MainnetEthSpec, SignedAggregateAndProof};
-use validator_store::ValidatorStore;
+use ssv_types::{OperatorId, msgid::Role};
 
 use super::common::*;
-use crate::Error;
-
-type SignAggregatesResult = Vec<Result<Vec<SignedAggregateAndProof<MainnetEthSpec>>, Error>>;
 
 const PRIMARY_COMMITTEE_OPERATOR_IDS: [OperatorId; 4] =
     [OperatorId(1), OperatorId(2), OperatorId(3), OperatorId(4)];
@@ -28,33 +30,50 @@ const SINGLE_VALIDATOR_COUNT: usize = 1;
 const PRIMARY_COMMITTEE_STARTING_VALIDATOR_INDEX: usize = 0;
 const SECONDARY_COMMITTEE_STARTING_VALIDATOR_INDEX: usize = 100;
 
-const NEXT_SLOT: u64 = TEST_SLOT + 1;
-const STREAM_ITEM_TIMEOUT: Duration = Duration::from_secs(5);
-const BLOCKED_STREAM_TIMEOUT: Duration = Duration::from_millis(500);
-
-/// `sign_aggregate_and_proofs` with empty input yields zero stream items.
-#[tokio::test(flavor = "multi_thread")]
-async fn sign_aggregate_and_proofs_empty_input() {
-    let committee = create_primary_committee_setup(SINGLE_VALIDATOR_COUNT);
-    let harness = ValidatorStoreTestHarness::new(vec![committee], OUR_OPERATOR_ID);
-
-    let results: SignAggregatesResult = harness
-        .validator_store
-        .sign_aggregate_and_proofs(vec![])
-        .collect()
-        .await;
-
+/// Asserts the stream yielded exactly one item and that item is an empty batch.
+///
+/// The empty batch is the Boole+ contract: Lighthouse's publish loop drops an empty result
+/// silently, which is what keeps Anchor the single publisher of committee aggregates.
+fn assert_single_empty_batch(results: SignAggregatesResult) {
+    assert_eq!(results.len(), 1, "expected exactly one stream item");
+    let batch = results
+        .into_iter()
+        .next()
+        .expect("stream item should exist")
+        .expect("the aggregate callback should not fail");
     assert!(
-        results.is_empty(),
-        "empty input should yield zero stream items"
+        batch.is_empty(),
+        "Lighthouse must receive nothing to publish at Boole+; the metadata service publishes \
+         committee aggregates from the decided value"
     );
 }
 
-/// `sign_aggregate_and_proofs` groups aggregates by `CommitteeId`, runs consensus once per
-/// committee, collects one signature per validator, and streams one batch per committee.
+// ==================== Boole+ tests ====================
+
+/// Empty input yields the same single empty batch as any other Boole+ call: there is no fork to
+/// determine and nothing to publish either way.
 #[tokio::test(flavor = "multi_thread")]
-async fn sign_aggregate_and_proofs_produces_one_stream_item_per_committee() {
+async fn sign_aggregate_and_proofs_empty_input_yields_one_empty_batch() {
     // Arrange
+    let committee = create_primary_committee_setup(SINGLE_VALIDATOR_COUNT);
+    let harness = ValidatorStoreTestHarness::new(vec![committee], OUR_OPERATOR_ID);
+
+    // Act
+    let results = harness.collect_aggregates(vec![]).await;
+
+    // Assert
+    assert_single_empty_batch(results);
+}
+
+/// Boole+ yields one empty batch however many committees the request spans, without waiting on
+/// `AggregationAssignments` and without collecting any signature of its own.
+///
+/// The single item is the stream's completion signal, not a per-committee result: the callback no
+/// longer groups by committee, because it no longer produces anything Lighthouse could publish. It
+/// also no longer parks on the assignments watch channel, which is why nothing is seeded here.
+#[tokio::test(flavor = "multi_thread")]
+async fn sign_aggregate_and_proofs_boole_yields_one_empty_batch_for_all_committees() {
+    // Arrange: two distinct committees, no assignments published for the slot at all.
     let committee_a = create_primary_committee_setup(PRIMARY_COMMITTEE_VALIDATOR_COUNT);
     let committee_b = create_secondary_committee_setup(SINGLE_VALIDATOR_COUNT);
     assert_ne!(
@@ -62,12 +81,6 @@ async fn sign_aggregate_and_proofs_produces_one_stream_item_per_committee() {
         committee_b.cluster.committee_id(),
     );
     let harness = ValidatorStoreTestHarness::new(vec![committee_a, committee_b], OUR_OPERATOR_ID);
-    // Seed aggregate assignments for both committees at TEST_SLOT so both committee batches can
-    // resolve their decided aggregate data.
-    harness.seed_aggregation_assignments_for_slot(
-        TEST_SLOT,
-        &[PRIMARY_COMMITTEE_INDEX, SECONDARY_COMMITTEE_INDEX],
-    );
     let aggregates = vec![
         harness.create_aggregate(PRIMARY_COMMITTEE_INDEX, FIRST_VALIDATOR_INDEX),
         harness.create_aggregate(PRIMARY_COMMITTEE_INDEX, SECOND_VALIDATOR_INDEX),
@@ -75,110 +88,68 @@ async fn sign_aggregate_and_proofs_produces_one_stream_item_per_committee() {
     ];
 
     // Act
-    let results: SignAggregatesResult = harness
-        .validator_store
-        .sign_aggregate_and_proofs(aggregates)
-        .collect()
-        .await;
+    let results = harness.collect_aggregates(aggregates).await;
 
     // Assert
-    assert_eq!(results.len(), 2, "expected one stream item per committee");
-    let all_signed: Vec<Vec<SignedAggregateAndProof<MainnetEthSpec>>> = results
-        .into_iter()
-        .map(|r| r.expect("each committee batch should succeed"))
-        .collect();
-    let total: usize = all_signed.iter().map(|batch| batch.len()).sum();
-    let expected_total = PRIMARY_COMMITTEE_VALIDATOR_COUNT + SINGLE_VALIDATOR_COUNT;
-    assert_eq!(
-        total, expected_total,
-        "expected {expected_total} total signed aggregates"
-    );
-
-    // We make one `sign_and_collect` call per validator.
-    // The committee requester stores the local batch size for that validator's committee:
-    // committee A has 2 validators, so it produces 2 calls, each with batch size 2;
-    // committee B has 1 validator, so it produces 1 call with batch size 1.
-    let captured = harness.captured_calls.lock();
-    assert_eq!(
-        captured.len(),
-        expected_total,
-        "expected {expected_total} sign_and_collect calls"
-    );
-    let batch_sizes: Vec<_> = captured
-        .iter()
-        .map(|call| match &call.requester {
-            SignatureRequester::Committee {
-                validator_partial_signature_batch_size,
-                ..
-            } => *validator_partial_signature_batch_size,
-            other => panic!("expected SignatureRequester::Committee, got: {other:?}"),
-        })
-        .collect();
-
-    let calls_with_batch_size = |batch_size: usize| {
-        batch_sizes
-            .iter()
-            .filter(|&&size| size == batch_size)
-            .count()
-    };
-    assert_eq!(
-        calls_with_batch_size(PRIMARY_COMMITTEE_VALIDATOR_COUNT),
-        PRIMARY_COMMITTEE_VALIDATOR_COUNT,
-        "committee A should make one call per validator, and each call should have batch size {}",
-        PRIMARY_COMMITTEE_VALIDATOR_COUNT,
-    );
-    assert_eq!(
-        calls_with_batch_size(SINGLE_VALIDATOR_COUNT),
-        SINGLE_VALIDATOR_COUNT,
-        "committee B should make one call for its only validator, and that call should have batch size {}",
-        SINGLE_VALIDATOR_COUNT,
+    assert_single_empty_batch(results);
+    assert!(
+        harness.captured_calls.lock().is_empty(),
+        "the callback must not collect signatures; signing belongs to the post-consensus execution"
     );
 }
 
-/// One committee blocked on missing `AggregationAssignments` must not stop another committee from
-/// producing its aggregate batch. This verifies that committee futures stay isolated.
-#[tokio::test(flavor = "current_thread", start_paused = true)]
-async fn sign_aggregate_and_proofs_failure_isolation() {
+// ==================== Pre-Boole tests ====================
+
+/// Pre-Boole the callback still signs one aggregate per validator and returns them for Lighthouse
+/// to publish. The empty-batch contract is Boole+ only.
+#[tokio::test(flavor = "multi_thread")]
+async fn sign_aggregate_and_proofs_pre_boole_signs_each_validator() {
     // Arrange
-    let committee_a = create_primary_committee_setup(SINGLE_VALIDATOR_COUNT);
-    let committee_b = create_secondary_committee_setup(SINGLE_VALIDATOR_COUNT);
-    let harness = ValidatorStoreTestHarness::new(vec![committee_a, committee_b], OUR_OPERATOR_ID);
-    // Only the primary committee gets aggregate assignments for TEST_SLOT.
-    harness.seed_aggregation_assignments_for_slot(TEST_SLOT, &[PRIMARY_COMMITTEE_INDEX]);
+    let committee = create_primary_committee_setup(PRIMARY_COMMITTEE_VALIDATOR_COUNT);
+    let harness =
+        ValidatorStoreTestHarness::new_with_fork(vec![committee], OUR_OPERATOR_ID, Fork::Alan);
     let aggregates = vec![
-        // Committee A uses TEST_SLOT and should complete.
         harness.create_aggregate(PRIMARY_COMMITTEE_INDEX, FIRST_VALIDATOR_INDEX),
-        // Committee B uses NEXT_SLOT, where no aggregate assignments were seeded, so it should
-        // stay blocked in the aggregate-assignment lookup.
-        harness.create_aggregate_at_slot(
-            SECONDARY_COMMITTEE_INDEX,
-            FIRST_VALIDATOR_INDEX,
-            NEXT_SLOT,
-        ),
+        harness.create_aggregate(PRIMARY_COMMITTEE_INDEX, SECOND_VALIDATOR_INDEX),
     ];
 
     // Act
-    let stream = harness
-        .validator_store
-        .sign_aggregate_and_proofs(aggregates);
-    tokio::pin!(stream);
-    let first = tokio::time::timeout(STREAM_ITEM_TIMEOUT, stream.next()).await;
-    let second = tokio::time::timeout(BLOCKED_STREAM_TIMEOUT, stream.next()).await;
+    let results = harness.collect_aggregates(aggregates).await;
 
-    // Assert
-    let first_item = first
-        .expect("first committee should complete within timeout")
-        .expect("stream should yield an item");
-    let signed = first_item.expect("first committee should succeed");
+    // Assert: one batch holding both validators' signed aggregates.
+    assert_eq!(results.len(), 1, "the pre-Boole path yields one batch");
+    let signed = results
+        .into_iter()
+        .next()
+        .expect("stream item should exist")
+        .expect("pre-Boole signing should succeed");
+    let signed_aggregators: HashSet<u64> = signed
+        .iter()
+        .map(|signed| signed.message().aggregator_index())
+        .collect();
+    let expected_aggregators: HashSet<u64> = [FIRST_VALIDATOR_INDEX, SECOND_VALIDATOR_INDEX]
+        .iter()
+        .map(|&position| harness.aggregator_index(PRIMARY_COMMITTEE_INDEX, position))
+        .collect();
     assert_eq!(
-        signed.len(),
-        1,
-        "successful committee should produce one signed item"
+        signed_aggregators, expected_aggregators,
+        "every requested validator should get a signed aggregate back"
     );
-    assert!(
-        second.is_err(),
-        "stuck committee should not produce a result"
+
+    // Signature collection is per validator, not batched into one committee message.
+    let captured = harness.captured_calls.lock();
+    assert_eq!(
+        captured.len(),
+        PRIMARY_COMMITTEE_VALIDATOR_COUNT,
+        "expected one sign_and_collect call per validator"
     );
+    for call in captured.iter() {
+        assert_eq!(call.metadata.role, Role::Aggregator);
+        assert!(
+            matches!(call.requester, SignatureRequester::SingleValidator { .. }),
+            "pre-Boole aggregates are collected per validator, not as a committee batch"
+        );
+    }
 }
 
 fn create_primary_committee_setup(num_validators: usize) -> CommitteeSetup {

--- a/anchor/validator_store/src/testing/committee_attestation_gloas.rs
+++ b/anchor/validator_store/src/testing/committee_attestation_gloas.rs
@@ -78,7 +78,7 @@ async fn gloas_decided_index_applied_to_every_validator_attestation() {
         OUR_OPERATOR,
         HarnessOptions {
             spec: gloas_at_genesis_spec(),
-            forced_gloas_index: Some(DECIDED_INDEX),
+            decider: MockConsensusDecider::forcing_gloas_index(DECIDED_INDEX),
             ..Default::default()
         },
     );
@@ -144,7 +144,7 @@ async fn gloas_all_operators_converge_on_decided_index_signing_root() {
         OperatorId(1),
         HarnessOptions {
             spec: gloas_at_genesis_spec(),
-            forced_gloas_index: Some(DECIDED_INDEX),
+            decider: MockConsensusDecider::forcing_gloas_index(DECIDED_INDEX),
             ..Default::default()
         },
     );
@@ -156,7 +156,7 @@ async fn gloas_all_operators_converge_on_decided_index_signing_root() {
         OperatorId(2),
         HarnessOptions {
             spec: gloas_at_genesis_spec(),
-            forced_gloas_index: Some(DECIDED_INDEX),
+            decider: MockConsensusDecider::forcing_gloas_index(DECIDED_INDEX),
             ..Default::default()
         },
     );
@@ -373,7 +373,7 @@ async fn sync_and_attestation_paths_seed_identical_gloas_instance() {
         OUR_OPERATOR,
         HarnessOptions {
             spec: gloas_at_genesis_spec(),
-            forced_gloas_index: Some(DECIDED_INDEX),
+            decider: MockConsensusDecider::forcing_gloas_index(DECIDED_INDEX),
             ..Default::default()
         },
     );
@@ -504,7 +504,7 @@ async fn sync_first_populates_the_decided_vote_cache() {
         OUR_OPERATOR,
         HarnessOptions {
             spec: gloas_at_genesis_spec(),
-            forced_gloas_index: Some(DECIDED_INDEX),
+            decider: MockConsensusDecider::forcing_gloas_index(DECIDED_INDEX),
             ..Default::default()
         },
     );

--- a/anchor/validator_store/src/testing/committee_contribution.rs
+++ b/anchor/validator_store/src/testing/committee_contribution.rs
@@ -1,0 +1,83 @@
+//! Integration tests for `sign_sync_committee_contributions()` at Boole+.
+//!
+//! At Boole+ this Lighthouse callback is deliberately inert, exactly like the aggregate one:
+//! Anchor is the authoritative publisher of committee sync contributions, signing and posting the
+//! decided worklist itself (see [`crate::aggregator_post_consensus`]). Anything the callback
+//! returned would be published a second time by Lighthouse, so it hands back an empty batch.
+//! Pre-Boole is unchanged and covered in `testing/sync_contribution.rs`.
+
+use ssv_types::OperatorId;
+
+use super::common::*;
+
+const OUR_OPERATOR_ID: OperatorId = OperatorId(1);
+const PRIMARY_COMMITTEE_INDEX: usize = 0;
+const SECONDARY_COMMITTEE_INDEX: usize = 1;
+const FIRST_VALIDATOR_INDEX: usize = 0;
+const SECOND_VALIDATOR_INDEX: usize = 1;
+
+const PRIMARY_COMMITTEE_VALIDATOR_COUNT: usize = 2;
+const SINGLE_VALIDATOR_COUNT: usize = 1;
+
+const FIRST_SUBCOMMITTEE: u64 = 0;
+const SECOND_SUBCOMMITTEE: u64 = 1;
+
+/// Empty input yields the same single empty batch as any other Boole+ call: there is no fork to
+/// determine and nothing to publish either way.
+#[tokio::test(flavor = "multi_thread")]
+async fn sign_sync_committee_contributions_empty_input_yields_one_empty_batch() {
+    // Arrange
+    let committee = create_primary_committee_setup(SINGLE_VALIDATOR_COUNT);
+    let harness = ValidatorStoreTestHarness::new(vec![committee], OUR_OPERATOR_ID);
+
+    // Act
+    let results = harness.collect_contributions(vec![]).await;
+
+    // Assert
+    assert_single_empty_batch(results, "sync contributions");
+}
+
+/// Boole+ yields one empty batch however many committees the request spans, without waiting on
+/// `AggregationAssignments` and without collecting any signature of its own.
+///
+/// The single item is the stream's completion signal, not a per-committee result: the callback no
+/// longer groups by committee, because it no longer produces anything Lighthouse could publish.
+/// It also no longer parks on the assignments watch channel, which is why nothing is seeded here.
+#[tokio::test(flavor = "multi_thread")]
+async fn sign_sync_committee_contributions_boole_yields_one_empty_batch_for_all_committees() {
+    // Arrange: two distinct committees, no assignments published for the slot at all.
+    let committee_a = create_primary_committee_setup(PRIMARY_COMMITTEE_VALIDATOR_COUNT);
+    let committee_b = create_secondary_committee_setup(SINGLE_VALIDATOR_COUNT);
+    assert_ne!(
+        committee_a.cluster.committee_id(),
+        committee_b.cluster.committee_id(),
+    );
+    let harness = ValidatorStoreTestHarness::new(vec![committee_a, committee_b], OUR_OPERATOR_ID);
+    let contributions = vec![
+        harness.create_contribution(
+            PRIMARY_COMMITTEE_INDEX,
+            FIRST_VALIDATOR_INDEX,
+            FIRST_SUBCOMMITTEE,
+        ),
+        harness.create_contribution(
+            PRIMARY_COMMITTEE_INDEX,
+            SECOND_VALIDATOR_INDEX,
+            SECOND_SUBCOMMITTEE,
+        ),
+        harness.create_contribution(
+            SECONDARY_COMMITTEE_INDEX,
+            FIRST_VALIDATOR_INDEX,
+            FIRST_SUBCOMMITTEE,
+        ),
+    ];
+
+    // Act
+    let results = harness.collect_contributions(contributions).await;
+
+    // Assert
+    assert_single_empty_batch(results, "sync contributions");
+    assert!(
+        harness.captured_calls.lock().is_empty(),
+        "the callback must not collect signatures; signing belongs to the post-consensus execution"
+    );
+}

--- a/anchor/validator_store/src/testing/common.rs
+++ b/anchor/validator_store/src/testing/common.rs
@@ -41,9 +41,10 @@ use tokio::{
 };
 use types::{
     Attestation, AttestationBase, AttestationData, ChainSpec, Checkpoint, Epoch, EthSpec, Graffiti,
-    Hash256, MainnetEthSpec, SelectionProof, SignedAggregateAndProof, Slot, SyncSubnetId,
+    Hash256, MainnetEthSpec, SelectionProof, SignedAggregateAndProof, SignedContributionAndProof,
+    Slot, SyncCommitteeContribution, SyncSelectionProof, SyncSubnetId,
 };
-use validator_store::{AggregateToSign, AttestationToSign, ValidatorStore};
+use validator_store::{AggregateToSign, AttestationToSign, ContributionToSign, ValidatorStore};
 
 use crate::{
     AggregationAssignments, AnchorValidatorStore, Error, VotingAssignments, VotingContext,
@@ -59,6 +60,10 @@ pub(super) const STREAM_TIMEOUT: Duration = Duration::from_secs(5);
 /// What the Lighthouse aggregate callback yields: one result per stream item.
 pub(super) type SignAggregatesResult =
     Vec<Result<Vec<SignedAggregateAndProof<MainnetEthSpec>>, Error>>;
+
+/// What the Lighthouse contribution callback yields: one result per stream item.
+pub(super) type SignContributionsResult =
+    Vec<Result<Vec<SignedContributionAndProof<MainnetEthSpec>>, Error>>;
 
 // ==================== Mock consensus decider ====================
 
@@ -117,10 +122,16 @@ type FailingPubkeys = Arc<Mutex<HashSet<PublicKeyBytes>>>;
 
 /// Mock that captures calls and returns a canned infinity signature, or a collection timeout for
 /// every call once [`ValidatorStoreTestHarness::fail_signature_collection`] is called, or for one
-/// validator's calls once [`ValidatorStoreTestHarness::fail_signature_collection_for`] is.
+/// validator's calls once [`ValidatorStoreTestHarness::fail_signature_collection_for`] is, or
+/// never resolves at all once [`ValidatorStoreTestHarness::hang_signature_collection`] is.
+///
+/// Failing and hanging are different: a failure resolves to an error, which readers count as
+/// `other_error`, while a hang leaves the root pending so the reader's own deadline decides its
+/// fate. Only the hang mode reaches a per-root deadline-expiry path.
 struct MockSignatureCollector {
     captured: CapturedCalls,
     fails: Arc<AtomicBool>,
+    hangs: Arc<AtomicBool>,
     failing_pubkeys: FailingPubkeys,
 }
 
@@ -148,6 +159,11 @@ impl SignatureCollecting for MockSignatureCollector {
         {
             return Box::pin(async { Err(CollectionError::CollectionTimeout) });
         }
+        // Stands in for a root whose quorum never arrives: the future stays pending, so the
+        // caller's deadline is what ends the wait.
+        if self.hangs.load(Ordering::Relaxed) {
+            return Box::pin(std::future::pending());
+        }
         let sig = Signature::infinity().expect("infinity signature");
         Box::pin(async move { Ok(Arc::new(sig)) })
     }
@@ -159,17 +175,20 @@ fn create_mock_collector() -> (
     Box<dyn SignatureCollecting>,
     CapturedCalls,
     Arc<AtomicBool>,
+    Arc<AtomicBool>,
     FailingPubkeys,
 ) {
     let captured: CapturedCalls = Arc::new(Mutex::new(Vec::new()));
     let fails = Arc::new(AtomicBool::new(false));
+    let hangs = Arc::new(AtomicBool::new(false));
     let failing_pubkeys: FailingPubkeys = Arc::new(Mutex::new(HashSet::new()));
     let mock = MockSignatureCollector {
         captured: Arc::clone(&captured),
         fails: Arc::clone(&fails),
+        hangs: Arc::clone(&hangs),
         failing_pubkeys: Arc::clone(&failing_pubkeys),
     };
-    (Box::new(mock), captured, fails, failing_pubkeys)
+    (Box::new(mock), captured, fails, hangs, failing_pubkeys)
 }
 
 // ==================== Committee setup ====================
@@ -178,6 +197,54 @@ pub(super) struct CommitteeSetup {
     pub(super) cluster: Cluster,
     pub(super) validators: Vec<ValidatorMetadata>,
     shares: Vec<Share>,
+}
+
+/// Standard two-committee topology shared by the Boole+ callback-gate tests
+/// (`committee_aggregate.rs` and `committee_contribution.rs`): a primary and a secondary
+/// committee with distinct operator sets and disjoint validator index spaces, both containing
+/// this operator.
+pub(super) const PRIMARY_COMMITTEE_OPERATOR_IDS: [OperatorId; 4] =
+    [OperatorId(1), OperatorId(2), OperatorId(3), OperatorId(4)];
+pub(super) const SECONDARY_COMMITTEE_OPERATOR_IDS: [OperatorId; 4] =
+    [OperatorId(1), OperatorId(5), OperatorId(6), OperatorId(7)];
+pub(super) const PRIMARY_COMMITTEE_STARTING_VALIDATOR_INDEX: usize = 0;
+pub(super) const SECONDARY_COMMITTEE_STARTING_VALIDATOR_INDEX: usize = 100;
+
+/// [`create_committee_setup`] for the standard primary committee.
+pub(super) fn create_primary_committee_setup(num_validators: usize) -> CommitteeSetup {
+    create_committee_setup(
+        &PRIMARY_COMMITTEE_OPERATOR_IDS,
+        num_validators,
+        PRIMARY_COMMITTEE_STARTING_VALIDATOR_INDEX,
+    )
+}
+
+/// [`create_committee_setup`] for the standard secondary committee.
+pub(super) fn create_secondary_committee_setup(num_validators: usize) -> CommitteeSetup {
+    create_committee_setup(
+        &SECONDARY_COMMITTEE_OPERATOR_IDS,
+        num_validators,
+        SECONDARY_COMMITTEE_STARTING_VALIDATOR_INDEX,
+    )
+}
+
+/// Asserts a callback stream yielded exactly one item and that item is an empty batch.
+///
+/// The empty batch is the Boole+ contract for both callback classes: Lighthouse's publish loops
+/// drop an empty result silently, which is what keeps Anchor the single publisher of committee
+/// duties. `what` names the class in failure messages ("aggregates", "sync contributions").
+pub(super) fn assert_single_empty_batch<T>(results: Vec<Result<Vec<T>, Error>>, what: &str) {
+    assert_eq!(results.len(), 1, "expected exactly one stream item");
+    let batch = results
+        .into_iter()
+        .next()
+        .expect("stream item should exist")
+        .unwrap_or_else(|e| panic!("the callback for {what} should not fail: {e:?}"));
+    assert!(
+        batch.is_empty(),
+        "Lighthouse must receive nothing to publish at Boole+; the metadata service publishes \
+         committee {what} from the decided value"
+    );
 }
 
 /// Builds a synthetic committee with deterministic validator and share data.
@@ -248,6 +315,8 @@ pub(super) struct ValidatorStoreTestHarness {
     pub(super) captured_calls: CapturedCalls,
     /// Set by [`Self::fail_signature_collection`]; read by the mock collector on every call.
     signature_collection_fails: Arc<AtomicBool>,
+    /// Filled by [`Self::hang_signature_collection`]; read by the mock collector on every call.
+    signature_collection_hangs: Arc<AtomicBool>,
     /// Filled by [`Self::fail_signature_collection_for`]; read by the mock collector on every
     /// call.
     failing_pubkeys: FailingPubkeys,
@@ -335,8 +404,13 @@ impl ValidatorStoreTestHarness {
             "test",
         ));
 
-        let (mock_collector, captured_calls, signature_collection_fails, failing_pubkeys) =
-            create_mock_collector();
+        let (
+            mock_collector,
+            captured_calls,
+            signature_collection_fails,
+            signature_collection_hangs,
+            failing_pubkeys,
+        ) = create_mock_collector();
 
         // Database
         let database = Arc::new(
@@ -426,6 +500,7 @@ impl ValidatorStoreTestHarness {
             committee_setups,
             captured_calls,
             signature_collection_fails,
+            signature_collection_hangs,
             failing_pubkeys,
             slot_clock,
             is_synced_tx,
@@ -539,10 +614,57 @@ impl ValidatorStoreTestHarness {
             .expect("the aggregate callback should complete within the stream timeout")
     }
 
+    /// Runs the Lighthouse contribution callback to completion.
+    pub(super) async fn collect_contributions(
+        &self,
+        contributions: Vec<ContributionToSign<MainnetEthSpec>>,
+    ) -> SignContributionsResult {
+        let stream = self
+            .validator_store
+            .sign_sync_committee_contributions(contributions);
+        tokio::time::timeout(STREAM_TIMEOUT, stream.collect())
+            .await
+            .expect("the contribution callback should complete within the stream timeout")
+    }
+
+    /// A contribution request at `TEST_SLOT`, as Lighthouse's sync committee service would send.
+    pub(super) fn create_contribution(
+        &self,
+        committee_idx: usize,
+        validator_idx: usize,
+        subcommittee_index: u64,
+    ) -> ContributionToSign<MainnetEthSpec> {
+        let validator = &self.committee_setups[committee_idx].validators[validator_idx];
+        let validator_index = validator
+            .index
+            .expect("test validator should have an index");
+
+        ContributionToSign {
+            aggregator_index: *validator_index as u64,
+            aggregator_pubkey: validator.public_key,
+            contribution: SyncCommitteeContribution {
+                slot: Slot::new(TEST_SLOT),
+                beacon_block_root: Hash256::zero(),
+                subcommittee_index,
+                aggregation_bits: Default::default(),
+                signature: AggregateSignature::infinity(),
+            },
+            selection_proof: SyncSelectionProof::from(Signature::empty()),
+        }
+    }
+
     /// Makes every subsequent `sign_and_collect` call fail, for tests of the paths a root that
     /// never reaches quorum takes. Calls are still captured.
     pub(super) fn fail_signature_collection(&self) {
         self.signature_collection_fails
+            .store(true, Ordering::Relaxed);
+    }
+
+    /// Makes every subsequent `sign_and_collect` call hang forever, so the caller's own deadline
+    /// decides each root's fate. This is the only way to reach a per-root deadline-expiry path;
+    /// [`Self::fail_signature_collection`] resolves to an error instead. Calls are still captured.
+    pub(super) fn hang_signature_collection(&self) {
+        self.signature_collection_hangs
             .store(true, Ordering::Relaxed);
     }
 

--- a/anchor/validator_store/src/testing/common.rs
+++ b/anchor/validator_store/src/testing/common.rs
@@ -32,6 +32,7 @@ use ssv_types::{
     ValidatorIndex, ValidatorMetadata,
     consensus::{AggregatorCommitteeConsensusData, QbftDataValidator},
 };
+use ssz::Encode;
 use task_executor::TaskExecutor;
 use tempfile::TempDir;
 use tokio::{

--- a/anchor/validator_store/src/testing/common.rs
+++ b/anchor/validator_store/src/testing/common.rs
@@ -65,6 +65,7 @@ impl<E: EthSpec> ConsensusDecider<E> for MockConsensusDecider {
 pub(super) type CapturedCalls = Arc<Mutex<Vec<CapturedSignatureCall>>>;
 
 pub(super) struct CapturedSignatureCall {
+    pub(super) metadata: SignatureMetadata,
     pub(super) requester: SignatureRequester,
     pub(super) validator_pubkey: PublicKeyBytes,
     pub(super) signing_root: Hash256,
@@ -80,11 +81,12 @@ struct MockSignatureCollector {
 impl SignatureCollecting for MockSignatureCollector {
     fn sign_and_collect(
         &self,
-        _metadata: SignatureMetadata,
+        metadata: SignatureMetadata,
         requester: SignatureRequester,
         signing_data: ValidatorSigningData,
     ) -> Pin<Box<dyn Future<Output = Result<Arc<Signature>, CollectionError>> + Send + '_>> {
         self.captured.lock().push(CapturedSignatureCall {
+            metadata,
             requester,
             validator_pubkey: signing_data.validator_pubkey,
             signing_root: signing_data.root,

--- a/anchor/validator_store/src/testing/common.rs
+++ b/anchor/validator_store/src/testing/common.rs
@@ -3,11 +3,21 @@
 //! Provides a `ValidatorStoreTestHarness` that wires up a real `AnchorValidatorStore` with
 //! in-memory database, mock consensus, and a mock signature collector.
 
-use std::{collections::HashMap, future::Future, pin::Pin, sync::Arc, time::Duration};
+use std::{
+    collections::{HashMap, HashSet},
+    future::Future,
+    pin::Pin,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
+    time::Duration,
+};
 
 use bls::{AggregateSignature, FixedBytesExtended, PublicKeyBytes, Signature};
 use database::{NetworkDatabase, PendingStateUpdates};
 use fork::{Fork, ForkSchedule};
+use futures::StreamExt;
 use parking_lot::Mutex;
 use qbft::Completed;
 use qbft_manager::{ConsensusDecider, QbftDecidable, QbftError, TimeoutMode};
@@ -18,27 +28,33 @@ use signature_collector::{
 use slashing_protection::SlashingDatabase;
 use slot_clock::{ManualSlotClock, SlotClock};
 use ssv_types::{
-    Cluster, ClusterId, ENCRYPTED_KEY_LENGTH, IndexSet, OperatorId, Share, ValidatorIndex,
-    ValidatorMetadata,
-    consensus::{
-        AggregatorCommitteeConsensusData, AssignedAggregator, DataVersion, QbftDataValidator,
-    },
+    Cluster, ClusterId, CommitteeId, ENCRYPTED_KEY_LENGTH, IndexSet, OperatorId, Share,
+    ValidatorIndex, ValidatorMetadata,
+    consensus::{AggregatorCommitteeConsensusData, QbftDataValidator},
 };
-use ssz::Encode;
-use ssz_types::VariableList;
 use task_executor::TaskExecutor;
 use tempfile::TempDir;
 use tokio::{sync::watch, time::Instant};
 use types::{
     Attestation, AttestationBase, AttestationData, ChainSpec, Checkpoint, Epoch, EthSpec, Graffiti,
-    Hash256, MainnetEthSpec, SelectionProof, Slot, SyncSubnetId,
+    Hash256, MainnetEthSpec, SelectionProof, SignedAggregateAndProof, Slot, SyncSubnetId,
 };
-use validator_store::{AggregateToSign, AttestationToSign};
+use validator_store::{AggregateToSign, AttestationToSign, ValidatorStore};
 
-use crate::{AggregationAssignments, AnchorValidatorStore, VotingAssignments, VotingContext};
+use crate::{
+    AggregationAssignments, AnchorValidatorStore, Error, VotingAssignments, VotingContext,
+    aggregator_post_consensus::AggregatorPostConsensusShared,
+};
 
 pub(super) const TEST_SLOT: u64 = 1;
 pub(super) const SLOT_DURATION_SECS: u64 = 12;
+/// Bound on any Lighthouse callback stream in these tests; a callback that blocks past it is a
+/// failure, not a slow machine.
+pub(super) const STREAM_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// What the Lighthouse aggregate callback yields: one result per stream item.
+pub(super) type SignAggregatesResult =
+    Vec<Result<Vec<SignedAggregateAndProof<MainnetEthSpec>>, Error>>;
 
 // ==================== Mock consensus decider ====================
 
@@ -73,9 +89,17 @@ pub(super) struct CapturedSignatureCall {
     pub(super) captured_at: Instant,
 }
 
-/// Mock that captures calls and returns a canned infinity signature.
+/// Validator pubkeys whose signature collection fails; shared with the harness so tests can fail
+/// a single validator's roots.
+type FailingPubkeys = Arc<Mutex<HashSet<PublicKeyBytes>>>;
+
+/// Mock that captures calls and returns a canned infinity signature, or a collection timeout for
+/// every call once [`ValidatorStoreTestHarness::fail_signature_collection`] is called, or for one
+/// validator's calls once [`ValidatorStoreTestHarness::fail_signature_collection_for`] is.
 struct MockSignatureCollector {
     captured: CapturedCalls,
+    fails: Arc<AtomicBool>,
+    failing_pubkeys: FailingPubkeys,
 }
 
 impl SignatureCollecting for MockSignatureCollector {
@@ -92,18 +116,38 @@ impl SignatureCollecting for MockSignatureCollector {
             signing_root: signing_data.root,
             captured_at: Instant::now(),
         });
+        // Stands in for any root that never reaches quorum; the caller only distinguishes
+        // success from failure.
+        if self.fails.load(Ordering::Relaxed)
+            || self
+                .failing_pubkeys
+                .lock()
+                .contains(&signing_data.validator_pubkey)
+        {
+            return Box::pin(async { Err(CollectionError::CollectionTimeout) });
+        }
         let sig = Signature::infinity().expect("infinity signature");
         Box::pin(async move { Ok(Arc::new(sig)) })
     }
 }
 
-/// Creates a mock signature collector and returns the shared captured calls handle.
-fn create_mock_collector() -> (Box<dyn SignatureCollecting>, CapturedCalls) {
+/// Creates a mock signature collector, returning the shared captured calls and failure-mode
+/// handles.
+fn create_mock_collector() -> (
+    Box<dyn SignatureCollecting>,
+    CapturedCalls,
+    Arc<AtomicBool>,
+    FailingPubkeys,
+) {
     let captured: CapturedCalls = Arc::new(Mutex::new(Vec::new()));
+    let fails = Arc::new(AtomicBool::new(false));
+    let failing_pubkeys: FailingPubkeys = Arc::new(Mutex::new(HashSet::new()));
     let mock = MockSignatureCollector {
         captured: Arc::clone(&captured),
+        fails: Arc::clone(&fails),
+        failing_pubkeys: Arc::clone(&failing_pubkeys),
     };
-    (Box::new(mock), captured)
+    (Box::new(mock), captured, fails, failing_pubkeys)
 }
 
 // ==================== Committee setup ====================
@@ -180,6 +224,11 @@ pub(super) struct ValidatorStoreTestHarness {
         Arc<AnchorValidatorStore<ManualSlotClock, MainnetEthSpec, MockConsensusDecider>>,
     committee_setups: Vec<CommitteeSetup>,
     pub(super) captured_calls: CapturedCalls,
+    /// Set by [`Self::fail_signature_collection`]; read by the mock collector on every call.
+    signature_collection_fails: Arc<AtomicBool>,
+    /// Filled by [`Self::fail_signature_collection_for`]; read by the mock collector on every
+    /// call.
+    failing_pubkeys: FailingPubkeys,
     /// Shares `current_time` with the clone held by the store, so tests can reposition the clock
     /// after construction.
     pub(super) slot_clock: ManualSlotClock,
@@ -246,7 +295,8 @@ impl ValidatorStoreTestHarness {
             "test",
         ));
 
-        let (mock_collector, captured_calls) = create_mock_collector();
+        let (mock_collector, captured_calls, signature_collection_fails, failing_pubkeys) =
+            create_mock_collector();
 
         // Database
         let database = Arc::new(
@@ -335,6 +385,8 @@ impl ValidatorStoreTestHarness {
             validator_store,
             committee_setups,
             captured_calls,
+            signature_collection_fails,
+            failing_pubkeys,
             slot_clock,
             is_synced_tx,
             _slashing_db_dir: slashing_db_dir,
@@ -348,6 +400,15 @@ impl ValidatorStoreTestHarness {
         validator_idx: usize,
     ) -> ValidatorMetadata {
         self.committee_setups[committee_idx].validators[validator_idx].clone()
+    }
+
+    /// The beacon-chain validator index of one committee member, as it appears in signed
+    /// aggregates and decided values.
+    pub(super) fn aggregator_index(&self, committee_idx: usize, validator_idx: usize) -> u64 {
+        *self
+            .validator_metadata(committee_idx, validator_idx)
+            .index
+            .expect("test validator should have an index") as u64
     }
 
     pub(super) fn seed_sync_voting_assignments_for_slot(
@@ -406,81 +467,49 @@ impl ValidatorStoreTestHarness {
         });
     }
 
-    /// Seeds `AggregationAssignments` for the given committees at the provided slot.
+    /// Publishes `consensus_data_by_ssv_committee` as the decided values at `TEST_SLOT`, returning
+    /// the executions the publish newly registered.
     ///
-    /// Each validator in the selected committee is treated as an attestation aggregator for a
-    /// single beacon committee index derived from the test committee position.
-    pub(super) fn seed_aggregation_assignments_for_slot(
+    /// This is the slot pipeline's Phase 3 step: registration happens before the assignments reach
+    /// the watch channel, and only vacant registrations come back, so a republish returns nothing.
+    pub(super) fn publish_decided_values(
         &self,
-        slot: u64,
-        committee_indices: &[usize],
-    ) {
-        let mut aggregator_committees = HashMap::new();
-        let mut consensus_data_by_ssv_committee = HashMap::new();
-
-        for &committee_idx in committee_indices {
-            let setup = &self.committee_setups[committee_idx];
-            let beacon_committee_index = committee_idx as u64;
-
-            for validator in &setup.validators {
-                aggregator_committees.insert(validator.public_key, beacon_committee_index);
-            }
-
-            let aggregators: Vec<_> = setup
-                .validators
-                .iter()
-                .map(|validator| AssignedAggregator {
-                    validator_index: validator.index.expect("test validator should have index"),
-                    selection_proof: Signature::empty(),
-                    committee_index: beacon_committee_index,
-                })
-                .collect();
-
-            let aggregated_attestation = AttestationBase::<MainnetEthSpec> {
-                aggregation_bits: ssz_types::BitList::with_capacity(128)
-                    .expect("bitlist should be valid"),
-                data: AttestationData {
-                    slot: Slot::new(slot),
-                    index: beacon_committee_index,
-                    beacon_block_root: Hash256::zero(),
-                    source: Checkpoint {
-                        epoch: Epoch::new(0),
-                        root: Hash256::zero(),
-                    },
-                    target: Checkpoint {
-                        epoch: Epoch::new(0),
-                        root: Hash256::zero(),
-                    },
-                },
-                signature: AggregateSignature::infinity(),
-            };
-
-            let consensus_data = AggregatorCommitteeConsensusData::<MainnetEthSpec> {
-                version: DataVersion::from(types::ForkName::Deneb),
-                aggregators: VariableList::new(aggregators)
-                    .expect("aggregator list should be valid"),
-                aggregator_committee_indexes: VariableList::new(vec![beacon_committee_index])
-                    .expect("committee indexes should be valid"),
-                aggregated_attestations: VariableList::new(vec![
-                    VariableList::new(aggregated_attestation.as_ssz_bytes())
-                        .expect("attestation bytes should fit"),
-                ])
-                .expect("aggregated attestations should be valid"),
-                contributors: VariableList::empty(),
-                sync_committee_contributions: VariableList::empty(),
-            };
-
-            consensus_data_by_ssv_committee
-                .insert(setup.cluster.committee_id(), Arc::new(consensus_data));
-        }
-
+        consensus_data_by_ssv_committee: HashMap<
+            CommitteeId,
+            Arc<AggregatorCommitteeConsensusData<MainnetEthSpec>>,
+        >,
+    ) -> Vec<(CommitteeId, AggregatorPostConsensusShared<MainnetEthSpec>)> {
         self.validator_store
             .update_aggregation_assignments(AggregationAssignments {
-                slot: Slot::new(slot),
-                aggregator_committees,
+                slot: Slot::new(TEST_SLOT),
+                aggregator_committees: HashMap::new(),
                 multi_sync_aggregators: HashMap::new(),
                 consensus_data_by_ssv_committee,
-            });
+            })
+    }
+
+    /// Runs the Lighthouse aggregate callback to completion.
+    pub(super) async fn collect_aggregates(
+        &self,
+        aggregates: Vec<AggregateToSign<MainnetEthSpec>>,
+    ) -> SignAggregatesResult {
+        let stream = self.validator_store.sign_aggregate_and_proofs(aggregates);
+        tokio::time::timeout(STREAM_TIMEOUT, stream.collect())
+            .await
+            .expect("the aggregate callback should complete within the stream timeout")
+    }
+
+    /// Makes every subsequent `sign_and_collect` call fail, for tests of the paths a root that
+    /// never reaches quorum takes. Calls are still captured.
+    pub(super) fn fail_signature_collection(&self) {
+        self.signature_collection_fails
+            .store(true, Ordering::Relaxed);
+    }
+
+    /// Makes every subsequent `sign_and_collect` call for `pubkey` fail, so one root can miss
+    /// quorum while its siblings still collect. Calls are still captured.
+    pub(super) fn fail_signature_collection_for(&self, pubkey: PublicKeyBytes) {
+        self.failing_pubkeys.lock().insert(pubkey);
     }
 
     pub(super) fn create_attestation(
@@ -532,15 +561,6 @@ impl ValidatorStoreTestHarness {
         committee_idx: usize,
         validator_idx: usize,
     ) -> AggregateToSign<MainnetEthSpec> {
-        self.create_aggregate_at_slot(committee_idx, validator_idx, TEST_SLOT)
-    }
-
-    pub(super) fn create_aggregate_at_slot(
-        &self,
-        committee_idx: usize,
-        validator_idx: usize,
-        slot: u64,
-    ) -> AggregateToSign<MainnetEthSpec> {
         let validator = &self.committee_setups[committee_idx].validators[validator_idx];
         let validator_index = validator
             .index
@@ -553,7 +573,7 @@ impl ValidatorStoreTestHarness {
                 aggregation_bits: ssz_types::BitList::with_capacity(128)
                     .expect("bitlist should be valid"),
                 data: AttestationData {
-                    slot: Slot::new(slot),
+                    slot: Slot::new(TEST_SLOT),
                     index: committee_idx as u64,
                     beacon_block_root: Hash256::zero(),
                     source: Checkpoint {

--- a/anchor/validator_store/src/testing/common.rs
+++ b/anchor/validator_store/src/testing/common.rs
@@ -34,7 +34,10 @@ use ssv_types::{
 };
 use task_executor::TaskExecutor;
 use tempfile::TempDir;
-use tokio::{sync::watch, time::Instant};
+use tokio::{
+    sync::{Barrier, watch},
+    time::Instant,
+};
 use types::{
     Attestation, AttestationBase, AttestationData, ChainSpec, Checkpoint, Epoch, EthSpec, Graffiti,
     Hash256, MainnetEthSpec, SelectionProof, SignedAggregateAndProof, Slot, SyncSubnetId,
@@ -58,9 +61,20 @@ pub(super) type SignAggregatesResult =
 
 // ==================== Mock consensus decider ====================
 
-/// Mock that instantly returns `Completed::Success(initial)`, echoing back the proposed data.
+/// Mock that either echoes the proposed data or returns one fixed SSZ-decoded value.
 /// Removes the need for `QbftManager` infrastructure and lets the signing pipeline run fully.
-pub(super) struct MockConsensusDecider;
+#[derive(Default)]
+pub(super) struct MockConsensusDecider {
+    fixed_decision: Option<(Vec<u8>, Arc<Barrier>)>,
+}
+
+impl MockConsensusDecider {
+    pub(super) fn fixed_after_barrier<D: Encode>(value: &D, parties: usize) -> Self {
+        Self {
+            fixed_decision: Some((value.as_ssz_bytes(), Arc::new(Barrier::new(parties)))),
+        }
+    }
+}
 
 impl<E: EthSpec> ConsensusDecider<E> for MockConsensusDecider {
     async fn decide_instance<D: QbftDecidable<E>>(
@@ -71,7 +85,14 @@ impl<E: EthSpec> ConsensusDecider<E> for MockConsensusDecider {
         _timeout_mode: TimeoutMode,
         _committee_members: &IndexSet<OperatorId>,
     ) -> Result<Completed<D>, QbftError> {
-        Ok(Completed::Success(initial))
+        let decided = match &self.fixed_decision {
+            Some((bytes, barrier)) => {
+                barrier.wait().await;
+                D::from_ssz_bytes(bytes).expect("fixed test consensus value should decode")
+            }
+            None => initial,
+        };
+        Ok(Completed::Success(decided))
     }
 }
 
@@ -253,6 +274,7 @@ impl ValidatorStoreTestHarness {
             our_operator_id,
             active_fork,
             Duration::ZERO,
+            MockConsensusDecider::default(),
         )
     }
 
@@ -266,6 +288,22 @@ impl ValidatorStoreTestHarness {
             our_operator_id,
             Fork::Boole,
             proposer_delay,
+            MockConsensusDecider::default(),
+        )
+    }
+
+    pub(super) fn new_with_fork_and_consensus(
+        committee_setups: Vec<CommitteeSetup>,
+        our_operator_id: OperatorId,
+        active_fork: Fork,
+        consensus: MockConsensusDecider,
+    ) -> Self {
+        Self::new_with_options(
+            committee_setups,
+            our_operator_id,
+            active_fork,
+            Duration::ZERO,
+            consensus,
         )
     }
 
@@ -274,6 +312,7 @@ impl ValidatorStoreTestHarness {
         our_operator_id: OperatorId,
         active_fork: Fork,
         proposer_delay: Duration,
+        consensus: MockConsensusDecider,
     ) -> Self {
         // Dummy RSA key for database operator identification (not used for decryption)
         let rsa_pubkey = database::test_utils::generators::pubkey::random_rsa();
@@ -364,7 +403,7 @@ impl ValidatorStoreTestHarness {
         let validator_store = AnchorValidatorStore::new(
             database,
             mock_collector,
-            Arc::new(MockConsensusDecider),
+            Arc::new(consensus),
             slashing_protection,
             true, // disable slashing protection for simpler testing
             slot_clock.clone(),

--- a/anchor/validator_store/src/testing/common.rs
+++ b/anchor/validator_store/src/testing/common.rs
@@ -3,7 +3,17 @@
 //! Provides a `ValidatorStoreTestHarness` that wires up a real `AnchorValidatorStore` with
 //! in-memory database, mock consensus, and a mock signature collector.
 
-use std::{any::Any, collections::HashMap, future::Future, pin::Pin, sync::Arc, time::Duration};
+use std::{
+    any::Any,
+    collections::{HashMap, HashSet},
+    future::Future,
+    pin::Pin,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
+    time::Duration,
+};
 
 use bls::{AggregateSignature, FixedBytesExtended, PublicKeyBytes, Signature};
 use database::{NetworkDatabase, PendingStateUpdates};
@@ -22,24 +32,29 @@ use ssv_types::{
     Cluster, ClusterId, CommitteeId, ENCRYPTED_KEY_LENGTH, IndexSet, OperatorId, Share,
     ValidatorIndex, ValidatorMetadata,
     consensus::{
-        AggregatorCommitteeConsensusData, AssignedAggregator, BeaconVote, DataVersion,
-        EnvelopeConsensusData, GloasBeaconVote, QbftDataValidator,
+        AggregatorCommitteeConsensusData, BeaconVote, EnvelopeConsensusData, GloasBeaconVote,
+        QbftDataValidator,
     },
 };
 use ssz::Encode;
-use ssz_types::VariableList;
 use task_executor::TaskExecutor;
 use tempfile::TempDir;
-use tokio::{sync::watch, time::Instant};
+use tokio::{
+    sync::{Barrier, watch},
+    time::Instant,
+};
 use types::{
     Attestation, AttestationBase, AttestationData, ChainSpec, Checkpoint, Epoch, EthSpec, Graffiti,
-    Hash256, MainnetEthSpec, SelectionProof, SingleAttestation, Slot, SyncSubnetId,
+    Hash256, MainnetEthSpec, SelectionProof, SignedAggregateAndProof, SignedContributionAndProof,
+    SingleAttestation, Slot, SyncCommitteeContribution, SyncSelectionProof, SyncSubnetId,
 };
-use validator_store::{AggregateToSign, AttestationToSign, SyncMessageToSign, ValidatorStore};
+use validator_store::{
+    AggregateToSign, AttestationToSign, ContributionToSign, SyncMessageToSign, ValidatorStore,
+};
 
 use crate::{
     AggregationAssignments, AnchorValidatorStore, Error, ProposerDelays, VotingAssignments,
-    VotingContext,
+    VotingContext, aggregator_post_consensus::AggregatorPostConsensusShared,
 };
 
 pub(super) const TEST_SLOT: u64 = 1;
@@ -49,6 +64,18 @@ pub(super) const CLOCK_OFFSET_INTO_TEST_SLOT_SECS: u64 = SLOT_DURATION_SECS / 3 
 
 /// The raw item stream `sign_attestations` yields: one `Result` batch per committee.
 pub(super) type SignAttestationsResult = Vec<Result<Vec<SingleAttestation>, Error>>;
+
+/// Bound on any Lighthouse callback stream in these tests; a callback that blocks past it is a
+/// failure, not a slow machine.
+pub(super) const STREAM_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// What the Lighthouse aggregate callback yields: one result per stream item.
+pub(super) type SignAggregatesResult =
+    Vec<Result<Vec<SignedAggregateAndProof<MainnetEthSpec>>, Error>>;
+
+/// What the Lighthouse contribution callback yields: one result per stream item.
+pub(super) type SignContributionsResult =
+    Vec<Result<Vec<SignedContributionAndProof<MainnetEthSpec>>, Error>>;
 
 /// Drives `sign_attestations` to completion and unwraps every committee batch.
 pub(super) async fn run_sign_attestations(
@@ -88,19 +115,29 @@ pub(super) struct CapturedDecideCall {
 ///
 /// When `forced_envelope_decision` is `Some`, it replaces the echo for `EnvelopeConsensusData`
 /// seeds. Every `decide_instance` call is captured, regardless of the configured behavior.
+///
+/// When `fixed_decision` is `Some`, every seed decides as that SSZ-encoded value once `parties`
+/// callers have reached the barrier, modeling a cluster decision that differs from each caller's
+/// own proposal.
+#[derive(Default)]
 pub(super) struct MockConsensusDecider {
     forced_gloas_index: Option<u64>,
     forced_envelope_decision: Option<EnvelopeConsensusData>,
+    fixed_decision: Option<(Vec<u8>, Arc<Barrier>)>,
     captured: CapturedDecides,
 }
 
 impl MockConsensusDecider {
     /// Echoes every decided seed back unchanged (default behavior used by most tests).
     pub(super) fn echoing() -> Self {
+        Self::default()
+    }
+
+    /// Decides every seed as `value` once `parties` callers have reached the barrier.
+    pub(super) fn fixed_after_barrier<D: Encode>(value: &D, parties: usize) -> Self {
         Self {
-            forced_gloas_index: None,
-            forced_envelope_decision: None,
-            captured: Arc::new(Mutex::new(Vec::new())),
+            fixed_decision: Some((value.as_ssz_bytes(), Arc::new(Barrier::new(parties)))),
+            ..Self::default()
         }
     }
 
@@ -109,8 +146,7 @@ impl MockConsensusDecider {
     pub(super) fn forcing_gloas_index(index: u64) -> Self {
         Self {
             forced_gloas_index: Some(index),
-            forced_envelope_decision: None,
-            captured: Arc::new(Mutex::new(Vec::new())),
+            ..Self::default()
         }
     }
 
@@ -118,9 +154,8 @@ impl MockConsensusDecider {
     /// decided another operator's envelope. Non-envelope seeds keep the echo behavior.
     pub(super) fn deciding_envelope(decided: EnvelopeConsensusData) -> Self {
         Self {
-            forced_gloas_index: None,
             forced_envelope_decision: Some(decided),
-            captured: Arc::new(Mutex::new(Vec::new())),
+            ..Self::default()
         }
     }
 
@@ -177,7 +212,14 @@ impl<E: EthSpec> ConsensusDecider<E> for MockConsensusDecider {
                 }
             }
         }
-        Ok(Completed::Success(initial))
+        let decided = match &self.fixed_decision {
+            Some((bytes, barrier)) => {
+                barrier.wait().await;
+                D::from_ssz_bytes(bytes).expect("fixed test consensus value should decode")
+            }
+            None => initial,
+        };
+        Ok(Completed::Success(decided))
     }
 }
 
@@ -197,16 +239,29 @@ pub(super) struct CapturedSignatureCall {
     pub(super) captured_at: Instant,
 }
 
-/// Mock that captures calls and returns a canned infinity signature, or a configured failure, or
-/// a future that never resolves (`hang`).
+/// Validator pubkeys whose signature collection fails; shared with the harness so tests can fail
+/// a single validator's roots.
+type FailingPubkeys = Arc<Mutex<HashSet<PublicKeyBytes>>>;
+
+/// Mock that captures calls and returns a canned infinity signature, or one of the configured
+/// failure modes: the `HarnessOptions` error for every call, a collection timeout for every call
+/// once [`ValidatorStoreTestHarness::fail_signature_collection`] is called, a timeout for one
+/// validator's calls once [`ValidatorStoreTestHarness::fail_signature_collection_for`] is, or a
+/// future that never resolves (`hangs`).
+///
+/// Failing and hanging are different: a failure resolves to an error, which readers count as
+/// `other_error`, while a hang leaves the root pending so the reader's own deadline decides its
+/// fate. Only the hang mode reaches a per-root deadline-expiry path. Hanging takes precedence
+/// over both failure modes.
 struct MockSignatureCollector {
     captured: CapturedCalls,
+    /// Set from `HarnessOptions::collector_failure`; every call fails with this error.
     failure: Option<CollectionError>,
-    /// When `true`, `sign_and_collect` captures the call and then returns a future that never
-    /// resolves, modeling a quorum that never forms. This lets tests drive the production
-    /// `tokio::time::timeout` in `sign_proposer_preferences` to elapse; `hang` takes precedence
-    /// over `failure`.
-    hang: bool,
+    fails: Arc<AtomicBool>,
+    /// Starts from `HarnessOptions::collector_hangs`; also set by
+    /// [`ValidatorStoreTestHarness::hang_signature_collection`].
+    hangs: Arc<AtomicBool>,
+    failing_pubkeys: FailingPubkeys,
 }
 
 impl SignatureCollecting for MockSignatureCollector {
@@ -225,11 +280,22 @@ impl SignatureCollecting for MockSignatureCollector {
             validator_pubkey: signing_data.validator_pubkey,
             captured_at: Instant::now(),
         });
-        if self.hang {
-            // Never resolves, so the caller only unblocks via the production collection timeout.
-            // `std::future::pending::<Result<Arc<Signature>, CollectionError>>()` is `Send`, which
-            // satisfies the returned future's bound.
+        // Stands in for a root whose quorum never arrives: the future stays pending, so the
+        // caller's deadline is what ends the wait.
+        // `std::future::pending::<Result<Arc<Signature>, CollectionError>>()` is `Send`, which
+        // satisfies the returned future's bound.
+        if self.hangs.load(Ordering::Relaxed) {
             return Box::pin(std::future::pending());
+        }
+        // Stands in for any root that never reaches quorum; the caller only distinguishes
+        // success from failure.
+        if self.fails.load(Ordering::Relaxed)
+            || self
+                .failing_pubkeys
+                .lock()
+                .contains(&signing_data.validator_pubkey)
+        {
+            return Box::pin(async { Err(CollectionError::CollectionTimeout) });
         }
         if let Some(failure) = self.failure.clone() {
             return Box::pin(async move { Err(failure) });
@@ -239,18 +305,30 @@ impl SignatureCollecting for MockSignatureCollector {
     }
 }
 
-/// Creates a mock signature collector and returns the shared captured calls handle.
+/// Creates a mock signature collector, returning the shared captured calls and failure-mode
+/// handles.
 fn create_mock_collector(
     failure: Option<CollectionError>,
     hang: bool,
-) -> (Box<dyn SignatureCollecting>, CapturedCalls) {
+) -> (
+    Box<dyn SignatureCollecting>,
+    CapturedCalls,
+    Arc<AtomicBool>,
+    Arc<AtomicBool>,
+    FailingPubkeys,
+) {
     let captured: CapturedCalls = Arc::new(Mutex::new(Vec::new()));
+    let fails = Arc::new(AtomicBool::new(false));
+    let hangs = Arc::new(AtomicBool::new(hang));
+    let failing_pubkeys: FailingPubkeys = Arc::new(Mutex::new(HashSet::new()));
     let mock = MockSignatureCollector {
         captured: Arc::clone(&captured),
         failure,
-        hang,
+        fails: Arc::clone(&fails),
+        hangs: Arc::clone(&hangs),
+        failing_pubkeys: Arc::clone(&failing_pubkeys),
     };
-    (Box::new(mock), captured)
+    (Box::new(mock), captured, fails, hangs, failing_pubkeys)
 }
 
 // ==================== Committee setup ====================
@@ -259,6 +337,54 @@ pub(super) struct CommitteeSetup {
     pub(super) cluster: Cluster,
     pub(super) validators: Vec<ValidatorMetadata>,
     shares: Vec<Share>,
+}
+
+/// Standard two-committee topology shared by the Boole+ callback-gate tests
+/// (`committee_aggregate.rs` and `committee_contribution.rs`): a primary and a secondary
+/// committee with distinct operator sets and disjoint validator index spaces, both containing
+/// this operator.
+pub(super) const PRIMARY_COMMITTEE_OPERATOR_IDS: [OperatorId; 4] =
+    [OperatorId(1), OperatorId(2), OperatorId(3), OperatorId(4)];
+pub(super) const SECONDARY_COMMITTEE_OPERATOR_IDS: [OperatorId; 4] =
+    [OperatorId(1), OperatorId(5), OperatorId(6), OperatorId(7)];
+pub(super) const PRIMARY_COMMITTEE_STARTING_VALIDATOR_INDEX: usize = 0;
+pub(super) const SECONDARY_COMMITTEE_STARTING_VALIDATOR_INDEX: usize = 100;
+
+/// [`create_committee_setup`] for the standard primary committee.
+pub(super) fn create_primary_committee_setup(num_validators: usize) -> CommitteeSetup {
+    create_committee_setup(
+        &PRIMARY_COMMITTEE_OPERATOR_IDS,
+        num_validators,
+        PRIMARY_COMMITTEE_STARTING_VALIDATOR_INDEX,
+    )
+}
+
+/// [`create_committee_setup`] for the standard secondary committee.
+pub(super) fn create_secondary_committee_setup(num_validators: usize) -> CommitteeSetup {
+    create_committee_setup(
+        &SECONDARY_COMMITTEE_OPERATOR_IDS,
+        num_validators,
+        SECONDARY_COMMITTEE_STARTING_VALIDATOR_INDEX,
+    )
+}
+
+/// Asserts a callback stream yielded exactly one item and that item is an empty batch.
+///
+/// The empty batch is the Boole+ contract for both callback classes: Lighthouse's publish loops
+/// drop an empty result silently, which is what keeps Anchor the single publisher of committee
+/// duties. `what` names the class in failure messages ("aggregates", "sync contributions").
+pub(super) fn assert_single_empty_batch<T>(results: Vec<Result<Vec<T>, Error>>, what: &str) {
+    assert_eq!(results.len(), 1, "expected exactly one stream item");
+    let batch = results
+        .into_iter()
+        .next()
+        .expect("stream item should exist")
+        .unwrap_or_else(|e| panic!("the callback for {what} should not fail: {e:?}"));
+    assert!(
+        batch.is_empty(),
+        "Lighthouse must receive nothing to publish at Boole+; the metadata service publishes \
+         committee {what} from the decided value"
+    );
 }
 
 /// Builds a synthetic committee with deterministic validator and share data.
@@ -335,12 +461,10 @@ pub(super) struct HarnessOptions {
     /// `TEST_SLOT` is pre-Electra. Tests that need a specific fork at `TEST_SLOT` (Electra or
     /// Gloas) supply a spec with the matching `*_fork_epoch` set to genesis.
     pub(super) spec: Arc<ChainSpec>,
-    /// When `Some`, the mock decides every `GloasBeaconVote` with this `attestation_data_index`,
-    /// modeling a cluster-decided index that may differ from each operator's local seed.
-    pub(super) forced_gloas_index: Option<u64>,
-    /// When `Some`, the mock decides every `EnvelopeConsensusData` seed as this value,
-    /// modeling a cluster that decided another operator's envelope.
-    pub(super) forced_envelope_decision: Option<EnvelopeConsensusData>,
+    /// Consensus decider wired into the store. Defaults to the echoing mock; tests that need a
+    /// cluster decision differing from the local seed supply a configured
+    /// [`MockConsensusDecider`].
+    pub(super) decider: MockConsensusDecider,
     /// SSV fork the store's `ForkSchedule` reports as active. Defaults to `Boole`; tests that
     /// exercise pre-Boole behaviour supply an earlier fork.
     pub(super) active_fork: Fork,
@@ -359,8 +483,7 @@ impl Default for HarnessOptions {
             // DB so the signing paths can record and check attestations.
             disable_slashing_protection: true,
             spec: Arc::new(ChainSpec::mainnet()),
-            forced_gloas_index: None,
-            forced_envelope_decision: None,
+            decider: MockConsensusDecider::echoing(),
             active_fork: Fork::Boole,
             proposer_delays: ProposerDelays::default(),
         }
@@ -405,6 +528,13 @@ pub(super) struct ValidatorStoreTestHarness {
     /// Not yet read by any harness-driven test; the envelope-signing e2e tests will consume it.
     #[expect(dead_code)]
     pub(super) captured_decides: CapturedDecides,
+    /// Set by [`Self::fail_signature_collection`]; read by the mock collector on every call.
+    signature_collection_fails: Arc<AtomicBool>,
+    /// Filled by [`Self::hang_signature_collection`]; read by the mock collector on every call.
+    signature_collection_hangs: Arc<AtomicBool>,
+    /// Filled by [`Self::fail_signature_collection_for`]; read by the mock collector on every
+    /// call.
+    failing_pubkeys: FailingPubkeys,
     /// Shares `current_time` with the clone held by the store, so tests can reposition the clock
     /// after construction.
     pub(super) slot_clock: ManualSlotClock,
@@ -442,6 +572,23 @@ impl ValidatorStoreTestHarness {
         )
     }
 
+    pub(super) fn new_with_fork_and_consensus(
+        committee_setups: Vec<CommitteeSetup>,
+        our_operator_id: OperatorId,
+        active_fork: Fork,
+        consensus: MockConsensusDecider,
+    ) -> Self {
+        Self::new_with_options(
+            committee_setups,
+            our_operator_id,
+            HarnessOptions {
+                active_fork,
+                decider: consensus,
+                ..Default::default()
+            },
+        )
+    }
+
     pub(super) fn new_with_options(
         committee_setups: Vec<CommitteeSetup>,
         our_operator_id: OperatorId,
@@ -469,8 +616,13 @@ impl ValidatorStoreTestHarness {
             "test",
         ));
 
-        let (mock_collector, captured_calls) =
-            create_mock_collector(options.collector_failure, options.collector_hangs);
+        let (
+            mock_collector,
+            captured_calls,
+            signature_collection_fails,
+            signature_collection_hangs,
+            failing_pubkeys,
+        ) = create_mock_collector(options.collector_failure, options.collector_hangs);
 
         // Database
         let database = Arc::new(
@@ -547,14 +699,7 @@ impl ValidatorStoreTestHarness {
 
         let (is_synced_tx, is_synced_rx) = watch::channel(true);
 
-        let decider = match (options.forced_gloas_index, options.forced_envelope_decision) {
-            (Some(index), None) => MockConsensusDecider::forcing_gloas_index(index),
-            (None, Some(decided)) => MockConsensusDecider::deciding_envelope(decided),
-            (None, None) => MockConsensusDecider::echoing(),
-            (Some(_), Some(_)) => {
-                panic!("harness options must not force both a Gloas index and an envelope decision")
-            }
-        };
+        let decider = options.decider;
         let captured_decides = decider.captured_decides();
 
         let spec = Arc::clone(&options.spec);
@@ -585,6 +730,9 @@ impl ValidatorStoreTestHarness {
             committee_setups,
             captured_calls,
             captured_decides,
+            signature_collection_fails,
+            signature_collection_hangs,
+            failing_pubkeys,
             slot_clock,
             is_synced_tx,
             spec,
@@ -601,6 +749,15 @@ impl ValidatorStoreTestHarness {
         validator_idx: usize,
     ) -> ValidatorMetadata {
         self.committee_setups[committee_idx].validators[validator_idx].clone()
+    }
+
+    /// The beacon-chain validator index of one committee member, as it appears in signed
+    /// aggregates and decided values.
+    pub(super) fn aggregator_index(&self, committee_idx: usize, validator_idx: usize) -> u64 {
+        *self
+            .validator_metadata(committee_idx, validator_idx)
+            .index
+            .expect("test validator should have an index") as u64
     }
 
     pub(super) fn seed_sync_voting_assignments_for_slot(
@@ -713,81 +870,96 @@ impl ValidatorStoreTestHarness {
             .cloned()
     }
 
-    /// Seeds `AggregationAssignments` for the given committees at the provided slot.
+    /// Publishes `consensus_data_by_ssv_committee` as the decided values at `TEST_SLOT`, returning
+    /// the executions the publish newly registered.
     ///
-    /// Each validator in the selected committee is treated as an attestation aggregator for a
-    /// single beacon committee index derived from the test committee position.
-    pub(super) fn seed_aggregation_assignments_for_slot(
+    /// This is the slot pipeline's Phase 3 step: registration happens before the assignments reach
+    /// the watch channel, and only vacant registrations come back, so a republish returns nothing.
+    pub(super) fn publish_decided_values(
         &self,
-        slot: u64,
-        committee_indices: &[usize],
-    ) {
-        let mut aggregator_committees = HashMap::new();
-        let mut consensus_data_by_ssv_committee = HashMap::new();
-
-        for &committee_idx in committee_indices {
-            let setup = &self.committee_setups[committee_idx];
-            let beacon_committee_index = committee_idx as u64;
-
-            for validator in &setup.validators {
-                aggregator_committees.insert(validator.public_key, beacon_committee_index);
-            }
-
-            let aggregators: Vec<_> = setup
-                .validators
-                .iter()
-                .map(|validator| AssignedAggregator {
-                    validator_index: validator.index.expect("test validator should have index"),
-                    selection_proof: Signature::empty(),
-                    committee_index: beacon_committee_index,
-                })
-                .collect();
-
-            let aggregated_attestation = AttestationBase::<MainnetEthSpec> {
-                aggregation_bits: ssz_types::BitList::with_capacity(128)
-                    .expect("bitlist should be valid"),
-                data: AttestationData {
-                    slot: Slot::new(slot),
-                    index: beacon_committee_index,
-                    beacon_block_root: Hash256::zero(),
-                    source: Checkpoint {
-                        epoch: Epoch::new(0),
-                        root: Hash256::zero(),
-                    },
-                    target: Checkpoint {
-                        epoch: Epoch::new(0),
-                        root: Hash256::zero(),
-                    },
-                },
-                signature: AggregateSignature::infinity(),
-            };
-
-            let consensus_data = AggregatorCommitteeConsensusData::<MainnetEthSpec> {
-                version: DataVersion::from(types::ForkName::Deneb),
-                aggregators: VariableList::new(aggregators)
-                    .expect("aggregator list should be valid"),
-                aggregator_committee_indexes: VariableList::new(vec![beacon_committee_index])
-                    .expect("committee indexes should be valid"),
-                aggregated_attestations: VariableList::new(vec![
-                    VariableList::new(aggregated_attestation.as_ssz_bytes())
-                        .expect("attestation bytes should fit"),
-                ])
-                .expect("aggregated attestations should be valid"),
-                contributors: VariableList::empty(),
-                sync_committee_contributions: VariableList::empty(),
-            };
-
-            consensus_data_by_ssv_committee
-                .insert(setup.cluster.committee_id(), Arc::new(consensus_data));
-        }
-
+        consensus_data_by_ssv_committee: HashMap<
+            CommitteeId,
+            Arc<AggregatorCommitteeConsensusData<MainnetEthSpec>>,
+        >,
+    ) -> Vec<(CommitteeId, AggregatorPostConsensusShared<MainnetEthSpec>)> {
         self.validator_store
             .update_aggregation_assignments(AggregationAssignments {
-                slot: Slot::new(slot),
-                aggregator_committees,
+                slot: Slot::new(TEST_SLOT),
+                aggregator_committees: HashMap::new(),
                 multi_sync_aggregators: HashMap::new(),
                 consensus_data_by_ssv_committee,
-            });
+            })
+    }
+
+    /// Runs the Lighthouse aggregate callback to completion.
+    pub(super) async fn collect_aggregates(
+        &self,
+        aggregates: Vec<AggregateToSign<MainnetEthSpec>>,
+    ) -> SignAggregatesResult {
+        let stream = self.validator_store.sign_aggregate_and_proofs(aggregates);
+        tokio::time::timeout(STREAM_TIMEOUT, stream.collect())
+            .await
+            .expect("the aggregate callback should complete within the stream timeout")
+    }
+
+    /// Runs the Lighthouse contribution callback to completion.
+    pub(super) async fn collect_contributions(
+        &self,
+        contributions: Vec<ContributionToSign<MainnetEthSpec>>,
+    ) -> SignContributionsResult {
+        let stream = self
+            .validator_store
+            .sign_sync_committee_contributions(contributions);
+        tokio::time::timeout(STREAM_TIMEOUT, stream.collect())
+            .await
+            .expect("the contribution callback should complete within the stream timeout")
+    }
+
+    /// A contribution request at `TEST_SLOT`, as Lighthouse's sync committee service would send.
+    pub(super) fn create_contribution(
+        &self,
+        committee_idx: usize,
+        validator_idx: usize,
+        subcommittee_index: u64,
+    ) -> ContributionToSign<MainnetEthSpec> {
+        let validator = &self.committee_setups[committee_idx].validators[validator_idx];
+        let validator_index = validator
+            .index
+            .expect("test validator should have an index");
+
+        ContributionToSign {
+            aggregator_index: *validator_index as u64,
+            aggregator_pubkey: validator.public_key,
+            contribution: SyncCommitteeContribution {
+                slot: Slot::new(TEST_SLOT),
+                beacon_block_root: Hash256::zero(),
+                subcommittee_index,
+                aggregation_bits: Default::default(),
+                signature: AggregateSignature::infinity(),
+            },
+            selection_proof: SyncSelectionProof::from(Signature::empty()),
+        }
+    }
+
+    /// Makes every subsequent `sign_and_collect` call fail, for tests of the paths a root that
+    /// never reaches quorum takes. Calls are still captured.
+    pub(super) fn fail_signature_collection(&self) {
+        self.signature_collection_fails
+            .store(true, Ordering::Relaxed);
+    }
+
+    /// Makes every subsequent `sign_and_collect` call hang forever, so the caller's own deadline
+    /// decides each root's fate. This is the only way to reach a per-root deadline-expiry path;
+    /// [`Self::fail_signature_collection`] resolves to an error instead. Calls are still captured.
+    pub(super) fn hang_signature_collection(&self) {
+        self.signature_collection_hangs
+            .store(true, Ordering::Relaxed);
+    }
+
+    /// Makes every subsequent `sign_and_collect` call for `pubkey` fail, so one root can miss
+    /// quorum while its siblings still collect. Calls are still captured.
+    pub(super) fn fail_signature_collection_for(&self, pubkey: PublicKeyBytes) {
+        self.failing_pubkeys.lock().insert(pubkey);
     }
 
     pub(super) fn create_attestation(
@@ -880,15 +1052,6 @@ impl ValidatorStoreTestHarness {
         committee_idx: usize,
         validator_idx: usize,
     ) -> AggregateToSign<MainnetEthSpec> {
-        self.create_aggregate_at_slot(committee_idx, validator_idx, TEST_SLOT)
-    }
-
-    pub(super) fn create_aggregate_at_slot(
-        &self,
-        committee_idx: usize,
-        validator_idx: usize,
-        slot: u64,
-    ) -> AggregateToSign<MainnetEthSpec> {
         let validator = &self.committee_setups[committee_idx].validators[validator_idx];
         let validator_index = validator
             .index
@@ -901,7 +1064,7 @@ impl ValidatorStoreTestHarness {
                 aggregation_bits: ssz_types::BitList::with_capacity(128)
                     .expect("bitlist should be valid"),
                 data: AttestationData {
-                    slot: Slot::new(slot),
+                    slot: Slot::new(TEST_SLOT),
                     index: committee_idx as u64,
                     beacon_block_root: Hash256::zero(),
                     source: Checkpoint {

--- a/anchor/validator_store/src/testing/mod.rs
+++ b/anchor/validator_store/src/testing/mod.rs
@@ -1,5 +1,6 @@
 mod common;
 
+mod aggregator_post_consensus;
 mod committee_aggregate;
 mod committee_attestation;
 mod proposer_delay;

--- a/anchor/validator_store/src/testing/mod.rs
+++ b/anchor/validator_store/src/testing/mod.rs
@@ -3,6 +3,7 @@ mod common;
 mod aggregator_post_consensus;
 mod committee_aggregate;
 mod committee_attestation;
+mod committee_contribution;
 mod proposer_delay;
 mod sync_contribution;
 mod sync_selection_proof;

--- a/anchor/validator_store/src/testing/mod.rs
+++ b/anchor/validator_store/src/testing/mod.rs
@@ -1,13 +1,16 @@
 mod common;
 
+mod aggregator_post_consensus;
 mod committee_aggregate;
 mod committee_attestation;
 mod committee_attestation_gloas;
 mod committee_attestation_slashing;
+mod committee_contribution;
 mod decided_block_root;
 mod decided_block_root_e2e;
 mod envelope_signing;
 mod payload_attestation;
 mod proposer_delay;
 mod proposer_preferences;
+mod sync_contribution;
 mod sync_selection_proof;

--- a/anchor/validator_store/src/testing/mod.rs
+++ b/anchor/validator_store/src/testing/mod.rs
@@ -4,4 +4,5 @@ mod aggregator_post_consensus;
 mod committee_aggregate;
 mod committee_attestation;
 mod proposer_delay;
+mod sync_contribution;
 mod sync_selection_proof;

--- a/anchor/validator_store/src/testing/sync_contribution.rs
+++ b/anchor/validator_store/src/testing/sync_contribution.rs
@@ -1,0 +1,368 @@
+//! Tests for pre-Boole post-consensus sync contribution preparation and batching.
+
+use std::{collections::HashMap, time::Duration};
+
+use bls::{AggregateSignature, Signature};
+use fork::Fork;
+use futures::StreamExt;
+use signature_collector::{SignatureRequester, SyncCommitteeBatchEntry};
+use ssv_types::{
+    OperatorId, ValidatorIndex,
+    consensus::{
+        BEACON_ROLE_SYNC_COMMITTEE_CONTRIBUTION, Contribution, ContributionWrapper, Contributions,
+        ProposerConsensusData, ValidatorDuty,
+    },
+    partial_sig::PartialSignatureKind,
+};
+use ssz::Encode;
+use ssz_types::VariableList;
+use types::{
+    ContributionAndProof, Domain, EthSpec, ForkName, Hash256, MainnetEthSpec, SignedRoot, Slot,
+    SyncCommitteeContribution, SyncSelectionProof, SyncSubnetId,
+};
+use validator_store::{ContributionToSign, ValidatorStore};
+
+use super::common::*;
+use crate::{
+    AggregationAssignments, CollectionMode, ContributionWaiter, SpecificError,
+    prepare_decided_sync_contributions, sync_committee_collection_mode,
+};
+
+const OUR_OPERATOR_ID: OperatorId = OperatorId(1);
+const AGGREGATOR_INDEX: u64 = 42;
+const DOMAIN_HASH: Hash256 = Hash256::repeat_byte(0xDD);
+
+#[derive(Clone, Copy, Debug)]
+struct ContributionSpec {
+    subnet: u64,
+    block_root_byte: u8,
+}
+
+fn contribution(spec: ContributionSpec) -> Contribution<MainnetEthSpec> {
+    Contribution {
+        selection_proof_sig: Signature::empty(),
+        contribution: SyncCommitteeContribution {
+            slot: Slot::new(TEST_SLOT),
+            beacon_block_root: Hash256::repeat_byte(spec.block_root_byte),
+            subcommittee_index: spec.subnet,
+            aggregation_bits: Default::default(),
+            signature: AggregateSignature::infinity(),
+        },
+    }
+}
+
+fn message(spec: ContributionSpec) -> ContributionAndProof<MainnetEthSpec> {
+    let contribution = contribution(spec);
+    ContributionAndProof {
+        aggregator_index: AGGREGATOR_INDEX,
+        contribution: contribution.contribution,
+        selection_proof: contribution.selection_proof_sig,
+    }
+}
+
+fn decided(specs: &[ContributionSpec]) -> Contributions<MainnetEthSpec> {
+    Contributions::new(
+        specs
+            .iter()
+            .copied()
+            .map(contribution)
+            .map(ContributionWrapper::from)
+            .collect(),
+    )
+    .expect("test contributions should fit the bounded decided value")
+}
+
+fn expected_descriptor(
+    entries: &[(ContributionSpec, usize)],
+    domain_hash: Hash256,
+) -> Vec<SyncCommitteeBatchEntry> {
+    let mut descriptor = entries
+        .iter()
+        .map(|(spec, multiplicity)| SyncCommitteeBatchEntry {
+            subnet_id: SyncSubnetId::new(spec.subnet),
+            signing_root: message(*spec).signing_root(domain_hash),
+            multiplicity: *multiplicity,
+        })
+        .collect::<Vec<_>>();
+    descriptor.sort_unstable_by_key(|entry| (u64::from(entry.subnet_id), entry.signing_root));
+    descriptor
+}
+
+#[test]
+fn decided_contribution_preparation_cases() {
+    struct Case {
+        name: &'static str,
+        decided: Vec<ContributionSpec>,
+        callback_subnet: u64,
+        expected_entries: Vec<(ContributionSpec, usize)>,
+    }
+
+    let a = ContributionSpec {
+        subnet: 0,
+        block_root_byte: 0x10,
+    };
+    let b = ContributionSpec {
+        subnet: 1,
+        block_root_byte: 0x11,
+    };
+    let c = ContributionSpec {
+        subnet: 2,
+        block_root_byte: 0x12,
+    };
+    let d = ContributionSpec {
+        subnet: 3,
+        block_root_byte: 0x13,
+    };
+    let same_subnet_first = ContributionSpec {
+        subnet: 1,
+        block_root_byte: 0x21,
+    };
+    let same_subnet_second = ContributionSpec {
+        subnet: 1,
+        block_root_byte: 0x20,
+    };
+
+    let cases = [
+        Case {
+            name: "one root",
+            decided: vec![a],
+            callback_subnet: 0,
+            expected_entries: vec![(a, 1)],
+        },
+        Case {
+            name: "two roots in reverse subnet order",
+            decided: vec![b, a],
+            callback_subnet: 1,
+            expected_entries: vec![(a, 1), (b, 1)],
+        },
+        Case {
+            name: "four shuffled roots",
+            decided: vec![d, b, a, c],
+            callback_subnet: 2,
+            expected_entries: vec![(a, 1), (b, 1), (c, 1), (d, 1)],
+        },
+        Case {
+            name: "same four roots in another permutation",
+            decided: vec![c, a, d, b],
+            callback_subnet: 2,
+            expected_entries: vec![(a, 1), (b, 1), (c, 1), (d, 1)],
+        },
+        Case {
+            name: "identical entry multiplicity",
+            decided: vec![b, a, b],
+            callback_subnet: 1,
+            expected_entries: vec![(a, 1), (b, 2)],
+        },
+        Case {
+            name: "decided subnet without a local callback",
+            decided: vec![a, d],
+            callback_subnet: 0,
+            expected_entries: vec![(a, 1), (d, 1)],
+        },
+        Case {
+            name: "two distinct roots on one subnet",
+            decided: vec![same_subnet_first, same_subnet_second],
+            callback_subnet: 1,
+            expected_entries: vec![(same_subnet_first, 1), (same_subnet_second, 1)],
+        },
+    ];
+
+    for case in cases {
+        let first_matching = case
+            .decided
+            .iter()
+            .copied()
+            .find(|spec| spec.subnet == case.callback_subnet)
+            .expect("valid case should contain its callback subnet");
+        let prepared = prepare_decided_sync_contributions(
+            decided(&case.decided),
+            SyncSubnetId::new(case.callback_subnet),
+            AGGREGATOR_INDEX,
+            DOMAIN_HASH,
+        )
+        .unwrap_or_else(|error| panic!("{} should prepare: {error:?}", case.name));
+        let expected = expected_descriptor(&case.expected_entries, DOMAIN_HASH);
+
+        assert_eq!(
+            prepared.callback_message,
+            message(first_matching),
+            "{}",
+            case.name
+        );
+        assert_eq!(
+            prepared.callback_signing_root,
+            message(first_matching).signing_root(DOMAIN_HASH),
+            "{}",
+            case.name
+        );
+        assert_eq!(prepared.descriptor, expected, "{}", case.name);
+
+        let total_multiplicity = expected
+            .iter()
+            .map(|entry| entry.multiplicity)
+            .sum::<usize>();
+        match sync_committee_collection_mode(
+            SyncSubnetId::new(case.callback_subnet),
+            prepared.descriptor,
+        ) {
+            CollectionMode::SingleValidator if total_multiplicity == 1 => {}
+            CollectionMode::SingleValidatorBatch {
+                subnet_id,
+                descriptor,
+            } if total_multiplicity > 1 => {
+                assert_eq!(subnet_id, SyncSubnetId::new(case.callback_subnet));
+                assert_eq!(descriptor, expected);
+            }
+            _ => panic!("{} selected the wrong collection mode", case.name),
+        }
+    }
+}
+
+#[test]
+fn decided_contribution_preparation_preserves_no_data_agreed() {
+    let result = prepare_decided_sync_contributions(
+        decided(&[ContributionSpec {
+            subnet: 0,
+            block_root_byte: 0x10,
+        }]),
+        SyncSubnetId::new(1),
+        AGGREGATOR_INDEX,
+        DOMAIN_HASH,
+    );
+
+    assert!(matches!(result, Err(SpecificError::NoDataAgreed)));
+}
+
+fn fixed_consensus_data(
+    validator_pubkey: bls::PublicKeyBytes,
+    validator_index: ValidatorIndex,
+    decided: &Contributions<MainnetEthSpec>,
+) -> ProposerConsensusData {
+    ProposerConsensusData {
+        duty: ValidatorDuty {
+            r#type: BEACON_ROLE_SYNC_COMMITTEE_CONTRIBUTION,
+            pub_key: validator_pubkey,
+            slot: Slot::new(TEST_SLOT),
+            validator_index,
+            committee_index: 0,
+            committee_length: 0,
+            committees_at_slot: 0,
+            validator_committee_index: AGGREGATOR_INDEX,
+            validator_sync_committee_indices: Default::default(),
+        },
+        version: ForkName::Altair.into(),
+        data_ssz: VariableList::new(decided.as_ssz_bytes())
+            .expect("decided contribution bytes should fit proposer consensus data"),
+    }
+}
+
+fn contribution_to_sign(
+    validator_pubkey: bls::PublicKeyBytes,
+    spec: ContributionSpec,
+) -> ContributionToSign<MainnetEthSpec> {
+    let data = contribution(spec);
+    ContributionToSign {
+        aggregator_index: AGGREGATOR_INDEX,
+        aggregator_pubkey: validator_pubkey,
+        contribution: data.contribution,
+        selection_proof: SyncSelectionProof::from(data.selection_proof_sig),
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn pre_boole_callbacks_use_the_complete_fixed_decided_descriptor() {
+    let committee = create_committee_setup(
+        &[OperatorId(1), OperatorId(2), OperatorId(3), OperatorId(4)],
+        1,
+        AGGREGATOR_INDEX as usize,
+    );
+    let validator = committee.validators[0].clone();
+    let callback_a = ContributionSpec {
+        subnet: 0,
+        block_root_byte: 0x31,
+    };
+    let callback_b = ContributionSpec {
+        subnet: 1,
+        block_root_byte: 0x32,
+    };
+    let phantom = ContributionSpec {
+        subnet: 3,
+        block_root_byte: 0x33,
+    };
+    let fixed_decided = decided(&[phantom, callback_b, callback_a]);
+    let validator_index = validator
+        .index
+        .expect("test validator should have an index");
+    let fixed_value = fixed_consensus_data(validator.public_key, validator_index, &fixed_decided);
+    let harness = ValidatorStoreTestHarness::new_with_fork_and_consensus(
+        vec![committee],
+        OUR_OPERATOR_ID,
+        Fork::Alan,
+        MockConsensusDecider::fixed_after_barrier(&fixed_value, 2),
+    );
+    harness
+        .validator_store
+        .update_aggregation_assignments(AggregationAssignments {
+            slot: Slot::new(TEST_SLOT),
+            aggregator_committees: HashMap::new(),
+            multi_sync_aggregators: HashMap::from([(
+                validator.public_key,
+                ContributionWaiter::new(2),
+            )]),
+            consensus_data_by_ssv_committee: HashMap::new(),
+        });
+
+    let stream = harness
+        .validator_store
+        .sign_sync_committee_contributions(vec![
+            contribution_to_sign(validator.public_key, callback_b),
+            contribution_to_sign(validator.public_key, callback_a),
+        ]);
+    let results = tokio::time::timeout(Duration::from_secs(5), stream.collect::<Vec<_>>())
+        .await
+        .expect("concurrent contribution callbacks should complete promptly");
+    let mut signed = results
+        .into_iter()
+        .next()
+        .expect("pre-Boole signing should produce one streamed result")
+        .expect("pre-Boole signing should succeed");
+    signed.sort_by_key(|item| item.message.contribution.subcommittee_index);
+    assert_eq!(signed.len(), 2);
+    assert_eq!(signed[0].message, message(callback_a));
+    assert_eq!(signed[1].message, message(callback_b));
+
+    let epoch = Slot::new(TEST_SLOT).epoch(MainnetEthSpec::slots_per_epoch());
+    let domain_hash = harness
+        .validator_store
+        .get_domain(epoch, Domain::ContributionAndProof);
+    let expected = expected_descriptor(
+        &[(callback_a, 1), (callback_b, 1), (phantom, 1)],
+        domain_hash,
+    );
+    let mut captured = harness.captured_calls.lock();
+    captured.sort_by_key(|call| match &call.requester {
+        SignatureRequester::SingleValidatorBatch { subnet_id, .. } => u64::from(*subnet_id),
+        other => panic!("expected post-consensus batch requester, got {other:?}"),
+    });
+    assert_eq!(captured.len(), 2);
+    for (call, callback) in captured.iter().zip([callback_a, callback_b]) {
+        assert_eq!(call.metadata.kind, PartialSignatureKind::PostConsensus);
+        assert_eq!(call.metadata.role, ssv_types::msgid::Role::SyncCommittee);
+        assert_eq!(call.metadata.slot, Slot::new(TEST_SLOT));
+        assert_eq!(call.validator_pubkey, validator.public_key);
+        let expected_root = message(callback).signing_root(domain_hash);
+        match &call.requester {
+            SignatureRequester::SingleValidatorBatch {
+                pubkey,
+                subnet_id,
+                descriptor,
+            } => {
+                assert_eq!(*pubkey, validator.public_key);
+                assert_eq!(*subnet_id, SyncSubnetId::new(callback.subnet));
+                assert_eq!(descriptor, &expected);
+            }
+            other => panic!("expected post-consensus batch requester, got {other:?}"),
+        }
+        assert_eq!(call.signing_root, expected_root);
+    }
+}

--- a/anchor/validator_store/src/testing/sync_contribution.rs
+++ b/anchor/validator_store/src/testing/sync_contribution.rs
@@ -1,0 +1,373 @@
+//! Tests for pre-Boole post-consensus sync contribution preparation and batching.
+
+use std::{collections::HashMap, time::Duration};
+
+use bls::{AggregateSignature, Signature};
+use fork::Fork;
+use futures::StreamExt;
+use signature_collector::{SignatureRequester, SyncCommitteeBatchEntry};
+use ssv_types::{
+    OperatorId, ValidatorIndex,
+    consensus::{
+        BEACON_ROLE_SYNC_COMMITTEE_CONTRIBUTION, Contribution, ContributionWrapper, Contributions,
+        ProposerConsensusData, ValidatorDuty,
+    },
+    partial_sig::PartialSignatureKind,
+};
+use ssz::Encode;
+use ssz_types::VariableList;
+use types::{
+    ContributionAndProof, Domain, EthSpec, ForkName, Hash256, MainnetEthSpec, SignedRoot, Slot,
+    SyncCommitteeContribution, SyncSelectionProof, SyncSubnetId,
+};
+use validator_store::{ContributionToSign, ValidatorStore};
+
+use super::common::*;
+use crate::{
+    AggregationAssignments, CollectionMode, ContributionWaiter, SpecificError,
+    prepare_decided_sync_contributions, sync_committee_collection_mode,
+};
+
+const OUR_OPERATOR_ID: OperatorId = OperatorId(1);
+const AGGREGATOR_INDEX: u64 = 42;
+const DOMAIN_HASH: Hash256 = Hash256::repeat_byte(0xDD);
+
+#[derive(Clone, Copy, Debug)]
+struct ContributionSpec {
+    subnet: u64,
+    block_root_byte: u8,
+}
+
+fn contribution(spec: ContributionSpec) -> Contribution<MainnetEthSpec> {
+    Contribution {
+        selection_proof_sig: Signature::empty(),
+        contribution: SyncCommitteeContribution {
+            slot: Slot::new(TEST_SLOT),
+            beacon_block_root: Hash256::repeat_byte(spec.block_root_byte),
+            subcommittee_index: spec.subnet,
+            aggregation_bits: Default::default(),
+            signature: AggregateSignature::infinity(),
+        },
+    }
+}
+
+fn message(spec: ContributionSpec) -> ContributionAndProof<MainnetEthSpec> {
+    let contribution = contribution(spec);
+    ContributionAndProof {
+        aggregator_index: AGGREGATOR_INDEX,
+        contribution: contribution.contribution,
+        selection_proof: contribution.selection_proof_sig,
+    }
+}
+
+fn decided(specs: &[ContributionSpec]) -> Contributions<MainnetEthSpec> {
+    Contributions::new(
+        specs
+            .iter()
+            .copied()
+            .map(contribution)
+            .map(ContributionWrapper::from)
+            .collect(),
+    )
+    .expect("test contributions should fit the bounded decided value")
+}
+
+fn expected_descriptor(
+    entries: &[(ContributionSpec, usize)],
+    domain_hash: Hash256,
+) -> Vec<SyncCommitteeBatchEntry> {
+    let mut descriptor = entries
+        .iter()
+        .map(|(spec, multiplicity)| SyncCommitteeBatchEntry {
+            subnet_id: SyncSubnetId::new(spec.subnet),
+            signing_root: message(*spec).signing_root(domain_hash),
+            multiplicity: *multiplicity,
+        })
+        .collect::<Vec<_>>();
+    descriptor.sort_unstable_by_key(|entry| (u64::from(entry.subnet_id), entry.signing_root));
+    descriptor
+}
+
+#[test]
+fn decided_contribution_preparation_cases() {
+    struct Case {
+        name: &'static str,
+        decided: Vec<ContributionSpec>,
+        callback_subnet: u64,
+        expected_entries: Vec<(ContributionSpec, usize)>,
+    }
+
+    let a = ContributionSpec {
+        subnet: 0,
+        block_root_byte: 0x10,
+    };
+    let b = ContributionSpec {
+        subnet: 1,
+        block_root_byte: 0x11,
+    };
+    let c = ContributionSpec {
+        subnet: 2,
+        block_root_byte: 0x12,
+    };
+    let d = ContributionSpec {
+        subnet: 3,
+        block_root_byte: 0x13,
+    };
+    let same_subnet_first = ContributionSpec {
+        subnet: 1,
+        block_root_byte: 0x21,
+    };
+    let same_subnet_second = ContributionSpec {
+        subnet: 1,
+        block_root_byte: 0x20,
+    };
+
+    let cases = [
+        Case {
+            name: "one root",
+            decided: vec![a],
+            callback_subnet: 0,
+            expected_entries: vec![(a, 1)],
+        },
+        Case {
+            name: "two roots in reverse subnet order",
+            decided: vec![b, a],
+            callback_subnet: 1,
+            expected_entries: vec![(a, 1), (b, 1)],
+        },
+        Case {
+            name: "four shuffled roots",
+            decided: vec![d, b, a, c],
+            callback_subnet: 2,
+            expected_entries: vec![(a, 1), (b, 1), (c, 1), (d, 1)],
+        },
+        Case {
+            name: "same four roots in another permutation",
+            decided: vec![c, a, d, b],
+            callback_subnet: 2,
+            expected_entries: vec![(a, 1), (b, 1), (c, 1), (d, 1)],
+        },
+        Case {
+            name: "identical entry multiplicity",
+            decided: vec![b, a, b],
+            callback_subnet: 1,
+            expected_entries: vec![(a, 1), (b, 2)],
+        },
+        Case {
+            name: "decided subnet without a local callback",
+            decided: vec![a, d],
+            callback_subnet: 0,
+            expected_entries: vec![(a, 1), (d, 1)],
+        },
+        Case {
+            name: "two distinct roots on one subnet",
+            decided: vec![same_subnet_first, same_subnet_second],
+            callback_subnet: 1,
+            expected_entries: vec![(same_subnet_first, 1), (same_subnet_second, 1)],
+        },
+    ];
+
+    for case in cases {
+        let first_matching = case
+            .decided
+            .iter()
+            .copied()
+            .find(|spec| spec.subnet == case.callback_subnet)
+            .expect("valid case should contain its callback subnet");
+        let prepared = prepare_decided_sync_contributions(
+            decided(&case.decided),
+            SyncSubnetId::new(case.callback_subnet),
+            AGGREGATOR_INDEX,
+            DOMAIN_HASH,
+        )
+        .unwrap_or_else(|error| panic!("{} should prepare: {error:?}", case.name));
+        let expected = expected_descriptor(&case.expected_entries, DOMAIN_HASH);
+
+        assert_eq!(
+            prepared.callback_message,
+            message(first_matching),
+            "{}",
+            case.name
+        );
+        assert_eq!(
+            prepared.callback_signing_root,
+            message(first_matching).signing_root(DOMAIN_HASH),
+            "{}",
+            case.name
+        );
+        assert_eq!(prepared.descriptor, expected, "{}", case.name);
+
+        let total_multiplicity = expected
+            .iter()
+            .map(|entry| entry.multiplicity)
+            .sum::<usize>();
+        match sync_committee_collection_mode(
+            SyncSubnetId::new(case.callback_subnet),
+            prepared.descriptor,
+        ) {
+            CollectionMode::SingleValidator if total_multiplicity == 1 => {}
+            CollectionMode::SingleValidatorBatch {
+                subnet_id,
+                descriptor,
+            } if total_multiplicity > 1 => {
+                assert_eq!(subnet_id, SyncSubnetId::new(case.callback_subnet));
+                assert_eq!(descriptor, expected);
+            }
+            _ => panic!("{} selected the wrong collection mode", case.name),
+        }
+    }
+}
+
+#[test]
+fn decided_contribution_preparation_preserves_no_data_agreed() {
+    let result = prepare_decided_sync_contributions(
+        decided(&[ContributionSpec {
+            subnet: 0,
+            block_root_byte: 0x10,
+        }]),
+        SyncSubnetId::new(1),
+        AGGREGATOR_INDEX,
+        DOMAIN_HASH,
+    );
+
+    assert!(matches!(result, Err(SpecificError::NoDataAgreed)));
+}
+
+fn fixed_consensus_data(
+    validator_pubkey: bls::PublicKeyBytes,
+    validator_index: ValidatorIndex,
+    decided: &Contributions<MainnetEthSpec>,
+) -> ProposerConsensusData {
+    ProposerConsensusData {
+        duty: ValidatorDuty {
+            r#type: BEACON_ROLE_SYNC_COMMITTEE_CONTRIBUTION,
+            pub_key: validator_pubkey,
+            slot: Slot::new(TEST_SLOT),
+            validator_index,
+            committee_index: 0,
+            committee_length: 0,
+            committees_at_slot: 0,
+            validator_committee_index: AGGREGATOR_INDEX,
+            validator_sync_committee_indices: Default::default(),
+        },
+        version: ForkName::Altair.into(),
+        data_ssz: VariableList::new(decided.as_ssz_bytes())
+            .expect("decided contribution bytes should fit proposer consensus data"),
+    }
+}
+
+fn contribution_to_sign(
+    validator_pubkey: bls::PublicKeyBytes,
+    spec: ContributionSpec,
+) -> ContributionToSign<MainnetEthSpec> {
+    let data = contribution(spec);
+    ContributionToSign {
+        aggregator_index: AGGREGATOR_INDEX,
+        aggregator_pubkey: validator_pubkey,
+        contribution: data.contribution,
+        selection_proof: SyncSelectionProof::from(data.selection_proof_sig),
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn pre_boole_callbacks_use_the_complete_fixed_decided_descriptor() {
+    let committee = create_committee_setup(
+        &[OperatorId(1), OperatorId(2), OperatorId(3), OperatorId(4)],
+        1,
+        AGGREGATOR_INDEX as usize,
+    );
+    let validator = committee.validators[0].clone();
+    let callback_a = ContributionSpec {
+        subnet: 0,
+        block_root_byte: 0x31,
+    };
+    let callback_b = ContributionSpec {
+        subnet: 1,
+        block_root_byte: 0x32,
+    };
+    let phantom = ContributionSpec {
+        subnet: 3,
+        block_root_byte: 0x33,
+    };
+    let fixed_decided = decided(&[phantom, callback_b, callback_a]);
+    let validator_index = validator
+        .index
+        .expect("test validator should have an index");
+    let fixed_value = fixed_consensus_data(validator.public_key, validator_index, &fixed_decided);
+    let harness = ValidatorStoreTestHarness::new_with_fork_and_consensus(
+        vec![committee],
+        OUR_OPERATOR_ID,
+        Fork::Alan,
+        MockConsensusDecider::fixed_after_barrier(&fixed_value, 2),
+    );
+    let new_executions =
+        harness
+            .validator_store
+            .update_aggregation_assignments(AggregationAssignments {
+                slot: Slot::new(TEST_SLOT),
+                aggregator_committees: HashMap::new(),
+                multi_sync_aggregators: HashMap::from([(
+                    validator.public_key,
+                    ContributionWaiter::new(2),
+                )]),
+                consensus_data_by_ssv_committee: HashMap::new(),
+            });
+    assert!(
+        new_executions.is_empty(),
+        "pre-Boole assignments without consensus data must not register aggregate executions"
+    );
+
+    let stream = harness
+        .validator_store
+        .sign_sync_committee_contributions(vec![
+            contribution_to_sign(validator.public_key, callback_b),
+            contribution_to_sign(validator.public_key, callback_a),
+        ]);
+    let results = tokio::time::timeout(Duration::from_secs(5), stream.collect::<Vec<_>>())
+        .await
+        .expect("concurrent contribution callbacks should complete promptly");
+    let mut signed = results
+        .into_iter()
+        .next()
+        .expect("pre-Boole signing should produce one streamed result")
+        .expect("pre-Boole signing should succeed");
+    signed.sort_by_key(|item| item.message.contribution.subcommittee_index);
+    assert_eq!(signed.len(), 2);
+    assert_eq!(signed[0].message, message(callback_a));
+    assert_eq!(signed[1].message, message(callback_b));
+
+    let epoch = Slot::new(TEST_SLOT).epoch(MainnetEthSpec::slots_per_epoch());
+    let domain_hash = harness
+        .validator_store
+        .get_domain(epoch, Domain::ContributionAndProof);
+    let expected = expected_descriptor(
+        &[(callback_a, 1), (callback_b, 1), (phantom, 1)],
+        domain_hash,
+    );
+    let mut captured = harness.captured_calls.lock();
+    captured.sort_by_key(|call| match &call.requester {
+        SignatureRequester::SingleValidatorBatch { subnet_id, .. } => u64::from(*subnet_id),
+        other => panic!("expected post-consensus batch requester, got {other:?}"),
+    });
+    assert_eq!(captured.len(), 2);
+    for (call, callback) in captured.iter().zip([callback_a, callback_b]) {
+        assert_eq!(call.metadata.kind, PartialSignatureKind::PostConsensus);
+        assert_eq!(call.metadata.role, ssv_types::msgid::Role::SyncCommittee);
+        assert_eq!(call.metadata.slot, Slot::new(TEST_SLOT));
+        assert_eq!(call.validator_pubkey, validator.public_key);
+        let expected_root = message(callback).signing_root(domain_hash);
+        match &call.requester {
+            SignatureRequester::SingleValidatorBatch {
+                pubkey,
+                subnet_id,
+                descriptor,
+            } => {
+                assert_eq!(*pubkey, validator.public_key);
+                assert_eq!(*subnet_id, SyncSubnetId::new(callback.subnet));
+                assert_eq!(descriptor, &expected);
+            }
+            other => panic!("expected post-consensus batch requester, got {other:?}"),
+        }
+        assert_eq!(call.signing_root, expected_root);
+    }
+}

--- a/anchor/validator_store/src/testing/sync_contribution.rs
+++ b/anchor/validator_store/src/testing/sync_contribution.rs
@@ -300,17 +300,22 @@ async fn pre_boole_callbacks_use_the_complete_fixed_decided_descriptor() {
         Fork::Alan,
         MockConsensusDecider::fixed_after_barrier(&fixed_value, 2),
     );
-    harness
-        .validator_store
-        .update_aggregation_assignments(AggregationAssignments {
-            slot: Slot::new(TEST_SLOT),
-            aggregator_committees: HashMap::new(),
-            multi_sync_aggregators: HashMap::from([(
-                validator.public_key,
-                ContributionWaiter::new(2),
-            )]),
-            consensus_data_by_ssv_committee: HashMap::new(),
-        });
+    let new_executions =
+        harness
+            .validator_store
+            .update_aggregation_assignments(AggregationAssignments {
+                slot: Slot::new(TEST_SLOT),
+                aggregator_committees: HashMap::new(),
+                multi_sync_aggregators: HashMap::from([(
+                    validator.public_key,
+                    ContributionWaiter::new(2),
+                )]),
+                consensus_data_by_ssv_committee: HashMap::new(),
+            });
+    assert!(
+        new_executions.is_empty(),
+        "pre-Boole assignments without consensus data must not register aggregate executions"
+    );
 
     let stream = harness
         .validator_store

--- a/anchor/validator_store/src/testing/sync_selection_proof.rs
+++ b/anchor/validator_store/src/testing/sync_selection_proof.rs
@@ -1,7 +1,7 @@
 //! Integration tests for sync selection proof descriptor construction.
 
 use fork::Fork;
-use signature_collector::{SignatureRequester, SyncSelectionProofDescriptor};
+use signature_collector::{SignatureRequester, SyncCommitteeBatchEntry};
 use ssv_types::OperatorId;
 use types::{Slot, SyncSubnetId};
 use validator_store::ValidatorStore;
@@ -85,14 +85,18 @@ async fn pre_boole_callbacks_receive_the_same_canonical_descriptor() {
         let expected_descriptor = case
             .expected_counts
             .iter()
-            .map(|(subnet, position_count)| SyncSelectionProofDescriptor {
+            .map(|(subnet, multiplicity)| SyncCommitteeBatchEntry {
                 subnet_id: SyncSubnetId::new(*subnet),
                 signing_root: harness
                     .validator_store
                     .compute_sync_selection_root(Slot::new(TEST_SLOT), *subnet),
-                position_count: *position_count,
+                multiplicity: *multiplicity,
             })
             .collect::<Vec<_>>();
+        let total_multiplicity = expected_descriptor
+            .iter()
+            .map(|entry| entry.multiplicity)
+            .sum::<usize>();
 
         let captured = harness.captured_calls.lock();
         assert_eq!(captured.len(), case.callbacks.len());
@@ -104,18 +108,23 @@ async fn pre_boole_callbacks_receive_the_same_canonical_descriptor() {
                 .expect("callback subnet should be present")
                 .signing_root;
             match &call.requester {
+                SignatureRequester::SingleValidator { pubkey } if total_multiplicity == 1 => {
+                    assert_eq!(*pubkey, validator.public_key);
+                    assert_eq!(call.signing_root, callback_root);
+                    assert_eq!(call.validator_pubkey, validator.public_key);
+                }
                 SignatureRequester::SingleValidatorBatch {
                     pubkey,
                     subnet_id,
                     descriptor,
-                } => {
+                } if total_multiplicity > 1 => {
                     assert_eq!(*pubkey, validator.public_key);
                     assert_eq!(*subnet_id, callback_subnet);
                     assert_eq!(descriptor, &expected_descriptor);
                     assert_eq!(call.signing_root, callback_root);
                     assert_eq!(call.validator_pubkey, validator.public_key);
                 }
-                other => panic!("expected SingleValidatorBatch, got {other:?}"),
+                other => panic!("unexpected signature requester: {other:?}"),
             }
         }
     }
@@ -257,7 +266,7 @@ async fn pre_boole_accepts_exactly_thirteen_positions() {
     assert!(matches!(
         &captured[0].requester,
         SignatureRequester::SingleValidatorBatch { descriptor, .. }
-            if descriptor[0].position_count == 13
+            if descriptor[0].multiplicity == 13
     ));
 }
 


### PR DESCRIPTION
**DO NOT MERGE / DO NOT SQUASH.** This PR exists only to run CI on the merge commit. The
merge commit is pushed directly to `epbs` with `git push upstream
merge-unstable-into-epbs:epbs`, so `epbs` keeps a two-parent merge and the eventual
`epbs` -> `unstable` merge does not re-conflict.

## Issue Addressed

`epbs` was 45/12 behind `unstable`. It misses the h2 0.4.16 bump (RUSTSEC-2026-0258, #1266),
so the audit job fails on `epbs` even though the fix is already on `unstable`.

## Proposed Changes

Merge of `upstream/unstable` (12 commits) into `epbs`. Conflicts and their resolutions:

- **`message_validator/partial_signature.rs`** - test import union. Unstable's new
  `validate_with_empty_validator_indices` helper (#1261) was ported onto the epbs signatures:
  four-argument `validate_partial_signature_message` and the extended `MockDutiesProvider`.
- **`validator_store/testing/mod.rs`** - module list union.
- **`validator_store/metadata_service.rs`** - import union; kept epbs's
  `resolve_committee_requests` and unstable's `spawn_aggregate_publisher`; kept unstable's
  `post_aggregate` / `post_contribution`. Dropped `filter_aggregators_with_attestations` and
  `filter_contributors_with_contributions`: epbs's composite fetch-key refactor removed their
  call sites, and no reference to either remains.
- **`validator_store/lib.rs`** - took unstable's move of `resolve_decided_aggregate` and the
  committee aggregate signing into `aggregator_post_consensus.rs`, then ported epbs's
  Gloas-aware `DataVersion::decode_attestation` into the moved copy (the moved copy still
  carried the pre-epbs Base/Electra branch). Import and `SpecificError` variant unions.
- **`validator_store/testing/common.rs`** - the harness had diverged on both sides.
  `MockConsensusDecider` now carries unstable's `fixed_after_barrier` alongside epbs's capture
  and forced-decision modes. `MockSignatureCollector` keeps epbs's construction-time failure
  and hang options plus unstable's runtime toggles, ordered hang, then `fails` /
  `failing_pubkeys`, then the configured failure, which preserves both sides' documented
  precedence. Unstable's `new_with_fork_and_consensus` became a `HarnessOptions` wrapper
  through a new `decider` field replacing `forced_gloas_index` / `forced_envelope_decision`
  (five call sites updated), so no other call site changed. `new_with_proposer_delay` and
  `seed_aggregation_assignments_for_slot` were dropped: both lost their only callers to the
  other side's rewrite. Also removed a duplicated `metadata` field that auto-merge produced in
  `CapturedSignatureCall`.
- **`ssv_network_config/lib.rs`** (auto-merged, but broken) - restored the `LARGE_BOOLE_EPOCH`
  test constant that epbs pruned and unstable's new duplicate-domain test (#1234) uses.

## Additional Info

Verification: no conflict markers; no duplicate functions or struct fields; item-level diff of
every file changed on both sides shows nothing dropped from either parent; the
`metadata_service.rs` delta against `epbs` matches unstable's delta against the merge base
exactly. `cargo check --workspace --all-targets`, `make cargo-fmt-check`, `make lint`, and the
`anchor_validator_store` / `message_validator` / `ssv_network_config` test suites all pass
locally. Cargo.lock carries h2 0.4.16 with epbs's Lighthouse `e58ec88fe` pins intact.
