### PR TITLE
fix(message_validator): derive per-epoch duty counts from the slot ring (SIP-94 §7 retention)

### DIFF
--- a/anchor/message_validator/src/consensus_message.rs
+++ b/anchor/message_validator/src/consensus_message.rs
@@ -59,11 +59,8 @@ pub(crate) fn validate_consensus_message(
         validation_context.operator_pub_keys,
     )?;
 
-    duty_state.update_for_consensus_message(
-        validation_context.signed_ssv_message,
-        &consensus_message,
-        validation_context.slots_per_epoch,
-    );
+    duty_state
+        .update_for_consensus_message(validation_context.signed_ssv_message, &consensus_message);
 
     // Return the validated message
     Ok(ValidatedSSVMessage::QbftMessage(consensus_message))
@@ -465,11 +462,11 @@ pub(crate) fn validate_qbft_message_by_duty_logic(
 
     // Rule: valid number of duties per epoch
     for &signer in signed_ssv_message.operator_ids() {
-        let signer_state = duty_state.get_or_create_operator(&signer);
+        let operator_state = duty_state.get_or_create_operator(&signer);
         validate_duty_count(
             validation_context,
             msg_slot,
-            signer_state,
+            operator_state,
             duty_provider.clone(),
         )?;
     }
@@ -1683,7 +1680,7 @@ mod tests {
             vec![],
             vec![],
         );
-        duty_state.update_for_consensus_message(&dummy_signed_msg, &dummy_qbft, 32);
+        duty_state.update_for_consensus_message(&dummy_signed_msg, &dummy_qbft);
 
         // Now validate a consensus message for height 1 (which is "old")
         let result = validate_qbft_message_by_duty_logic(

--- a/anchor/message_validator/src/duty_state.rs
+++ b/anchor/message_validator/src/duty_state.rs
@@ -1,7 +1,4 @@
-use std::{
-    cmp::Ordering,
-    collections::{HashMap, HashSet},
-};
+use std::collections::{HashMap, HashSet};
 
 use libp2p::PeerId;
 use ssv_types::{
@@ -74,26 +71,18 @@ impl DutyState {
     /// Updates the duty state with new incoming messages.
     ///
     /// For each operator involved in the signed message, this method:
-    /// - Determines the corresponding slot and estimated epoch,
     /// - Retrieves or creates the operator's state,
     /// - And delegates the update to the operator's state.
     pub(crate) fn update_for_consensus_message(
         &mut self,
         signed_ssv_message: &SignedSSVMessage,
         consensus_message: &QbftMessage,
-        slots_per_epoch: u64,
     ) {
         let msg_slot = Slot::from(consensus_message.height);
-        let estimated_msg_epoch = Epoch::new(msg_slot.as_u64() / slots_per_epoch);
 
         for signer in signed_ssv_message.operator_ids() {
             let operator_state = self.get_or_create_operator(signer);
-            operator_state.update(
-                signed_ssv_message,
-                consensus_message,
-                &msg_slot,
-                &estimated_msg_epoch,
-            );
+            operator_state.update(signed_ssv_message, consensus_message, &msg_slot);
         }
     }
 
@@ -103,12 +92,10 @@ impl DutyState {
         &mut self,
         partial_signature_messages: &PartialSignatureMessages,
         signer: &OperatorId,
-        slots_per_epoch: u64,
         received_from: Option<PeerId>,
     ) -> Result<(), ValidationFailure> {
         let operator_state = self.get_or_create_operator(signer);
         let message_slot = partial_signature_messages.slot;
-        let message_epoch = Epoch::new(message_slot.as_u64() / slots_per_epoch);
 
         // Get or create a signer state for this slot
         let signer_state = match operator_state.get_signer_state_mut(&message_slot) {
@@ -116,11 +103,7 @@ impl DutyState {
             _ => {
                 // Create a new signer state
                 let new_signer_state = SignerState::new(message_slot, FIRST_ROUND);
-                operator_state.set_signer_state_for_first_round(
-                    &message_slot,
-                    &message_epoch,
-                    new_signer_state,
-                )
+                operator_state.set_signer_state(&message_slot, new_signer_state)
             }
         };
 
@@ -186,12 +169,6 @@ pub struct OperatorState {
     state: Vec<Option<SignerState>>,
     /// The highest slot number that has been processed for this operator.
     max_slot: Slot,
-    /// The highest epoch number that has been processed.
-    max_epoch: Epoch,
-    /// The count of duties processed in the current epoch.
-    curr_epoch_duties: u64,
-    /// The count of duties processed in the previous epoch.
-    prev_epoch_duties: u64,
 }
 
 impl OperatorState {
@@ -200,9 +177,6 @@ impl OperatorState {
         Self {
             state: vec![None; stored_slot_count],
             max_slot: Slot::new(0),
-            max_epoch: Epoch::new(0),
-            curr_epoch_duties: 0,
-            prev_epoch_duties: 0,
         }
     }
 
@@ -211,12 +185,16 @@ impl OperatorState {
         self.max_slot
     }
 
-    pub(crate) fn get_duty_count(&self, epoch: Epoch) -> u64 {
-        match epoch {
-            e if e == self.max_epoch => self.curr_epoch_duties,
-            e if e == self.max_epoch - 1 => self.prev_epoch_duties,
-            _ => 0, // unused because messages from too old epochs must be rejected in advance
-        }
+    /// Counts the duties recorded for `epoch` by probing the ring at each of the epoch's slots.
+    ///
+    /// The ring holds exactly one occupied entry per counted duty slot, so occupancy is an
+    /// exact per-epoch count (SIP-94 §7 retention) as long as the ring spans the role's whole
+    /// message acceptance window; `stored_slot_count` owns that sizing guarantee.
+    pub(crate) fn get_duty_count(&self, epoch: Epoch, slots_per_epoch: u64) -> u64 {
+        epoch
+            .slot_iter(slots_per_epoch)
+            .filter(|slot| self.get_signer_state(slot).is_some())
+            .count() as u64
     }
 
     /// Retrieves a mutable SignerState reference for a given slot.
@@ -235,17 +213,6 @@ impl OperatorState {
             .filter(|s| s.slot == *slot)
     }
 
-    /// Sets the signer state for a round change in the circular buffer at the computed index.
-    fn set_signer_state_for_round_change(
-        &mut self,
-        slot: &Slot,
-        signer_state: SignerState,
-    ) -> &mut SignerState {
-        let index = slot.as_usize() % self.state.len();
-        self.state[index] = Some(signer_state);
-        self.state[index].as_mut().unwrap()
-    }
-
     /// Returns true if we have not seen a message for a duty in `slot` yet.
     pub(crate) fn is_first_message_for_duty(&self, slot: Slot) -> bool {
         self.get_signer_state(&slot).is_none()
@@ -261,37 +228,30 @@ impl OperatorState {
         signed_ssv_message: &SignedSSVMessage,
         consensus_message: &QbftMessage,
         msg_slot: &Slot,
-        estimated_msg_epoch: &Epoch,
     ) {
         let maybe_signer_state = self.get_signer_state_mut(msg_slot);
 
         let signer_state = if let Some(signer_state) = maybe_signer_state {
             if consensus_message.round > signer_state.round {
                 let signer_state = SignerState::new(*msg_slot, consensus_message.round);
-                self.set_signer_state_for_round_change(msg_slot, signer_state)
+                self.set_signer_state(msg_slot, signer_state)
             } else {
                 signer_state
             }
         } else {
             let signer_state = SignerState::new(*msg_slot, consensus_message.round);
-            self.set_signer_state_for_first_round(msg_slot, estimated_msg_epoch, signer_state)
+            self.set_signer_state(msg_slot, signer_state)
         };
 
         signer_state.update(signed_ssv_message, consensus_message);
     }
 
-    /// Sets the SignerState for the first round of a slot and updates tracking for the maximum slot
-    /// and epoch.
+    /// Sets the SignerState for a slot (first message or round change alike) and updates
+    /// tracking for the maximum slot.
     ///
     /// - Inserts the signer state into the circular buffer.
     /// - Updates `max_slot` if the new slot is higher.
-    /// - Updates `max_epoch` and resets duty counters if the epoch has advanced.
-    fn set_signer_state_for_first_round(
-        &mut self,
-        msg_slot: &Slot,
-        estimated_msg_epoch: &Epoch,
-        signer_state: SignerState,
-    ) -> &mut SignerState {
+    fn set_signer_state(&mut self, msg_slot: &Slot, signer_state: SignerState) -> &mut SignerState {
         let index = msg_slot.as_usize() % self.state.len();
         self.state[index] = Some(signer_state);
 
@@ -299,22 +259,6 @@ impl OperatorState {
             self.max_slot = *msg_slot;
         }
 
-        match estimated_msg_epoch.cmp(&self.max_epoch) {
-            Ordering::Greater => {
-                self.max_epoch = *estimated_msg_epoch;
-                self.prev_epoch_duties = self.curr_epoch_duties;
-                self.curr_epoch_duties = 1;
-            }
-            Ordering::Equal => {
-                self.curr_epoch_duties += 1;
-            }
-            Ordering::Less => {
-                // Messages with epochs lower than the current max are aggregated into
-                // previous epoch duties. It is assumed that such messages have already
-                // been validated as not too outdated.
-                self.prev_epoch_duties += 1;
-            }
-        }
         self.state[index].as_mut().unwrap()
     }
 }
@@ -417,7 +361,7 @@ mod tests {
         );
 
         // Update the duty state
-        duty_state.update_for_consensus_message(&signed_ssv_message, &qbft_message, 32);
+        duty_state.update_for_consensus_message(&signed_ssv_message, &qbft_message);
 
         // Retrieve the operator state
         let operator_state = duty_state.get_or_create_operator(&operator_id);
@@ -460,7 +404,7 @@ mod tests {
         );
 
         // Update duty state with single-signer commit
-        duty_state.update_for_consensus_message(&signed_single_signer, &single_signer_commit, 32);
+        duty_state.update_for_consensus_message(&signed_single_signer, &single_signer_commit);
 
         // Create a commit message with multiple signers (decided message, should NOT be counted)
         let multi_signer_commit =
@@ -474,7 +418,7 @@ mod tests {
         );
 
         // Update duty state with multi-signer commit
-        duty_state.update_for_consensus_message(&signed_multi_signer, &multi_signer_commit, 32);
+        duty_state.update_for_consensus_message(&signed_multi_signer, &multi_signer_commit);
 
         // Retrieve the operator state
         let operator_state = duty_state.get_or_create_operator(&operator_id);
@@ -490,5 +434,168 @@ mod tests {
         } else {
             panic!("SignerState should exist for the slot");
         }
+    }
+
+    /// Slots per epoch used by the ring-derived duty-count tests.
+    const SLOTS_PER_EPOCH: u64 = 32;
+
+    /// Role-8 (`ProposerPreferences`) ring size via the production selector, so these tests
+    /// cannot drift from the sizing `get_duty_count`'s exactness depends on. Mainnet-shaped
+    /// params give `(1 + min_seed_lookahead) * spe + 2 * spe = 128`, four concurrent epochs.
+    fn role_8_ring() -> usize {
+        crate::stored_slot_count(
+            Role::ProposerPreferences,
+            SLOTS_PER_EPOCH,
+            &crate::tests::spec_with_gloas(None),
+        )
+    }
+
+    /// Records a duty for `operator_id` at `slot` by feeding a consensus message through the
+    /// production update path.
+    fn record_duty_at_slot(duty_state: &mut DutyState, operator_id: OperatorId, slot: Slot) {
+        let qbft_message =
+            QbftMessageBuilder::new(Role::ProposerPreferences, QbftMessageType::Proposal)
+                .with_height(slot.as_u64())
+                .build();
+        let signed_ssv_message = create_signed_consensus_message(
+            qbft_message.clone(),
+            vec![operator_id],
+            vec![],
+            vec![],
+        );
+        duty_state.update_for_consensus_message(&signed_ssv_message, &qbft_message);
+    }
+
+    #[test]
+    fn test_duty_counts_survive_later_epoch_acceptance() {
+        // Ring-derived counts must stay exact for EVERY epoch still inside the acceptance
+        // window, not just the newest one. The deleted two-bucket counters pinned only
+        // (max_epoch, max_epoch - 1): accepting an E+2 message advanced max_epoch to E+2,
+        // relabeling E's count as E+1's and zeroing reads for E.
+        let mut duty_state = DutyState::new(role_8_ring());
+        let operator_id = OperatorId(1);
+        let epoch = Epoch::new(10); // slots 320..=351
+
+        // 3 duties in E, 2 in E+1, then 1 in E+2 (the later-epoch acceptance).
+        let epoch_start = epoch.start_slot(SLOTS_PER_EPOCH);
+        for offset in [0, 7, 31] {
+            record_duty_at_slot(&mut duty_state, operator_id, epoch_start + offset);
+        }
+        let next_epoch_start = (epoch + 1).start_slot(SLOTS_PER_EPOCH);
+        for offset in [3, 20] {
+            record_duty_at_slot(&mut duty_state, operator_id, next_epoch_start + offset);
+        }
+        record_duty_at_slot(
+            &mut duty_state,
+            operator_id,
+            (epoch + 2).start_slot(SLOTS_PER_EPOCH) + 5,
+        );
+
+        let operator_state = duty_state.get_or_create_operator(&operator_id);
+
+        // E's count survives the E+2 acceptance (the old bucket code returned 0 for E here).
+        assert_eq!(
+            operator_state.get_duty_count(epoch, SLOTS_PER_EPOCH),
+            3,
+            "epoch E count must survive acceptance of a later-epoch message"
+        );
+        assert_eq!(
+            operator_state.get_duty_count(epoch + 1, SLOTS_PER_EPOCH),
+            2,
+            "epoch E+1 count should be exact"
+        );
+        assert_eq!(
+            operator_state.get_duty_count(epoch + 2, SLOTS_PER_EPOCH),
+            1,
+            "epoch E+2 count should be exact"
+        );
+        assert_eq!(
+            operator_state.get_duty_count(epoch - 1, SLOTS_PER_EPOCH),
+            0,
+            "epoch E-1 has no recorded duties"
+        );
+        assert_eq!(
+            operator_state.get_duty_count(epoch + 3, SLOTS_PER_EPOCH),
+            0,
+            "epoch E+3 has no recorded duties"
+        );
+    }
+
+    #[test]
+    fn test_duty_counts_not_conflated_across_older_epochs() {
+        // Duties arriving for epochs older than the newest-seen one must be attributed to
+        // their own epochs. The deleted counters' Ordering::Less arm lumped every epoch below
+        // max_epoch into the single prev bucket: with max_epoch at E+2, the 2 duties in E and
+        // 3 in E+1 below would all read as 5 for E+1 and 0 for E.
+        let mut duty_state = DutyState::new(role_8_ring());
+        let operator_id = OperatorId(1);
+        let epoch = Epoch::new(10);
+
+        // 1 duty in E+2 first, so the newest-seen epoch sits two ahead of the others.
+        record_duty_at_slot(
+            &mut duty_state,
+            operator_id,
+            (epoch + 2).start_slot(SLOTS_PER_EPOCH) + 5,
+        );
+        // Then 2 duties in E and 3 in E+1.
+        let epoch_start = epoch.start_slot(SLOTS_PER_EPOCH);
+        for offset in [1, 30] {
+            record_duty_at_slot(&mut duty_state, operator_id, epoch_start + offset);
+        }
+        let next_epoch_start = (epoch + 1).start_slot(SLOTS_PER_EPOCH);
+        for offset in [0, 11, 31] {
+            record_duty_at_slot(&mut duty_state, operator_id, next_epoch_start + offset);
+        }
+
+        let operator_state = duty_state.get_or_create_operator(&operator_id);
+
+        assert_eq!(
+            operator_state.get_duty_count(epoch, SLOTS_PER_EPOCH),
+            2,
+            "epoch E count must not be conflated into a shared older-epoch bucket"
+        );
+        assert_eq!(
+            operator_state.get_duty_count(epoch + 1, SLOTS_PER_EPOCH),
+            3,
+            "epoch E+1 count must not absorb epoch E's duties"
+        );
+        assert_eq!(
+            operator_state.get_duty_count(epoch + 2, SLOTS_PER_EPOCH),
+            1,
+            "epoch E+2 count should be exact"
+        );
+    }
+
+    #[test]
+    fn test_duty_counts_ignore_aliased_ring_entries() {
+        // The ring is modulo-indexed, so slots exactly `ring size` apart share an index. An
+        // occupied index only counts toward the epoch of the slot actually stored there:
+        // probing must check the stored slot, not raw index occupancy, or a stale entry left
+        // behind by an evicted epoch would be counted into a live epoch.
+        let mut duty_state = DutyState::new(role_8_ring());
+        let operator_id = OperatorId(1);
+
+        // One duty at slot 325 (epoch 10, offset 5), ring index 325 % 128 = 69.
+        record_duty_at_slot(
+            &mut duty_state,
+            operator_id,
+            Epoch::new(10).start_slot(SLOTS_PER_EPOCH) + 5,
+        );
+
+        let operator_state = duty_state.get_or_create_operator(&operator_id);
+
+        // Epoch 14 spans slots 448..=479, whose ring indices 64..=95 include index 69 (via
+        // slot 453). The entry stored there belongs to slot 325, so it must not be counted.
+        assert_eq!(
+            operator_state.get_duty_count(Epoch::new(14), SLOTS_PER_EPOCH),
+            0,
+            "an aliased ring entry from another epoch's slot must not be counted"
+        );
+        // Self-check: the same entry still counts toward its own epoch.
+        assert_eq!(
+            operator_state.get_duty_count(Epoch::new(10), SLOTS_PER_EPOCH),
+            1,
+            "the recorded duty must count toward the epoch of its stored slot"
+        );
     }
 }

--- a/anchor/message_validator/src/lib.rs
+++ b/anchor/message_validator/src/lib.rs
@@ -742,20 +742,40 @@ impl<S: SlotClock + 'static, D: DutiesProvider> Validator<S, D> {
 
 /// Number of slots the `DutyState` ring must retain for `role`.
 ///
-/// Default: keep the last two epochs. `ProposerPreferences` also spans the proposer lookahead into
-/// the future (its envelope slot is a future `proposal_slot`), so its ring must cover
-/// `lookahead + default`; otherwise a validly accepted future-slot write would evict a live slot's
-/// dedup state (the ring is indexed by `slot % len`).
+/// Two consumers rely on the sizing (the ring is indexed by `slot % len`):
+/// - Per-slot signer state (dedup, message counts): an entry must not be evicted while its slot is
+///   still inside the role's message acceptance window (earliness + lateness, see
+///   `early_slot_allowance` / `message_lateness`).
+/// - `OperatorState::get_duty_count`, which derives per-epoch duty counts from ring occupancy
+///   (SIP-94 §7 retention). Exactness needs MORE than the acceptance window: a count query for the
+///   epoch of the oldest acceptable slot probes back to that epoch's FIRST slot, so the ring must
+///   cover `earliness + lateness + slots_per_epoch`, plus one slot padding the sub-slot lateness
+///   margins (`LATE_MESSAGE_MARGIN` + `CLOCK_ERROR_TOLERANCE`).
+///
+/// The default arm covers the widest default-role window (lateness `slots_per_epoch +
+/// LATE_SLOT_ALLOWANCE`, no earliness). `ProposerPreferences` spans the proposer lookahead into
+/// the future (its envelope slot is a future `proposal_slot`) with a 2-slot lateness; its
+/// lookahead-sized ring exceeds its bound (`64 + 2 + 32 + 1 = 99 <= 128`) with headroom.
+///
+/// The match is exhaustive so adding a role forces an explicit sizing decision here; a silent
+/// default would under-size a wide-window role and quietly disable its duty limit.
 ///
 /// Shared by the production selector (`get_duty_state`) and its regression test so neither can
 /// drift from the other.
 pub(crate) fn stored_slot_count(role: Role, slots_per_epoch: u64, spec: &ChainSpec) -> usize {
-    let default = slots_per_epoch * 2;
     let count = match role {
         Role::ProposerPreferences => {
-            (1 + spec.min_seed_lookahead.as_u64()) * slots_per_epoch + default
+            (1 + spec.min_seed_lookahead.as_u64()) * slots_per_epoch + 2 * slots_per_epoch
         }
-        _ => default,
+        Role::Committee
+        | Role::Aggregator
+        | Role::Proposer
+        | Role::SyncCommittee
+        | Role::ValidatorRegistration
+        | Role::VoluntaryExit
+        | Role::PTCAttester
+        | Role::EnvelopeProposer
+        | Role::AggregatorCommittee => 2 * slots_per_epoch + LATE_SLOT_ALLOWANCE + 1,
     };
     count as usize
 }
@@ -1114,35 +1134,39 @@ fn message_lateness(
 pub(crate) fn validate_duty_count(
     validation_context: &ValidationContext<impl SlotClock>,
     slot: Slot,
-    signer_state: &mut OperatorState,
+    operator_state: &OperatorState,
     duty_provider: Arc<impl DutiesProvider>,
 ) -> Result<(), ValidationFailure> {
-    if let Some(limit) = duty_limit(
+    let Some(limit) = duty_limit(
         validation_context,
         slot,
         &validation_context.committee_info.validator_indices,
         duty_provider,
-    )? {
-        // Get current duty count for this signer
-        let epoch = slot.epoch(validation_context.slots_per_epoch);
-        let duty_count = signer_state.get_duty_count(epoch);
+    )?
+    else {
+        return Ok(());
+    };
 
-        // Error if this validator has already been assigned at least as many duties
-        // as allowed for the target epoch. We perform this check *before* incrementing
-        // the in-memory count (so the very first duty will see count==0), hence the
-        // inclusive “>=” comparison.
-        // We only want to check the limit if this is the first message of that duty, as otherwise
-        // the check will fail for non-first messages of the last allowed duty. We do this by
-        // checking if there is a signer state already set for that slot. If so, we have already
-        // processed a message for this duty and the counter will not be increased further in
-        // `OperatorState::update`, so we skip the limit check here also.
-        if signer_state.is_first_message_for_duty(slot) && duty_count >= limit {
-            return Err(ValidationFailure::ExcessiveDutyCount {
-                got: duty_count,
-                limit,
-                role: validation_context.role,
-            });
-        }
+    // We only want to check the limit if this is the first message of that duty, as otherwise
+    // the check will fail for non-first messages of the last allowed duty. We do this by
+    // checking if there is a signer state already set for that slot. If so, we have already
+    // processed a message for this duty and it contributes no new count; skipping also
+    // avoids deriving the count from the ring for every follow-up message.
+    if !operator_state.is_first_message_for_duty(slot) {
+        return Ok(());
+    }
+
+    // Error if this validator has already been assigned at least as many duties as allowed
+    // for the target epoch. We perform this check *before* the duty is recorded in the ring
+    // (so the very first duty will see count==0), hence the inclusive “>=” comparison.
+    let epoch = slot.epoch(validation_context.slots_per_epoch);
+    let duty_count = operator_state.get_duty_count(epoch, validation_context.slots_per_epoch);
+    if duty_count >= limit {
+        return Err(ValidationFailure::ExcessiveDutyCount {
+            got: duty_count,
+            limit,
+            role: validation_context.role,
+        });
     }
 
     Ok(())
@@ -1422,6 +1446,7 @@ mod tests {
     // Helper struct for directly creating consensus messages for tests
     pub(crate) struct QbftMessageBuilder {
         msg_type: QbftMessageType,
+        height: u64,
         round: u64,
         identifier: MessageId,
         prepare_justification: Vec<SignedSSVMessage>,
@@ -1432,11 +1457,17 @@ mod tests {
         pub(crate) fn new(role: Role, msg_type: QbftMessageType) -> Self {
             Self {
                 msg_type,
+                height: 1,
                 round: 1,
                 identifier: create_message_id_for_test(role),
                 prepare_justification: vec![],
                 round_change_justification: vec![],
             }
+        }
+
+        pub(crate) fn with_height(mut self, height: u64) -> Self {
+            self.height = height;
+            self
         }
 
         pub(crate) fn with_round(mut self, round: u64) -> Self {
@@ -1493,7 +1524,7 @@ mod tests {
 
             QbftMessage {
                 qbft_message_type: self.msg_type,
-                height: 1,
+                height: self.height,
                 round: self.round,
                 identifier: (&self.identifier).into(),
                 root: Hash256::from([0u8; 32]),

--- a/anchor/message_validator/src/partial_signature.rs
+++ b/anchor/message_validator/src/partial_signature.rs
@@ -73,12 +73,7 @@ pub(crate) fn validate_partial_signature_message(
         .first()
         .ok_or(ValidationFailure::NoSigners)?;
 
-    duty_state.update_for_partial_signature(
-        &messages,
-        signer,
-        validation_context.slots_per_epoch,
-        received_from,
-    )?;
+    duty_state.update_for_partial_signature(&messages, signer, received_from)?;
 
     Ok(ValidatedSSVMessage::PartialSignatureMessages(messages))
 }
@@ -1668,7 +1663,7 @@ mod tests {
             .unwrap(),
         };
         duty_state
-            .update_for_partial_signature(&dummy_messages, &signer_id, 32, None)
+            .update_for_partial_signature(&dummy_messages, &signer_id, None)
             .unwrap();
 
         // Now validate a message for slot 1 (which is "old")
@@ -3988,7 +3983,7 @@ mod tests {
             .unwrap(),
         };
         duty_state
-            .update_for_partial_signature(&dummy, &signer_id, SLOTS_PER_EPOCH_TEST, None)
+            .update_for_partial_signature(&dummy, &signer_id, None)
             .unwrap();
 
         // Now an Aggregator message for an EARLIER slot (2) must be rejected.
@@ -4390,11 +4385,12 @@ mod tests {
         let ring = crate::stored_slot_count(Role::ProposerPreferences, SLOTS_PER_EPOCH_TEST, &spec);
         let mut duty_state = DutyState::new(ring);
 
-        // Guard: a representative non-role-8 role keeps the plain two-epoch default, confirming the
-        // lookahead expansion is specific to `ProposerPreferences`.
+        // Guard: a representative non-role-8 role keeps the count-exact default (two epochs plus
+        // the late-slot allowance plus a margin slot), confirming the lookahead expansion is
+        // specific to `ProposerPreferences`.
         assert_eq!(
             crate::stored_slot_count(Role::Proposer, SLOTS_PER_EPOCH_TEST, &spec),
-            (2 * SLOTS_PER_EPOCH_TEST) as usize,
+            (2 * SLOTS_PER_EPOCH_TEST + crate::LATE_SLOT_ALLOWANCE + 1) as usize,
         );
 
         let slot_s = Slot::new(1);
@@ -4490,6 +4486,79 @@ mod tests {
             |failure| matches!(failure, ValidationFailure::RelayedDuplicateMessage { .. }),
             "RelayedDuplicateMessage (slot S retained its first root across the far-slot write)",
         );
+    }
+
+    #[test]
+    fn test_proposer_preferences_saturated_epochs_not_conflated() {
+        // The devnet-visible regression this fix removes: role-8 duties legitimately spread
+        // across concurrent epochs (earliness allows a proposal_slot up to
+        // (1 + min_seed_lookahead) * spe ahead), and the deleted two-bucket counters conflated
+        // every epoch below the newest-seen one into a single bucket. With 32 duties spread
+        // over epochs 0 and 1 while an epoch-2 duty was recorded, that shared bucket hit the
+        // slots-per-epoch duty limit and a legitimate first message for a free epoch-1 slot
+        // was IGNORE'd as ExcessiveDutyCount. Ring-derived counts are per-epoch, so every
+        // message here must be accepted end to end through validate_partial_signature_message
+        // (epoch derived from the MESSAGE slot, first-message gate, ring occupancy).
+        // (Asserting ExcessiveDutyCount for role 8 is impossible under exact counting: the
+        // count only reaches the limit when every slot of the epoch is occupied, leaving no
+        // first message to reject.)
+        let (committee_info, private_key, map) = four_node_committee_and_keypair();
+        let signer_id = OperatorId(1);
+
+        // Production ring-size selector: (1 + 1) * spe + 2 * spe = 128 on mainnet-based specs.
+        let spec = spec_with_gloas(None);
+        let ring = crate::stored_slot_count(Role::ProposerPreferences, SLOTS_PER_EPOCH_TEST, &spec);
+        let mut duty_state = DutyState::new(ring);
+
+        // Wall clock stays at slot 1 (epoch 0) throughout; every message slot below is inside
+        // the role-8 window [wall - 2, wall + 2 * spe].
+        let wall_slot = Slot::new(1);
+        let accept = |duty_state: &mut DutyState, slot: Slot| {
+            // One distinct root per slot; the dedup set is per (signer, slot).
+            let signed = create_signed_proposer_preferences_message(
+                signer_id,
+                &private_key,
+                slot,
+                Hash256::from([slot.as_u64() as u8; 32]),
+            );
+            let ctx =
+                create_proposer_preferences_context(&signed, &committee_info, &map, wall_slot);
+            let result = validate_partial_signature_message(
+                ctx,
+                duty_state,
+                Arc::new(MockDutiesProvider::default()),
+                None,
+            );
+            assert!(
+                result.is_ok(),
+                "expected acceptance at slot {slot}, got: {result:?}"
+            );
+        };
+
+        // 16 duties in epoch 0, 16 in epoch 1, then 1 in epoch 2, so the two nearer epochs
+        // keep receiving duties while a later epoch already holds recorded state. (The test
+        // clock has no start times for slots before the wall slot, so epoch 0 starts at 2.)
+        for slot in 2..18u64 {
+            accept(&mut duty_state, Slot::new(slot));
+        }
+        for slot in 32..48u64 {
+            accept(&mut duty_state, Slot::new(slot));
+        }
+        accept(&mut duty_state, Slot::new(64));
+
+        // 16 more duties across epochs 0 and 1. Under the old counters each of these landed
+        // in the shared older-epoch bucket, pushing it to 32 (= the role-8 duty limit).
+        for slot in 18..32u64 {
+            accept(&mut duty_state, Slot::new(slot));
+        }
+        for slot in 48..50u64 {
+            accept(&mut duty_state, Slot::new(slot));
+        }
+
+        // The load-bearing acceptance: a first message for a FREE epoch-1 slot. Epoch 1 holds
+        // only 18 duties, so exact per-epoch counting admits it; the old conflated bucket read
+        // 32 >= 32 here and dropped an honest preference share.
+        accept(&mut duty_state, Slot::new(50));
     }
 
     #[test]
@@ -4698,11 +4767,7 @@ mod tests {
 
         // Persist the accepted consensus so `max_slot == 1` before Act 2; without it the state
         // would stay at `max_slot == 0` and never exercise the equality boundary.
-        shared_duty_state.update_for_consensus_message(
-            &consensus_signed_msg,
-            &qbft_message,
-            SLOTS_PER_EPOCH_TEST,
-        );
+        shared_duty_state.update_for_consensus_message(&consensus_signed_msg, &qbft_message);
 
         // Act: same-slot PostConsensus partial sig against the now-advanced shared state.
         let partial_sig_signed_msg = create_signed_envelope_proposer_message(
@@ -4745,7 +4810,7 @@ mod tests {
             vec![],
             vec![],
         );
-        state.update_for_consensus_message(&signed_msg, &qbft, SLOTS_PER_EPOCH_TEST);
+        state.update_for_consensus_message(&signed_msg, &qbft);
     }
 
     #[test]
@@ -4812,7 +4877,7 @@ mod tests {
             PartialSignatureMessages::from_ssz_bytes(dummy_partial_sig.ssv_message().data())
                 .expect("dummy envelope message must decode");
         duty_state
-            .update_for_partial_signature(&messages, &OperatorId(1), SLOTS_PER_EPOCH_TEST, None)
+            .update_for_partial_signature(&messages, &OperatorId(1), None)
             .expect("seeding partial-signature state must succeed");
 
         // Arrange: Consensus message at height 5 (lower than 10).
@@ -4921,6 +4986,180 @@ mod tests {
                 )
             },
             "Repeated EnvelopeProposer PostConsensus for the same signer/slot must be rejected",
+        );
+    }
+
+    // ==================== Aggregator duty-limit helpers ====================
+
+    /// Slot layout for the Aggregator duty-limit test: three distinct duty slots inside
+    /// epoch 0, in ascending order because Aggregator is a monotonic-slot role.
+    const AGGREGATOR_SLOT_A: u64 = 1;
+    const AGGREGATOR_SLOT_B: u64 = 2;
+    const AGGREGATOR_SLOT_C: u64 = 3;
+
+    /// Helper to create a SignedSSVMessage for Aggregator testing at a chosen slot.
+    fn create_signed_aggregator_message(
+        signer_id: OperatorId,
+        private_key: &Rsa<Private>,
+        kind: PartialSignatureKind,
+        slot: Slot,
+    ) -> SignedSSVMessage {
+        let partial_sig_messages = PartialSignatureMessages {
+            kind,
+            slot,
+            messages: VariableList::new(vec![PartialSignatureMessage {
+                partial_signature: Signature::empty(),
+                signing_root: Hash256::from([0u8; 32]),
+                signer: signer_id,
+                // ValidatorIndex(0) is in the test committee's validator_indices.
+                validator_index: ValidatorIndex(0),
+            }])
+            .unwrap(),
+        };
+
+        let msg_id = create_message_id_for_test(Role::Aggregator);
+        let ssv_msg = SSVMessage::new(
+            MsgType::SSVPartialSignatureMsgType,
+            msg_id,
+            partial_sig_messages.as_ssz_bytes(),
+        )
+        .unwrap();
+
+        let p_key = PKey::from_rsa(private_key.clone()).unwrap();
+        let mut signer = Signer::new(MessageDigest::sha256(), &p_key).unwrap();
+        signer.update(&ssv_msg.as_ssz_bytes()).unwrap();
+        let signature = signer.sign_to_vec().unwrap().try_into().unwrap();
+
+        SignedSSVMessage::new(vec![signature], vec![signer_id], ssv_msg, vec![]).unwrap()
+    }
+
+    /// Builds an Aggregator validation context whose genesis (slot 0) sits
+    /// `AGGREGATOR_SLOT_C` slots in the past, so every duty slot used by the test has
+    /// started by `received_at` (Aggregator has no earliness allowance) and none is
+    /// anywhere near the `slots_per_epoch + LATE_SLOT_ALLOWANCE` lateness bound.
+    fn create_aggregator_context<'a>(
+        signed_msg: &'a SignedSSVMessage,
+        committee_info: &'a crate::CommitteeInfo,
+        operator_pub_keys: &'a HashMap<OperatorId, Rsa<Public>>,
+    ) -> ValidationContext<'a, ManualSlotClock> {
+        let now = SystemTime::now();
+        let genesis = now - Duration::from_secs(12 * AGGREGATOR_SLOT_C);
+        let slot_clock = ManualSlotClock::new(
+            Slot::new(0),
+            genesis.duration_since(UNIX_EPOCH).unwrap(),
+            Duration::from_secs(12),
+        );
+
+        ValidationContext {
+            signed_ssv_message: signed_msg,
+            committee_info,
+            role: Role::Aggregator,
+            received_at: now,
+            slots_per_epoch: SLOTS_PER_EPOCH_TEST,
+            epochs_per_sync_committee_period: 256,
+            sync_committee_size: 512,
+            slot_clock,
+            operator_pub_keys,
+            // Aggregator is deprecated at Boole; Alan keeps the role active.
+            fork_schedule: generate_fork_schedule(Fork::Alan),
+            spec: spec_with_gloas(None),
+        }
+    }
+
+    #[test]
+    fn test_aggregator_duty_limit_enforced_and_follow_ups_exempt() {
+        // Aggregator's per-epoch duty limit is 2, and only the FIRST message of a duty
+        // consumes it: follow-up messages for an already-counted slot are exempt, so the
+        // last allowed duty can still complete its post-consensus phase. This drives
+        // validate_partial_signature_message end to end and pins both halves: the
+        // follow-up exemption at the limit (step 4) and the enforcement of the
+        // ring-derived count against a fresh duty (step 5).
+        let (committee_info, private_key, map) = four_node_committee_and_keypair();
+        let signer_id = OperatorId(1);
+
+        // Production ring-size selector: 2 * spe + LATE_SLOT_ALLOWANCE + 1 = 67 for
+        // Aggregator, shared across all five calls so counts accumulate.
+        let spec = spec_with_gloas(None);
+        let ring = crate::stored_slot_count(Role::Aggregator, SLOTS_PER_EPOCH_TEST, &spec);
+        let mut duty_state = DutyState::new(ring);
+
+        let run = |duty_state: &mut DutyState, kind: PartialSignatureKind, slot: u64| {
+            let signed =
+                create_signed_aggregator_message(signer_id, &private_key, kind, Slot::new(slot));
+            let ctx = create_aggregator_context(&signed, &committee_info, &map);
+            validate_partial_signature_message(
+                ctx,
+                duty_state,
+                Arc::new(MockDutiesProvider::default()),
+                None,
+            )
+        };
+
+        // 1) First duty at slot A: count 0 < 2, accepted.
+        let result = run(
+            &mut duty_state,
+            PartialSignatureKind::SelectionProofPartialSig,
+            AGGREGATOR_SLOT_A,
+        );
+        assert!(
+            result.is_ok(),
+            "first duty must be accepted, got: {result:?}"
+        );
+
+        // 2) Follow-up at slot A: same duty, exempt from the count.
+        let result = run(
+            &mut duty_state,
+            PartialSignatureKind::PostConsensus,
+            AGGREGATOR_SLOT_A,
+        );
+        assert!(
+            result.is_ok(),
+            "follow-up for the first duty must be accepted, got: {result:?}"
+        );
+
+        // 3) Second duty at slot B: count 1 < 2, accepted.
+        let result = run(
+            &mut duty_state,
+            PartialSignatureKind::SelectionProofPartialSig,
+            AGGREGATOR_SLOT_B,
+        );
+        assert!(
+            result.is_ok(),
+            "second duty must be accepted, got: {result:?}"
+        );
+
+        // 4) Follow-up at slot B: the derived count now equals the limit, but a follow-up
+        //    contributes no new duty and must not be re-checked against it.
+        let result = run(
+            &mut duty_state,
+            PartialSignatureKind::PostConsensus,
+            AGGREGATOR_SLOT_B,
+        );
+        assert!(
+            result.is_ok(),
+            "follow-up for the last allowed duty must be exempt from the duty limit, got: \
+             {result:?}"
+        );
+
+        // 5) Third duty at slot C: count 2 >= limit 2, rejected.
+        let result = run(
+            &mut duty_state,
+            PartialSignatureKind::SelectionProofPartialSig,
+            AGGREGATOR_SLOT_C,
+        );
+        assert_validation_error(
+            result,
+            |failure| {
+                matches!(
+                    failure,
+                    ValidationFailure::ExcessiveDutyCount {
+                        got: 2,
+                        limit: 2,
+                        role: Role::Aggregator,
+                    }
+                )
+            },
+            "ExcessiveDutyCount with got=2, limit=2 (third Aggregator duty in the epoch)",
         );
     }
 }


### PR DESCRIPTION
## Problem, Evidence, and Context

SIP-94 §7 requires duty counts to be retained for every epoch with slots inside a role's message acceptance window. Role 8 (`ProposerPreferences`) accepts slots spanning up to four concurrent epochs, but `OperatorState` kept only two rolling epoch buckets: accepting an epoch E+2 message relabeled E's count as E+1's and zeroed reads for E, and the older-epoch arm conflated all past epochs into one bucket. Fail-open admits nothing extra for role 8, but the fail-closed direction (a conflated bucket hitting the limit) drops honest preference shares on small devnets where one validator holds many proposal slots, which presents as a protocol bug during testing.

- Issue: #1271 (last open item in the Proposer Preferences Duty milestone)
- Spec: SIP-94 §7 retention requirement (ssvlabs/SIPs #94)
- Precursor: #1254 / #1272 (same file)

## Change Overview

- Delete the three counter fields and their relabeling writer; `get_duty_count(epoch, slots_per_epoch)` now derives the count by probing the ring at each of the epoch's slot keys. The ring already records exactly one occupied entry per counted duty slot, so counts gain a single source of truth that cannot drift from the dedup state.
- `validate_duty_count` checks `is_first_message_for_duty` before deriving (the count is only meaningful for first messages, and this keeps the walk off the per-message path); takes `&OperatorState`.
- The two now-identical setters merge into one `set_signer_state` (the round-change path's `max_slot` guard was always a no-op).
- Ring sizing: derivation is exact only if the ring also covers a full epoch beyond the acceptance window, so the default grows 64 -> 67 (`2*spe + LATE_SLOT_ALLOWANCE + 1`); role 8 stays at 128 (already exact with headroom). `stored_slot_count` is now exhaustive over `Role` so adding a role forces an explicit sizing decision instead of silently under-sizing.
- Intentionally unchanged: verdict classifications (`ExcessiveDutyCount` stays Ignore), the 4-root dedup rule, validation ordering, and all wire behavior.

Reviewer note: two acceptance criteria in #1271 are deliberately deviated from. "Duty-limit behavior for every other role is unchanged" holds as no-reachable-regression, not byte-identical: derived counts fix the same conflation edges for all limited roles (including VoluntaryExit, whose observed count, unlike its limit, comes from these counters). "No change to ring sizing" was dropped in favor of the 64 -> 67 exactness fix; one existing guard assertion updates accordingly.

Rejected alternative: widening to four buckets keeps the relabeling arithmetic (the bug class being fixed) and a second state that can drift from the ring; go-ssv retains that structure upstream, which is deliberate SIP-backed divergence with no interop surface (Ignore-class decisions only, both implementations).

## Risks, Trade-offs, and Mitigations

- The count walk is at most `slots_per_epoch` vector probes, gated to first messages, and sits next to provider lookups and an RSA verify that dominate it. The whole check-then-record sequence runs under the existing per-MessageId shard guard, so no new interleavings.
- Larger default rings cost 3 extra `Option<SignerState>` slots per operator state and can newly (correctly) Ignore a message at a saturated epoch tail that the undersized ring would have admitted.
- Under exact counting, `ExcessiveDutyCount` is unreachable for the two roles whose limit equals `slots_per_epoch` (a full epoch leaves no first message to reject); the limit remains as the SIP-specified backstop.

## Validation

- `cargo test -p message_validator`: 128 passed; `make lint`, `make cargo-fmt-check`, `make test` all clean.
- The two module regressions and the pipeline saturation test all fail under a temporary revert to the bucket code (the saturation test with exactly `ExcessiveDutyCount { got: 32, limit: 32 }`, the fail-closed scenario from the issue).
- Three explicit mutations are pinned by tests, verified by applying each and confirming failure: dropping the slot-equality filter (stale-entry miscounts), deleting the first-message gate (follow-ups of the last allowed duty wrongly rejected), and a count stuck at zero.
- ssv-mini: a mixed 2 Anchor + 2 go-ssv Boole run at this branch head (fork + 6.7 epochs: zero ExcessiveDutyCount, zero errors, duties healthy across all classes, memory flat), plus an all-Anchor Gloas run with role 8 live (preference batches signed, published, and cross-validated by all four operators across epochs 2-5 with zero validation failures).

## Rollback

Single revert; all state is in-memory and rebuilt from gossip after restart. No config, schema, or wire impact.

## Blockers / Dependencies

#1273 removes `received_from` through the same `update_for_partial_signature` signature; whichever lands second rebases (mechanical).

## Additional Info / Next Steps

None; no follow-up work is planned from this PR.
