### PR TITLE
fix: resolve trait-solver recursion overflow on recent nightly

### DIFF
--- a/anchor/eth/src/sync.rs
+++ b/anchor/eth/src/sync.rs
@@ -1,5 +1,5 @@
 use std::{
-    cmp::{max, min},
+    cmp::min,
     collections::{HashMap, VecDeque},
     sync::Arc,
 };
@@ -13,7 +13,7 @@ use alloy::{
     transports::{RpcError, TransportErrorKind},
 };
 use database::{NetworkDatabase, SlashingProtection};
-use futures::{FutureExt, Stream, StreamExt, stream::FuturesOrdered};
+use futures::{Stream, StreamExt, stream::FuturesOrdered};
 use reqwest::Url;
 use sensitive_url::SensitiveUrl;
 use ssv_network_config::SsvNetworkConfig;
@@ -545,7 +545,11 @@ impl SsvEventSyncer {
         Ok(())
     }
 
-    // Construct a future that will fetch logs in the range from_block..to_block
+    // Construct a future that will fetch logs in the range from_block..to_block.
+    //
+    // RPC providers cap the size of a `getLogs` response, so a range that is too busy is rejected
+    // rather than returned. When that happens the range is split in half and each half is fetched
+    // separately, repeating down to a single block before giving up.
     #[instrument(skip(self, deployment_address, events), level = "debug")]
     fn fetch_logs(
         &self,
@@ -556,84 +560,57 @@ impl SsvEventSyncer {
     ) -> impl Future<Output = Result<Vec<Log>, ExecutionError>> + Send {
         // Setup filter and rpc client
         let rpc_client = self.rpc_client.clone();
-        let filter = Filter::new()
-            .address(deployment_address)
-            .from_block(from_block)
-            .to_block(to_block)
-            .events(events);
+        let filter = Filter::new().address(deployment_address).events(events);
 
-        // Try to fetch logs with a retry upon error. Try up to MAX_RETRIES times and error if we
-        // exceed this as we can assume there is some underlying connection issue
         async move {
-            debug!("Fetching logs");
-            let timer = metrics::start_timer_vec(
-                &metrics::EXECUTION_LOG_FETCH_TIME,
-                &[format!("{}", to_block - from_block + 1).as_str()],
-            );
+            let mut logs = Vec::new();
+            // Ranges left to fetch. Kept as a stack so that `pop` walks the ranges in ascending
+            // block order, matching the order the caller expects the logs in.
+            let mut pending = vec![(from_block, to_block)];
 
-            match rpc_client.get_logs(&filter).await {
-                Ok(logs) => {
-                    debug!(log_count = logs.len(), "Successfully fetched logs");
-                    metrics::stop_timer(timer);
-                    Ok(logs)
-                }
-                Err(e) => {
-                    // Subdivide if we have tried more than one block and if the error may be some
-                    // kind of response size limit.
-                    let subdivide = from_block != to_block
-                        && matches!(
-                            &e,
-                            RpcError::Transport(TransportErrorKind::HttpError(_))
-                                | RpcError::ErrorResp(_)
-                        );
+            while let Some((from, to)) = pending.pop() {
+                debug!(from, to, "Fetching logs");
+                let timer = metrics::start_timer_vec(
+                    &metrics::EXECUTION_LOG_FETCH_TIME,
+                    &[format!("{}", to - from + 1).as_str()],
+                );
 
-                    if subdivide {
-                        self.subdivide_fetch_logs(
-                            from_block,
-                            to_block,
-                            deployment_address,
-                            events,
-                            2,
-                        )
-                        .boxed()
-                        .await
-                    } else {
-                        Err(ExecutionError::RpcError(format!(
-                            "Error fetching logs: {e}"
-                        )))
+                let filter = filter.clone().from_block(from).to_block(to);
+                match rpc_client.get_logs(&filter).await {
+                    Ok(fetched) => {
+                        debug!(log_count = fetched.len(), "Successfully fetched logs");
+                        metrics::stop_timer(timer);
+                        logs.extend(fetched);
+                    }
+                    Err(e) => {
+                        // Subdivide if we have tried more than one block and if the error may be
+                        // some kind of response size limit.
+                        let subdivide = from != to
+                            && matches!(
+                                &e,
+                                RpcError::Transport(TransportErrorKind::HttpError(_))
+                                    | RpcError::ErrorResp(_)
+                            );
+
+                        if !subdivide {
+                            return Err(ExecutionError::RpcError(format!(
+                                "Error fetching logs: {e}"
+                            )));
+                        }
+
+                        info!(from, to, "Subdividing log retrieval");
+                        // `from != to` guarantees at least two blocks, so both halves are
+                        // non-empty and strictly smaller than the range being split.
+                        let mid = from + (to - from + 1).div_ceil(2) - 1;
+                        // Push the upper half first so the lower half is fetched first.
+                        pending.push((mid + 1, to));
+                        pending.push((from, mid));
                     }
                 }
             }
+
+            Ok(logs)
         }
-    }
-
-    // Subdivide log fetching to avoid log response size limits
-    #[instrument(skip(self, deployment_address, events), level = "debug")]
-    async fn subdivide_fetch_logs(
-        &self,
-        from_block: u64,
-        to_block: u64,
-        deployment_address: Address,
-        events: &[&str],
-        subdivision_factor: u64,
-    ) -> Result<Vec<Log>, ExecutionError> {
-        info!("Subdividing log retrieval");
-
-        let num_blocks = (to_block - from_block) + 1;
-        let target_size = max(1, num_blocks.div_ceil(subdivision_factor));
-        let mut result = vec![];
-
-        let mut current = from_block;
-        while current <= to_block {
-            let to = min(current + (target_size - 1), to_block);
-            let logs = self
-                .fetch_logs(current, to, deployment_address, events)
-                .await?;
-            result.extend(logs);
-            current = to + 1;
-        }
-
-        Ok(result)
     }
 
     /// Exit logs need the block timestamps set. Ensure every exit in a batch of logs has a block

--- a/anchor/validator_store/src/metadata_service.rs
+++ b/anchor/validator_store/src/metadata_service.rs
@@ -10,7 +10,10 @@ use eth2::{
     BeaconNodeHttpClient,
     types::{BlockId, SyncContributionData},
 };
-use futures::stream::{FuturesUnordered, StreamExt};
+use futures::{
+    FutureExt,
+    stream::{FuturesUnordered, StreamExt},
+};
 use slot_clock::SlotClock;
 use ssv_types::{
     CommitteeId, IndexSet, ValidatorIndex, VariableList,
@@ -735,19 +738,27 @@ impl<E: EthSpec, T: SlotClock + 'static> MetadataService<E, T> {
         // Uses `FuturesUnordered` internally to collect results as they complete.
         // After BEACON_API_FETCH_TIMEOUT (2s), returns whatever has been collected.
         // This ensures we don't block on slow beacon nodes while still getting partial data.
+        //
+        // Both arms are boxed to keep the `Send` proof for the spawned phase-3 task shallow. The
+        // trait solver otherwise walks the whole chain from `executor.spawn` down through
+        // `tokio::join!`'s `MaybeDone` nesting into these two futures, which exceeds the default
+        // recursion limit. `BoxFuture` is unconditionally `Send`, so the walk stops here. See
+        // https://github.com/rust-lang/rust/issues/159228.
         let (aggregated_attestations, sync_contributions) = tokio::join!(
             self.fetch_aggregated_attestations(
                 slot,
                 &voting_context.beacon_vote,
                 &attestation_committee_indexes,
                 BEACON_API_FETCH_TIMEOUT,
-            ),
+            )
+            .boxed(),
             self.fetch_sync_contributions(
                 slot,
                 voting_context.beacon_vote.block_root,
                 &all_subnet_ids,
                 BEACON_API_FETCH_TIMEOUT,
-            ),
+            )
+            .boxed(),
         );
 
         // Build consensus data per committee


### PR DESCRIPTION
## Problem, Evidence, and Context

`cargo-udeps` fails on **every** branch, not just new PRs. It is the only nightly job in CI, so nothing else catches this.

- Last green: nightly `e71c0f1e3` (2026-08-18), run [32275248291](https://github.com/sigp/anchor/actions/runs/32275248291).
- Every run from 2026-08-24 onward fails on nightly `fb6531d55` (2026-08-23), including three unrelated dependabot runs ([32697425240](https://github.com/sigp/anchor/actions/runs/32697425240), [32698198029](https://github.com/sigp/anchor/actions/runs/32698198029), [32700599160](https://github.com/sigp/anchor/actions/runs/32700599160)) and #1272.
- Cause: rustc's next solver now tracks recursion depth accurately during trait solving, roughly doubling the depth the same code needs ([rust-lang/rust#159228](https://github.com/rust-lang/rust/issues/159228)).

Reproduced locally on `nightly-2026-08-24` (= the exact CI compiler). Two symptoms with **different** causes:

| | `eth/src/sync.rs:598` | `validator_store/src/metadata_service.rs` |
|---|---|---|
| severity | hard `E0275`, fails the build | future-incompat warning |
| `#![recursion_limit]` | no effect at 256 / 1024 / 4096 | fixes it |
| real cause | genuine solver cycle | depth; default 128 just short (144 clears it) |

`fetch_logs` returned `impl Future + Send` and called `subdivide_fetch_logs(..).boxed()`, which called `fetch_logs` again. Proving one future is `Send` requires proving the other is, so no limit resolves it. Pinning the toolchain would only defer something the new solver will never accept once it reaches stable.

No issue filed for this; I searched before opening.

## Change Overview

Both crates now cut the proof chain structurally instead of raising a budget.

**Start with `anchor/eth/src/sync.rs`** — the mutual recursion between `fetch_logs` and `subdivide_fetch_logs` is replaced by an explicit worklist. `fetch_logs` holds a stack of pending `(from, to)` ranges; on a response-size error it pushes the two halves rather than recursing. `subdivide_fetch_logs` is deleted: its only caller was the recursion, and `subdivision_factor` was hardcoded `2` at that one site. Net −21 lines, no `.boxed()`, no allocation, and the returned future no longer captures `&self`.

**Then `metadata_service.rs`** — two `.boxed()` calls plus a comment. The `Send` proof for the spawned phase-3 task walked from `executor.spawn` down through `tokio::join!`'s `MaybeDone` nesting into both fetch futures; half the depth was join! internals. `BoxFuture` is unconditionally `Send`, so the walk stops there.

Deliberately unchanged: fetch order, RPC call pattern, error classification and messages, metric labels and timer semantics, and every public signature.

## Risks, Trade-offs, and Mitigations

**Blast radius is the main risk.** `sync.rs` is the sole production path by which SSV contract events (`OperatorAdded`, `ValidatorAdded`, `ClusterLiquidated`, …) reach the database — `process_logs` has exactly two production callers, both in this file. `process_logs` buffers per block and flushes on a block-number change, so it **assumes ascending log order**, and the subdivision path is exactly where ordering could break.

Mitigated by differential-testing the old and new splitting algorithms over 53,104 scenarios (see Validation). Zero mismatches on order, call pattern, or error outcome.

**Known gap:** the subdivision path has no test, before or after this PR. The existing `anchor/eth/tests/` suites call `process_logs` directly with pre-built logs and never go through `fetch_logs`. The differential test validates a transcription of the algorithm, not the shipped Rust.

**Behavior change, intentional:** per-recursion-level `#[instrument]` spans are gone, since there is only one function now. `from`/`to` moved onto the `debug!`/`info!` events, so the range is still in the logs, but the span tree is flatter. The old messages carried no range of their own and relied entirely on span context.

**Trade-off:** boxing costs two heap allocations per phase-3 run, twice per slot, against a 2s beacon-API timeout in the same function.

## Validation

On `nightly-2026-08-24` (`fb6531d55`), the exact failing compiler:

- `cargo check --workspace --tests --all-targets` — clean; zero `E0275`, zero `recursion_depth_exceeding_limit`. Confirmed failing on this branch's parent.
- `cargo fmt --all --check` — clean.
- `cargo clippy --workspace --tests -- -D warnings -D clippy::allow_attributes` — clean.
- `cargo test --workspace` — all green (requires `git submodule update --init` for `spec_tests`).

Differential test of the two splitting algorithms, comparing the full sequence of attempted ranges, the sequence of successful ranges, the returned log order, and the error outcome including which range failed:

- exhaustive over every subset of failing sub-ranges for spans 1–7
- 20k randomised size-threshold oracles (the realistic "provider caps response size" case)
- 20k randomised non-monotone flaky oracles

53,104 scenarios, 0 mismatches.

Filter builder reordering verified against `alloy-rpc-types-eth-1.7.3/src/filter.rs:499,506,574,588` — `block_option`, `address`, and `topics` are independent fields.

## Rollback

Plain revert; no config, data, or operational impact. Reverting restores the nightly CI failure.

## Blockers / Dependencies

`epbs` carries the identical `sync.rs`, so it stays red until an `unstable` → `epbs` merge follows this. That is what unblocks #1272.

## Additional Info / Next Steps

Worth adding a test for the subdivision path, either by extracting the split decision as a pure function or by mocking the provider to force `ErrorResp` on large ranges. Left out here to keep this focused on unbreaking CI.