### PR TITLE
fix: use Bookworm for devnet builds

### DIFF
--- a/Dockerfile.devnet
+++ b/Dockerfile.devnet
@@ -1,5 +1,5 @@
 ARG RUST_VERSION=1.93.1
-FROM rust:${RUST_VERSION}-bullseye AS builder
+FROM rust:${RUST_VERSION}-bookworm AS builder
 RUN apt update && apt dist-upgrade -y && apt install -y cmake libclang-dev
 COPY . anchor
 ARG FEATURES=spec-minimal


### PR DESCRIPTION
## Problem, Evidence, and Context

The [local-testnet image build on #1297](https://github.com/sigp/anchor/actions/runs/34172220729/job/101894564546?pr=1297) fails during `apt update` because Bullseye security repository metadata has expired. [Debian 11 LTS ended on 31 August 2026](https://www.debian.org/News/2026/20260831).

## Change Overview

Use Debian Bookworm for the devnet Rust builder. Keep Rust 1.93.1 and the Ubuntu 24.04 runtime image unchanged.

## Risks, Trade-offs, and Mitigations

Bookworm changes the native build dependencies. The local-testnet workflow must verify the image builds and Anchor runs in the existing runtime image before merge.

## Validation

- Confirmed the official `rust:1.93.1-bookworm` image tag exists for Linux amd64.
- `git diff --check` and `make cargo-fmt-check` pass.
- Local lint and release tests: pending.
- Docker build and local-testnet execution: pending PR CI.

## Rollback

Revert this commit; the Bullseye repository failure may return.
