### PR TITLE
chore: merge unstable into epbs (CI check only, do not squash)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -765,7 +765,7 @@ dependencies = [
 
 [[package]]
 name = "anchor"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "assert_cmd",
  "async-channel 1.9.0",
@@ -1813,7 +1813,7 @@ dependencies = [
 
 [[package]]
 name = "client"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anchor_validator_store",
  "beacon_node_fallback",
@@ -4333,7 +4333,7 @@ dependencies = [
 
 [[package]]
 name = "keygen"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "clap",
  "global_config",
@@ -4348,7 +4348,7 @@ dependencies = [
 
 [[package]]
 name = "keysplit"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "alloy",
  "base64",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3074,13 +3074,13 @@ checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "fastbloom"
-version = "0.14.1"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7f34442dbe69c60fe8eaf58a8cafff81a1f278816d8ab4db255b3bef4ac3c4"
+checksum = "ef975e30683b2d965054bb0a836f8973857c4ebf6acf274fe46617cd285060d8"
 dependencies = [
- "getrandom 0.3.4",
+ "foldhash 0.2.0",
  "libm",
- "rand 0.9.2",
+ "portable-atomic",
  "siphasher",
 ]
 
@@ -3432,11 +3432,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -3446,11 +3444,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
  "rand_core 0.10.0",
  "wasip2",
  "wasip3",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -3674,7 +3674,7 @@ dependencies = [
  "idna",
  "ipnet",
  "jni",
- "rand 0.10.0",
+ "rand 0.10.2",
  "thiserror 2.0.18",
  "tinyvec",
  "tokio",
@@ -3694,7 +3694,7 @@ dependencies = [
  "jni",
  "once_cell",
  "prefix-trie",
- "rand 0.10.0",
+ "rand 0.10.2",
  "ring",
  "thiserror 2.0.18",
  "tinyvec",
@@ -3719,7 +3719,7 @@ dependencies = [
  "ndk-context",
  "once_cell",
  "parking_lot",
- "rand 0.10.0",
+ "rand 0.10.2",
  "resolv-conf",
  "smallvec",
  "system-configuration",
@@ -4102,7 +4102,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "log",
- "rand 0.10.0",
+ "rand 0.10.2",
  "tokio",
  "url",
  "xmltree",
@@ -6247,15 +6247,16 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.15"
+version = "0.11.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
+checksum = "04759210543be93709136e28212294a659ef5001836ff4eab4d663e4529bba83"
 dependencies = [
  "bytes",
  "fastbloom",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.10.2",
+ "rand_pcg",
  "ring",
  "rustc-hash",
  "rustls",
@@ -6355,9 +6356,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.10.0"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
  "chacha20 0.10.0",
  "getrandom 0.4.2",
@@ -6408,6 +6409,15 @@ name = "rand_core"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.0",
+]
 
 [[package]]
 name = "rand_xorshift"
@@ -8492,7 +8502,7 @@ checksum = "a68d3c8f01c0cfa54a75291d83601161799e4a89a39e0929f4b0354d88757a37"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
- "rand 0.10.0",
+ "rand 0.10.2",
  "serde_core",
  "wasm-bindgen",
 ]

--- a/anchor/Cargo.toml
+++ b/anchor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "anchor"
-version = "1.3.0"
+version = "1.3.1"
 edition = { workspace = true }
 authors = ["Sigma Prime <contact@sigmaprime.io>"]
 rust-version = "1.91.0"

--- a/anchor/client/Cargo.toml
+++ b/anchor/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "client"
-version = "1.3.0"
+version = "1.3.1"
 authors = ["Sigma Prime <contact@sigmaprime.io"]
 edition = { workspace = true }
 

--- a/anchor/common/version/src/lib.rs
+++ b/anchor/common/version/src/lib.rs
@@ -17,8 +17,8 @@ pub const VERSION: &str = git_version!(
         // NOTE: using --match instead of --exclude for compatibility with old Git
         "--match=thiswillnevermatchlol"
     ],
-    prefix = "Anchor/v1.3.0-",
-    fallback = "Anchor/v1.3.0"
+    prefix = "Anchor/v1.3.1-",
+    fallback = "Anchor/v1.3.1"
 );
 
 /// Returns the first eight characters of the latest commit hash for this build.

--- a/anchor/eth/src/sync.rs
+++ b/anchor/eth/src/sync.rs
@@ -1,5 +1,5 @@
 use std::{
-    cmp::{max, min},
+    cmp::min,
     collections::{HashMap, VecDeque},
     sync::Arc,
 };
@@ -13,7 +13,7 @@ use alloy::{
     transports::{RpcError, TransportErrorKind},
 };
 use database::{NetworkDatabase, SlashingProtection};
-use futures::{FutureExt, Stream, StreamExt, stream::FuturesOrdered};
+use futures::{Stream, StreamExt, stream::FuturesOrdered};
 use reqwest::Url;
 use sensitive_url::SensitiveUrl;
 use ssv_network_config::SsvNetworkConfig;
@@ -545,7 +545,11 @@ impl SsvEventSyncer {
         Ok(())
     }
 
-    // Construct a future that will fetch logs in the range from_block..to_block
+    // Construct a future that will fetch logs in the range from_block..to_block.
+    //
+    // RPC providers cap the size of a `getLogs` response, so a range that is too busy is rejected
+    // rather than returned. When that happens the range is split in half and each half is fetched
+    // separately, repeating down to a single block before giving up.
     #[instrument(skip(self, deployment_address, events), level = "debug")]
     fn fetch_logs(
         &self,
@@ -556,84 +560,57 @@ impl SsvEventSyncer {
     ) -> impl Future<Output = Result<Vec<Log>, ExecutionError>> + Send {
         // Setup filter and rpc client
         let rpc_client = self.rpc_client.clone();
-        let filter = Filter::new()
-            .address(deployment_address)
-            .from_block(from_block)
-            .to_block(to_block)
-            .events(events);
+        let filter = Filter::new().address(deployment_address).events(events);
 
-        // Try to fetch logs with a retry upon error. Try up to MAX_RETRIES times and error if we
-        // exceed this as we can assume there is some underlying connection issue
         async move {
-            debug!("Fetching logs");
-            let timer = metrics::start_timer_vec(
-                &metrics::EXECUTION_LOG_FETCH_TIME,
-                &[format!("{}", to_block - from_block + 1).as_str()],
-            );
+            let mut logs = Vec::new();
+            // Ranges left to fetch. Kept as a stack so that `pop` walks the ranges in ascending
+            // block order, matching the order the caller expects the logs in.
+            let mut pending = vec![(from_block, to_block)];
 
-            match rpc_client.get_logs(&filter).await {
-                Ok(logs) => {
-                    debug!(log_count = logs.len(), "Successfully fetched logs");
-                    metrics::stop_timer(timer);
-                    Ok(logs)
-                }
-                Err(e) => {
-                    // Subdivide if we have tried more than one block and if the error may be some
-                    // kind of response size limit.
-                    let subdivide = from_block != to_block
-                        && matches!(
-                            &e,
-                            RpcError::Transport(TransportErrorKind::HttpError(_))
-                                | RpcError::ErrorResp(_)
-                        );
+            while let Some((from, to)) = pending.pop() {
+                debug!(from, to, "Fetching logs");
+                let timer = metrics::start_timer_vec(
+                    &metrics::EXECUTION_LOG_FETCH_TIME,
+                    &[format!("{}", to - from + 1).as_str()],
+                );
 
-                    if subdivide {
-                        self.subdivide_fetch_logs(
-                            from_block,
-                            to_block,
-                            deployment_address,
-                            events,
-                            2,
-                        )
-                        .boxed()
-                        .await
-                    } else {
-                        Err(ExecutionError::RpcError(format!(
-                            "Error fetching logs: {e}"
-                        )))
+                let filter = filter.clone().from_block(from).to_block(to);
+                match rpc_client.get_logs(&filter).await {
+                    Ok(fetched) => {
+                        debug!(log_count = fetched.len(), "Successfully fetched logs");
+                        metrics::stop_timer(timer);
+                        logs.extend(fetched);
+                    }
+                    Err(e) => {
+                        // Subdivide if we have tried more than one block and if the error may be
+                        // some kind of response size limit.
+                        let subdivide = from != to
+                            && matches!(
+                                &e,
+                                RpcError::Transport(TransportErrorKind::HttpError(_))
+                                    | RpcError::ErrorResp(_)
+                            );
+
+                        if !subdivide {
+                            return Err(ExecutionError::RpcError(format!(
+                                "Error fetching logs: {e}"
+                            )));
+                        }
+
+                        info!(from, to, "Subdividing log retrieval");
+                        // `from != to` guarantees at least two blocks, so both halves are
+                        // non-empty and strictly smaller than the range being split.
+                        let mid = from + (to - from + 1).div_ceil(2) - 1;
+                        // Push the upper half first so the lower half is fetched first.
+                        pending.push((mid + 1, to));
+                        pending.push((from, mid));
                     }
                 }
             }
+
+            Ok(logs)
         }
-    }
-
-    // Subdivide log fetching to avoid log response size limits
-    #[instrument(skip(self, deployment_address, events), level = "debug")]
-    async fn subdivide_fetch_logs(
-        &self,
-        from_block: u64,
-        to_block: u64,
-        deployment_address: Address,
-        events: &[&str],
-        subdivision_factor: u64,
-    ) -> Result<Vec<Log>, ExecutionError> {
-        info!("Subdividing log retrieval");
-
-        let num_blocks = (to_block - from_block) + 1;
-        let target_size = max(1, num_blocks.div_ceil(subdivision_factor));
-        let mut result = vec![];
-
-        let mut current = from_block;
-        while current <= to_block {
-            let to = min(current + (target_size - 1), to_block);
-            let logs = self
-                .fetch_logs(current, to, deployment_address, events)
-                .await?;
-            result.extend(logs);
-            current = to + 1;
-        }
-
-        Ok(result)
     }
 
     /// Exit logs need the block timestamps set. Ensure every exit in a batch of logs has a block

--- a/anchor/keygen/Cargo.toml
+++ b/anchor/keygen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "keygen"
-version = "1.3.0"
+version = "1.3.1"
 edition = { workspace = true }
 authors = ["Sigma Prime <contact@sigmaprime.io>"]
 

--- a/anchor/keysplit/Cargo.toml
+++ b/anchor/keysplit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "keysplit"
-version = "1.3.0"
+version = "1.3.1"
 edition = { workspace = true }
 authors = ["Sigma Prime <contact@sigmaprime.io>"]
 

--- a/anchor/validator_store/src/metadata_service.rs
+++ b/anchor/validator_store/src/metadata_service.rs
@@ -10,7 +10,10 @@ use eth2::{
     BeaconNodeHttpClient,
     types::{BlockId, SyncContributionData},
 };
-use futures::stream::{FuturesUnordered, StreamExt};
+use futures::{
+    FutureExt,
+    stream::{FuturesUnordered, StreamExt},
+};
 use slot_clock::SlotClock;
 use ssv_types::{
     CommitteeId, IndexSet, ValidatorIndex, VariableList,
@@ -735,19 +738,27 @@ impl<E: EthSpec, T: SlotClock + 'static> MetadataService<E, T> {
         // Uses `FuturesUnordered` internally to collect results as they complete.
         // After BEACON_API_FETCH_TIMEOUT (2s), returns whatever has been collected.
         // This ensures we don't block on slow beacon nodes while still getting partial data.
+        //
+        // Both arms are boxed to keep the `Send` proof for the spawned phase-3 task shallow. The
+        // trait solver otherwise walks the whole chain from `executor.spawn` down through
+        // `tokio::join!`'s `MaybeDone` nesting into these two futures, which exceeds the default
+        // recursion limit. `BoxFuture` is unconditionally `Send`, so the walk stops here. See
+        // https://github.com/rust-lang/rust/issues/159228.
         let (aggregated_attestations, sync_contributions) = tokio::join!(
             self.fetch_aggregated_attestations(
                 slot,
                 &voting_context.beacon_vote,
                 &attestation_committee_indexes,
                 BEACON_API_FETCH_TIMEOUT,
-            ),
+            )
+            .boxed(),
             self.fetch_sync_contributions(
                 slot,
                 voting_context.beacon_vote.block_root,
                 &all_subnet_ids,
                 BEACON_API_FETCH_TIMEOUT,
-            ),
+            )
+            .boxed(),
         );
 
         // Build consensus data per committee


### PR DESCRIPTION
**DO NOT MERGE / DO NOT SQUASH.** This PR exists only to run CI. The merge commit will be pushed directly to `epbs` with `git push upstream merge-unstable-into-epbs:epbs`, preserving both parents. Using the merge button would squash unstable's commits into new SHAs and guarantee conflicts when `epbs` eventually merges back into `unstable`.

## Why now

`cargo-udeps` has been red on every branch since nightly `fb6531d55` (2026-08-23) because rustc's next solver now tracks trait-solving recursion depth accurately ([rust-lang/rust#159228](https://github.com/rust-lang/rust/issues/159228)). Fixed on `unstable` in #1274; `epbs` carries the identical `anchor/eth/src/sync.rs` and is still broken. This merge is what unblocks #1272.

## Incoming

4 commits (`761f664f..c4a4232b`):

- `c4a4232b` fix: resolve trait-solver recursion overflow on recent nightly (#1274)
- `9c89b238` Merge `stable` into `unstable` (backmerge)
- `d793dbed` chore: Release v1.3.1 (#1268)
- `ce2202e3` chore: bump deps in stable (#1265)

## Conflict resolutions

One conflict, in `anchor/validator_store/src/metadata_service.rs`, and it was comment-only.

epbs had replaced the old `// Parallel fetch from beacon node ... Uses FuturesUnordered internally` comment with `// Fetch both categories concurrently ...` as part of its `resolve_committee_requests` refactor. unstable's only change to that block was appending a paragraph explaining why the two `tokio::join!` arms are boxed. Resolution keeps **epbs's code and comment** and **appends unstable's boxing paragraph**. The `.boxed()` calls themselves auto-merged cleanly onto epbs's refactored call, which now passes `committee_requests.aggregate_attestation_keys` / `.sync_contribution_keys`.

`Cargo.lock` auto-merged; `cargo metadata` produced no further changes. epbs keeps its own lighthouse pin `e58ec88fe` (unstable is on `b263df5`), and the lock contains that single rev.

## Verification

- Both parents present on `a4eb597a`: `8a508ae8` (epbs) and `c4a4232b` (unstable).
- Every file unstable changed in this range is byte-identical in the merge result, except `Cargo.lock` and `metadata_service.rs` (both verified by hand above). `anchor/eth/src/sync.rs` matches unstable exactly and `subdivide_fetch_logs` is gone.
- Merge result diffed against **both** parents: vs `epbs` shows only unstable's delta (the `FutureExt` import, the comment, the two `.boxed()` calls) and nothing else.
- No leftover conflict markers; no duplicate `fn` names or struct fields from auto-merge.
- v1.3.1 bumps carried (`anchor`/`keygen` at 1.3.1 in the lock, `Anchor/v1.3.1` in the version crate).
- `cargo check --workspace --all-targets`, `make cargo-fmt-check`, `make lint` all pass.
- On `nightly-2026-08-24` (the compiler that broke CI): zero `E0275`, so `cargo-udeps` should go green.

## Known, not introduced by this merge

`anchor/validator_store/src/metadata_service.rs:844` still emits a `recursion_depth_exceeding_limit` **warning** on nightly. It is an epbs-only chain, unrelated to the one #1274 fixed: `executor.spawn` → `publish_decided_aggregates` → `FuturesUnordered` → `publish_committee_aggregates` → `FuturesUnordered<Either<..>>` in `aggregator_post_consensus.rs`, where both functions carry four generic closure/future params.

It does not fail CI (the udeps job sets `RUSTFLAGS: ""` and allows warnings on nightly), but it will become a hard error in a future rustc. Left out deliberately so this stays a clean union of the two branches; it wants its own PR against `epbs`.

The pre-existing `ethereum_ssz_derive` unused-patch warning is unchanged — the root `Cargo.toml` is byte-identical to epbs.