### PR TITLE
feat: admit one envelope dissemination per signer and sign by binding

### DIFF
--- a/anchor/common/dissemination_store/Cargo.toml
+++ b/anchor/common/dissemination_store/Cargo.toml
@@ -10,3 +10,7 @@ parking_lot = { workspace = true }
 ssv_types = { workspace = true }
 tokio = { workspace = true }
 types = { workspace = true }
+
+[dev-dependencies]
+# `start_paused` in the wait tests: the deadline is the only thing they wait on.
+tokio = { workspace = true, features = ["test-util"] }

--- a/anchor/common/dissemination_store/src/lib.rs
+++ b/anchor/common/dissemination_store/src/lib.rs
@@ -1,13 +1,14 @@
 //! Handoff store for SIP-94 §6 envelope disseminations.
 //!
 //! The message receiver writes every validator-accepted `EnvelopeDissemination` for a
-//! `(validator, slot)`; the envelope duty runner scans them in arrival order for the first
-//! whose envelope binds to its own §4 decision. Message validation admits at most one
-//! dissemination per (`MessageId`, signer, slot) (SIP-94 §7) and only from committee members,
-//! so the candidate list is bounded by committee size on the validated path. The store itself
-//! enforces neither: it is a handoff, and validation is its only production writer.
+//! `(validator, slot)`; the envelope duty runner scans them in arrival order and selects one by
+//! content (see `sign_disseminated_envelope` for why selection cannot be by arrival). Message
+//! validation admits at most one dissemination per (`MessageId`, signer, slot) (SIP-94 §7) and
+//! only from committee members, so the candidate list is bounded by committee size on the
+//! validated path. The store enforces neither: it is a handoff, and validation is its only
+//! production writer.
 
-use std::collections::HashMap;
+use std::{collections::HashMap, sync::Arc};
 
 use bls::PublicKeyBytes;
 use parking_lot::Mutex;
@@ -24,25 +25,20 @@ struct Key {
     slot: Slot,
 }
 
-/// The candidates accepted for one key, and a counter that wakes waiters when one lands.
+/// The candidates accepted for one key, and a signal that wakes waiters when one lands.
+#[derive(Default)]
 struct Entry {
     /// Accepted disseminations in arrival order, tagged with the operator that signed each.
-    candidates: Vec<(OperatorId, EnvelopeDissemination)>,
-    /// Set to `candidates.len()` on every push. A `watch` receiver treats the value present
-    /// when it subscribes as already seen, so a waiter must subscribe while holding the same
-    /// lock it reads `candidates` under. Subscribing after releasing the lock would miss a
-    /// candidate pushed in between and could sleep to its deadline with a match already in
-    /// the vector.
-    version: watch::Sender<usize>,
-}
-
-impl Default for Entry {
-    fn default() -> Self {
-        Self {
-            candidates: Vec::new(),
-            version: watch::Sender::new(0),
-        }
-    }
+    /// `Arc` so a waiter's visit is a refcount bump: a candidate carries up to
+    /// `SSVMessageDataLen` bytes, and cloning it would copy them under the lock the receiver
+    /// also takes, letting the sender's byte count set this node's lock-hold time.
+    candidates: Vec<(OperatorId, Arc<EnvelopeDissemination>)>,
+    /// Bumped on every push; the value carries nothing, only the change matters. A `watch`
+    /// receiver treats the version present when it subscribes as already seen, so a waiter must
+    /// subscribe while holding the same lock it reads `candidates` under. Subscribing after
+    /// releasing the lock would miss a candidate pushed in between and could sleep to its
+    /// deadline with a match already in the vector.
+    version: watch::Sender<()>,
 }
 
 /// Shared store connecting the message receiver (writer) to the envelope duty runner (reader).
@@ -59,10 +55,8 @@ impl DisseminationStore {
     /// Appends an accepted dissemination for `(validator, slot)` and wakes the waiters.
     ///
     /// Every accepted candidate is kept, because the runner selects by content rather than by
-    /// arrival: discarding here would hand a Byzantine committee member the slot by letting it
-    /// win the race. Entries older than `MAX_DISSEMINATION_AGE_SLOTS` relative to the inserted
-    /// slot are dropped on insert (addition on the stored side, so an early slot cannot
-    /// underflow).
+    /// arrival. Entries older than `MAX_DISSEMINATION_AGE_SLOTS` relative to the inserted slot
+    /// are dropped on insert (addition on the stored side, so an early slot cannot underflow).
     pub fn insert(
         &self,
         validator: PublicKeyBytes,
@@ -74,8 +68,8 @@ impl DisseminationStore {
         Self::sweep(&mut inner, slot);
 
         let entry = inner.entry(Key { validator, slot }).or_default();
-        entry.candidates.push((signer, dissemination));
-        entry.version.send_replace(entry.candidates.len());
+        entry.candidates.push((signer, Arc::new(dissemination)));
+        entry.version.send_replace(());
     }
 
     /// Returns the first candidate for `(validator, slot)` that `predicate` accepts, waiting
@@ -94,11 +88,14 @@ impl DisseminationStore {
         let key = Key { validator, slot };
         let mut cursor = 0;
 
+        // Once per call: `slot` is fixed, so a key surviving this cannot go stale during the
+        // wait, and a candidate arriving meanwhile was already swept against its own slot.
+        Self::sweep(&mut self.inner.lock(), slot);
+
         loop {
             // One critical section for both, per the `version` note above.
             let (candidate, mut version) = {
                 let mut inner = self.inner.lock();
-                Self::sweep(&mut inner, slot);
                 let entry = inner.entry(key).or_default();
                 (
                     entry.candidates.get(cursor).cloned(),
@@ -148,6 +145,7 @@ mod tests {
         }
     }
 
+    /// The default-tagged candidate, for tests that never compare two candidates.
     fn dissemination(slot: u64) -> EnvelopeDissemination {
         tagged(slot, 0xAA)
     }
@@ -178,7 +176,7 @@ mod tests {
         }
     }
 
-    #[tokio::test]
+    #[tokio::test(start_paused = true)]
     async fn stored_candidate_matches_without_waiting() {
         let store = DisseminationStore::new();
         store.insert(pubkey(1), OperatorId(1), dissemination(5));
@@ -189,7 +187,7 @@ mod tests {
         assert_eq!(got, Some(dissemination(5)));
     }
 
-    #[tokio::test]
+    #[tokio::test(start_paused = true)]
     async fn candidates_accumulate_in_arrival_order() {
         let store = DisseminationStore::new();
         store.insert(pubkey(1), OperatorId(1), tagged(5, 0xAA));
@@ -272,7 +270,7 @@ mod tests {
         );
     }
 
-    #[tokio::test]
+    #[tokio::test(start_paused = true)]
     async fn wait_times_out_when_nothing_matches() {
         let store = DisseminationStore::new();
         store.insert(pubkey(1), OperatorId(1), tagged(5, 0xAA));
@@ -307,7 +305,7 @@ mod tests {
         assert_eq!(w2.await.unwrap(), Some(dissemination(5)));
     }
 
-    #[tokio::test]
+    #[tokio::test(start_paused = true)]
     async fn timed_out_wait_can_retry_against_the_backlog() {
         let store = DisseminationStore::new();
 
@@ -327,7 +325,7 @@ mod tests {
         );
     }
 
-    #[tokio::test]
+    #[tokio::test(start_paused = true)]
     async fn keys_are_isolated() {
         let store = DisseminationStore::new();
         store.insert(pubkey(1), OperatorId(1), dissemination(5));
@@ -346,7 +344,7 @@ mod tests {
         );
     }
 
-    #[tokio::test]
+    #[tokio::test(start_paused = true)]
     async fn insert_evicts_entries_past_the_age_window() {
         let store = DisseminationStore::new();
         store.insert(pubkey(1), OperatorId(1), dissemination(5));
@@ -365,7 +363,7 @@ mod tests {
         );
     }
 
-    #[tokio::test]
+    #[tokio::test(start_paused = true)]
     async fn unanswered_waits_stay_bounded() {
         let store = DisseminationStore::new();
         // Many timed-out waits across distinct slots, no inserts at all.

--- a/anchor/common/dissemination_store/src/lib.rs
+++ b/anchor/common/dissemination_store/src/lib.rs
@@ -1,16 +1,18 @@
 //! Handoff store for SIP-94 §6 envelope disseminations.
 //!
-//! The message receiver writes the first validator-accepted `EnvelopeDissemination` per
-//! `(validator, slot)`; the envelope duty runner awaits it. Message validation's first-valid
-//! rule delivers at most one dissemination per key for the process lifetime, so the store is
-//! first-write-wins and never replaces an entry.
+//! The message receiver writes every validator-accepted `EnvelopeDissemination` for a
+//! `(validator, slot)`; the envelope duty runner scans them in arrival order for the first
+//! whose envelope binds to its own §4 decision. Message validation admits at most one
+//! dissemination per (`MessageId`, signer, slot) (SIP-94 §7) and only from committee members,
+//! so the candidate list is bounded by committee size on the validated path. The store itself
+//! enforces neither: it is a handoff, and validation is its only production writer.
 
 use std::collections::HashMap;
 
 use bls::PublicKeyBytes;
 use parking_lot::Mutex;
-use ssv_types::dissemination::EnvelopeDissemination;
-use tokio::{sync::oneshot, time::Instant};
+use ssv_types::{OperatorId, dissemination::EnvelopeDissemination};
+use tokio::{sync::watch, time::Instant};
 use types::Slot;
 
 /// Number of slots an entry stays readable, mirroring the decided-block context retention.
@@ -22,12 +24,25 @@ struct Key {
     slot: Slot,
 }
 
-enum Entry {
-    /// The accepted dissemination for the key.
-    Ready(EnvelopeDissemination),
-    /// Runners awaiting the dissemination. Senders are pruned when closed, so timed-out or
-    /// cancelled waiters do not accumulate.
-    Waiting(Vec<oneshot::Sender<EnvelopeDissemination>>),
+/// The candidates accepted for one key, and a counter that wakes waiters when one lands.
+struct Entry {
+    /// Accepted disseminations in arrival order, tagged with the operator that signed each.
+    candidates: Vec<(OperatorId, EnvelopeDissemination)>,
+    /// Set to `candidates.len()` on every push. A `watch` receiver treats the value present
+    /// when it subscribes as already seen, so a waiter must subscribe while holding the same
+    /// lock it reads `candidates` under. Subscribing after releasing the lock would miss a
+    /// candidate pushed in between and could sleep to its deadline with a match already in
+    /// the vector.
+    version: watch::Sender<usize>,
+}
+
+impl Default for Entry {
+    fn default() -> Self {
+        Self {
+            candidates: Vec::new(),
+            version: watch::Sender::new(0),
+        }
+    }
 }
 
 /// Shared store connecting the message receiver (writer) to the envelope duty runner (reader).
@@ -41,70 +56,72 @@ impl DisseminationStore {
         Self::default()
     }
 
-    /// Records the accepted dissemination for `(validator, slot)` and wakes every waiter.
+    /// Appends an accepted dissemination for `(validator, slot)` and wakes the waiters.
     ///
-    /// First-write-wins: a `Ready` entry is never replaced. Entries older than
-    /// `MAX_DISSEMINATION_AGE_SLOTS` relative to the inserted slot are dropped on insert
-    /// (addition on the stored side, so an early slot cannot underflow).
-    pub fn insert(&self, validator: PublicKeyBytes, dissemination: EnvelopeDissemination) {
+    /// Every accepted candidate is kept, because the runner selects by content rather than by
+    /// arrival: discarding here would hand a Byzantine committee member the slot by letting it
+    /// win the race. Entries older than `MAX_DISSEMINATION_AGE_SLOTS` relative to the inserted
+    /// slot are dropped on insert (addition on the stored side, so an early slot cannot
+    /// underflow).
+    pub fn insert(
+        &self,
+        validator: PublicKeyBytes,
+        signer: OperatorId,
+        dissemination: EnvelopeDissemination,
+    ) {
         let slot = dissemination.slot;
-        let key = Key { validator, slot };
         let mut inner = self.inner.lock();
         Self::sweep(&mut inner, slot);
 
-        match inner.entry(key) {
-            std::collections::hash_map::Entry::Vacant(entry) => {
-                entry.insert(Entry::Ready(dissemination));
-            }
-            std::collections::hash_map::Entry::Occupied(mut entry) => match entry.get_mut() {
-                Entry::Ready(_) => {}
-                Entry::Waiting(waiters) => {
-                    for waiter in waiters.drain(..) {
-                        // A dropped receiver (timed-out waiter) is fine; the value stays Ready.
-                        let _ = waiter.send(dissemination.clone());
-                    }
-                    entry.insert(Entry::Ready(dissemination));
-                }
-            },
-        }
+        let entry = inner.entry(Key { validator, slot }).or_default();
+        entry.candidates.push((signer, dissemination));
+        entry.version.send_replace(entry.candidates.len());
     }
 
-    /// Awaits the dissemination for `(validator, slot)` until `deadline`.
+    /// Returns the first candidate for `(validator, slot)` that `predicate` accepts, waiting
+    /// for later arrivals until `deadline`.
     ///
-    /// Returns immediately when the entry is already `Ready`. A timed-out or cancelled wait
-    /// leaves a `Ready` value available for a later call. Waiter registrations sweep stale
-    /// keys and prune closed senders, so unanswered waits stay bounded even when no
-    /// dissemination ever arrives.
-    pub async fn wait(
+    /// Candidates are visited once each, in arrival order, starting from those already stored.
+    /// `predicate` runs outside the store lock, so it may decode and validate the envelope.
+    /// Returns `None` when the deadline passes with no candidate accepted.
+    pub async fn wait_matching<T>(
         &self,
         validator: PublicKeyBytes,
         slot: Slot,
         deadline: Instant,
-    ) -> Option<EnvelopeDissemination> {
-        let receiver = {
-            let key = Key { validator, slot };
-            let mut inner = self.inner.lock();
-            Self::sweep(&mut inner, slot);
-            for entry in inner.values_mut() {
-                if let Entry::Waiting(waiters) = entry {
-                    waiters.retain(|waiter| !waiter.is_closed());
+        mut predicate: impl FnMut(OperatorId, &EnvelopeDissemination) -> Option<T>,
+    ) -> Option<T> {
+        let key = Key { validator, slot };
+        let mut cursor = 0;
+
+        loop {
+            // One critical section for both, per the `version` note above.
+            let (candidate, mut version) = {
+                let mut inner = self.inner.lock();
+                Self::sweep(&mut inner, slot);
+                let entry = inner.entry(key).or_default();
+                (
+                    entry.candidates.get(cursor).cloned(),
+                    entry.version.subscribe(),
+                )
+            };
+
+            if let Some((signer, dissemination)) = candidate {
+                cursor += 1;
+                if let Some(accepted) = predicate(signer, &dissemination) {
+                    return Some(accepted);
                 }
+                continue;
             }
 
-            match inner
-                .entry(key)
-                .or_insert_with(|| Entry::Waiting(Vec::new()))
-            {
-                Entry::Ready(dissemination) => return Some(dissemination.clone()),
-                Entry::Waiting(waiters) => {
-                    let (sender, receiver) = oneshot::channel();
-                    waiters.push(sender);
-                    receiver
-                }
+            match tokio::time::timeout_at(deadline, version.changed()).await {
+                // A candidate landed; read it on the next pass.
+                Ok(Ok(())) => {}
+                // The entry was swept while waiting, so nothing more can arrive under it.
+                Ok(Err(_sender_dropped)) => return None,
+                Err(_elapsed) => return None,
             }
-        };
-
-        tokio::time::timeout_at(deadline, receiver).await.ok()?.ok()
+        }
     }
 
     /// Drops entries older than `MAX_DISSEMINATION_AGE_SLOTS` relative to `slot`. A call for
@@ -122,11 +139,17 @@ mod tests {
 
     use super::*;
 
-    fn dissemination(slot: u64) -> EnvelopeDissemination {
+    /// A dissemination for `slot` whose envelope bytes are all `tag`, so tests can tell
+    /// candidates apart and match on one.
+    fn tagged(slot: u64, tag: u8) -> EnvelopeDissemination {
         EnvelopeDissemination {
             slot: Slot::new(slot),
-            envelope: VariableList::new(vec![0xAA; 8]).unwrap(),
+            envelope: VariableList::new(vec![tag; 8]).unwrap(),
         }
+    }
+
+    fn dissemination(slot: u64) -> EnvelopeDissemination {
+        tagged(slot, 0xAA)
     }
 
     fn pubkey(byte: u8) -> PublicKeyBytes {
@@ -137,86 +160,206 @@ mod tests {
         Instant::now() + Duration::from_millis(200)
     }
 
-    #[tokio::test]
-    async fn ready_before_wait_returns_immediately() {
-        let store = DisseminationStore::new();
-        store.insert(pubkey(1), dissemination(5));
+    /// Accepts any candidate, returning it.
+    fn accept_any(
+        _signer: OperatorId,
+        dissemination: &EnvelopeDissemination,
+    ) -> Option<EnvelopeDissemination> {
+        Some(dissemination.clone())
+    }
 
-        let got = store.wait(pubkey(1), Slot::new(5), soon()).await;
+    /// Accepts only the candidate whose envelope bytes carry `tag`, standing in for the
+    /// runner's decision-binding check.
+    fn accept_tag(
+        tag: u8,
+    ) -> impl FnMut(OperatorId, &EnvelopeDissemination) -> Option<EnvelopeDissemination> {
+        move |_signer, dissemination| {
+            (dissemination.envelope[0] == tag).then(|| dissemination.clone())
+        }
+    }
+
+    #[tokio::test]
+    async fn stored_candidate_matches_without_waiting() {
+        let store = DisseminationStore::new();
+        store.insert(pubkey(1), OperatorId(1), dissemination(5));
+
+        let got = store
+            .wait_matching(pubkey(1), Slot::new(5), soon(), accept_any)
+            .await;
         assert_eq!(got, Some(dissemination(5)));
     }
 
     #[tokio::test]
-    async fn wait_before_ready_wakes_all_same_key_waiters() {
+    async fn candidates_accumulate_in_arrival_order() {
+        let store = DisseminationStore::new();
+        store.insert(pubkey(1), OperatorId(1), tagged(5, 0xAA));
+        store.insert(pubkey(1), OperatorId(2), tagged(5, 0xBB));
+
+        let seen = Arc::new(Mutex::new(Vec::new()));
+        let recorder = seen.clone();
+        let got = store
+            .wait_matching(pubkey(1), Slot::new(5), soon(), move |signer, d| {
+                recorder.lock().push((signer, d.envelope[0]));
+                None::<()>
+            })
+            .await;
+
+        assert_eq!(got, None, "no candidate was accepted");
+        assert_eq!(
+            *seen.lock(),
+            vec![(OperatorId(1), 0xAA), (OperatorId(2), 0xBB)],
+            "candidates must be visited in arrival order, each tagged with its signer"
+        );
+    }
+
+    /// The behaviour this store exists for: a rejected candidate must not consume the slot.
+    #[tokio::test]
+    async fn rejected_candidate_is_skipped_and_a_later_arrival_matches() {
+        let store = Arc::new(DisseminationStore::new());
+        // The undesired candidate is already stored when the wait starts.
+        store.insert(pubkey(1), OperatorId(1), tagged(5, 0xAA));
+
+        let waiter = tokio::spawn({
+            let store = store.clone();
+            let deadline = Instant::now() + Duration::from_secs(5);
+            async move {
+                store
+                    .wait_matching(pubkey(1), Slot::new(5), deadline, accept_tag(0xBB))
+                    .await
+            }
+        });
+        // Let the waiter drain the backlog and register for the next arrival.
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        store.insert(pubkey(1), OperatorId(2), tagged(5, 0xBB));
+
+        assert_eq!(
+            waiter.await.unwrap(),
+            Some(tagged(5, 0xBB)),
+            "the wait must skip the rejected candidate and take the later matching one"
+        );
+    }
+
+    #[tokio::test]
+    async fn each_candidate_is_visited_once() {
+        let store = Arc::new(DisseminationStore::new());
+        let visits = Arc::new(Mutex::new(Vec::new()));
+
+        let waiter = tokio::spawn({
+            let store = store.clone();
+            let recorder = visits.clone();
+            let deadline = Instant::now() + Duration::from_millis(400);
+            async move {
+                store
+                    .wait_matching(pubkey(1), Slot::new(5), deadline, move |signer, _| {
+                        recorder.lock().push(signer);
+                        None::<()>
+                    })
+                    .await
+            }
+        });
+
+        for id in 1..=3u64 {
+            tokio::time::sleep(Duration::from_millis(30)).await;
+            store.insert(pubkey(1), OperatorId(id), dissemination(5));
+        }
+
+        assert_eq!(waiter.await.unwrap(), None);
+        assert_eq!(
+            *visits.lock(),
+            vec![OperatorId(1), OperatorId(2), OperatorId(3)],
+            "the cursor must not re-offer a candidate the predicate already rejected"
+        );
+    }
+
+    #[tokio::test]
+    async fn wait_times_out_when_nothing_matches() {
+        let store = DisseminationStore::new();
+        store.insert(pubkey(1), OperatorId(1), tagged(5, 0xAA));
+
+        let got = store
+            .wait_matching(pubkey(1), Slot::new(5), soon(), accept_tag(0xBB))
+            .await;
+        assert_eq!(got, None, "an unmatched backlog must still time out");
+    }
+
+    #[tokio::test]
+    async fn concurrent_waiters_each_see_the_candidate() {
         let store = Arc::new(DisseminationStore::new());
         let deadline = Instant::now() + Duration::from_secs(5);
-        let w1 = tokio::spawn({
-            let store = store.clone();
-            async move { store.wait(pubkey(1), Slot::new(5), deadline).await }
-        });
-        let w2 = tokio::spawn({
-            let store = store.clone();
-            async move { store.wait(pubkey(1), Slot::new(5), deadline).await }
-        });
+        let spawn_waiter = || {
+            tokio::spawn({
+                let store = store.clone();
+                async move {
+                    store
+                        .wait_matching(pubkey(1), Slot::new(5), deadline, accept_any)
+                        .await
+                }
+            })
+        };
+        let (w1, w2) = (spawn_waiter(), spawn_waiter());
         // Let both waiters register before the insert.
         tokio::time::sleep(Duration::from_millis(50)).await;
 
-        store.insert(pubkey(1), dissemination(5));
+        store.insert(pubkey(1), OperatorId(1), dissemination(5));
 
         assert_eq!(w1.await.unwrap(), Some(dissemination(5)));
         assert_eq!(w2.await.unwrap(), Some(dissemination(5)));
     }
 
     #[tokio::test]
-    async fn timed_out_wait_can_retry_against_ready() {
+    async fn timed_out_wait_can_retry_against_the_backlog() {
         let store = DisseminationStore::new();
 
-        let got = store.wait(pubkey(1), Slot::new(5), soon()).await;
+        let got = store
+            .wait_matching(pubkey(1), Slot::new(5), soon(), accept_any)
+            .await;
         assert_eq!(got, None, "no insert: the wait must time out");
 
-        store.insert(pubkey(1), dissemination(5));
-        let got = store.wait(pubkey(1), Slot::new(5), soon()).await;
+        store.insert(pubkey(1), OperatorId(1), dissemination(5));
+        let got = store
+            .wait_matching(pubkey(1), Slot::new(5), soon(), accept_any)
+            .await;
         assert_eq!(
             got,
             Some(dissemination(5)),
-            "the value must stay available after an earlier timed-out wait"
+            "candidates must stay available after an earlier timed-out wait"
         );
-    }
-
-    #[tokio::test]
-    async fn first_write_wins() {
-        let store = DisseminationStore::new();
-        let first = dissemination(5);
-        let mut second = dissemination(5);
-        second.envelope = VariableList::new(vec![0xBB; 8]).unwrap();
-
-        store.insert(pubkey(1), first.clone());
-        store.insert(pubkey(1), second);
-
-        let got = store.wait(pubkey(1), Slot::new(5), soon()).await;
-        assert_eq!(got, Some(first), "a Ready entry must never be replaced");
     }
 
     #[tokio::test]
     async fn keys_are_isolated() {
         let store = DisseminationStore::new();
-        store.insert(pubkey(1), dissemination(5));
+        store.insert(pubkey(1), OperatorId(1), dissemination(5));
 
-        assert_eq!(store.wait(pubkey(2), Slot::new(5), soon()).await, None);
-        assert_eq!(store.wait(pubkey(1), Slot::new(6), soon()).await, None);
+        assert_eq!(
+            store
+                .wait_matching(pubkey(2), Slot::new(5), soon(), accept_any)
+                .await,
+            None
+        );
+        assert_eq!(
+            store
+                .wait_matching(pubkey(1), Slot::new(6), soon(), accept_any)
+                .await,
+            None
+        );
     }
 
     #[tokio::test]
     async fn insert_evicts_entries_past_the_age_window() {
         let store = DisseminationStore::new();
-        store.insert(pubkey(1), dissemination(5));
+        store.insert(pubkey(1), OperatorId(1), dissemination(5));
         store.insert(
             pubkey(1),
+            OperatorId(1),
             dissemination(5 + MAX_DISSEMINATION_AGE_SLOTS + 1),
         );
 
         assert_eq!(
-            store.wait(pubkey(1), Slot::new(5), soon()).await,
+            store
+                .wait_matching(pubkey(1), Slot::new(5), soon(), accept_any)
+                .await,
             None,
             "an insert past the age window must evict the older entry"
         );
@@ -227,7 +370,9 @@ mod tests {
         let store = DisseminationStore::new();
         // Many timed-out waits across distinct slots, no inserts at all.
         for slot in 0..100u64 {
-            let _ = store.wait(pubkey(1), Slot::new(slot), Instant::now()).await;
+            let _ = store
+                .wait_matching(pubkey(1), Slot::new(slot), Instant::now(), accept_any)
+                .await;
         }
 
         let inner = store.inner.lock();
@@ -236,18 +381,9 @@ mod tests {
             "wait-created entries must be swept; got {} keys",
             inner.len()
         );
-        let waiters: usize = inner
-            .values()
-            .map(|entry| match entry {
-                Entry::Ready(_) => 0,
-                Entry::Waiting(waiters) => waiters.len(),
-            })
-            .sum();
-        // The final wait's own sender has no later registration to prune it; everything
-        // older must be gone.
         assert!(
-            waiters <= 1,
-            "closed senders must be pruned on later registrations; got {waiters}"
+            inner.values().all(|entry| entry.candidates.is_empty()),
+            "a wait must not create candidates"
         );
     }
 }

--- a/anchor/common/dissemination_store/src/lib.rs
+++ b/anchor/common/dissemination_store/src/lib.rs
@@ -1,8 +1,8 @@
 //! Handoff store for SIP-94 §6 envelope disseminations.
 //!
 //! The message receiver writes every validator-accepted `EnvelopeDissemination` for a
-//! `(validator, slot)`; the envelope duty runner scans them in arrival order and selects one by
-//! content (see `sign_disseminated_envelope` for why selection cannot be by arrival). Message
+//! `(validator, slot)`; the envelope duty runner scans them in insertion order and selects one by
+//! content (see `sign_disseminated_envelope` for why selection cannot be by order). Message
 //! validation admits at most one dissemination per (`MessageId`, signer, slot) (SIP-94 §7) and
 //! only from committee members, so the candidate list is bounded by committee size on the
 //! validated path. The store enforces neither: it is a handoff, and validation is its only
@@ -25,7 +25,7 @@ struct Key {
     slot: Slot,
 }
 
-/// Accepted disseminations for one key, in arrival order, tagged with the operator that signed
+/// Accepted disseminations for one key, in insertion order, tagged with the operator that signed
 /// each. `Arc` so a waiter's visit is a refcount bump: a candidate carries up to
 /// `SSVMessageDataLen` bytes, and cloning it would copy them under the lock the receiver also
 /// takes, letting the sender's byte count set this node's lock-hold time.
@@ -75,7 +75,9 @@ impl DisseminationStore {
     /// Returns the first candidate for `(validator, slot)` that `predicate` accepts, waiting
     /// for later arrivals until `deadline`.
     ///
-    /// Candidates are visited once each, in arrival order, starting from those already stored.
+    /// Candidates are visited once each, in insertion order, starting from those already stored.
+    /// That is the order the receiver's worker pool finished validating them in, which need not be
+    /// the order they arrived from the network, and differs between operators either way.
     /// `predicate` runs outside the store lock, so it may decode and validate the envelope.
     /// Returns `None` when the deadline passes with no candidate accepted.
     pub async fn wait_matching<T>(
@@ -91,8 +93,11 @@ impl DisseminationStore {
         // Before the first read, so no insert can slip between them and be treated as seen.
         let mut version = self.version.subscribe();
 
-        // Once per call: `slot` is fixed, so a key surviving this cannot go stale during the
-        // wait, and a candidate arriving meanwhile was already swept against its own slot.
+        // Once per call. A later insert can only evict this key by carrying a slot at least
+        // `MAX_DISSEMINATION_AGE_SLOTS` + 1 ahead, and every caller's deadline falls inside `slot`
+        // itself (`envelope_deadline`), so the wait is long over by then. A deadline allowed to
+        // outlive that window would reintroduce the case this rules out: the key would be swept
+        // and could then be re-created empty, leaving `cursor` past candidates it never visited.
         Self::sweep(&mut self.inner.lock(), slot);
 
         loop {
@@ -211,7 +216,7 @@ mod tests {
         assert_eq!(
             *seen.lock(),
             vec![(OperatorId(1), 0xAA), (OperatorId(2), 0xBB)],
-            "candidates must be visited in arrival order, each tagged with its signer"
+            "candidates must be visited in insertion order, each tagged with its signer"
         );
     }
 

--- a/anchor/common/dissemination_store/src/lib.rs
+++ b/anchor/common/dissemination_store/src/lib.rs
@@ -25,26 +25,22 @@ struct Key {
     slot: Slot,
 }
 
-/// The candidates accepted for one key, and a signal that wakes waiters when one lands.
-#[derive(Default)]
-struct Entry {
-    /// Accepted disseminations in arrival order, tagged with the operator that signed each.
-    /// `Arc` so a waiter's visit is a refcount bump: a candidate carries up to
-    /// `SSVMessageDataLen` bytes, and cloning it would copy them under the lock the receiver
-    /// also takes, letting the sender's byte count set this node's lock-hold time.
-    candidates: Vec<(OperatorId, Arc<EnvelopeDissemination>)>,
-    /// Bumped on every push; the value carries nothing, only the change matters. A `watch`
-    /// receiver treats the version present when it subscribes as already seen, so a waiter must
-    /// subscribe while holding the same lock it reads `candidates` under. Subscribing after
-    /// releasing the lock would miss a candidate pushed in between and could sleep to its
-    /// deadline with a match already in the vector.
-    version: watch::Sender<()>,
-}
+/// Accepted disseminations for one key, in arrival order, tagged with the operator that signed
+/// each. `Arc` so a waiter's visit is a refcount bump: a candidate carries up to
+/// `SSVMessageDataLen` bytes, and cloning it would copy them under the lock the receiver also
+/// takes, letting the sender's byte count set this node's lock-hold time.
+type Candidates = Vec<(OperatorId, Arc<EnvelopeDissemination>)>;
 
 /// Shared store connecting the message receiver (writer) to the envelope duty runner (reader).
 #[derive(Default)]
 pub struct DisseminationStore {
-    inner: Mutex<HashMap<Key, Entry>>,
+    inner: Mutex<HashMap<Key, Candidates>>,
+    /// Bumped on every insert; the value carries nothing, only the change matters. Store-level
+    /// rather than per key so a waiter can subscribe before it first reads, which is what makes
+    /// the wakeup sound: a `watch` receiver treats the version present at subscription as seen,
+    /// so a candidate pushed between a read and a later subscribe would be missed. It also
+    /// outlives every entry, so a swept entry cannot strand a waiter on a dropped sender.
+    version: watch::Sender<()>,
 }
 
 impl DisseminationStore {
@@ -64,12 +60,16 @@ impl DisseminationStore {
         dissemination: EnvelopeDissemination,
     ) {
         let slot = dissemination.slot;
-        let mut inner = self.inner.lock();
-        Self::sweep(&mut inner, slot);
-
-        let entry = inner.entry(Key { validator, slot }).or_default();
-        entry.candidates.push((signer, Arc::new(dissemination)));
-        entry.version.send_replace(());
+        {
+            let mut inner = self.inner.lock();
+            Self::sweep(&mut inner, slot);
+            inner
+                .entry(Key { validator, slot })
+                .or_default()
+                .push((signer, Arc::new(dissemination)));
+        }
+        // Outside the lock: waking a waiter that would immediately contend on it helps nobody.
+        self.version.send_replace(());
     }
 
     /// Returns the first candidate for `(validator, slot)` that `predicate` accepts, waiting
@@ -88,21 +88,23 @@ impl DisseminationStore {
         let key = Key { validator, slot };
         let mut cursor = 0;
 
+        // Before the first read, so no insert can slip between them and be treated as seen.
+        let mut version = self.version.subscribe();
+
         // Once per call: `slot` is fixed, so a key surviving this cannot go stale during the
         // wait, and a candidate arriving meanwhile was already swept against its own slot.
         Self::sweep(&mut self.inner.lock(), slot);
 
         loop {
-            // One critical section for both, per the `version` note above.
-            let (candidate, mut version) = {
-                let mut inner = self.inner.lock();
-                let entry = inner.entry(key).or_default();
-                (
-                    entry.candidates.get(cursor).cloned(),
-                    entry.version.subscribe(),
-                )
-            };
+            // Reads only: a waiter never creates an entry, so waiting for a slot that never
+            // receives a dissemination leaves nothing behind.
+            let candidate = self
+                .inner
+                .lock()
+                .get(&key)
+                .and_then(|candidates| candidates.get(cursor).cloned());
 
+            // Outside the lock: the predicate decodes and validates the envelope.
             if let Some((signer, dissemination)) = candidate {
                 cursor += 1;
                 if let Some(accepted) = predicate(signer, &dissemination) {
@@ -111,19 +113,22 @@ impl DisseminationStore {
                 continue;
             }
 
-            match tokio::time::timeout_at(deadline, version.changed()).await {
-                // A candidate landed; read it on the next pass.
-                Ok(Ok(())) => {}
-                // The entry was swept while waiting, so nothing more can arrive under it.
-                Ok(Err(_sender_dropped)) => return None,
-                Err(_elapsed) => return None,
+            // An insert for an unrelated key also wakes this, costing one re-read of a cursor
+            // that has not moved. Inserts run about once per proposal slot, so that is free.
+            // `changed()` errors only if the sender dropped, which cannot happen while this
+            // borrow of the store is alive.
+            if tokio::time::timeout_at(deadline, version.changed())
+                .await
+                .is_err()
+            {
+                return None;
             }
         }
     }
 
     /// Drops entries older than `MAX_DISSEMINATION_AGE_SLOTS` relative to `slot`. A call for
     /// an old slot cannot evict a newer entry.
-    fn sweep(inner: &mut HashMap<Key, Entry>, slot: Slot) {
+    fn sweep(inner: &mut HashMap<Key, Candidates>, slot: Slot) {
         inner.retain(|stored_key, _| stored_key.slot + MAX_DISSEMINATION_AGE_SLOTS >= slot);
     }
 }
@@ -364,7 +369,7 @@ mod tests {
     }
 
     #[tokio::test(start_paused = true)]
-    async fn unanswered_waits_stay_bounded() {
+    async fn unanswered_waits_create_nothing() {
         let store = DisseminationStore::new();
         // Many timed-out waits across distinct slots, no inserts at all.
         for slot in 0..100u64 {
@@ -373,15 +378,58 @@ mod tests {
                 .await;
         }
 
-        let inner = store.inner.lock();
         assert!(
-            inner.len() as u64 <= MAX_DISSEMINATION_AGE_SLOTS + 1,
-            "wait-created entries must be swept; got {} keys",
-            inner.len()
+            store.inner.lock().is_empty(),
+            "a wait must not create an entry, so unanswered waits leave the store empty"
         );
-        assert!(
-            inner.values().all(|entry| entry.candidates.is_empty()),
-            "a wait must not create candidates"
+    }
+
+    /// A waiter that has already drained the backlog still sees a candidate that arrives after
+    /// it parks. This is the wakeup path, and it is the reason the store owns the signal.
+    #[tokio::test]
+    async fn parked_waiter_wakes_on_a_later_arrival() {
+        let store = Arc::new(DisseminationStore::new());
+        // Seed one candidate the predicate will refuse, so the waiter drains and then parks.
+        store.insert(pubkey(1), OperatorId(1), tagged(5, 0xAA));
+
+        let waiter = tokio::spawn({
+            let store = store.clone();
+            let deadline = Instant::now() + Duration::from_secs(5);
+            async move {
+                store
+                    .wait_matching(pubkey(1), Slot::new(5), deadline, accept_tag(0xBB))
+                    .await
+            }
+        });
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        store.insert(pubkey(1), OperatorId(2), tagged(5, 0xBB));
+
+        assert_eq!(waiter.await.unwrap(), Some(tagged(5, 0xBB)));
+    }
+
+    /// An insert for an unrelated key wakes every waiter; the woken waiter must re-park rather
+    /// than treat the wake as a candidate.
+    #[tokio::test]
+    async fn insert_for_another_key_does_not_satisfy_a_waiter() {
+        let store = Arc::new(DisseminationStore::new());
+        let waiter = tokio::spawn({
+            let store = store.clone();
+            let deadline = Instant::now() + Duration::from_millis(300);
+            async move {
+                store
+                    .wait_matching(pubkey(1), Slot::new(5), deadline, accept_any)
+                    .await
+            }
+        });
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        store.insert(pubkey(2), OperatorId(1), dissemination(5));
+
+        assert_eq!(
+            waiter.await.unwrap(),
+            None,
+            "another key's insert must not end this wait"
         );
     }
 }

--- a/anchor/message_receiver/src/manager.rs
+++ b/anchor/message_receiver/src/manager.rs
@@ -199,24 +199,22 @@ impl<E: types::EthSpec, S: SlotClock + 'static, D: DutiesProvider> MessageReceiv
                             error!(gossipsub_message_id = ?message_id, ssv_msg_id = ?msg_id, ?err, "Unable to receive partial signature message");
                         }
                     }
-                    ValidatedSSVMessage::EnvelopeDissemination(dissemination) => {
+                    ValidatedSSVMessage::EnvelopeDissemination {
+                        signer,
+                        dissemination,
+                    } => {
                         // Validation admits the class only for validator-scoped role-9 message
-                        // IDs with exactly one signer, so both lookups always resolve. The
-                        // signer keys the store's candidates so the runner can name the
-                        // operator behind a dissemination it rejects (SIP-94 §6).
-                        match (
-                            msg_id.duty_executor(),
-                            signed_ssv_message.operator_ids().first(),
-                        ) {
-                            (Some(DutyExecutor::Validator(validator_pubkey)), Some(signer)) => {
+                        // IDs, so the duty executor is always a validator public key.
+                        match msg_id.duty_executor() {
+                            Some(DutyExecutor::Validator(validator_pubkey)) => {
                                 receiver.dissemination_store.insert(
                                     validator_pubkey,
-                                    *signer,
+                                    signer,
                                     dissemination,
                                 );
                             }
                             _ => {
-                                error!(gossipsub_message_id = ?message_id, ssv_msg_id = ?msg_id, "Envelope dissemination without a validator duty executor and a single signer");
+                                error!(gossipsub_message_id = ?message_id, ssv_msg_id = ?msg_id, "Envelope dissemination without a validator duty executor");
                             }
                         }
                     }

--- a/anchor/message_receiver/src/manager.rs
+++ b/anchor/message_receiver/src/manager.rs
@@ -201,15 +201,22 @@ impl<E: types::EthSpec, S: SlotClock + 'static, D: DutiesProvider> MessageReceiv
                     }
                     ValidatedSSVMessage::EnvelopeDissemination(dissemination) => {
                         // Validation admits the class only for validator-scoped role-9 message
-                        // IDs, so the duty executor is always a validator public key.
-                        match msg_id.duty_executor() {
-                            Some(DutyExecutor::Validator(validator_pubkey)) => {
-                                receiver
-                                    .dissemination_store
-                                    .insert(validator_pubkey, dissemination);
+                        // IDs with exactly one signer, so both lookups always resolve. The
+                        // signer keys the store's candidates so the runner can name the
+                        // operator behind a dissemination it rejects (SIP-94 §6).
+                        match (
+                            msg_id.duty_executor(),
+                            signed_ssv_message.operator_ids().first(),
+                        ) {
+                            (Some(DutyExecutor::Validator(validator_pubkey)), Some(signer)) => {
+                                receiver.dissemination_store.insert(
+                                    validator_pubkey,
+                                    *signer,
+                                    dissemination,
+                                );
                             }
                             _ => {
-                                error!(gossipsub_message_id = ?message_id, ssv_msg_id = ?msg_id, "Envelope dissemination without a validator duty executor");
+                                error!(gossipsub_message_id = ?message_id, ssv_msg_id = ?msg_id, "Envelope dissemination without a validator duty executor and a single signer");
                             }
                         }
                     }

--- a/anchor/message_validator/src/dissemination.rs
+++ b/anchor/message_validator/src/dissemination.rs
@@ -16,18 +16,19 @@ use crate::{
 /// The class is structural-only at this layer: the inner envelope must SSZ-decode as a
 /// blinded execution payload envelope (shape, Reject-class), but the checks binding it to
 /// the block-QBFT decision are runner concerns, and validation never judges the envelope's
-/// content against the decision. Dedup is first-valid per (`MessageId`, slot): the first
-/// message passing all other rules is recorded, and further dissemination messages for the
+/// content against the decision. Dedup is one per (`MessageId`, signer, slot): a signer's
+/// first message passing all other rules is recorded, and its further disseminations for the
 /// tuple are Ignore regardless of content or peer (an honest origin retry can repeat one
 /// after the recipient's gossip duplicate cache expires, so repetition does not prove peer
-/// fault).
+/// fault). Another committee member's dissemination for the same slot is admitted on its own
+/// budget.
 ///
-/// First-valid means first STRUCTURALLY valid, by design: SIP-94 accepts that a Byzantine
-/// committee member can consume a slot's dissemination budget with a decision-unbound or
-/// payload-unbound (but well-formed) carrier, costing at most one missed self-build reveal
-/// (never a wrong payload on chain). Do not move semantic rejection into a
-/// replacement-capable store; the named hardening for that trade is sign-all, a protocol
-/// change.
+/// Admitting one per signer is what lets the runner pick by content (SIP-94 §6: it signs the
+/// first dissemination that passes the decision bindings, not the first that arrives), so a
+/// Byzantine committee member cannot cost the reveal merely by winning the race with a
+/// well-formed but decision-unbound carrier. Forwarding stays bounded because only committee
+/// members pass validation. The residual is a binding-passing forgery, whose `payload_root` no
+/// operator can check; the named hardening for that is sign-all, a protocol change.
 pub(crate) fn validate_envelope_dissemination(
     validation_context: ValidationContext<impl SlotClock>,
     duty_state: &mut DutyState,
@@ -92,10 +93,13 @@ pub(crate) fn validate_envelope_dissemination(
         duty_provider.clone(),
     )?;
 
-    // Rule: first-valid dedup per (`MessageId`, slot), signer-independent. Ignore-class.
-    if duty_state.is_dissemination_recorded(slot) {
+    // Rule: dedup per (`MessageId`, signer, slot). Ignore-class.
+    if duty_state
+        .get_or_create_operator(&signer)
+        .is_dissemination_recorded(slot)
+    {
         return Err(ValidationFailure::RelayedDuplicateMessage {
-            got: format!("envelope dissemination for slot {slot}"),
+            got: format!("envelope dissemination for slot {slot} from operator {signer}"),
         });
     }
 
@@ -108,9 +112,11 @@ pub(crate) fn validate_envelope_dissemination(
 
     verify_single_signer(&validation_context, signer)?;
 
-    // Record only after every other rule passed, so a rejected message cannot consume the
-    // slot's single dissemination budget.
-    duty_state.record_dissemination(slot, &signer);
+    // Record only after every other rule passed, so a rejected message cannot consume this
+    // signer's dissemination budget for the slot.
+    duty_state
+        .get_or_create_operator(&signer)
+        .record_dissemination(slot);
 
     Ok(ValidatedSSVMessage::EnvelopeDissemination(dissemination))
 }
@@ -325,12 +331,10 @@ mod tests {
     }
 
     #[test]
-    fn second_dissemination_for_slot_ignored_regardless_of_signer() {
-        let (committee_info, private_key, mut map) = four_node_committee_and_keypair();
-        // A second operator with its own key, so the dedup is proven signer-independent.
-        let (private_key_2, public_key_2) = generate_test_key_pair();
-        map.insert(OperatorId(2), public_key_2);
+    fn second_dissemination_from_the_same_signer_ignored() {
+        let (committee_info, private_key, map) = four_node_committee_and_keypair();
         let mut duty_state = DutyState::new(64);
+        let provider = Arc::new(MockDutiesProvider::default());
 
         let first =
             create_signed_dissemination(Role::EnvelopeProposer, OperatorId(1), &private_key);
@@ -342,12 +346,57 @@ mod tests {
             1,
             Some(0),
         );
-        validate_envelope_dissemination(
-            ctx,
-            &mut duty_state,
-            Arc::new(MockDutiesProvider::default()),
-        )
-        .expect("first dissemination must be accepted");
+        validate_envelope_dissemination(ctx, &mut duty_state, provider.clone())
+            .expect("first dissemination must be accepted");
+
+        // Same signer, same slot: the signer's budget for the tuple is spent.
+        let second =
+            create_signed_dissemination(Role::EnvelopeProposer, OperatorId(1), &private_key);
+        let ctx = create_dissemination_context(
+            &second,
+            &committee_info,
+            Role::EnvelopeProposer,
+            &map,
+            1,
+            Some(0),
+        );
+        let result = validate_envelope_dissemination(ctx, &mut duty_state, provider);
+
+        match &result {
+            Err(failure @ ValidationFailure::RelayedDuplicateMessage { .. }) => {
+                assert_eq!(
+                    MessageAcceptance::from(failure),
+                    MessageAcceptance::Ignore,
+                    "a signer's further dissemination for a recorded slot must be Ignore, not Reject: an honest retry can repeat one after the gossip duplicate cache expires"
+                );
+            }
+            other => panic!("expected RelayedDuplicateMessage, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn dissemination_from_a_second_signer_accepted_for_the_same_slot() {
+        // SIP-94 §7 dedup is per (`MessageId`, signer, slot). Admitting one carrier per
+        // committee member is what lets the runner choose by content instead of by arrival, so
+        // a first carrier that fails the decision bindings cannot cost the slot's reveal.
+        let (committee_info, private_key, mut map) = four_node_committee_and_keypair();
+        let (private_key_2, public_key_2) = generate_test_key_pair();
+        map.insert(OperatorId(2), public_key_2);
+        let mut duty_state = DutyState::new(64);
+        let provider = Arc::new(MockDutiesProvider::default());
+
+        let first =
+            create_signed_dissemination(Role::EnvelopeProposer, OperatorId(1), &private_key);
+        let ctx = create_dissemination_context(
+            &first,
+            &committee_info,
+            Role::EnvelopeProposer,
+            &map,
+            1,
+            Some(0),
+        );
+        validate_envelope_dissemination(ctx, &mut duty_state, provider.clone())
+            .expect("first dissemination must be accepted");
 
         let second =
             create_signed_dissemination(Role::EnvelopeProposer, OperatorId(2), &private_key_2);
@@ -359,22 +408,9 @@ mod tests {
             1,
             Some(0),
         );
-        let result = validate_envelope_dissemination(
-            ctx,
-            &mut duty_state,
-            Arc::new(MockDutiesProvider::default()),
-        );
 
-        match &result {
-            Err(failure @ ValidationFailure::RelayedDuplicateMessage { .. }) => {
-                assert_eq!(
-                    MessageAcceptance::from(failure),
-                    MessageAcceptance::Ignore,
-                    "a further dissemination for a recorded slot must be Ignore, not Reject"
-                );
-            }
-            other => panic!("expected RelayedDuplicateMessage, got {other:?}"),
-        }
+        validate_envelope_dissemination(ctx, &mut duty_state, provider)
+            .expect("a second committee member's dissemination must be accepted on its own budget");
     }
 
     #[test]

--- a/anchor/message_validator/src/dissemination.rs
+++ b/anchor/message_validator/src/dissemination.rs
@@ -114,11 +114,12 @@ pub(crate) fn validate_envelope_dissemination(
 
     // Record only after every other rule passed, so a rejected message cannot consume this
     // signer's dissemination budget for the slot.
-    duty_state
-        .get_or_create_operator(&signer)
-        .record_dissemination(slot);
+    operator_state.record_dissemination(slot);
 
-    Ok(ValidatedSSVMessage::EnvelopeDissemination(dissemination))
+    Ok(ValidatedSSVMessage::EnvelopeDissemination {
+        signer,
+        dissemination,
+    })
 }
 
 #[cfg(test)]
@@ -292,7 +293,9 @@ mod tests {
         );
 
         match result {
-            Ok(ValidatedSSVMessage::EnvelopeDissemination(d)) => {
+            Ok(ValidatedSSVMessage::EnvelopeDissemination {
+                dissemination: d, ..
+            }) => {
                 assert_eq!(d.slot, Slot::new(TEST_SLOT));
             }
             other => panic!("expected accepted dissemination, got {other:?}"),

--- a/anchor/message_validator/src/duty_state.rs
+++ b/anchor/message_validator/src/duty_state.rs
@@ -307,6 +307,12 @@ pub(crate) struct SignerState {
     seen_signers: HashSet<CommitteeId>,
     /// True once an envelope dissemination from this signer was accepted for this slot
     /// (SIP-94 §7). Only `Role::EnvelopeProposer` message IDs ever set it.
+    ///
+    /// Nothing clears it, and that rests on role 9 having no consensus path: `OperatorState::
+    /// update` is the one writer that replaces a `SignerState` outright, and it is reachable
+    /// only for QBFT roles, which `Role::EnvelopeProposer` is not (`max_round()` is `None`, so
+    /// consensus messages for it are rejected before any state update). A future role that both
+    /// disseminates and runs QBFT would need this bit carried across the replacement.
     dissemination_recorded: bool,
     /// Accepted signing roots for the root-budgeted kinds, boxed and lazily allocated on the
     /// first such packet: every role's ring entries share this struct, but only
@@ -412,6 +418,30 @@ mod tests {
         hash_data,
         tests::{QbftMessageBuilder, create_signed_consensus_message},
     };
+
+    /// The dissemination flag lives in a slot ring, so a read for a slot that merely aliases a
+    /// recorded one must not inherit its flag. Without the ring's stored-slot filter an honest
+    /// dissemination exactly `stored_slot_count` slots later would be silently Ignored, and the
+    /// monotonic-slot guard would not catch it because the incoming slot is higher.
+    #[test]
+    fn dissemination_record_does_not_alias_across_the_ring() {
+        const RING: usize = 64;
+        let mut duty_state = DutyState::new(RING);
+        let recorded = Slot::new(5);
+        let aliased = recorded + RING as u64;
+
+        let operator_state = duty_state.get_or_create_operator(&OperatorId(1));
+        operator_state.record_dissemination(recorded);
+
+        assert!(
+            operator_state.is_dissemination_recorded(recorded),
+            "the recorded slot must read as recorded"
+        );
+        assert!(
+            !operator_state.is_dissemination_recorded(aliased),
+            "slot {aliased} shares a ring index with the recorded slot {recorded} and must read as absent"
+        );
+    }
 
     #[test]
     fn test_duty_state_update() {

--- a/anchor/message_validator/src/duty_state.rs
+++ b/anchor/message_validator/src/duty_state.rs
@@ -52,11 +52,6 @@ pub(crate) struct DutyState {
     operators: HashMap<OperatorId, OperatorState>,
     /// The number of slots for which state is stored (defines the size of the circular buffer)
     stored_slot_count: usize,
-    /// Slot-indexed ring recording whether an envelope dissemination was already accepted for a
-    /// slot of this `MessageId` (SIP-94 §7 first-valid dedup: one dissemination per
-    /// (`MessageId`, slot), signer-independent). Allocated on first record: only
-    /// `Role::EnvelopeProposer` message IDs ever populate it.
-    disseminated_slots: Vec<Option<Slot>>,
 }
 
 impl DutyState {
@@ -65,30 +60,6 @@ impl DutyState {
         Self {
             operators: HashMap::new(),
             stored_slot_count,
-            disseminated_slots: Vec::new(),
-        }
-    }
-
-    /// True if a dissemination was already recorded for `slot` (SIP-94 §7: further
-    /// dissemination messages for the tuple are Ignore, regardless of content or peer).
-    pub(crate) fn is_dissemination_recorded(&self, slot: Slot) -> bool {
-        !self.disseminated_slots.is_empty()
-            && self.disseminated_slots[slot.as_usize() % self.disseminated_slots.len()]
-                == Some(slot)
-    }
-
-    /// Records the accepted dissemination for `slot` and creates the sender's signer state so
-    /// the duty counts toward `signer`'s per-epoch ring occupancy.
-    pub(crate) fn record_dissemination(&mut self, slot: Slot, signer: &OperatorId) {
-        if self.disseminated_slots.is_empty() {
-            self.disseminated_slots = vec![None; self.stored_slot_count];
-        }
-        let index = slot.as_usize() % self.disseminated_slots.len();
-        self.disseminated_slots[index] = Some(slot);
-
-        let operator_state = self.get_or_create_operator(signer);
-        if operator_state.is_first_message_for_duty(slot) {
-            operator_state.set_signer_state(&slot, SignerState::new(slot, FIRST_ROUND));
         }
     }
 
@@ -249,6 +220,29 @@ impl OperatorState {
         self.get_signer_state(&slot).is_none()
     }
 
+    /// True if this signer already had a dissemination accepted for `slot` (SIP-94 §7 dedup,
+    /// one per (`MessageId`, signer, slot): further disseminations for the tuple are Ignore,
+    /// regardless of content or peer). A ring entry held by a different slot reads as absent,
+    /// like every other per-slot lookup here.
+    pub(crate) fn is_dissemination_recorded(&self, slot: Slot) -> bool {
+        self.get_signer_state(&slot)
+            .is_some_and(|state| state.dissemination_recorded)
+    }
+
+    /// Records this signer's accepted dissemination for `slot`, creating its signer state
+    /// when the dissemination is the duty's first message so the duty counts toward the
+    /// per-epoch ring occupancy and advances `max_slot`, exactly as a first partial signature
+    /// would. An existing state is kept, not replaced: a partial signature may have arrived
+    /// first, and its counts must survive.
+    pub(crate) fn record_dissemination(&mut self, slot: Slot) {
+        if self.is_first_message_for_duty(slot) {
+            self.set_signer_state(&slot, SignerState::new(slot, FIRST_ROUND));
+        }
+        if let Some(state) = self.get_signer_state_mut(&slot) {
+            state.dissemination_recorded = true;
+        }
+    }
+
     /// Updates the SignerState for the given slot.
     ///
     /// If a state already exists and the incoming consensus round is higher,
@@ -311,6 +305,9 @@ pub(crate) struct SignerState {
     pub(crate) proposal_hash: Option<[u8; 32]>,
     /// A set of CommitteeIds indicating which committees have already been seen.
     seen_signers: HashSet<CommitteeId>,
+    /// True once an envelope dissemination from this signer was accepted for this slot
+    /// (SIP-94 §7). Only `Role::EnvelopeProposer` message IDs ever set it.
+    dissemination_recorded: bool,
     /// Accepted signing roots for the root-budgeted kinds, boxed and lazily allocated on the
     /// first such packet: every role's ring entries share this struct, but only
     /// `Role::ProposerPreferences` messages can ever populate it
@@ -337,6 +334,7 @@ impl SignerState {
             message_counts: MessageCounts::default(),
             proposal_hash: None,
             seen_signers: HashSet::new(),
+            dissemination_recorded: false,
             root_budgets: None,
         }
     }

--- a/anchor/message_validator/src/lib.rs
+++ b/anchor/message_validator/src/lib.rs
@@ -329,7 +329,12 @@ impl From<SignedSSVMessageError> for ValidationFailure {
 pub enum ValidatedSSVMessage {
     QbftMessage(QbftMessage),
     PartialSignatureMessages(PartialSignatureMessages),
-    EnvelopeDissemination(EnvelopeDissemination),
+    /// The carrier plus the committee member that signed it. Validation proves there is
+    /// exactly one signer, and the envelope duty names it when rejecting a candidate.
+    EnvelopeDissemination {
+        signer: OperatorId,
+        dissemination: EnvelopeDissemination,
+    },
 }
 
 #[derive(Debug)]

--- a/anchor/message_validator/src/partial_signature.rs
+++ b/anchor/message_validator/src/partial_signature.rs
@@ -4483,6 +4483,50 @@ mod tests {
     }
 
     #[test]
+    fn dissemination_does_not_reset_an_earlier_partial_sig_budget() {
+        // `record_dissemination` keeps an existing SignerState rather than replacing it, because
+        // both message classes share one per-(signer, slot) entry and gossip orders them freely.
+        // Replacing it would hand back the signer's spent Envelope partial-signature budget, so
+        // a signer whose share arrives before its dissemination could send a second share.
+        let (committee_info, private_key, map) = four_node_committee_and_keypair();
+        let mut duty_state = crate::duty_state::DutyState::new(64);
+        let share = |root: u8| {
+            create_signed_envelope_proposer_message(
+                OperatorId(1),
+                &private_key,
+                Slot::new(1),
+                Hash256::from([root; 32]),
+            )
+        };
+
+        // Arrange: the signer's one Envelope share for the slot, before its dissemination.
+        let first = share(0x33);
+        validate_partial_signature_message(
+            create_envelope_proposer_context(&first, &committee_info, &map, Slot::new(1)),
+            &mut duty_state,
+            Arc::new(MockDutiesProvider::default()),
+        )
+        .expect("the signer's first Envelope share must be accepted");
+
+        // Act: its dissemination for the same slot lands afterwards.
+        duty_state
+            .get_or_create_operator(&OperatorId(1))
+            .record_dissemination(Slot::new(1));
+
+        // Assert: the spent share budget survives, so a second share is still refused.
+        let second = share(0x44);
+        let result = validate_partial_signature_message(
+            create_envelope_proposer_context(&second, &committee_info, &map, Slot::new(1)),
+            &mut duty_state,
+            Arc::new(MockDutiesProvider::default()),
+        );
+        assert!(
+            result.is_err(),
+            "a dissemination must not reset the signer's Envelope partial-signature budget for the slot, so the second share must still be refused, got: {result:?}"
+        );
+    }
+
+    #[test]
     fn envelope_proposer_dissemination_advances_blocks_lower_partial_sig() {
         // §7 monotonic-slot rule, dissemination-advances direction: a dissemination at slot 10
         // must block a later Envelope partial sig at the lower slot 5.

--- a/anchor/message_validator/src/partial_signature.rs
+++ b/anchor/message_validator/src/partial_signature.rs
@@ -4450,7 +4450,9 @@ mod tests {
         // applies once all its rules pass (those rules are covered in `dissemination.rs`; what
         // this test pins is the shared max_slot).
         let mut duty_state = crate::duty_state::DutyState::new(64);
-        duty_state.record_dissemination(Slot::new(1), &OperatorId(1));
+        duty_state
+            .get_or_create_operator(&OperatorId(1))
+            .record_dissemination(Slot::new(1));
 
         // Arrange: Envelope partial sig at slot 1 (equal to the disseminated slot).
         let partial_sig_signed_msg = create_signed_envelope_proposer_message(
@@ -4488,7 +4490,9 @@ mod tests {
 
         // Arrange: Seed DutyState at slot 10 via the dissemination validator's state effect.
         let mut duty_state = crate::duty_state::DutyState::new(64);
-        duty_state.record_dissemination(Slot::new(10), &OperatorId(1));
+        duty_state
+            .get_or_create_operator(&OperatorId(1))
+            .record_dissemination(Slot::new(10));
 
         // Arrange: Envelope partial sig at slot 5 (lower than 10).
         let partial_sig_signed_msg = create_signed_envelope_proposer_message(

--- a/anchor/operator_doppelganger/src/service.rs
+++ b/anchor/operator_doppelganger/src/service.rs
@@ -18,7 +18,7 @@ fn extract_message_slot(validated_message: &ValidatedSSVMessage) -> Slot {
     match validated_message {
         ValidatedSSVMessage::QbftMessage(msg) => Slot::new(msg.height),
         ValidatedSSVMessage::PartialSignatureMessages(msg) => msg.slot,
-        ValidatedSSVMessage::EnvelopeDissemination(msg) => msg.slot,
+        ValidatedSSVMessage::EnvelopeDissemination { dissemination, .. } => dissemination.slot,
     }
 }
 
@@ -213,7 +213,7 @@ impl OperatorDoppelgangerService {
                      Another instance of this operator is running. Shutting down to prevent equivocation."
                 );
             }
-            ValidatedSSVMessage::EnvelopeDissemination(_) => {
+            ValidatedSSVMessage::EnvelopeDissemination { .. } => {
                 error!(
                     operator_id = *own_operator_id,
                     duty_executor = ?msg_id.duty_executor(),

--- a/anchor/validator_store/src/lib.rs
+++ b/anchor/validator_store/src/lib.rs
@@ -1131,6 +1131,12 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> AnchorValidator
         // costing the reveal by merely winning the race. A candidate whose envelope does not
         // decode is unreachable through gossip, which decodes it before accepting, and is
         // skipped on the same principle rather than ending the duty.
+        //
+        // Arrival order is node-local, so the accepted residual (`payload_root` is unchecked)
+        // still splits operators across two binding-passing roots when a forgery races the
+        // honest carrier. The symptom is then a signature collection timeout below, not the
+        // dissemination timeout in this block: each root collects some shares and neither
+        // reaches threshold. Costs the reveal, never a wrong payload.
         let mut rejected = 0usize;
         let Some(disseminated) = self
             .dissemination_store

--- a/anchor/validator_store/src/lib.rs
+++ b/anchor/validator_store/src/lib.rs
@@ -9,7 +9,10 @@ use std::{
     future::Future,
     num::NonZeroUsize,
     str::from_utf8,
-    sync::{Arc, LazyLock, Weak},
+    sync::{
+        Arc, LazyLock, Weak,
+        atomic::{AtomicUsize, Ordering},
+    },
     time::Duration,
 };
 
@@ -1108,8 +1111,8 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> AnchorValidator
     /// runs detached from Lighthouse's envelope callback on purpose: that callback first fetches
     /// this operator's own envelope from its beacon node and never reaches the store when the
     /// node holds none (its local bid was external), so a non-builder share must not depend on
-    /// it. Awaits the builder operator's dissemination until the payload-due deadline, validates
-    /// it against the decided context, and contributes this operator's partial signature.
+    /// it. Awaits disseminations until the payload-due deadline, signs the first whose envelope
+    /// passes the decided context's bindings, and contributes this operator's partial signature.
     /// Publishes nothing: only the builder operator holds the payload bytes.
     pub(crate) async fn sign_disseminated_envelope(
         self: Arc<Self>,
@@ -1125,24 +1128,57 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> AnchorValidator
             .envelope_deadline(slot)
             .inspect_err(|_| record_outcome(metrics::ENVELOPE_OUTCOME_FAILED))?;
 
-        let Some(dissemination) = self
+        // Selection is by content, not by arrival (SIP-94 §6): each committee member may
+        // disseminate once per slot, and this signs the first candidate that binds to the
+        // decided block. Skipping a failing candidate is what stops a Byzantine member from
+        // costing the reveal by merely winning the race. A candidate whose envelope does not
+        // decode is unreachable through gossip, which decodes it before accepting, and is
+        // skipped on the same principle rather than ending the duty.
+        let rejected = AtomicUsize::new(0);
+        let Some(disseminated) = self
             .dissemination_store
-            .wait(validator.public_key, slot, deadline)
+            .wait_matching(
+                validator.public_key,
+                slot,
+                deadline,
+                |signer, dissemination| match dissemination.blinded_envelope::<E>() {
+                    Ok(blinded) => match context.validate_blinded(&blinded) {
+                        Ok(()) => Some(blinded),
+                        Err(err) => {
+                            rejected.fetch_add(1, Ordering::Relaxed);
+                            warn!(
+                                %signer,
+                                ?err,
+                                "Skipping a disseminated envelope that failed the decision bindings"
+                            );
+                            None
+                        }
+                    },
+                    Err(err) => {
+                        rejected.fetch_add(1, Ordering::Relaxed);
+                        warn!(
+                            %signer,
+                            ?err,
+                            "Skipping a disseminated envelope whose bytes did not decode"
+                        );
+                        None
+                    }
+                },
+            )
             .await
         else {
+            // The count separates "nothing arrived" from "only unusable candidates arrived",
+            // which the error alone cannot say and the spawn boundary never sees.
+            warn!(
+                %slot,
+                rejected = rejected.load(Ordering::Relaxed),
+                "No envelope dissemination matching the decision arrived before the payload-due deadline"
+            );
             record_outcome(metrics::ENVELOPE_OUTCOME_FAILED);
             return Err(Error::SpecificError(SpecificError::DisseminationTimeout {
                 slot,
             }));
         };
-        let disseminated = dissemination.blinded_envelope::<E>().map_err(|err| {
-            record_outcome(metrics::ENVELOPE_OUTCOME_FAILED);
-            Error::SpecificError(SpecificError::DisseminationUndecodable(err))
-        })?;
-        context.validate_blinded(&disseminated).map_err(|err| {
-            record_outcome(metrics::ENVELOPE_OUTCOME_FAILED);
-            Error::SpecificError(err)
-        })?;
 
         // `payload_root` is trusted from the builder operator by design (SIP-94 §6).
         let domain_hash = self.get_domain(slot.epoch(E::slots_per_epoch()), Domain::BeaconBuilder);
@@ -3070,12 +3106,10 @@ pub enum SpecificError {
     EnvelopeDeadlinePassed {
         slot: Slot,
     },
-    /// No dissemination arrived before the payload-due deadline.
+    /// No dissemination binding to the decided block arrived before the payload-due deadline.
     DisseminationTimeout {
         slot: Slot,
     },
-    /// The disseminated envelope bytes did not decode as a blinded envelope.
-    DisseminationUndecodable(ssz::DecodeError),
     /// Building or sending the builder's dissemination broadcast failed.
     DisseminationBroadcastFailed(CollectionError),
     /// A blinded envelope failed a decision binding against the decided block context

--- a/anchor/validator_store/src/lib.rs
+++ b/anchor/validator_store/src/lib.rs
@@ -9,10 +9,7 @@ use std::{
     future::Future,
     num::NonZeroUsize,
     str::from_utf8,
-    sync::{
-        Arc, LazyLock, Weak,
-        atomic::{AtomicUsize, Ordering},
-    },
+    sync::{Arc, LazyLock, Weak},
     time::Duration,
 };
 
@@ -1134,35 +1131,37 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> AnchorValidator
         // costing the reveal by merely winning the race. A candidate whose envelope does not
         // decode is unreachable through gossip, which decodes it before accepting, and is
         // skipped on the same principle rather than ending the duty.
-        let rejected = AtomicUsize::new(0);
+        let mut rejected = 0usize;
         let Some(disseminated) = self
             .dissemination_store
             .wait_matching(
                 validator.public_key,
                 slot,
                 deadline,
-                |signer, dissemination| match dissemination.blinded_envelope::<E>() {
-                    Ok(blinded) => match context.validate_blinded(&blinded) {
-                        Ok(()) => Some(blinded),
-                        Err(err) => {
-                            rejected.fetch_add(1, Ordering::Relaxed);
+                |signer, dissemination| {
+                    let blinded = dissemination
+                        .blinded_envelope::<E>()
+                        .inspect_err(|err| {
+                            rejected += 1;
+                            warn!(
+                                %signer,
+                                ?err,
+                                "Skipping a disseminated envelope whose bytes did not decode"
+                            );
+                        })
+                        .ok()?;
+                    context
+                        .validate_blinded(&blinded)
+                        .inspect_err(|err| {
+                            rejected += 1;
                             warn!(
                                 %signer,
                                 ?err,
                                 "Skipping a disseminated envelope that failed the decision bindings"
                             );
-                            None
-                        }
-                    },
-                    Err(err) => {
-                        rejected.fetch_add(1, Ordering::Relaxed);
-                        warn!(
-                            %signer,
-                            ?err,
-                            "Skipping a disseminated envelope whose bytes did not decode"
-                        );
-                        None
-                    }
+                        })
+                        .ok()?;
+                    Some(blinded)
                 },
             )
             .await
@@ -1171,7 +1170,7 @@ impl<T: SlotClock, E: EthSpec, C: ConsensusDecider<E> + 'static> AnchorValidator
             // which the error alone cannot say and the spawn boundary never sees.
             warn!(
                 %slot,
-                rejected = rejected.load(Ordering::Relaxed),
+                rejected,
                 "No envelope dissemination matching the decision arrived before the payload-due deadline"
             );
             record_outcome(metrics::ENVELOPE_OUTCOME_FAILED);

--- a/anchor/validator_store/src/testing/envelope_signing.rs
+++ b/anchor/validator_store/src/testing/envelope_signing.rs
@@ -107,25 +107,16 @@ fn insert_dissemination_from(
     envelope: &ExecutionPayloadEnvelope<MainnetEthSpec>,
 ) -> BlindedExecutionPayloadEnvelope<MainnetEthSpec> {
     let blinded = BlindedExecutionPayloadEnvelope::from_full(envelope);
-    insert_dissemination_bytes(harness, pubkey, signer, blinded.as_ssz_bytes());
-    blinded
-}
-
-/// Inserts raw candidate bytes, for the undecodable case the message receiver cannot produce.
-fn insert_dissemination_bytes(
-    harness: &ValidatorStoreTestHarness,
-    pubkey: PublicKeyBytes,
-    signer: OperatorId,
-    bytes: Vec<u8>,
-) {
     harness.dissemination_store.insert(
         pubkey,
         signer,
         EnvelopeDissemination {
             slot: Slot::new(TEST_SLOT),
-            envelope: VariableList::new(bytes).expect("candidate bytes should fit"),
+            envelope: VariableList::new(blinded.as_ssz_bytes())
+                .expect("blinded envelope bytes should fit"),
         },
     );
+    blinded
 }
 
 /// A single-validator committee over `test_operator_ids()` and its validator's public key.
@@ -643,8 +634,16 @@ async fn non_builder_task_skips_unusable_candidates_and_signs_the_binding_one() 
     seed_context(&harness, pubkey, context);
 
     // Ahead of the honest candidate: bytes that do not decode, then a decodable envelope
-    // bound to a different beacon block root.
-    insert_dissemination_bytes(&harness, pubkey, OperatorId(1), vec![0xFF; 3]);
+    // bound to a different beacon block root. The receiver cannot produce undecodable bytes
+    // (pubsub decodes before accepting), so they go in directly.
+    harness.dissemination_store.insert(
+        pubkey,
+        OperatorId(1),
+        EnvelopeDissemination {
+            slot: Slot::new(TEST_SLOT),
+            envelope: VariableList::new(vec![0xFF; 3]).expect("garbage bytes should fit"),
+        },
+    );
     let mut mismatched = builder_envelope.clone();
     mismatched.beacon_block_root = Hash256::repeat_byte(0xDD);
     insert_dissemination_from(&harness, pubkey, OperatorId(2), &mismatched);

--- a/anchor/validator_store/src/testing/envelope_signing.rs
+++ b/anchor/validator_store/src/testing/envelope_signing.rs
@@ -95,16 +95,37 @@ fn insert_dissemination(
     pubkey: PublicKeyBytes,
     envelope: &ExecutionPayloadEnvelope<MainnetEthSpec>,
 ) -> BlindedExecutionPayloadEnvelope<MainnetEthSpec> {
+    insert_dissemination_from(harness, pubkey, OperatorId(1), envelope)
+}
+
+/// [`insert_dissemination`] attributed to a specific committee member, for the tests that
+/// need several candidates for one slot (SIP-94 §7 admits one per signer).
+fn insert_dissemination_from(
+    harness: &ValidatorStoreTestHarness,
+    pubkey: PublicKeyBytes,
+    signer: OperatorId,
+    envelope: &ExecutionPayloadEnvelope<MainnetEthSpec>,
+) -> BlindedExecutionPayloadEnvelope<MainnetEthSpec> {
     let blinded = BlindedExecutionPayloadEnvelope::from_full(envelope);
+    insert_dissemination_bytes(harness, pubkey, signer, blinded.as_ssz_bytes());
+    blinded
+}
+
+/// Inserts raw candidate bytes, for the undecodable case the message receiver cannot produce.
+fn insert_dissemination_bytes(
+    harness: &ValidatorStoreTestHarness,
+    pubkey: PublicKeyBytes,
+    signer: OperatorId,
+    bytes: Vec<u8>,
+) {
     harness.dissemination_store.insert(
         pubkey,
+        signer,
         EnvelopeDissemination {
             slot: Slot::new(TEST_SLOT),
-            envelope: VariableList::new(blinded.as_ssz_bytes())
-                .expect("blinded envelope bytes should fit"),
+            envelope: VariableList::new(bytes).expect("candidate bytes should fit"),
         },
     );
-    blinded
 }
 
 /// A single-validator committee over `test_operator_ids()` and its validator's public key.
@@ -611,18 +632,56 @@ async fn non_builder_without_dissemination_times_out() {
     assert_no_outward_action(&harness, "when no dissemination arrives");
 }
 
-/// A disseminated envelope that fails a decision binding is never signed.
+/// Selection is by content, not arrival (SIP-94 §6): unusable candidates that arrive first
+/// are skipped, so a Byzantine committee member cannot cost the reveal by winning the race.
 #[tokio::test(flavor = "multi_thread")]
-async fn non_builder_rejects_binding_mismatched_dissemination() {
+async fn non_builder_task_skips_unusable_candidates_and_signs_the_binding_one() {
+    let _guard = METRIC_TEST_LOCK.lock().await;
+    let (harness, pubkey) = gloas_harness();
+    let builder_envelope = self_build_envelope(test_decided_root());
+    let context = context_for(&builder_envelope, false);
+    seed_context(&harness, pubkey, context);
+
+    // Ahead of the honest candidate: bytes that do not decode, then a decodable envelope
+    // bound to a different beacon block root.
+    insert_dissemination_bytes(&harness, pubkey, OperatorId(1), vec![0xFF; 3]);
+    let mut mismatched = builder_envelope.clone();
+    mismatched.beacon_block_root = Hash256::repeat_byte(0xDD);
+    insert_dissemination_from(&harness, pubkey, OperatorId(2), &mismatched);
+    let honest = insert_dissemination_from(&harness, pubkey, OperatorId(3), &builder_envelope);
+    let counters = OutcomeCounters::snapshot();
+
+    let domain_hash = envelope_domain_hash(&harness);
+    run_non_builder_task(&harness, pubkey, context)
+        .await
+        .expect("the task must sign the binding candidate behind the unusable ones");
+
+    counters.assert_deltas(0, 1, 0);
+    let captured = harness.captured_calls.lock();
+    assert_eq!(
+        captured.len(),
+        1,
+        "exactly one signature share is contributed"
+    );
+    assert_eq!(
+        captured[0].signing_root,
+        honest.signing_root(domain_hash),
+        "the signed root must be the binding candidate's, not either unusable one's"
+    );
+}
+
+/// With candidates present but none binding to the decision, the task abstains at the
+/// deadline rather than signing one of them.
+#[tokio::test(start_paused = true)]
+async fn non_builder_task_times_out_when_no_candidate_binds() {
     let _guard = METRIC_TEST_LOCK.lock().await;
     let (harness, pubkey) = gloas_harness();
     let local_envelope = self_build_envelope(test_decided_root());
     let context = context_for(&local_envelope, false);
     seed_context(&harness, pubkey, context);
-    // Disseminated envelope binds to a different beacon block root.
-    let mut forged = local_envelope.clone();
-    forged.beacon_block_root = Hash256::repeat_byte(0xDD);
-    insert_dissemination(&harness, pubkey, &forged);
+    let mut mismatched = local_envelope.clone();
+    mismatched.beacon_block_root = Hash256::repeat_byte(0xDD);
+    insert_dissemination_from(&harness, pubkey, OperatorId(1), &mismatched);
     let counters = OutcomeCounters::snapshot();
 
     let result = run_non_builder_task(&harness, pubkey, context).await;
@@ -631,47 +690,50 @@ async fn non_builder_rejects_binding_mismatched_dissemination() {
         matches!(
             result,
             Err(Error::SpecificError(
-                SpecificError::EnvelopeBindingMismatch {
-                    field: "beacon_block_root"
-                }
+                SpecificError::DisseminationTimeout { .. }
             ))
         ),
-        "a binding-mismatched dissemination must be rejected, got {result:?}"
+        "a slot of non-binding candidates must time out, got {result:?}"
     );
     counters.assert_deltas(0, 0, 1);
-    assert_no_outward_action(&harness, "for a binding-mismatched dissemination");
+    assert_no_outward_action(&harness, "when no candidate binds to the decision");
 }
 
-/// Disseminated bytes that do not decode as a blinded envelope are never signed.
+/// Pins the residual SIP-94 §6 accepts: `payload_root` is unchecked, so a forgery that passes
+/// all four bindings and arrives first is signed. Sign-all is the named hardening; adopting it
+/// flips this test rather than a comment.
 #[tokio::test(flavor = "multi_thread")]
-async fn non_builder_rejects_undecodable_dissemination() {
+async fn non_builder_task_signs_a_binding_forgery_that_arrives_first() {
     let _guard = METRIC_TEST_LOCK.lock().await;
     let (harness, pubkey) = gloas_harness();
-    let envelope = self_build_envelope(test_decided_root());
-    let context = context_for(&envelope, false);
+    let mut builder_envelope = self_build_envelope(test_decided_root());
+    builder_envelope.payload.block_number = 42;
+    let context = context_for(&builder_envelope, false);
     seed_context(&harness, pubkey, context);
-    harness.dissemination_store.insert(
-        pubkey,
-        EnvelopeDissemination {
-            slot: Slot::new(TEST_SLOT),
-            envelope: VariableList::new(vec![0xFF; 3]).expect("garbage bytes should fit"),
-        },
+
+    // Same four bindings, different payload: only `payload_root` differs, and nothing checks it.
+    let mut forged = builder_envelope.clone();
+    forged.payload.block_number = 99;
+    let forged_blinded = insert_dissemination_from(&harness, pubkey, OperatorId(1), &forged);
+    let honest = insert_dissemination_from(&harness, pubkey, OperatorId(2), &builder_envelope);
+    assert_ne!(
+        forged_blinded.payload_root, honest.payload_root,
+        "the forgery must differ from the honest envelope only in payload_root"
     );
     let counters = OutcomeCounters::snapshot();
 
-    let result = run_non_builder_task(&harness, pubkey, context).await;
+    let domain_hash = envelope_domain_hash(&harness);
+    run_non_builder_task(&harness, pubkey, context)
+        .await
+        .expect("a binding-passing candidate is signed");
 
-    assert!(
-        matches!(
-            result,
-            Err(Error::SpecificError(
-                SpecificError::DisseminationUndecodable { .. }
-            ))
-        ),
-        "undecodable disseminated bytes must be rejected, got {result:?}"
+    counters.assert_deltas(0, 1, 0);
+    let captured = harness.captured_calls.lock();
+    assert_eq!(
+        captured[0].signing_root,
+        forged_blinded.signing_root(domain_hash),
+        "the first binding-passing candidate is signed, forged payload_root included"
     );
-    counters.assert_deltas(0, 0, 1);
-    assert_no_outward_action(&harness, "for an undecodable dissemination");
 }
 
 // ==================== Gate tests ====================


### PR DESCRIPTION
## Problem, Evidence, and Context (Required)

A single committee member could cost the cluster its self-build reveal by winning a race.

SIP-94 §7 admitted one `EnvelopeDissemination` per `(MessageId, slot)`, signer-independent, and §6 signed whichever one arrived first. The first structurally valid carrier was therefore the only one an operator would forward or consider. A member that broadcast a well-formed but decision-unbound envelope ahead of the builder made every non-builder abstain, and the payload never revealed. Nothing about that requires a sophisticated attacker: one misbehaving member, once, is enough.

Both halves of the rule come from review of the SIP by Iurii (ssvlabs), whose asks were classified MUST where they are observable on the SSV wire. These two are: a go-ssv implementation that dedups per slot instead of per signer would drop disseminations Anchor admits, and the two would disagree about which envelope to sign. The SIP text edit follows this PR rather than preceding it, so the rule is proven implementable before it is written down.

Builds on #1286.

## Change Overview (Required)

Admit one dissemination per `(MessageId, signer, slot)`, and have the non-builder task sign the first candidate whose envelope satisfies the decided block's four bindings rather than the first that arrives. Forwarding stays bounded because only committee members pass validation, so the candidate list is capped by committee size.

Read it in this order:

1. `message_validator/src/duty_state.rs` - the dedup record moves from a signer-independent ring on `DutyState` to a flag on the signer's own `SignerState`, which is already the per-signer per-slot record and already carries the max-slot and per-epoch duty-count effects the old record reproduced by hand.
2. `message_validator/src/dissemination.rs` - the validation rule itself.
3. `common/dissemination_store/src/lib.rs` - the store keeps every accepted candidate per `(validator, slot)` behind an `Arc`, and `wait_matching` walks them once each, running the caller's predicate outside the lock.
4. `validator_store/src/lib.rs` - `sign_disseminated_envelope` supplies that predicate.
5. `message_receiver/src/manager.rs` and `operator_doppelganger/src/service.rs` - mechanical pattern updates for the reshaped variant.

What did not change: the wire format, the four bindings themselves, the builder's own publish path, and the deliberate decision to leave `payload_root` unchecked. No Lighthouse changes.

## Risks, Trade-offs, and Mitigations (Required)

**The accepted residual is unchanged and still real.** `payload_root` is not among the checked bindings, so a forgery that passes all four bindings while carrying a different payload root splits operators across two roots. Arrival order is node-local, so each root collects some shares and neither reaches threshold. The symptom is a signature collection timeout, never a wrong payload. This is documented at the selection site.

**A store entry now holds a list rather than one value.** Bounded on the validated path by committee size, at most one candidate per member per slot. A cap was proposed in review and declined: it cannot fire unless some other invariant is already broken, and it would then drop a candidate that may be the honest one, trading bounded transient memory for a missed reveal.

**The dedup flag is never cleared.** That rests on role 9 having no consensus path, since `OperatorState::update` is the only writer that replaces a `SignerState` outright and it is reachable only for QBFT roles. A future role that both disseminates and runs QBFT would need the bit carried across the replacement. Stated at the field.

## Validation (Required)

Unit: 12 in `dissemination_store`, 139 in `message_validator`, 168 in `anchor_validator_store`, workspace otherwise green, `make cargo-fmt-check` and `make lint` clean.

Two guards were documented in prose but pinned by no test, found by mutation testing. Making `record_dissemination` always replace the `SignerState` passed the entire suite, and is a live budget-reset bug: gossip does not order a signer's dissemination against its own partial signature and the two share one per-signer-per-slot entry. Dropping the ring's stored-slot filter also passed, and would silently ignore an honest dissemination exactly one ring length later. Both now have tests, each confirmed to fail against its mutation.

Devnet: 4-operator all-Anchor Gloas run on ssv-mini, operators split across two beacon nodes so each proposal has both builder and non-builder operators. 11 managed proposals, 11 of 11 envelopes revealed on chain and served by the BN. The accounting invariant held exactly on every operator (`signed_other + published == received`, and `delegated == lh_sentinel == signed_other`). Zero dissemination timeouts, zero binding mismatches, zero skipped candidates, zero validation failures, zero restarts. Reveal timing 0.15s to 0.39s into the slot.

That topology also exercises the §7 change directly, which is worth stating because it is not obvious: two operators share the builder's beacon node and build the identical block, so both broadcast, putting two disseminations from two distinct signers on one key every proposal. Under the old per-slot rule the second would have been rejected at validation on every receiving node.

Not exercised, and not claimed: a candidate that fails the bindings. Both candidates in a healthy cluster pass, so the skip-and-continue path never runs. Demonstrating it needs a patched operator broadcasting a binding-failing envelope.

## Rollback (Required for behavior or runtime changes; optional otherwise)

Revert the four commits. No config, no schema, no wire change, so a reverted node interoperates with a non-reverted one except that it reverts to admitting one dissemination per slot.

## Blockers / Dependencies (Optional)

The SIP-94 §6/§7 text edit follows this PR.

## Additional Info / Next Steps (Optional)

The review found eight points a second implementer could resolve differently, which will go into the SIP text rather than staying here. Two are sharp: recording a claimed signer before verifying its signature would be a censorship primitive, and the committee-size bound on the candidate list only holds if the text requires the signer to be a committee member rather than merely a known operator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SJP7vu2EGTFknFswZpjNjJ
