### PR TITLE
chore: backmerge stable → unstable (v1.3.1 release)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -765,7 +765,7 @@ dependencies = [
 
 [[package]]
 name = "anchor"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "assert_cmd",
  "async-channel 1.9.0",
@@ -1813,7 +1813,7 @@ dependencies = [
 
 [[package]]
 name = "client"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anchor_validator_store",
  "beacon_node_fallback",
@@ -4333,7 +4333,7 @@ dependencies = [
 
 [[package]]
 name = "keygen"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "clap",
  "global_config",
@@ -4348,7 +4348,7 @@ dependencies = [
 
 [[package]]
 name = "keysplit"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "alloy",
  "base64",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3074,13 +3074,13 @@ checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "fastbloom"
-version = "0.14.1"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7f34442dbe69c60fe8eaf58a8cafff81a1f278816d8ab4db255b3bef4ac3c4"
+checksum = "ef975e30683b2d965054bb0a836f8973857c4ebf6acf274fe46617cd285060d8"
 dependencies = [
- "getrandom 0.3.4",
+ "foldhash 0.2.0",
  "libm",
- "rand 0.9.2",
+ "portable-atomic",
  "siphasher",
 ]
 
@@ -3432,11 +3432,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -3446,11 +3444,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
  "rand_core 0.10.0",
  "wasip2",
  "wasip3",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -3674,7 +3674,7 @@ dependencies = [
  "idna",
  "ipnet",
  "jni",
- "rand 0.10.0",
+ "rand 0.10.2",
  "thiserror 2.0.18",
  "tinyvec",
  "tokio",
@@ -3694,7 +3694,7 @@ dependencies = [
  "jni",
  "once_cell",
  "prefix-trie",
- "rand 0.10.0",
+ "rand 0.10.2",
  "ring",
  "thiserror 2.0.18",
  "tinyvec",
@@ -3719,7 +3719,7 @@ dependencies = [
  "ndk-context",
  "once_cell",
  "parking_lot",
- "rand 0.10.0",
+ "rand 0.10.2",
  "resolv-conf",
  "smallvec",
  "system-configuration",
@@ -4102,7 +4102,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "log",
- "rand 0.10.0",
+ "rand 0.10.2",
  "tokio",
  "url",
  "xmltree",
@@ -6247,15 +6247,16 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.15"
+version = "0.11.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
+checksum = "04759210543be93709136e28212294a659ef5001836ff4eab4d663e4529bba83"
 dependencies = [
  "bytes",
  "fastbloom",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.10.2",
+ "rand_pcg",
  "ring",
  "rustc-hash",
  "rustls",
@@ -6355,9 +6356,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.10.0"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
  "chacha20 0.10.0",
  "getrandom 0.4.2",
@@ -6408,6 +6409,15 @@ name = "rand_core"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.0",
+]
 
 [[package]]
 name = "rand_xorshift"
@@ -8492,7 +8502,7 @@ checksum = "a68d3c8f01c0cfa54a75291d83601161799e4a89a39e0929f4b0354d88757a37"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
- "rand 0.10.0",
+ "rand 0.10.2",
  "serde_core",
  "wasm-bindgen",
 ]

--- a/anchor/Cargo.toml
+++ b/anchor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "anchor"
-version = "1.3.0"
+version = "1.3.1"
 edition = { workspace = true }
 authors = ["Sigma Prime <contact@sigmaprime.io>"]
 rust-version = "1.91.0"

--- a/anchor/client/Cargo.toml
+++ b/anchor/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "client"
-version = "1.3.0"
+version = "1.3.1"
 authors = ["Sigma Prime <contact@sigmaprime.io"]
 edition = { workspace = true }
 

--- a/anchor/common/version/src/lib.rs
+++ b/anchor/common/version/src/lib.rs
@@ -17,8 +17,8 @@ pub const VERSION: &str = git_version!(
         // NOTE: using --match instead of --exclude for compatibility with old Git
         "--match=thiswillnevermatchlol"
     ],
-    prefix = "Anchor/v1.3.0-",
-    fallback = "Anchor/v1.3.0"
+    prefix = "Anchor/v1.3.1-",
+    fallback = "Anchor/v1.3.1"
 );
 
 /// Returns the first eight characters of the latest commit hash for this build.

--- a/anchor/keygen/Cargo.toml
+++ b/anchor/keygen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "keygen"
-version = "1.3.0"
+version = "1.3.1"
 edition = { workspace = true }
 authors = ["Sigma Prime <contact@sigmaprime.io>"]
 

--- a/anchor/keysplit/Cargo.toml
+++ b/anchor/keysplit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "keysplit"
-version = "1.3.0"
+version = "1.3.1"
 edition = { workspace = true }
 authors = ["Sigma Prime <contact@sigmaprime.io>"]
 


### PR DESCRIPTION
Backmerge of `stable` into `unstable` after the v1.3.1 release.

Brings across `chore: Release v1.3.1 (#1268)` and `chore: bump deps in stable (#1265)`. Merged with no conflicts.

**Do not use the merge button.** The repo is squash-only, and a squash drops the second parent, which would leave `stable` outside `unstable`'s ancestry — the exact thing this PR exists to correct, while appearing to succeed. This PR is for CI and visibility only; the merge commit is direct-pushed.

Checked locally on the merge commit:

- `cargo metadata --locked` — lockfile self-consistent and matching the manifests
- no crate downgraded relative to `unstable`
- `make cargo-fmt-check` — clean
- `make lint` (clippy `-D warnings`) — 0 warnings
- `cargo test --workspace --no-run` — all test binaries compile

🤖 Generated with [Claude Code](https://claude.com/claude-code)
